### PR TITLE
fix: use `modern-module` to output tree-shakable artifact

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Rslib Contributing Guide
+
+## Setup the Environment
+
+TODO
+
+## Caveats
+
+The project is still under development, so it possible dependents on unstable Rsbuild / Rspack versions.
+
+Current unstable versions are:
+
+| Package      | Version                             | Link                                                    |
+| ------------ | ----------------------------------- | ------------------------------------------------------- |
+| @rspack/core | 0.7.5-canary-b89dbb3-20240620182932 | [PR](https://github.com/web-infra-dev/rspack/pull/6877) |

--- a/e2e/cases/define/index.test.ts
+++ b/e2e/cases/define/index.test.ts
@@ -3,7 +3,7 @@ import { type RslibConfig, build } from '@rslib/core';
 import { expect, test } from 'vitest';
 import { globContentJSON } from '#helper';
 
-test.fails('define', async () => {
+test('define', async () => {
   delete process.env.NODE_ENV;
 
   const rslibConfig: RslibConfig = {
@@ -28,6 +28,9 @@ test.fails('define', async () => {
     source: {
       entry: {
         main: join(__dirname, './js/src/index.js'),
+      },
+      define: {
+        VERSION: JSON.stringify('1.0.0'),
       },
     },
   };

--- a/e2e/cases/define/js/src/index.js
+++ b/e2e/cases/define/js/src/index.js
@@ -1,1 +1,5 @@
+import { a } from './value';
+
+export { a };
+
 console.info(VERSION);

--- a/e2e/cases/define/js/src/value.js
+++ b/e2e/cases/define/js/src/value.js
@@ -1,0 +1,4 @@
+// TODO: Rspack only can handle exports from concatenated modules now.
+// Adding this file to let the compile pass as the moment.
+// Remove this file when Rspack could export from single module.`
+export const a = 1;

--- a/examples/basic/src/constants.ts
+++ b/examples/basic/src/constants.ts
@@ -1,0 +1,2 @@
+export const hello: string = 'Hello';
+export const world: string = 'World';

--- a/examples/basic/src/index.ts
+++ b/examples/basic/src/index.ts
@@ -1,3 +1,3 @@
-const message: string = 'Hello, Rslib';
-
-console.log(message);
+import { hello, world } from './constants';
+const message: string = `${hello}, ${world}!`;
+export { hello, world, message as default };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "sort-package-json": "npx sort-package-json \"packages/*/package.json\"",
     "test:artifact": "vitest run  --project artifact",
     "test:e2e": "cd e2e && pnpm run test",
-    "test:unit": "vitest run  --project unit"
+    "test:unit": "vitest run  --project unit",
+    "watch": "pnpm build --watch"
   },
   "simple-git-hooks": {
     "pre-commit": "npx nano-staged"
@@ -42,5 +43,10 @@
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=9.0.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "@rspack/core": "0.7.5-canary-b89dbb3-20240620182932"
+    }
   }
 }

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -27,8 +27,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           "concatenateModules": true,
         },
         "output": {
+          "iife": false,
           "library": {
-            "type": "module",
+            "type": "modern-module",
           },
           "module": true,
         },
@@ -57,17 +58,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
     "tools": {
       "htmlPlugin": false,
       "rspack": {
-        "experiments": {
-          "outputModule": true,
-        },
-        "optimization": {
-          "concatenateModules": true,
-        },
         "output": {
           "library": {
-            "type": "module",
+            "type": "commonjs",
           },
-          "module": true,
         },
       },
     },
@@ -90,17 +84,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
     "tools": {
       "htmlPlugin": false,
       "rspack": {
-        "experiments": {
-          "outputModule": true,
-        },
-        "optimization": {
-          "concatenateModules": true,
-        },
         "output": {
           "library": {
-            "type": "module",
+            "type": "umd",
           },
-          "module": true,
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@rspack/core': 0.7.5-canary-b89dbb3-20240620182932
+
 importers:
 
   .:
@@ -1099,56 +1102,56 @@ packages:
   '@rsbuild/shared@0.7.9':
     resolution: {integrity: sha512-g/xQoa1PJR5305EXqXW5v+gFaYjzlwFvOzv0hOrmF0n2tEO1gO5PD/dwdWw1F3I9I79OshCZk0ru0XLshg/waQ==}
 
-  '@rspack/binding-darwin-arm64@0.7.4':
-    resolution: {integrity: sha512-K78fUe9OhFTV61kHYCuahNkBXCFJMmqSGyIgNtLR9Psk82IVCHkvxY5565An1Quvo1UmgVh5R2YmylKE81mwiw==}
+  '@rspack/binding-darwin-arm64@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-xrK0GhPFkGalSdDN4ueEbVOD2TkGEegdKb6xgo645DB1AV6PBT8JxmTLjCfMnjSG08Y7jvJ9nG19Wxerv9UT9A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@0.7.4':
-    resolution: {integrity: sha512-EQriu7oE+tZv25g5VJH6Ael74U42fmpb4zGs7wLmWyKfCtO6SegL3tJ8Jc6mMmp+vg949dVvkw7uB6TJjOqx2g==}
+  '@rspack/binding-darwin-x64@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-0MBA6IMt4Qni0aTpeCEMsweICMWKmYXp5eYWsZLJjjhFXVcGzJbiGwjzD4kI06j0M36uVxOU5Z2ZQB1HWzMvxw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@0.7.4':
-    resolution: {integrity: sha512-yhJLkU1zEXMyHNWhh8pBEaK6cRAjFzRK2hqejhhZ0K+lqC0Af9bKvZyXXGrMfmmHlsh1VJ9VVmi21qcXr/kdzg==}
+  '@rspack/binding-linux-arm64-gnu@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-rLVrY24Z22QhbkAPzKk8TYoxg8Tsi1wh556v+wmcY4Ijgb9DJGU4pE8ZDPkesEaKJC3RjrLbl1aJcWdR7RGKsA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@0.7.4':
-    resolution: {integrity: sha512-6GV3Ztl6Q1zdJmNo+dwHiJd2Y/IEH9qWOh4YHiyzYGbQQYpfhhLYwKexalWaAAhdMm6KKoeqzklgHImCINImEg==}
+  '@rspack/binding-linux-arm64-musl@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-u3d3KJYm8kiLH9sekzNIemFcvP87K0/Jzru/9+6DnTmz8SrlRFmGgx0QqJYwfhukDAzojxFsT1q/rXSbMB+Akw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@0.7.4':
-    resolution: {integrity: sha512-KFdAEIZ7mPnT0y198xVOa8vIT9tgpEFVidCSIlxdk65UGC59g6UxEQq1EVAbcBi1Ou6Zza/UtxIlzk6Ev6KDkQ==}
+  '@rspack/binding-linux-x64-gnu@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-rMYwwWTJxYDxztBLZcKOIiqnXhME1Zzd4vQWFWfA3nuqCpkmO11Uj6vB+um17bkq+pqlcuxsi6dhAwFqmCyMtw==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@0.7.4':
-    resolution: {integrity: sha512-qekcXkv12oWRztZHXGzNAI92/O/+abU35/nGDycZmMtr+Qt2XS5hE1T9oBQ54yecIzUVDGNcYwhIMWBX6E2dmQ==}
+  '@rspack/binding-linux-x64-musl@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-0qRIzKWIwttHnBok7V++8vxrEMMG2zMszHo0ChNPA3C5yhBqCQsx03ng4f+c+zi5exrzyCR7rgZLbQxwdcIieA==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-win32-arm64-msvc@0.7.4':
-    resolution: {integrity: sha512-D1BccimBVeA/k2ty/28ER/j3s/c0n0MtN4kpyjYwgRILVLRSr+rfbC75i8wYh8r8AXjhNWNG88LmrFN9e9i7Ug==}
+  '@rspack/binding-win32-arm64-msvc@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-lj+tgQJFnl551Ga/8fm2pyQqTc7HsCkPe51/cRHPsQkhPWZQTYMMwqUbnSsC5NZHJxqcnuvSJuelWzVT6ni1gg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@0.7.4':
-    resolution: {integrity: sha512-5//TZH0Y4fRuTQ/ZmNOVaIfPIQXtgNAI78QxvF8Amygk4Uqklpo3ceHGP+yZfZgjh3mzjoUK+22fWbq/cUmW0w==}
+  '@rspack/binding-win32-ia32-msvc@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-s1yAJX3fIAngCCwt8bIU0SXXQsWs0X3sMSV2qdWHlRtTr+dX4ZBEn/aRcUro6uhPy9n3TxJEQ24etoGexiLo6A==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@0.7.4':
-    resolution: {integrity: sha512-C3ZxIEYKvnjQbV19FfQE6CGO6vcGp2JcvSQCc6SHwU/KNxLDrI1pA7XUG5TKoGSsqVEDZN6H8fJxLUYPQBjJcg==}
+  '@rspack/binding-win32-x64-msvc@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-odbIdIbbppXXDAlsB2bvRHs8d7sRkmXSfunp2ZdZFLOWzWLeb9XniMkQnjVbC3UynHilBoIr/JFTY4lftGbiwQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@0.7.4':
-    resolution: {integrity: sha512-H1rTtYxbxe40miV2gYLPwIxEn2yMY6+bq+fjfiRu61kTvllexPMBYgFpKqSAc5Qyyto9j9uCkR4MJEYj2R/SQQ==}
+  '@rspack/binding@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-Ir3D3wF6/0yEYP6fVP+B7AvvJ0gQi9kFukFAQsI9yqpoLb9TrT4NeIOYsBuB41xbHiIleltbqUSzBOYAhRi3SA==}
 
-  '@rspack/core@0.7.4':
-    resolution: {integrity: sha512-HECQ0WL8iVS1Mwq2W2hfrStZZbtTPl/GjDdAZDMToPqWtSVGww99UDGIYTHW8G6kawQ3GY6wa86WTQNfXEpSCA==}
+  '@rspack/core@0.7.5-canary-b89dbb3-20240620182932':
+    resolution: {integrity: sha512-IjM3td4I9EHOZS0kTLUtXdL/Es0RkXIh22pajupNxHhmeL+IgswtNSPbvV3xQph88AwmWGNQwoiMunBkD7x1WA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -1865,7 +1868,7 @@ packages:
     resolution: {integrity: sha512-uVXGYq19bcsX7Q/53VqXQjCKXw0eUMHlFGDLTaqzgj/ckverfhZQvXyA6ecFBaF9XUH16jfCTCyALYi0lJcagg==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
-      '@rspack/core': 0.x || 1.x
+      '@rspack/core': 0.7.5-canary-b89dbb3-20240620182932
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -3994,66 +3997,66 @@ snapshots:
   '@rsbuild/core@0.7.9':
     dependencies:
       '@rsbuild/shared': 0.7.9(@swc/helpers@0.5.3)
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.5-canary-b89dbb3-20240620182932(@swc/helpers@0.5.3)
       '@swc/helpers': 0.5.3
       core-js: 3.36.1
-      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))
+      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.5-canary-b89dbb3-20240620182932(@swc/helpers@0.5.3))
       postcss: 8.4.38
 
   '@rsbuild/shared@0.7.9(@swc/helpers@0.5.3)':
     dependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.5-canary-b89dbb3-20240620182932(@swc/helpers@0.5.3)
       caniuse-lite: 1.0.30001636
-      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))
+      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.5-canary-b89dbb3-20240620182932(@swc/helpers@0.5.3))
       postcss: 8.4.38
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@rspack/binding-darwin-arm64@0.7.4':
+  '@rspack/binding-darwin-arm64@0.7.5-canary-b89dbb3-20240620182932':
     optional: true
 
-  '@rspack/binding-darwin-x64@0.7.4':
+  '@rspack/binding-darwin-x64@0.7.5-canary-b89dbb3-20240620182932':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@0.7.4':
+  '@rspack/binding-linux-arm64-gnu@0.7.5-canary-b89dbb3-20240620182932':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@0.7.4':
+  '@rspack/binding-linux-arm64-musl@0.7.5-canary-b89dbb3-20240620182932':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@0.7.4':
+  '@rspack/binding-linux-x64-gnu@0.7.5-canary-b89dbb3-20240620182932':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@0.7.4':
+  '@rspack/binding-linux-x64-musl@0.7.5-canary-b89dbb3-20240620182932':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@0.7.4':
+  '@rspack/binding-win32-arm64-msvc@0.7.5-canary-b89dbb3-20240620182932':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@0.7.4':
+  '@rspack/binding-win32-ia32-msvc@0.7.5-canary-b89dbb3-20240620182932':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@0.7.4':
+  '@rspack/binding-win32-x64-msvc@0.7.5-canary-b89dbb3-20240620182932':
     optional: true
 
-  '@rspack/binding@0.7.4':
+  '@rspack/binding@0.7.5-canary-b89dbb3-20240620182932':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.7.4
-      '@rspack/binding-darwin-x64': 0.7.4
-      '@rspack/binding-linux-arm64-gnu': 0.7.4
-      '@rspack/binding-linux-arm64-musl': 0.7.4
-      '@rspack/binding-linux-x64-gnu': 0.7.4
-      '@rspack/binding-linux-x64-musl': 0.7.4
-      '@rspack/binding-win32-arm64-msvc': 0.7.4
-      '@rspack/binding-win32-ia32-msvc': 0.7.4
-      '@rspack/binding-win32-x64-msvc': 0.7.4
+      '@rspack/binding-darwin-arm64': 0.7.5-canary-b89dbb3-20240620182932
+      '@rspack/binding-darwin-x64': 0.7.5-canary-b89dbb3-20240620182932
+      '@rspack/binding-linux-arm64-gnu': 0.7.5-canary-b89dbb3-20240620182932
+      '@rspack/binding-linux-arm64-musl': 0.7.5-canary-b89dbb3-20240620182932
+      '@rspack/binding-linux-x64-gnu': 0.7.5-canary-b89dbb3-20240620182932
+      '@rspack/binding-linux-x64-musl': 0.7.5-canary-b89dbb3-20240620182932
+      '@rspack/binding-win32-arm64-msvc': 0.7.5-canary-b89dbb3-20240620182932
+      '@rspack/binding-win32-ia32-msvc': 0.7.5-canary-b89dbb3-20240620182932
+      '@rspack/binding-win32-x64-msvc': 0.7.5-canary-b89dbb3-20240620182932
 
-  '@rspack/core@0.7.4(@swc/helpers@0.5.3)':
+  '@rspack/core@0.7.5-canary-b89dbb3-20240620182932(@swc/helpers@0.5.3)':
     dependencies:
       '@module-federation/runtime-tools': 0.1.6
-      '@rspack/binding': 0.7.4
+      '@rspack/binding': 0.7.5-canary-b89dbb3-20240620182932
       caniuse-lite: 1.0.30001636
       tapable: 2.2.1
       webpack-sources: 3.2.3
@@ -4892,9 +4895,9 @@ snapshots:
 
   hosted-git-info@2.8.9: {}
 
-  html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3)):
+  html-rspack-plugin@5.7.2(@rspack/core@0.7.5-canary-b89dbb3-20240620182932(@swc/helpers@0.5.3)):
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.5-canary-b89dbb3-20240620182932(@swc/helpers@0.5.3)
 
   human-id@1.0.2: {}
 


### PR DESCRIPTION
## Summary

Using canary Rspack version to build tree-shake friendly artifacts.
The sad thing is it will panic if there's only one module to compile as concatenated module won't be processed and the exports definition will lose. I'll figure out how to fix it afterwards.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
