### PR TITLE
feat: support platform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,6 @@ The project is still under development, so it possible dependents on unstable Rs
 
 Current unstable versions are:
 
-| Package      | Version                             | Link                                                    |
-| ------------ | ----------------------------------- | ------------------------------------------------------- |
-| @rspack/core | 0.7.5-canary-0d03907-20240624125011 | [PR](https://github.com/web-infra-dev/rspack/pull/6877) |
+| Package      | Version                                                 | Link                                                      |
+| ------------ | ------------------------------------------------------- | --------------------------------------------------------- |
+| @rspack/core | @rspack/core-canary@1.0.0-canary-0b368b6-20240704171208 | [PR](https://github.com/webpack/webpack/pull/11751/files) |

--- a/biome.json
+++ b/biome.json
@@ -35,6 +35,7 @@
   },
   "linter": {
     "enabled": true,
+    "ignore": ["./e2e/cases/**/*/src/*"],
     "rules": {
       "recommended": true,
       "style": {

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,46 +1,46 @@
 # Modern.js Module tests coverage
 
-Rslib will try to cover the common scenarios in the [integration test cases of Modern.js Module](https://github.com/web-infra-dev/modern.js/tree/main/tests/integration/module). This document is used to record the coverage situation. The supported types are divided into three types: "fully supported", "not supported, but planned to support" and "not supported, not planned to support".
+Rslib will try to cover the common scenarios in the [integration test cases of Modern.js Module](https://github.com/web-infra-dev/modern.js/tree/main/tests/integration/module). This document is used to record the coverage situation. The supported types are divided into three types: "fully supported", "Partial supported", "not supported, but planned to support" and "not supported, not planned to support".
 
 ## build
 
-| Supported | Will support | Will not support |
-| --------- | ------------ | ---------------- |
-| 🟢        | 🟡           | ⚪️               |
+| Supported | Partial supported | Will support | Will not support |
+| --------- | ----------------- | ------------ | ---------------- |
+| 🟢        | 🟡                | ⚪️           | ⚫️              |
 
-| Feature         | Status | Note |
-| --------------- | ------ | ---- |
-| alias           | 🟢     |      |
-| asset           | 🟡     |      |
-| autoExtension   | 🟡     |      |
-| autoExternal    | 🟡     |      |
-| banner-footer   | 🟡     |      |
-| buildType       | 🟡     |      |
-| copy            | 🟡     |      |
-| decorator       | 🟡     |      |
-| define          | 🟢     |      |
-| dts             | 🟡     |      |
-| dts-composite   | 🟡     |      |
-| esbuildOptions  | 🟡     |      |
-| externals       | 🟡     |      |
-| format          | 🟡     |      |
-| input           | 🟡     |      |
-| jsx             | 🟡     |      |
-| metafile        | 🟡     |      |
-| minify          | 🟡     |      |
-| platform        | 🟡     |      |
-| redirect        | 🟡     |      |
-| resolve         | 🟡     |      |
-| shims           | 🟡     |      |
-| sideEffects     | 🟡     |      |
-| sourceDir       | 🟡     |      |
-| sourceMap       | 🟡     |      |
-| splitting       | 🟡     |      |
-| style           | 🟡     |      |
-| target          | 🟡     |      |
-| transformImport | 🟡     |      |
-| transformLodash | 🟡     |      |
-| tsconfig        | 🟡     |      |
-| tsconfigExtends | 🟡     |      |
-| umdGlobals      | 🟡     |      |
-| umdModuleName   | 🟡     |      |
+| Feature         | Status | Note                                                                                                                    |
+| --------------- | ------ | ----------------------------------------------------------------------------------------------------------------------- |
+| alias           | 🟢     |                                                                                                                         |
+| asset           | ⚪️     |                                                                                                                         |
+| autoExtension   | ⚪️     |                                                                                                                         |
+| autoExternal    | ⚪️     |                                                                                                                         |
+| banner-footer   | ⚪️     |                                                                                                                         |
+| buildType       | ⚪️     |                                                                                                                         |
+| copy            | ⚪️     |                                                                                                                         |
+| decorator       | ⚪️     |                                                                                                                         |
+| define          | 🟢     |                                                                                                                         |
+| dts             | ⚪️     |                                                                                                                         |
+| dts-composite   | ⚪️     |                                                                                                                         |
+| esbuildOptions  | ⚪️     |                                                                                                                         |
+| externals       | 🟡     | Support auto externalize Node.js built-in modules.<br />Should also support auto externalize `devDep && !peerDep` deps. |
+| format          | ⚪️     |                                                                                                                         |
+| input           | ⚪️     |                                                                                                                         |
+| jsx             | ⚪️     |                                                                                                                         |
+| metafile        | ⚪️     |                                                                                                                         |
+| minify          | ⚪️     |                                                                                                                         |
+| platform        | ⚪️     |                                                                                                                         |
+| redirect        | ⚪️     |                                                                                                                         |
+| resolve         | ⚪️     |                                                                                                                         |
+| shims           | ⚪️     |                                                                                                                         |
+| sideEffects     | ⚪️     |                                                                                                                         |
+| sourceDir       | ⚪️     |                                                                                                                         |
+| sourceMap       | ⚪️     |                                                                                                                         |
+| splitting       | ⚪️     |                                                                                                                         |
+| style           | ⚪️     |                                                                                                                         |
+| target          | ⚪️     |                                                                                                                         |
+| transformImport | ⚪️     |                                                                                                                         |
+| transformLodash | ⚪️     |                                                                                                                         |
+| tsconfig        | ⚪️     |                                                                                                                         |
+| tsconfigExtends | ⚪️     |                                                                                                                         |
+| umdGlobals      | ⚪️     |                                                                                                                         |
+| umdModuleName   | ⚪️     |                                                                                                                         |

--- a/e2e/cases/alias/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/alias/__snapshots__/index.test.ts.snap
@@ -1,33 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`alias in ts 1`] = `
-"var __webpack_exports__ = {};
-
-;// CONCATENATED MODULE: ./e2e/cases/alias/ts/src/a.ts
-const a = 'hello world';
-
-;// CONCATENATED MODULE: ./e2e/cases/alias/ts/src/index.ts
-
-console.info(a);
-
-export { a };
-"
-`;
-
-exports[`alias in ts 2`] = `
-"(() => { // webpackBootstrap
-"use strict";
-var __webpack_modules__ = ({
-"522": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  a: function() { return a; }
-});
-const a = 'hello world';
-
-
-}),
-
-});
+"var __webpack_modules__ = ({});
 /************************************************************************/
 // The module cache
 var __webpack_module_cache__ = {};
@@ -53,40 +27,82 @@ return module.exports;
 }
 
 /************************************************************************/
-// webpack/runtime/define_property_getters
+// webpack/runtime/rspack_version
 (() => {
-__webpack_require__.d = function(exports, definition) {
-	for(var key in definition) {
-        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
-        }
-    }
-};
-})();
-// webpack/runtime/has_own_property
-(() => {
-__webpack_require__.o = function (obj, prop) {
-	return Object.prototype.hasOwnProperty.call(obj, prop);
+__webpack_require__.rv = function () {
+	return "1.0.0-canary-0b368b6-20240704171208";
 };
 
 })();
-// webpack/runtime/make_namespace_object
+// webpack/runtime/rspack_unique_id
 (() => {
-// define __esModule on exports
-__webpack_require__.r = function(exports) {
-	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-	}
-	Object.defineProperty(exports, '__esModule', { value: true });
-};
+__webpack_require__.ruid = "bundler=rspack@1.0.0-canary-0b368b6-20240704171208";
 
 })();
 /************************************************************************/
 var __webpack_exports__ = {};
-__webpack_require__.r(__webpack_exports__);
-/* harmony import */var _src_a__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(522);
 
-console.info(_src_a__WEBPACK_IMPORTED_MODULE_0__.a);
+;// CONCATENATED MODULE: ./e2e/cases/alias/ts/src/a.ts
+const a = 'hello world';
+
+;// CONCATENATED MODULE: ./e2e/cases/alias/ts/src/index.ts
+
+console.info(a);
+
+export { a };
+"
+`;
+
+exports[`alias in ts 2`] = `
+"(() => { // webpackBootstrap
+"use strict";
+var __webpack_modules__ = ({});
+/************************************************************************/
+// The module cache
+var __webpack_module_cache__ = {};
+
+// The require function
+function __webpack_require__(moduleId) {
+
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+
+}
+
+/************************************************************************/
+// webpack/runtime/rspack_version
+(() => {
+__webpack_require__.rv = function () {
+	return "1.0.0-canary-0b368b6-20240704171208";
+};
+
+})();
+// webpack/runtime/rspack_unique_id
+(() => {
+__webpack_require__.ruid = "bundler=rspack@1.0.0-canary-0b368b6-20240704171208";
+
+})();
+/************************************************************************/
+var __webpack_exports__ = {};
+
+;// CONCATENATED MODULE: ./e2e/cases/alias/ts/src/a.ts
+const a = 'hello world';
+
+;// CONCATENATED MODULE: ./e2e/cases/alias/ts/src/index.ts
+
+console.info(a);
 
 var __webpack_export_target__ = exports;
 for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];

--- a/e2e/cases/alias/index.test.ts
+++ b/e2e/cases/alias/index.test.ts
@@ -1,33 +1,27 @@
 import { join } from 'node:path';
-import { build } from '@rslib/core';
 import { expect, test } from 'vitest';
-import { getEntryJsResults } from '#shared';
-import { loadConfig } from '../../../packages/core/src/config';
+import { buildAndGetResults } from '#shared';
 
 test('alias in js', async () => {
   delete process.env.NODE_ENV;
 
   const fixturePath = join(__dirname, 'js');
-  const rslibConfig = await loadConfig(join(fixturePath, 'rslib.config.ts'));
-  await build(rslibConfig);
-  const results = await getEntryJsResults(rslibConfig);
+  const { entries } = await buildAndGetResults(fixturePath);
 
-  expect(results.esm).toContain('hello world');
-  expect(results.cjs).toContain('hello world');
+  expect(entries.esm).toContain('hello world');
+  expect(entries.cjs).toContain('hello world');
 });
 
 test('alias in ts', async () => {
   delete process.env.NODE_ENV;
 
   const fixturePath = join(__dirname, 'ts');
-  const rslibConfig = await loadConfig(join(fixturePath, 'rslib.config.ts'));
-  await build(rslibConfig);
-  const results = await getEntryJsResults(rslibConfig);
+  const { entries } = await buildAndGetResults(fixturePath);
 
-  expect(results.esm).toContain('hello world');
-  expect(results.cjs).toContain('hello world');
+  expect(entries.esm).toContain('hello world');
+  expect(entries.cjs).toContain('hello world');
 
   // simple artifacts check
-  expect(results.esm).toMatchSnapshot();
-  expect(results.cjs).toMatchSnapshot();
+  expect(entries.esm).toMatchSnapshot();
+  expect(entries.cjs).toMatchSnapshot();
 });

--- a/e2e/cases/cli/index.test.ts
+++ b/e2e/cases/cli/index.test.ts
@@ -7,8 +7,6 @@ import { globContentJSON } from '#helper';
 test.todo('build command', async () => {});
 
 test('inspect command', async () => {
-  delete process.env.NODE_ENV;
-
   await fse.remove(path.join(__dirname, 'dist'));
   execSync('npx rslib inspect', {
     cwd: __dirname,

--- a/e2e/cases/define/index.test.ts
+++ b/e2e/cases/define/index.test.ts
@@ -1,33 +1,27 @@
 import { join } from 'node:path';
-import { build } from '@rslib/core';
 import { expect, test } from 'vitest';
-import { getEntryJsResults } from '#shared';
-import { loadConfig } from '../../../packages/core/src/config';
+import { buildAndGetResults } from '#shared';
 
 test('define in js', async () => {
-  delete process.env.NODE_ENV;
-
   const fixturePath = join(__dirname, 'js');
-  const rslibConfig = await loadConfig(join(fixturePath, 'rslib.config.ts'));
-  await build(rslibConfig);
-  const results = await getEntryJsResults(rslibConfig);
+  const { entries } = await buildAndGetResults(fixturePath);
 
-  expect(results.esm).not.toContain('console.info(VERSION)');
-  expect(results.esm).toContain('1.0.0');
-  expect(results.cjs).not.toContain('console.info(VERSION)');
-  expect(results.cjs).toContain('1.0.0');
+  // TODO: remove js/ts dir in cases `define` and `alias`
+  // supersede with a complex js/ts combined case
+  expect(entries.esm).not.toContain('console.info(VERSION)');
+  expect(entries.esm).toContain('1.0.0');
+
+  expect(entries.cjs).not.toContain('console.info(VERSION)');
+  expect(entries.cjs).toContain('1.0.0');
 });
 
 test('define in ts', async () => {
-  delete process.env.NODE_ENV;
-
   const fixturePath = join(__dirname, 'ts');
-  const rslibConfig = await loadConfig(join(fixturePath, 'rslib.config.ts'));
-  await build(rslibConfig);
-  const results = await getEntryJsResults(rslibConfig);
+  const { entries } = await buildAndGetResults(fixturePath);
 
-  expect(results.esm).not.toContain('console.info(VERSION)');
-  expect(results.esm).toContain('1.0.0');
-  expect(results.cjs).not.toContain('console.info(VERSION)');
-  expect(results.cjs).toContain('1.0.0');
+  expect(entries.esm).not.toContain('console.info(VERSION)');
+  expect(entries.esm).toContain('1.0.0');
+
+  expect(entries.cjs).not.toContain('console.info(VERSION)');
+  expect(entries.cjs).toContain('1.0.0');
 });

--- a/e2e/cases/externals/browser/index.test.ts
+++ b/e2e/cases/externals/browser/index.test.ts
@@ -1,0 +1,11 @@
+import { join } from 'node:path';
+import { expect, test } from 'vitest';
+import { buildAndGetResults } from '#shared';
+
+test('should fail when platform is not "node"', async () => {
+  delete process.env.NODE_ENV;
+
+  const fixturePath = join(__dirname);
+  const build = buildAndGetResults(fixturePath);
+  await expect(build).rejects.toThrowError('Rspack build failed!');
+});

--- a/e2e/cases/externals/browser/rslib.config.ts
+++ b/e2e/cases/externals/browser/rslib.config.ts
@@ -1,0 +1,15 @@
+import { join } from 'node:path';
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  source: {
+    entry: {
+      main: join(__dirname, 'src/index.ts'),
+    },
+  },
+  output: {
+    externals: { react: 'react' },
+  },
+});

--- a/e2e/cases/externals/browser/src/index.ts
+++ b/e2e/cases/externals/browser/src/index.ts
@@ -1,0 +1,6 @@
+import fs from 'fs'; // Should not be resolved when target is not "node"
+import assert from 'node:assert'; // Should not be resolved when target is not "node"
+
+export const foo = () => {
+  assert(fs, 'fs exists');
+};

--- a/e2e/cases/externals/node/index.test.ts
+++ b/e2e/cases/externals/node/index.test.ts
@@ -1,0 +1,26 @@
+import { join } from 'node:path';
+import { expect, test } from 'vitest';
+import { buildAndGetResults } from '#shared';
+
+test('auto externalize Node.js built-in modules when platform is "node"', async () => {
+  delete process.env.NODE_ENV;
+
+  const fixturePath = join(__dirname);
+  const { entries } = await buildAndGetResults(fixturePath);
+
+  for (const external of [
+    'import * as __WEBPACK_EXTERNAL_MODULE_fs__ from "fs"',
+    'import * as __WEBPACK_EXTERNAL_MODULE_node_assert__ from "node:assert"',
+    'import * as __WEBPACK_EXTERNAL_MODULE_react__ from "react"',
+  ]) {
+    expect(entries.esm).toContain(external);
+  }
+
+  for (const external of [
+    'var external_fs_namespaceObject = require("fs");',
+    'var external_node_assert_namespaceObject = require("node:assert");',
+    'var external_react_namespaceObject = require("react");',
+  ]) {
+    expect(entries.cjs).toContain(external);
+  }
+});

--- a/e2e/cases/externals/node/rslib.config.ts
+++ b/e2e/cases/externals/node/rslib.config.ts
@@ -1,0 +1,18 @@
+import { join } from 'node:path';
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig(__dirname, { platform: 'node' }),
+    generateBundleCjsConfig(__dirname, { platform: 'node' }),
+  ],
+  source: {
+    entry: {
+      main: join(__dirname, 'src/index.ts'),
+    },
+  },
+  output: {
+    externals: { react: 'react' },
+  },
+});

--- a/e2e/cases/externals/node/src/index.ts
+++ b/e2e/cases/externals/node/src/index.ts
@@ -1,0 +1,8 @@
+import fs from 'fs'; // handle bare node built-in modules
+import assert from 'node:assert'; // handle node built-in modules with node: protocol
+import React from 'react'; // works with the externals option in rslib.config.ts
+
+export const foo = () => {
+  assert(fs, 'fs exists');
+  assert(React.version);
+};

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,9 @@
   "scripts": {
     "test": "playwright test"
   },
+  "dependencies": {
+    "react": "^18.3.1"
+  },
   "devDependencies": {
     "@playwright/test": "1.43.1",
     "@rsbuild/core": "1.0.0-alpha.3",
@@ -16,6 +19,7 @@
     "@rslib/tsconfig": "workspace:*",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "18.x",
+    "@types/react": "^18.3.3",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0"
   }

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -2,6 +2,8 @@ import { join } from 'node:path';
 import { mergeRsbuildConfig as mergeConfig } from '@rsbuild/core';
 import type { LibConfig, RslibConfig } from '@rslib/core';
 import { globContentJSON } from '#helper';
+import { build } from '../../packages/core/src/build';
+import { loadConfig } from '../../packages/core/src/config';
 
 export function generateBundleEsmConfig(
   cwd: string,
@@ -16,7 +18,7 @@ export function generateBundleEsmConfig(
     },
   };
 
-  return mergeConfig(esmBasicConfig, config);
+  return mergeConfig(esmBasicConfig, config)!;
 }
 
 export function generateBundleCjsConfig(
@@ -32,7 +34,7 @@ export function generateBundleCjsConfig(
     },
   };
 
-  return mergeConfig(cjsBasicConfig, config);
+  return mergeConfig(cjsBasicConfig, config)!;
 }
 
 export async function getEntryJsResults(rslibConfig: RslibConfig) {
@@ -53,3 +55,10 @@ export async function getEntryJsResults(rslibConfig: RslibConfig) {
 
   return results;
 }
+
+export const buildAndGetResults = async (fixturePath: string) => {
+  const rslibConfig = await loadConfig(join(fixturePath, 'rslib.config.ts'));
+  await build(rslibConfig);
+  const entries = await getEntryJsResults(rslibConfig);
+  return { entries };
+};

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "pnpm run build && simple-git-hooks",
     "sort-package-json": "npx sort-package-json \"packages/*/package.json\"",
     "test:artifact": "vitest run --project artifact",
+    "test:artifact:watch": "vitest --project artifact",
     "test:e2e": "cd e2e && pnpm run test",
     "test:unit": "vitest run --project unit",
     "watch": "pnpm build --watch"
@@ -49,7 +50,7 @@
   },
   "pnpm": {
     "overrides": {
-      "@rspack/core": "0.7.5-canary-0d03907-20240624125011"
+      "@rspack/core": "npm:@rspack/core-canary@1.0.0-canary-0b368b6-20240704171208"
     }
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 export { build } from './build';
 export { runCli } from './cli/commands';
 export { prepareCli } from './cli/prepare';
-export { defineConfig } from './config';
+export { defineConfig, loadConfig } from './config';
 
 export * from './utils/logger';
 export * from './utils/helper';

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -1,9 +1,10 @@
 import type { RsbuildConfig } from '@rsbuild/core';
 
-export type Format = 'esm' | 'cjs' | 'umd' | 'iife';
+export type Format = 'esm' | 'cjs' | 'umd';
 
 export interface LibConfig extends RsbuildConfig {
   format?: Format;
+  platform?: 'node' | 'browser' | 'neutral';
 }
 
 export interface RslibConfig extends RsbuildConfig {

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -1,3 +1,69 @@
 import color from 'picocolors';
 
+/**
+ * Node.js built-in modules.
+ * Copied from https://github.com/webpack/webpack/blob/dd44b206a9c50f4b4cb4d134e1a0bd0387b159a3/lib/node/NodeTargetPlugin.js#L12-L72
+ */
+export const nodeBuiltInModules = [
+  'assert',
+  'assert/strict',
+  'async_hooks',
+  'buffer',
+  'child_process',
+  'cluster',
+  'console',
+  'constants',
+  'crypto',
+  'dgram',
+  'diagnostics_channel',
+  'dns',
+  'dns/promises',
+  'domain',
+  'events',
+  'fs',
+  'fs/promises',
+  'http',
+  'http2',
+  'https',
+  'inspector',
+  'inspector/promises',
+  'module',
+  'net',
+  'os',
+  'path',
+  'path/posix',
+  'path/win32',
+  'perf_hooks',
+  'process',
+  'punycode',
+  'querystring',
+  'readline',
+  'readline/promises',
+  'repl',
+  'stream',
+  'stream/consumers',
+  'stream/promises',
+  'stream/web',
+  'string_decoder',
+  'sys',
+  'timers',
+  'timers/promises',
+  'tls',
+  'trace_events',
+  'tty',
+  'url',
+  'util',
+  'util/types',
+  'v8',
+  'vm',
+  'wasi',
+  'worker_threads',
+  'zlib',
+  /^node:/,
+
+  // cspell:word pnpapi
+  // Yarn PnP adds pnpapi as "builtin"
+  'pnpapi',
+];
+
 export { color };

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -27,6 +27,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
     "tools": {
       "htmlPlugin": false,
       "rspack": {
+        "externalsType": "commonjs",
         "output": {
           "library": {
             "type": "commonjs",
@@ -59,11 +60,12 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
         "experiments": {
           "outputModule": true,
         },
+        "externalsType": "module",
         "optimization": {
           "concatenateModules": true,
         },
         "output": {
-          "iife": false,
+          "chunkFormat": "module",
           "library": {
             "type": "modern-module",
           },
@@ -93,6 +95,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
     "tools": {
       "htmlPlugin": false,
       "rspack": {
+        "externalsType": "umd",
         "output": {
           "library": {
             "type": "umd",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@rspack/core': 0.7.5-canary-0d03907-20240624125011
+  '@rspack/core': npm:@rspack/core-canary@1.0.0-canary-0b368b6-20240704171208
 
 importers:
 
@@ -55,6 +55,10 @@ importers:
         version: 1.6.0(@types/node@18.19.34)(terser@5.19.2)
 
   e2e:
+    dependencies:
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
     devDependencies:
       '@playwright/test':
         specifier: 1.43.1
@@ -74,6 +78,9 @@ importers:
       '@types/node':
         specifier: 18.x
         version: 18.19.34
+      '@types/react':
+        specifier: ^18.3.3
+        version: 18.3.3
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
@@ -919,17 +926,17 @@ packages:
   '@modern-js/utils@2.53.0':
     resolution: {integrity: sha512-RMdrfhjnCist+/EiCQ7h+MsZbV802ow/8130LkzD3IR+eYXtEaKsahWnIT7+pN87/Rsi+3QgcV4AUyAinfwOVQ==}
 
-  '@module-federation/runtime-tools@0.1.6':
-    resolution: {integrity: sha512-7ILVnzMIa0Dlc0Blck5tVZG1tnk1MmLnuZpLOMpbdW+zl+N6wdMjjHMjEZFCUAJh2E5XJ3BREwfX8Ets0nIkLg==}
+  '@module-federation/runtime-tools@0.2.3':
+    resolution: {integrity: sha512-capN8CVTCEqNAjnl102girrkevczoQfnQYyiYC4WuyKsg7+LUqfirIe1Eiyv6VSE2UgvOTZDnqvervA6rBOlmg==}
 
-  '@module-federation/runtime@0.1.6':
-    resolution: {integrity: sha512-nj6a+yJ+QxmcE89qmrTl4lphBIoAds0PFPVGnqLRWflwAP88jrCcrrTqRhARegkFDL+wE9AE04+h6jzlbIfMKg==}
+  '@module-federation/runtime@0.2.3':
+    resolution: {integrity: sha512-N+ZxBUb1mkmfO9XT1BwgYQgShtUTlijHbukqQ4afFka5lRAT+ayC7RKfHJLz0HbuexKPCmPBDfdmCnErR5WyTQ==}
 
-  '@module-federation/sdk@0.1.6':
-    resolution: {integrity: sha512-qifXpyYLM7abUeEOIfv0oTkguZgRZuwh89YOAYIZJlkP6QbRG7DJMQvtM8X2yHXm9PTk0IYNnOJH0vNQCo6auQ==}
+  '@module-federation/sdk@0.2.3':
+    resolution: {integrity: sha512-W9zrPchLocyCBc/B8CW21akcfJXLl++9xBe1L1EtgxZGfj/xwHt0GcBWE/y+QGvYTL2a1iZjwscbftbUhxgxXg==}
 
-  '@module-federation/webpack-bundler-runtime@0.1.6':
-    resolution: {integrity: sha512-K5WhKZ4RVNaMEtfHsd/9CNCgGKB0ipbm/tgweNNeC11mEuBTNxJ09Y630vg3WPkKv9vfMCuXg2p2Dk+Q/KWTSA==}
+  '@module-federation/webpack-bundler-runtime@0.2.3':
+    resolution: {integrity: sha512-L/jt2uJ+8dwYiyn9GxryzDR6tr/Wk8rpgvelM2EBeLIhu7YxCHSmSjQYhw3BTux9zZIr47d1K9fGjBFsVRd/SQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1105,62 +1112,66 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
 
-  '@rspack/binding-darwin-arm64@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-9e2dMR8BFB0rlfAKIVPmGCb9oaS86EWRbetWzKcqVTw46tHmi30De1eN5ElAfo3q0AtEruCfX7DDa0Shdja1xQ==}
+  '@rspack/binding-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-xD7yZvDXMQ0Xt+8IbOS2LGMTmuv+KVFDIc796BfvtDzLrQZYC0A5RM6+h6mE/ylCqlGpkJzumgX8yqwdXbMQjw==}
+
+  '@rspack/binding-darwin-arm64-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-8lmoehcZqS2rLMvs4jtrGILZdke827nmz1tMaIJM1oXmJGwyCr1No9l4bglcB+onyzJiMYRzzqpOm9e42T22Aw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-V9FYzxgEpp844X/y1YDTKtEhmjhrhlQ2ZvjSMlm2/Pa3OCqHtYBLBSlAWH6Otrk78frXeIoHU6BipoqKfTovRg==}
+  '@rspack/binding-darwin-x64-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-PRt1EleIHrECGTEMVW3PJNP2FtoeKreB5FSeqk5VYQ76Hy9VAreDsCH3l2qcovIOJgoSx0+WclgyVarD3CgTbw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-EqInxgIlsR78nVainp3NwGOScqt52LiAjHkCWPTbZFl9YI4zmAmM2u2zZ1UT+KqeWuBdR5gKMdMqzpBGYW7FeQ==}
+  '@rspack/binding-linux-arm64-gnu-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-WV0VRheOMYj0TrZFQm+7gQcVSGB0spJSyDDTnDGHUHv9YJCtq4ZW2U3QsU+bOgIlXwvLekaFktZt7bjregAttQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-LLmskYsVFV1Ze4pqznddz8c7c762Lx306nsqeO6GgGtFuxrfF6LDmTlYTef+SDzXi561AjWua/jfVOacdm+GAw==}
+  '@rspack/binding-linux-arm64-musl-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-C/BghGjgqSLbvEeQTeSo5BVQ2my7M4/1i7+TuIVC1ZN1ukdJwelLIBAXeNFygJ1dViFiip9R9lQ98OIpD57sGQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-9sbjQGYMtv0IcggIdOpqT1ht3Vlo3SJ4/9gE+MeimsIJQixdAfx4keP77HgYUUBioa3jpYNVdzUjZzQoe4GuKw==}
+  '@rspack/binding-linux-x64-gnu-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-mGCNI0MzABXbdqWrrGXB9AMjki/cMnHEXVWBV3U9HfOltmT8oBGzn9CrkiildUr1Cn+sh97cEw+SBYdDt/wt+Q==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-nTE2ZepDPgjKdcVjHoMoINQVTdNvHTb8HcUt6mK/2wQPiaA2iaHqabwJ6l+P4gyhaBOO21ZBY3gbZneKujAj9Q==}
+  '@rspack/binding-linux-x64-musl-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-jmIXwwIdX0wmUeKkcIVjjefB5zR2zJW3JHt/Pw1RRmiPWr0kTyQE0zmjq18rcyA+tk+7TusIg5C1jw9sbtCcsQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-win32-arm64-msvc@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-8CzQC/UgvzLjfhkFFw2yE7Gez3I4+UAYls5letOeNZW/MyThr6BqHxehTt+DYluabIGhuLktS701hWkZZ3TGPQ==}
+  '@rspack/binding-win32-arm64-msvc-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-fwaG7886DZJQXesQ2JRY6B8GTIYe4CiL/EvFVmUMWRNkQNKiN7pN/X0iGIOdo8ULeHGZwj1QnK3BWo3GONBRLw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-czBSsA9VFmlvRk6Zk2egZTkpz8F48jv0VqRY6fhwVgiEwLFbBjJYrmlKmrkAXnkUinERu6d7j+AAvjP/sbiJug==}
+  '@rspack/binding-win32-ia32-msvc-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-2D7TohCLKzg+PZcSvBlc/K2TCWVhqG59dUrhIS9XaRN0Honq/xpm+rVtV82cc3ZVZv4OKJsImHkr13CsH6V1kg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-m056OFXIz0WZ3gsaq6yHSMpKpjn+i1bDAGhH3eGQYMNrxNdVQP9SipRxlojUemw1VIlaXnAK86fKaiioErWuSA==}
+  '@rspack/binding-win32-x64-msvc-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-fWbPHCCs0wO2UbIO9hN9o5SW+UJQNn1+VFlEFUdZJ27dFX8QiSXr8z803IngbXH7NQIDjAn0rgbGjC4tUcgngA==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-PZFGTGvIFUvy/6kOvOc0xMRWjw9EQd39iG0wht2Le6HQPYyVOTdOHpjr/LYyK4dxjwZ4rpxdwH78GB0A+O2fjA==}
-
-  '@rspack/core@0.7.5-canary-0d03907-20240624125011':
-    resolution: {integrity: sha512-cqENtQ3rvzphcfbKmV3hKOOKacoSLjY/1mkNh/6iB0yLc8sNZetTfe4j7u9in5X5wTvFLmTfKS9EKWotU5lQZg==}
+  '@rspack/core-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-akx08dWyWgS/5U9P2y07k9UjZA07UfSHHWoY1zlwOyME7nM8pwii5LD7Yg+xrEKxI79aY7bRbfAgNtWMwXstoA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
     peerDependenciesMeta:
       '@swc/helpers':
         optional: true
+
+  '@rspack/lite-tapable-canary@1.0.0-canary-0b368b6-20240704171208':
+    resolution: {integrity: sha512-6+To8RkPFvWwjnl4yrf+FF8Az5zkDJgHfKWLiRqJ89Jbk9GcbqEUMB4LYvbmRb6FoB8wGDmyhe5aCCpRhz4UQg==}
+    engines: {node: '>=16.0.0'}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -1197,6 +1208,12 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/prop-types@15.7.12':
+    resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
+
+  '@types/react@18.3.3':
+    resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -1481,6 +1498,9 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csv-generate@3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
@@ -1877,7 +1897,7 @@ packages:
     resolution: {integrity: sha512-uVXGYq19bcsX7Q/53VqXQjCKXw0eUMHlFGDLTaqzgj/ckverfhZQvXyA6ecFBaF9XUH16jfCTCyALYi0lJcagg==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
-      '@rspack/core': 0.7.5-canary-0d03907-20240624125011
+      '@rspack/core': npm:@rspack/core-canary@1.0.0-canary-0b368b6-20240704171208
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -2163,6 +2183,10 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -2531,6 +2555,10 @@ packages:
 
   react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -3039,10 +3067,6 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-
-  webpack-sources@3.2.3:
-    resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
-    engines: {node: '>=10.13.0'}
 
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -3881,21 +3905,21 @@ snapshots:
       lodash: 4.17.21
       rslog: 1.2.2
 
-  '@module-federation/runtime-tools@0.1.6':
+  '@module-federation/runtime-tools@0.2.3':
     dependencies:
-      '@module-federation/runtime': 0.1.6
-      '@module-federation/webpack-bundler-runtime': 0.1.6
+      '@module-federation/runtime': 0.2.3
+      '@module-federation/webpack-bundler-runtime': 0.2.3
 
-  '@module-federation/runtime@0.1.6':
+  '@module-federation/runtime@0.2.3':
     dependencies:
-      '@module-federation/sdk': 0.1.6
+      '@module-federation/sdk': 0.2.3
 
-  '@module-federation/sdk@0.1.6': {}
+  '@module-federation/sdk@0.2.3': {}
 
-  '@module-federation/webpack-bundler-runtime@0.1.6':
+  '@module-federation/webpack-bundler-runtime@0.2.3':
     dependencies:
-      '@module-federation/runtime': 0.1.6
-      '@module-federation/sdk': 0.1.6
+      '@module-federation/runtime': 0.2.3
+      '@module-federation/sdk': 0.2.3
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4009,63 +4033,64 @@ snapshots:
 
   '@rsbuild/core@1.0.0-alpha.3':
     dependencies:
-      '@rspack/core': 0.7.5-canary-0d03907-20240624125011(@swc/helpers@0.5.11)
+      '@rspack/core': '@rspack/core-canary@1.0.0-canary-0b368b6-20240704171208(@swc/helpers@0.5.11)'
       '@swc/helpers': 0.5.11
       caniuse-lite: 1.0.30001640
       core-js: 3.37.1
-      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.5-canary-0d03907-20240624125011(@swc/helpers@0.5.11))
+      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core-canary@1.0.0-canary-0b368b6-20240704171208(@swc/helpers@0.5.11))
       postcss: 8.4.39
     optionalDependencies:
       fsevents: 2.3.3
 
-  '@rspack/binding-darwin-arm64@0.7.5-canary-0d03907-20240624125011':
-    optional: true
-
-  '@rspack/binding-darwin-x64@0.7.5-canary-0d03907-20240624125011':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@0.7.5-canary-0d03907-20240624125011':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@0.7.5-canary-0d03907-20240624125011':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@0.7.5-canary-0d03907-20240624125011':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@0.7.5-canary-0d03907-20240624125011':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@0.7.5-canary-0d03907-20240624125011':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@0.7.5-canary-0d03907-20240624125011':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@0.7.5-canary-0d03907-20240624125011':
-    optional: true
-
-  '@rspack/binding@0.7.5-canary-0d03907-20240624125011':
+  '@rspack/binding-canary@1.0.0-canary-0b368b6-20240704171208':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.7.5-canary-0d03907-20240624125011
-      '@rspack/binding-darwin-x64': 0.7.5-canary-0d03907-20240624125011
-      '@rspack/binding-linux-arm64-gnu': 0.7.5-canary-0d03907-20240624125011
-      '@rspack/binding-linux-arm64-musl': 0.7.5-canary-0d03907-20240624125011
-      '@rspack/binding-linux-x64-gnu': 0.7.5-canary-0d03907-20240624125011
-      '@rspack/binding-linux-x64-musl': 0.7.5-canary-0d03907-20240624125011
-      '@rspack/binding-win32-arm64-msvc': 0.7.5-canary-0d03907-20240624125011
-      '@rspack/binding-win32-ia32-msvc': 0.7.5-canary-0d03907-20240624125011
-      '@rspack/binding-win32-x64-msvc': 0.7.5-canary-0d03907-20240624125011
+      '@rspack/binding-darwin-arm64': '@rspack/binding-darwin-arm64-canary@1.0.0-canary-0b368b6-20240704171208'
+      '@rspack/binding-darwin-x64': '@rspack/binding-darwin-x64-canary@1.0.0-canary-0b368b6-20240704171208'
+      '@rspack/binding-linux-arm64-gnu': '@rspack/binding-linux-arm64-gnu-canary@1.0.0-canary-0b368b6-20240704171208'
+      '@rspack/binding-linux-arm64-musl': '@rspack/binding-linux-arm64-musl-canary@1.0.0-canary-0b368b6-20240704171208'
+      '@rspack/binding-linux-x64-gnu': '@rspack/binding-linux-x64-gnu-canary@1.0.0-canary-0b368b6-20240704171208'
+      '@rspack/binding-linux-x64-musl': '@rspack/binding-linux-x64-musl-canary@1.0.0-canary-0b368b6-20240704171208'
+      '@rspack/binding-win32-arm64-msvc': '@rspack/binding-win32-arm64-msvc-canary@1.0.0-canary-0b368b6-20240704171208'
+      '@rspack/binding-win32-ia32-msvc': '@rspack/binding-win32-ia32-msvc-canary@1.0.0-canary-0b368b6-20240704171208'
+      '@rspack/binding-win32-x64-msvc': '@rspack/binding-win32-x64-msvc-canary@1.0.0-canary-0b368b6-20240704171208'
 
-  '@rspack/core@0.7.5-canary-0d03907-20240624125011(@swc/helpers@0.5.11)':
+  '@rspack/binding-darwin-arm64-canary@1.0.0-canary-0b368b6-20240704171208':
+    optional: true
+
+  '@rspack/binding-darwin-x64-canary@1.0.0-canary-0b368b6-20240704171208':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu-canary@1.0.0-canary-0b368b6-20240704171208':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl-canary@1.0.0-canary-0b368b6-20240704171208':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu-canary@1.0.0-canary-0b368b6-20240704171208':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl-canary@1.0.0-canary-0b368b6-20240704171208':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc-canary@1.0.0-canary-0b368b6-20240704171208':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc-canary@1.0.0-canary-0b368b6-20240704171208':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc-canary@1.0.0-canary-0b368b6-20240704171208':
+    optional: true
+
+  '@rspack/core-canary@1.0.0-canary-0b368b6-20240704171208(@swc/helpers@0.5.11)':
     dependencies:
-      '@module-federation/runtime-tools': 0.1.6
-      '@rspack/binding': 0.7.5-canary-0d03907-20240624125011
+      '@module-federation/runtime-tools': 0.2.3
+      '@rspack/binding': '@rspack/binding-canary@1.0.0-canary-0b368b6-20240704171208'
+      '@rspack/lite-tapable': '@rspack/lite-tapable-canary@1.0.0-canary-0b368b6-20240704171208'
       caniuse-lite: 1.0.30001640
-      tapable: 2.2.1
-      webpack-sources: 3.2.3
     optionalDependencies:
       '@swc/helpers': 0.5.11
+
+  '@rspack/lite-tapable-canary@1.0.0-canary-0b368b6-20240704171208': {}
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -4101,6 +4126,13 @@ snapshots:
       undici-types: 5.26.5
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/prop-types@15.7.12': {}
+
+  '@types/react@18.3.3':
+    dependencies:
+      '@types/prop-types': 15.7.12
+      csstype: 3.1.3
 
   '@types/semver@7.5.8': {}
 
@@ -4407,6 +4439,8 @@ snapshots:
   cspell-ban-words@0.0.3: {}
 
   cssesc@3.0.0: {}
+
+  csstype@3.1.3: {}
 
   csv-generate@3.4.3: {}
 
@@ -4905,9 +4939,9 @@ snapshots:
 
   hosted-git-info@2.8.9: {}
 
-  html-rspack-plugin@5.7.2(@rspack/core@0.7.5-canary-0d03907-20240624125011(@swc/helpers@0.5.11)):
+  html-rspack-plugin@5.7.2(@rspack/core-canary@1.0.0-canary-0b368b6-20240704171208(@swc/helpers@0.5.11)):
     optionalDependencies:
-      '@rspack/core': 0.7.5-canary-0d03907-20240624125011(@swc/helpers@0.5.11)
+      '@rspack/core': '@rspack/core-canary@1.0.0-canary-0b368b6-20240704171208(@swc/helpers@0.5.11)'
 
   human-id@1.0.2: {}
 
@@ -5137,6 +5171,10 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   loupe@2.3.7:
     dependencies:
@@ -5534,6 +5572,10 @@ snapshots:
       w-json: 1.3.10
 
   react-is@18.2.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   read-pkg-up@7.0.1:
     dependencies:
@@ -6086,8 +6128,6 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
-
-  webpack-sources@3.2.3: {}
 
   which-boxed-primitive@1.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- add `platform` config
- auto externalize node built-in modules when platform is `node`

**Concern of introducing `platform` config**

- If we use keep using `target` field, some config will be changed internally (for now, `externalsTypes` for built-in modules has changed), which will lead to misalignment between Rsbuild and Rslib.
- If we using another field, such as `platform` as of now. `output.target` will conflict with it, we should drop it from Rsbuild available config for Rslib.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
