### PR TITLE
feat: add syntax placeholder, supersede platform with target

### DIFF
--- a/e2e/cases/externals/node/rslib.config.ts
+++ b/e2e/cases/externals/node/rslib.config.ts
@@ -4,8 +4,8 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, { platform: 'node' }),
-    generateBundleCjsConfig(__dirname, { platform: 'node' }),
+    generateBundleEsmConfig(__dirname, { output: { target: 'node' } }),
+    generateBundleCjsConfig(__dirname, { output: { target: 'node' } }),
   ],
   source: {
     entry: {

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -1,12 +1,38 @@
 import type { RsbuildConfig } from '@rsbuild/core';
 
 export type Format = 'esm' | 'cjs' | 'umd';
-export type Platform = 'node' | 'browser' | 'neutral';
+
+export type EcmaScriptVersion =
+  | 'esnext'
+  | 'es5'
+  | 'es6'
+  | 'es2015'
+  | 'es2016'
+  | 'es2017'
+  | 'es2018'
+  | 'es2019'
+  | 'es2020'
+  | 'es2021'
+  | 'es2022'
+  | 'es2023'
+  | 'es2024';
+
+export type Syntax =
+  // Use browserslist config file
+  | 'browserslist'
+  // ECMAScript versions as an common used addition to browserslist query
+  | EcmaScriptVersion
+  | EcmaScriptVersion[]
+  // Support inline browserslist query, like defined in package.json
+  | string[];
 
 export interface LibConfig extends RsbuildConfig {
   format?: Format;
-  platform?: Platform;
   autoExtension?: boolean;
+  output?: RsbuildConfig['output'] & {
+    /** Support esX and browserslist query */
+    syntax?: Syntax;
+  };
 }
 
 export interface RslibConfig extends RsbuildConfig {

--- a/packages/core/src/utils/browserslist.ts
+++ b/packages/core/src/utils/browserslist.ts
@@ -1,0 +1,8 @@
+import type { EcmaScriptVersion } from '../types/config';
+
+export const esVersionToBrowserList = (
+  _esVersion: EcmaScriptVersion,
+): string[] => {
+  // TODO: transform esX to browserslist
+  return [];
+};


### PR DESCRIPTION
## Summary

It will take some time to implement esX mapping to browserslist. And the code contains some refactor of config.ts. I'd like to merge the code first and finish the syntax field afterwards.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
