### PR TITLE
feat: use `named` moduleIds for readability

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -85,6 +85,9 @@ export async function createInternalRsbuildConfig(): Promise<RsbuildConfig> {
     tools: {
       htmlPlugin: false,
       rspack: {
+        optimization: {
+          moduleIds: 'named',
+        },
         experiments: {
           rspackFuture: {
             bundlerInfo: {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -39,6 +39,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           },
         },
         "externalsType": "commonjs",
+        "optimization": {
+          "moduleIds": "named",
+        },
         "output": {
           "chunkFormat": "commonjs",
           "iife": false,
@@ -87,6 +90,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
         "externalsType": "module",
         "optimization": {
           "concatenateModules": true,
+          "moduleIds": "named",
         },
         "output": {
           "chunkFormat": "module",
@@ -133,6 +137,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           },
         },
         "externalsType": "umd",
+        "optimization": {
+          "moduleIds": "named",
+        },
         "output": {
           "library": {
             "type": "umd",


### PR DESCRIPTION
## Summary

Using `named` `moduleIds` for better artifact readability.

before

```js
var __webpack_modules__ = ({
"1": (function (module) {
module.exports = 1;


}),

// --- snip ---
```
after

```js
var __webpack_modules__ = ({
"./src/c.ts": (function (module) {
module.exports = 1;


}),
--- snip ---
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
