### PR TITLE
docs: add banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<picture>
+  <img alt="Rslib Banner" src="https://assets.rspack.dev/rslib/rslib-banner.png">
+</picture>
+
 # Rslib
 
 The Rsbuild-based library build tool.


### PR DESCRIPTION
## Summary

Add Rslib banner to README.

## Related Links

https://github.com/rspack-contrib/rstack-design-resources

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
