### PR TITLE
chore: use prettier to format json files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,7 @@ compiled
 doc_build
 
 # ignore all JS/TS files, use Biome
-**/*[.js,.ts,.jsx,.tsx.json,.json5]
+**/*.js
+**/*.ts
+**/*.jsx
+**/*.tsx

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,13 +24,13 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "[json5]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[json]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[jsonc]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"

--- a/biome.json
+++ b/biome.json
@@ -28,6 +28,11 @@
       "quoteStyle": "single"
     }
   },
+  "json": {
+    "formatter": {
+      "enabled": false
+    }
+  },
   "linter": {
     "enabled": true,
     "ignore": ["./e2e/cases/**/*/src/*"],

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "pre-commit": "npx nano-staged"
   },
   "nano-staged": {
-    "*.{md,mdx,css,less,scss}": "prettier --write",
-    "*.{js,jsx,ts,tsx,mjs,cjs,json,jsonc,json5}": ["biome check --write"],
+    "*.{md,mdx,css,less,scss,json,jsonc,json5}": "prettier --write",
+    "*.{js,jsx,ts,tsx,mjs,cjs}": [
+      "biome check --write"
+    ],
     "package.json": "pnpm run check-dependency-version"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Use prettier to format json files instead of biome, for auto format `package.json` better with `prettier-plugin-packagejson`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
