### PR TITLE
fix: browserslist query and rspack target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,4 @@ Current unstable versions are:
 
 | Package      | Link                                                    |
 | ------------ | ------------------------------------------------------- |
-| @rspack/core | [PR](https://github.com/web-infra-dev/rspack/pull/7210) |
+| @rspack/core | [PR](https://github.com/web-infra-dev/rspack/pull/7394) |

--- a/e2e/cases/alias/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/alias/__snapshots__/index.test.ts.snap
@@ -9,7 +9,6 @@ const a = 'hello world';
 
 console.info(a);
 
-export { a };
 "
 `;
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "pnpm": {
     "overrides": {
-      "@rspack/core": "npm:@rspack/core-canary@1.0.0-canary-d77b591-20240718094414"
+      "@rspack/core": "npm:@rspack/core-canary@1.0.0-canary-338cfbe-20240731183605"
     }
   }
 }

--- a/packages/core/src/utils/syntax.ts
+++ b/packages/core/src/utils/syntax.ts
@@ -122,7 +122,9 @@ const ESX_TO_BROWSERSLIST: Record<
 
 export const transformSyntaxToBrowserslist = (
   syntax: Syntax,
-): NonNullable<RsbuildConfig['output']>['overrideBrowserslist'] => {
+): NonNullable<
+  NonNullable<RsbuildConfig['output']>['overrideBrowserslist']
+> => {
   // only single esX is allowed
   if (typeof syntax === 'string' && syntax.toLowerCase().startsWith('es')) {
     if (syntax.toLowerCase() in ESX_TO_BROWSERSLIST) {
@@ -132,7 +134,7 @@ export const transformSyntaxToBrowserslist = (
             return version;
           }
 
-          return `${engine} ${version}`;
+          return `${engine} >= ${version}`;
         },
       );
     }

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -1,154 +1,218 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1`] = `
-{
-  "cjs": {
-    "dev": {
-      "progressBar": false,
-    },
-    "output": {
-      "distPath": {
-        "js": "./",
+[
+  {
+    "config": {
+      "dev": {
+        "progressBar": false,
       },
-      "filename": {
-        "js": "[name].js",
+      "output": {
+        "distPath": {
+          "js": "./",
+        },
+        "filename": {
+          "js": "[name].js",
+        },
+        "filenameHash": false,
+        "minify": false,
+        "overrideBrowserslist": [
+          "last 1 node versions",
+          "last 1 Chrome versions",
+          "last 1 Firefox versions",
+          "last 1 Edge versions",
+          "last 1 Safari versions",
+          "last 1 ios_saf versions",
+          "not dead",
+        ],
       },
-      "filenameHash": false,
-      "minify": false,
-    },
-    "source": {
-      "alias": {
-        "bar": "bar/cjs",
-        "foo": "foo",
+      "source": {
+        "alias": {
+          "bar": "bar",
+          "foo": "foo/esm",
+        },
+        "entry": {},
+        "preEntry": "./b.js",
       },
-      "entry": {},
-      "preEntry": [
-        "./a.js",
-        "./c.js",
-        "./d.js",
-      ],
-    },
-    "tools": {
-      "htmlPlugin": false,
-      "rspack": {
-        "experiments": {
-          "rspackFuture": {
-            "bundlerInfo": {
-              "force": false,
+      "tools": {
+        "htmlPlugin": false,
+        "rspack": [
+          {
+            "experiments": {
+              "outputModule": true,
+            },
+            "externalsType": "module",
+            "optimization": {
+              "concatenateModules": true,
+            },
+            "output": {
+              "chunkFormat": "module",
+              "library": {
+                "type": "modern-module",
+              },
+              "module": true,
             },
           },
-        },
-        "externalsType": "commonjs",
-        "optimization": {
-          "moduleIds": "named",
-        },
-        "output": {
-          "chunkFormat": "commonjs",
-          "iife": false,
-          "library": {
-            "type": "commonjs",
+          [Function],
+          {
+            "target": [
+              "web",
+            ],
           },
-        },
-        "target": "es2022",
-      },
-      "swc": [Function],
-    },
-  },
-  "esm": {
-    "dev": {
-      "progressBar": false,
-    },
-    "output": {
-      "distPath": {
-        "js": "./",
-      },
-      "filename": {
-        "js": "[name].js",
-      },
-      "filenameHash": false,
-      "minify": false,
-    },
-    "source": {
-      "alias": {
-        "bar": "bar",
-        "foo": "foo/esm",
-      },
-      "entry": {},
-      "preEntry": "./b.js",
-    },
-    "tools": {
-      "htmlPlugin": false,
-      "rspack": {
-        "experiments": {
-          "outputModule": true,
-          "rspackFuture": {
-            "bundlerInfo": {
-              "force": false,
+          {
+            "experiments": {
+              "rspackFuture": {
+                "bundlerInfo": {
+                  "force": false,
+                },
+              },
+            },
+            "optimization": {
+              "moduleIds": "named",
             },
           },
-        },
-        "externalsType": "module",
-        "optimization": {
-          "concatenateModules": true,
-          "moduleIds": "named",
-        },
-        "output": {
-          "chunkFormat": "module",
-          "library": {
-            "type": "modern-module",
-          },
-          "module": true,
-        },
-        "target": "es2022",
+        ],
       },
-      "swc": [Function],
     },
+    "format": "esm",
   },
-  "umd": {
-    "dev": {
-      "progressBar": false,
-    },
-    "output": {
-      "distPath": {
-        "js": "./",
+  {
+    "config": {
+      "dev": {
+        "progressBar": false,
       },
-      "filename": {
-        "js": "[name].js",
+      "output": {
+        "distPath": {
+          "js": "./",
+        },
+        "filename": {
+          "js": "[name].js",
+        },
+        "filenameHash": false,
+        "minify": false,
+        "overrideBrowserslist": [
+          "last 1 node versions",
+          "last 1 Chrome versions",
+          "last 1 Firefox versions",
+          "last 1 Edge versions",
+          "last 1 Safari versions",
+          "last 1 ios_saf versions",
+          "not dead",
+        ],
       },
-      "filenameHash": false,
-      "minify": false,
-    },
-    "source": {
-      "alias": {
-        "bar": "bar",
-        "foo": "foo",
+      "source": {
+        "alias": {
+          "bar": "bar/cjs",
+          "foo": "foo",
+        },
+        "entry": {},
+        "preEntry": [
+          "./a.js",
+          "./c.js",
+          "./d.js",
+        ],
       },
-      "entry": {},
-      "preEntry": "./a.js",
-    },
-    "tools": {
-      "htmlPlugin": false,
-      "rspack": {
-        "experiments": {
-          "rspackFuture": {
-            "bundlerInfo": {
-              "force": false,
+      "tools": {
+        "htmlPlugin": false,
+        "rspack": [
+          {
+            "externalsType": "commonjs",
+            "output": {
+              "chunkFormat": "commonjs",
+              "iife": false,
+              "library": {
+                "type": "commonjs",
+              },
             },
           },
-        },
-        "externalsType": "umd",
-        "optimization": {
-          "moduleIds": "named",
-        },
-        "output": {
-          "library": {
-            "type": "umd",
+          [Function],
+          {
+            "target": [
+              "web",
+            ],
           },
-        },
-        "target": "es2022",
+          {
+            "experiments": {
+              "rspackFuture": {
+                "bundlerInfo": {
+                  "force": false,
+                },
+              },
+            },
+            "optimization": {
+              "moduleIds": "named",
+            },
+          },
+        ],
       },
-      "swc": [Function],
     },
+    "format": "cjs",
   },
-}
+  {
+    "config": {
+      "dev": {
+        "progressBar": false,
+      },
+      "output": {
+        "distPath": {
+          "js": "./",
+        },
+        "filename": {
+          "js": "[name].js",
+        },
+        "filenameHash": false,
+        "minify": false,
+        "overrideBrowserslist": [
+          "last 1 node versions",
+          "last 1 Chrome versions",
+          "last 1 Firefox versions",
+          "last 1 Edge versions",
+          "last 1 Safari versions",
+          "last 1 ios_saf versions",
+          "not dead",
+        ],
+      },
+      "source": {
+        "alias": {
+          "bar": "bar",
+          "foo": "foo",
+        },
+        "entry": {},
+        "preEntry": "./a.js",
+      },
+      "tools": {
+        "htmlPlugin": false,
+        "rspack": [
+          {
+            "externalsType": "umd",
+            "output": {
+              "library": {
+                "type": "umd",
+              },
+            },
+          },
+          [Function],
+          {
+            "target": [
+              "web",
+            ],
+          },
+          {
+            "experiments": {
+              "rspackFuture": {
+                "bundlerInfo": {
+                  "force": false,
+                },
+              },
+            },
+            "optimization": {
+              "moduleIds": "named",
+            },
+          },
+        ],
+      },
+    },
+    "format": "umd",
+  },
+]
 `;

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -186,3 +186,123 @@ describe('Should compose create Rsbuild config correctly', () => {
     expect(composedRsbuildConfig).toMatchSnapshot();
   });
 });
+
+describe('syntax', () => {
+  test('`syntax` default value', async () => {
+    const rslibConfig: RslibConfig = {
+      lib: [
+        {
+          format: 'esm',
+        },
+      ],
+    };
+
+    const composedRsbuildConfig = await composeCreateRsbuildConfig(
+      rslibConfig,
+      process.cwd(),
+    );
+
+    expect(
+      composedRsbuildConfig[0].config.output?.overrideBrowserslist,
+    ).toMatchInlineSnapshot(`
+      [
+        "last 1 node versions",
+        "last 1 Chrome versions",
+        "last 1 Firefox versions",
+        "last 1 Edge versions",
+        "last 1 Safari versions",
+        "last 1 ios_saf versions",
+        "not dead",
+      ]
+    `);
+  });
+
+  test('`syntax` default value should determined by target `web`', async () => {
+    const rslibConfig: RslibConfig = {
+      lib: [
+        {
+          format: 'esm',
+        },
+      ],
+      output: {
+        target: 'web',
+      },
+    };
+
+    const composedRsbuildConfig = await composeCreateRsbuildConfig(
+      rslibConfig,
+      process.cwd(),
+    );
+
+    expect(
+      composedRsbuildConfig[0].config.output?.overrideBrowserslist,
+    ).toMatchInlineSnapshot(`
+      [
+        "last 1 Chrome versions",
+        "last 1 Firefox versions",
+        "last 1 Edge versions",
+        "last 1 Safari versions",
+        "last 1 ios_saf versions",
+        "not dead",
+      ]
+    `);
+  });
+
+  test('`syntax` default value should determined by target `node`', async () => {
+    const rslibConfig: RslibConfig = {
+      lib: [
+        {
+          format: 'esm',
+        },
+      ],
+      output: {
+        target: 'node',
+      },
+    };
+
+    const composedRsbuildConfig = await composeCreateRsbuildConfig(
+      rslibConfig,
+      process.cwd(),
+    );
+
+    expect(
+      composedRsbuildConfig[0].config.output?.overrideBrowserslist,
+    ).toMatchInlineSnapshot(`
+      [
+        "last 1 node versions",
+      ]
+    `);
+  });
+
+  test('`syntax` could accept `esX` and transform to browserslist', async () => {
+    const rslibConfig: RslibConfig = {
+      lib: [
+        {
+          output: {
+            syntax: 'es2015',
+          },
+          format: 'esm',
+        },
+      ],
+    };
+
+    const composedRsbuildConfig = await composeCreateRsbuildConfig(
+      rslibConfig,
+      process.cwd(),
+    );
+
+    expect(
+      composedRsbuildConfig[0].config.output?.overrideBrowserslist,
+    ).toMatchInlineSnapshot(`
+      [
+        "Chrome >= 63.0.0",
+        "Edge >= 79.0.0",
+        "Firefox >= 67.0.0",
+        "iOS >= 13.0.0",
+        "Node >= 10.0.0",
+        "Opera >= 50.0.0",
+        "Safari >= 13.0.0",
+      ]
+    `);
+  });
+});

--- a/packages/core/tests/syntax.test.ts
+++ b/packages/core/tests/syntax.test.ts
@@ -5,28 +5,28 @@ describe('Correctly resolve syntax', () => {
   test('esX', async () => {
     expect(transformSyntaxToBrowserslist('es6')).toMatchInlineSnapshot(`
       [
-        "Chrome 63.0.0",
-        "Edge 79.0.0",
-        "Firefox 67.0.0",
-        "iOS 13.0.0",
+        "Chrome >= 63.0.0",
+        "Edge >= 79.0.0",
+        "Firefox >= 67.0.0",
+        "iOS >= 13.0.0",
         "node > 12.20.0 and node < 13.0.0",
         "node > 13.2.0",
-        "Opera 50.0.0",
-        "Safari 13.0.0",
+        "Opera >= 50.0.0",
+        "Safari >= 13.0.0",
       ]
     `);
 
     expect(transformSyntaxToBrowserslist('es2018')).toMatchInlineSnapshot(`
       [
-        "Chrome 64.0.0",
-        "Edge 79.0.0",
-        "Firefox 78.0.0",
-        "iOS 16.4.0",
+        "Chrome >= 64.0.0",
+        "Edge >= 79.0.0",
+        "Firefox >= 78.0.0",
+        "iOS >= 16.4.0",
         "node > 18.20.0 and node < 19.0.0",
         "node > 20.12.0 and node < 21.0.0",
         "node > 21.3.0",
-        "Opera 51.0.0",
-        "Safari 16.4.0",
+        "Opera >= 51.0.0",
+        "Safari >= 16.4.0",
       ]
     `);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@rspack/core': npm:@rspack/core-canary@1.0.0-canary-d77b591-20240718094414
+  '@rspack/core': npm:@rspack/core-canary@1.0.0-canary-338cfbe-20240731183605
 
 importers:
 
@@ -1197,56 +1197,56 @@ packages:
     peerDependencies:
       '@rsbuild/core': ^1.0.1-beta.9
 
-  '@rspack/binding-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-0DTf4WeXs8mcoZ8maeuD8kZCnPmvZxY8VCED3bL5oMRM8VT9ons8dggn1UFDBaiUoqyD7Ko2OFKb3n1VYHboYw==}
+  '@rspack/binding-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-lFl8Xt8QcNX0I1Kb/NfJYOa3B8iLBqw9T6CGylWbu0wQQ5TUnspGPfL7MIzi+mZ/eOaEcpIafUlCk+mcd5nC9Q==}
 
-  '@rspack/binding-darwin-arm64-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-7Drn6VzjpkBvmeMmV+SjZFN1IxtiNvVGzzLERH3SuRyYT6lv/WthgiOocCtcPQxTbCbBS67NGTglPndWZIOuDg==}
+  '@rspack/binding-darwin-arm64-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-tO1ps4zfEk+3Sn4vKdn4RNcFqWl5IaNyYXZRHQtQXzJNAEBuSYeL9EDZMngjHQ7ymVfgwKR5Q+Tm0+SfPqO3cA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-XfBueryD7RHweNJlpXbk0+mswCJFhiey3Cw+RZuO8SJnur+u66ePeH2OF3Atuk8ToKMsXEX81vkcGrZ2LwntIg==}
+  '@rspack/binding-darwin-x64-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-puZ3ShmJZfj+wanaD6QX0sE3DFYDiSr3tHopLUPtDi2ogPR4EhhFmrHMHhZYcUetAxo9EDCVNolGn3hxIrpwcw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-6f5OSeprOAx0fdyKAdtUnZJvI1NoesPZtcutbuounYr8EBnWU9OcC795iSzLj9lsbsZ6ZcWwaRb45vLcJRd9vw==}
+  '@rspack/binding-linux-arm64-gnu-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-JHh3W3l3dIbOtB8raKANqHn8L60IBTXx5CvjgoWHxqVlHeH8Szp7Uwnzf/7obWUbwONafOB9TBgqsKiRXtEn3w==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-Ajx3GNSOO5eeth9FLY9DMmLEaTiijT5SybTV2nibzb5DLXz41ZjNWCiK2VqlJAf7nodF9QZPsEO/T3V0Ky6Q7Q==}
+  '@rspack/binding-linux-arm64-musl-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-/hkCF7w2ijmn260uPb49e3aaPjH/QWxymfLPI5nvC4+/Bk1XdYawIiy4A35Bv8kOuZciYYH3TMgkbXblqdamFA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-nkdF/E3h8H9dKGKmIOkEv+yn8i7gH9E2WRcfsBdNxHAxS+XUEZFc9xNbSsk6auf/1Crznb+umc6hvQ5nQrTUDQ==}
+  '@rspack/binding-linux-x64-gnu-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-Vpnqu3knK6YTmgvgIEFvEs1DbyVjyghdIrzIdkiJwhRF4AntZe3kxuM+x8fN94iDFHfRhWHTb1OkAooySaEGaw==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-Cpezgks1pBD1ZBfi3g2Lz8u3LCYVa/jfnrOxEzs0KXaFskKtehZpJQBFx4m0iOaJRIVL/CEz3P8yhbU0Uzhi4g==}
+  '@rspack/binding-linux-x64-musl-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-ALlBgaoRXzYLeBfJLjVF9BpegYDD3wFk7Dtfnk/Ij9kTbzPmhYN5+5FIlTpANBbXfrknp+XqYoPRLsXI1EXtog==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-win32-arm64-msvc-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-iSHftYqDPMQOoNTN0Rnadi0cYnvJGSGNuHB0rhnRJysFlkwQWdwLnJXHigqwxQQT0a2fSjuUdeXnobf8f0uMwQ==}
+  '@rspack/binding-win32-arm64-msvc-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-ZH1F1zDnjRBPjfO1JzEwa9Wivy8oH81VFQVny0EWhqkzybjldrecAAp51+tsHcEiq8Tuc4c6BhJMfk2QWzQ+BQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-edtlZ9NnufE2DKVcQgMpTNTCjp8BDsHgWfN6YsoJjzjHJvtWiubShnp2/1wrwxmbYzCS09w9v6+Sy8apRz6OeA==}
+  '@rspack/binding-win32-ia32-msvc-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-ww0uq30GTb33UpQ5fP07elvfCedlH+CM9BKpNidPci97/mSLcn823/jCBW2yzLauxFbcAdTWabaV5UhvmTfkAQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-q8+CKpTbwtXDYnWIsLlMKGjO00pEOHBhbhmOrcO0qKHrVGBP5brb6WA37tYAN330fErsLT0FTppa3LV8Vd0nCQ==}
+  '@rspack/binding-win32-x64-msvc-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-W2rL0V0S2KL9yUKSy493In/gWBPCcNIn9Ry1xegTbpNMU/++F5T9ZqI/whHets0uQMU9cKWFfQZmsSzCrIXiTg==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/core-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-JgmIq1GUdi8e93dQBI1JQFKg3szLBhar1lZCodH3Mqyht+C0wGSRaoy+QegHLkgpx+00qUWLDf3M3eLP4lqntA==}
+  '@rspack/core-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-gPjYRA29rstYJHkcWmLuIgRq2mCknj22A1E65tg4i/K5yI6nCUxi+nvGVBBvNWKky+5ikGZxWK5O2I0IyH7hsQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -1254,8 +1254,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/lite-tapable-canary@1.0.0-canary-d77b591-20240718094414':
-    resolution: {integrity: sha512-rTGAkDCbq7pyVV2BhkYx0xgK65XEhv4VAkZB5HBhbs2HeB2qkP0yT8NZEgkAtMg5R6Q54dndeZGLFboqYtlF5w==}
+  '@rspack/lite-tapable-canary@1.0.0-canary-338cfbe-20240731183605':
+    resolution: {integrity: sha512-emikuiIbELsdO28IxMgjkcw8sovk9/BF+L7V3Ix75NLFc2+5MZ8LGteUFrhxfuXr/7eFY1eje858ZmeRPNr4fw==}
     engines: {node: '>=16.0.0'}
 
   '@rspack/lite-tapable@1.0.0-beta.1':
@@ -4082,7 +4082,7 @@ snapshots:
 
   '@rsbuild/core@1.0.1-beta.8':
     dependencies:
-      '@rspack/core': '@rspack/core-canary@1.0.0-canary-d77b591-20240718094414(@swc/helpers@0.5.11)'
+      '@rspack/core': '@rspack/core-canary@1.0.0-canary-338cfbe-20240731183605(@swc/helpers@0.5.11)'
       '@rspack/lite-tapable': 1.0.0-beta.1
       '@swc/helpers': 0.5.11
       caniuse-lite: 1.0.30001643
@@ -4096,55 +4096,55 @@ snapshots:
       '@rspack/plugin-react-refresh': 1.0.0-beta.1(react-refresh@0.14.2)
       react-refresh: 0.14.2
 
-  '@rspack/binding-canary@1.0.0-canary-d77b591-20240718094414':
+  '@rspack/binding-canary@1.0.0-canary-338cfbe-20240731183605':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': '@rspack/binding-darwin-arm64-canary@1.0.0-canary-d77b591-20240718094414'
-      '@rspack/binding-darwin-x64': '@rspack/binding-darwin-x64-canary@1.0.0-canary-d77b591-20240718094414'
-      '@rspack/binding-linux-arm64-gnu': '@rspack/binding-linux-arm64-gnu-canary@1.0.0-canary-d77b591-20240718094414'
-      '@rspack/binding-linux-arm64-musl': '@rspack/binding-linux-arm64-musl-canary@1.0.0-canary-d77b591-20240718094414'
-      '@rspack/binding-linux-x64-gnu': '@rspack/binding-linux-x64-gnu-canary@1.0.0-canary-d77b591-20240718094414'
-      '@rspack/binding-linux-x64-musl': '@rspack/binding-linux-x64-musl-canary@1.0.0-canary-d77b591-20240718094414'
-      '@rspack/binding-win32-arm64-msvc': '@rspack/binding-win32-arm64-msvc-canary@1.0.0-canary-d77b591-20240718094414'
-      '@rspack/binding-win32-ia32-msvc': '@rspack/binding-win32-ia32-msvc-canary@1.0.0-canary-d77b591-20240718094414'
-      '@rspack/binding-win32-x64-msvc': '@rspack/binding-win32-x64-msvc-canary@1.0.0-canary-d77b591-20240718094414'
+      '@rspack/binding-darwin-arm64': '@rspack/binding-darwin-arm64-canary@1.0.0-canary-338cfbe-20240731183605'
+      '@rspack/binding-darwin-x64': '@rspack/binding-darwin-x64-canary@1.0.0-canary-338cfbe-20240731183605'
+      '@rspack/binding-linux-arm64-gnu': '@rspack/binding-linux-arm64-gnu-canary@1.0.0-canary-338cfbe-20240731183605'
+      '@rspack/binding-linux-arm64-musl': '@rspack/binding-linux-arm64-musl-canary@1.0.0-canary-338cfbe-20240731183605'
+      '@rspack/binding-linux-x64-gnu': '@rspack/binding-linux-x64-gnu-canary@1.0.0-canary-338cfbe-20240731183605'
+      '@rspack/binding-linux-x64-musl': '@rspack/binding-linux-x64-musl-canary@1.0.0-canary-338cfbe-20240731183605'
+      '@rspack/binding-win32-arm64-msvc': '@rspack/binding-win32-arm64-msvc-canary@1.0.0-canary-338cfbe-20240731183605'
+      '@rspack/binding-win32-ia32-msvc': '@rspack/binding-win32-ia32-msvc-canary@1.0.0-canary-338cfbe-20240731183605'
+      '@rspack/binding-win32-x64-msvc': '@rspack/binding-win32-x64-msvc-canary@1.0.0-canary-338cfbe-20240731183605'
 
-  '@rspack/binding-darwin-arm64-canary@1.0.0-canary-d77b591-20240718094414':
+  '@rspack/binding-darwin-arm64-canary@1.0.0-canary-338cfbe-20240731183605':
     optional: true
 
-  '@rspack/binding-darwin-x64-canary@1.0.0-canary-d77b591-20240718094414':
+  '@rspack/binding-darwin-x64-canary@1.0.0-canary-338cfbe-20240731183605':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu-canary@1.0.0-canary-d77b591-20240718094414':
+  '@rspack/binding-linux-arm64-gnu-canary@1.0.0-canary-338cfbe-20240731183605':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl-canary@1.0.0-canary-d77b591-20240718094414':
+  '@rspack/binding-linux-arm64-musl-canary@1.0.0-canary-338cfbe-20240731183605':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu-canary@1.0.0-canary-d77b591-20240718094414':
+  '@rspack/binding-linux-x64-gnu-canary@1.0.0-canary-338cfbe-20240731183605':
     optional: true
 
-  '@rspack/binding-linux-x64-musl-canary@1.0.0-canary-d77b591-20240718094414':
+  '@rspack/binding-linux-x64-musl-canary@1.0.0-canary-338cfbe-20240731183605':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc-canary@1.0.0-canary-d77b591-20240718094414':
+  '@rspack/binding-win32-arm64-msvc-canary@1.0.0-canary-338cfbe-20240731183605':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc-canary@1.0.0-canary-d77b591-20240718094414':
+  '@rspack/binding-win32-ia32-msvc-canary@1.0.0-canary-338cfbe-20240731183605':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc-canary@1.0.0-canary-d77b591-20240718094414':
+  '@rspack/binding-win32-x64-msvc-canary@1.0.0-canary-338cfbe-20240731183605':
     optional: true
 
-  '@rspack/core-canary@1.0.0-canary-d77b591-20240718094414(@swc/helpers@0.5.11)':
+  '@rspack/core-canary@1.0.0-canary-338cfbe-20240731183605(@swc/helpers@0.5.11)':
     dependencies:
       '@module-federation/runtime-tools': 0.2.3
-      '@rspack/binding': '@rspack/binding-canary@1.0.0-canary-d77b591-20240718094414'
-      '@rspack/lite-tapable': '@rspack/lite-tapable-canary@1.0.0-canary-d77b591-20240718094414'
+      '@rspack/binding': '@rspack/binding-canary@1.0.0-canary-338cfbe-20240731183605'
+      '@rspack/lite-tapable': '@rspack/lite-tapable-canary@1.0.0-canary-338cfbe-20240731183605'
       caniuse-lite: 1.0.30001643
     optionalDependencies:
       '@swc/helpers': 0.5.11
 
-  '@rspack/lite-tapable-canary@1.0.0-canary-d77b591-20240718094414': {}
+  '@rspack/lite-tapable-canary@1.0.0-canary-338cfbe-20240731183605': {}
 
   '@rspack/lite-tapable@1.0.0-beta.1': {}
 


### PR DESCRIPTION
## Summary

- Adding `>=` to browserslist query(e.g. `Chrome 120.0.0` -> `Chrome >= 120.0.0`) as it's not valid before, we didn't notice that because SWC could accept that([playground](https://play.swc.rs/?version=1.7.4&code=H4sIAAAAAAAAA0vOSSwuVnBUqOZSUFBOUrBVMOSqBQCnW%2F80FAAAAA%3D%3D&config=H4sIAAAAAAAAA1WPSw6CMBCG95yimTUhbDTGO3gC46KpA5bQR2YKkZDe3YIWZNf5%2FsdM50IIQDvCVczpmYYgqcXACdxBvcgZFKdLVVc1PJIhlkugY7UHvCRG2uZEeLJBvhMBVEayIu0DlFnteJEa2TOuKH4V6J1jzMqPGW11M%2F13K2c8IfPRuFilbXs8Nm8HG%2FccVjF%2FcvK43sdn2E152VYMmm85GWjAIn4AzaQM5jABAAA%3D)), but the lightningcss tool in Rspack is using browserslist to resolve the query in advance and it will throw an error.

   <img width="538" alt="image" src="https://github.com/user-attachments/assets/aef650bf-f7d7-49c0-8a60-5790816b15a0">
- Change the default `syntax` to not dead browsers last 1 version. However, this is not correct for all scenes. As the default `syntax` should be determined by current `target` (`node` or `web`), but in current implementation, the configs have an order which makes it hard to access the later from the former. We need a refactor IMO, to build some config builder like https://github.com/webpack/webpack/blob/main/lib/config/defaults.js. @Timeless0911 What's your opinion.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
