### PR TITLE
chore(infra/e2e): @e2e/helper rather than #imports

### DIFF
--- a/e2e/cases/alias/index.test.ts
+++ b/e2e/cases/alias/index.test.ts
@@ -1,5 +1,5 @@
+import { buildAndGetResults } from '@e2e/helper';
 import { expect, test } from 'vitest';
-import { buildAndGetResults } from '#shared';
 
 test('source.alias', async () => {
   const fixturePath = __dirname;

--- a/e2e/cases/alias/rslib.config.ts
+++ b/e2e/cases/alias/rslib.config.ts
@@ -1,5 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
 
 export default defineConfig({
   lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],

--- a/e2e/cases/autoExtension/index.test.ts
+++ b/e2e/cases/autoExtension/index.test.ts
@@ -1,6 +1,6 @@
 import { extname, join } from 'node:path';
+import { buildAndGetResults } from '@e2e/helper';
 import { expect, test } from 'vitest';
-import { buildAndGetResults } from '#shared';
 
 test('autoExtension generate .mjs in build artifacts with esm format when type is commonjs', async () => {
   const fixturePath = join(__dirname, 'type-commonjs');

--- a/e2e/cases/autoExtension/type-commonjs/rslib.config.ts
+++ b/e2e/cases/autoExtension/type-commonjs/rslib.config.ts
@@ -1,8 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import {
-  generateBundleCjsConfig,
-  generateBundleEsmConfig,
-} from '../../../scripts/shared';
 
 export default defineConfig({
   lib: [

--- a/e2e/cases/autoExtension/type-module/rslib.config.ts
+++ b/e2e/cases/autoExtension/type-module/rslib.config.ts
@@ -1,8 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import {
-  generateBundleCjsConfig,
-  generateBundleEsmConfig,
-} from '../../../scripts/shared';
 
 export default defineConfig({
   lib: [

--- a/e2e/cases/bundle-false/basic/rslib.config.ts
+++ b/e2e/cases/bundle-false/basic/rslib.config.ts
@@ -1,5 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
 
 export default defineConfig({
   lib: [

--- a/e2e/cases/bundle-false/index.test.ts
+++ b/e2e/cases/bundle-false/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
+import { buildAndGetResults } from '@e2e/helper';
 import { expect, test } from 'vitest';
-import { buildAndGetResults } from '#shared';
 
 test('bundle: false', async () => {
   const fixturePath = join(__dirname, 'basic');

--- a/e2e/cases/cli/index.test.ts
+++ b/e2e/cases/cli/index.test.ts
@@ -1,8 +1,8 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
+import { globContentJSON } from '@e2e/helper';
 import fse from 'fs-extra';
 import { expect, test } from 'vitest';
-import { globContentJSON } from '#helper';
 
 test.todo('build command', async () => {});
 

--- a/e2e/cases/cli/rslib.config.ts
+++ b/e2e/cases/cli/rslib.config.ts
@@ -1,5 +1,5 @@
+import { generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import { generateBundleEsmConfig } from '#shared';
 
 export default defineConfig({
   lib: [generateBundleEsmConfig(__dirname)],

--- a/e2e/cases/define/index.test.ts
+++ b/e2e/cases/define/index.test.ts
@@ -1,5 +1,5 @@
+import { buildAndGetResults } from '@e2e/helper';
 import { expect, test } from 'vitest';
-import { buildAndGetResults } from '#shared';
 
 test('source.define', async () => {
   const fixturePath = __dirname;

--- a/e2e/cases/define/rslib.config.ts
+++ b/e2e/cases/define/rslib.config.ts
@@ -1,5 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
 
 export default defineConfig({
   lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],

--- a/e2e/cases/dts/bundle-false/rslib.config.ts
+++ b/e2e/cases/dts/bundle-false/rslib.config.ts
@@ -1,5 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
 
 export default defineConfig({
   lib: [

--- a/e2e/cases/dts/index.test.ts
+++ b/e2e/cases/dts/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
+import { buildAndGetResults } from '@e2e/helper';
 import { expect, test } from 'vitest';
-import { buildAndGetResults } from '#shared';
 
 test('dts when bundle: false', async () => {
   const fixturePath = join(__dirname, 'bundle-false');

--- a/e2e/cases/externals/browser/index.test.ts
+++ b/e2e/cases/externals/browser/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
+import { buildAndGetResults } from '@e2e/helper';
 import { expect, test } from 'vitest';
-import { buildAndGetResults } from '#shared';
 
 test('should fail to build when `output.target` is not "node"', async () => {
   const fixturePath = join(__dirname);

--- a/e2e/cases/externals/browser/rslib.config.ts
+++ b/e2e/cases/externals/browser/rslib.config.ts
@@ -1,5 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
 
 export default defineConfig({
   lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],

--- a/e2e/cases/externals/node/index.test.ts
+++ b/e2e/cases/externals/node/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
+import { buildAndGetResults } from '@e2e/helper';
 import { expect, test } from 'vitest';
-import { buildAndGetResults } from '#shared';
 
 test('auto externalize Node.js built-in modules when `output.target` is "node"', async () => {
   const fixturePath = join(__dirname);

--- a/e2e/cases/externals/node/rslib.config.ts
+++ b/e2e/cases/externals/node/rslib.config.ts
@@ -1,5 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
 
 export default defineConfig({
   lib: [

--- a/e2e/cases/syntax/config/index.test.ts
+++ b/e2e/cases/syntax/config/index.test.ts
@@ -1,5 +1,5 @@
+import { buildAndGetResults } from '@e2e/helper';
 import { expect, test } from 'vitest';
-import { buildAndGetResults } from '#shared';
 
 test('should downgrade class private method by default', async () => {
   const fixturePath = __dirname;

--- a/e2e/cases/syntax/config/rslib.config.ts
+++ b/e2e/cases/syntax/config/rslib.config.ts
@@ -1,5 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
 
 export default defineConfig({
   lib: [

--- a/e2e/cases/syntax/default/index.test.ts
+++ b/e2e/cases/syntax/default/index.test.ts
@@ -1,5 +1,5 @@
+import { buildAndGetResults } from '@e2e/helper';
 import { expect, test } from 'vitest';
-import { buildAndGetResults } from '#shared';
 
 test('should downgrade class private method by default', async () => {
   const fixturePath = __dirname;

--- a/e2e/cases/syntax/default/rslib.config.ts
+++ b/e2e/cases/syntax/default/rslib.config.ts
@@ -1,5 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import { generateBundleCjsConfig, generateBundleEsmConfig } from '#shared';
 
 export default defineConfig({
   lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,10 +2,6 @@
   "name": "@rslib/e2e",
   "private": true,
   "type": "module",
-  "imports": {
-    "#helper": "./scripts/helper.ts",
-    "#shared": "./scripts/shared.ts"
-  },
   "scripts": {
     "test": "playwright test --pass-with-no-tests"
   },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,6 +13,7 @@
     "react": "^18.3.1"
   },
   "devDependencies": {
+    "@e2e/helper": "workspace:*",
     "@playwright/test": "1.43.1",
     "@rsbuild/core": "1.0.1-beta.8",
     "@rslib/core": "workspace:*",

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -6,7 +6,7 @@ import fg, {
 } from 'fast-glob';
 import fse from 'fs-extra';
 
-export const getFiles = async (pattern: string) => {};
+export const getFiles = async (_pattern: string) => {};
 
 // fast-glob only accepts posix path
 // https://github.com/mrmlnc/fast-glob#convertpathtopatternpath

--- a/e2e/scripts/index.ts
+++ b/e2e/scripts/index.ts
@@ -1,0 +1,2 @@
+export * from './helper';
+export * from './shared';

--- a/e2e/scripts/main.ts
+++ b/e2e/scripts/main.ts
@@ -1,1 +1,0 @@
-import {} from '@rslib/core';

--- a/e2e/scripts/package.json
+++ b/e2e/scripts/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@e2e/helper",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.ts",
+  "types": "index.ts"
+}

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -1,16 +1,12 @@
 import { join } from 'node:path';
 import {
   type InspectConfigResult,
-  type Rspack,
   mergeRsbuildConfig as mergeConfig,
 } from '@rsbuild/core';
 import type { LibConfig, RslibConfig } from '@rslib/core';
-import { globContentJSON } from '#helper';
 import { build } from '../../packages/core/src/build';
-import {
-  composeCreateRsbuildConfig,
-  loadConfig,
-} from '../../packages/core/src/config';
+import { loadConfig } from '../../packages/core/src/config';
+import { globContentJSON } from './helper';
 
 export function generateBundleEsmConfig(
   cwd: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
     devDependencies:
+      '@e2e/helper':
+        specifier: workspace:*
+        version: link:scripts
       '@playwright/test':
         specifier: 1.43.1
         version: 1.43.1
@@ -96,6 +99,8 @@ importers:
   e2e/cases/autoExtension/type-module: {}
 
   e2e/cases/dts/bundle: {}
+
+  e2e/scripts: {}
 
   examples/express-plugin:
     devDependencies:


### PR DESCRIPTION
## Summary

at present, e2e cases with `package.json` ignore the imports field and it is too inconvenient

https://github.com/web-infra-dev/rslib/blob/864c46eb3fd6edbc336e926a7a92aeb7511c2f99/e2e/cases/autoExtension/type-commonjs/rslib.config.ts#L5

so, we can align with rsbuild, use `@e2e/helper` package to solve this issue

<!--- Provide links of related issues or pages -->


