### PR TITLE
chore(infra/e2e): use package name rather than "../"

### DIFF
--- a/e2e/cases/dts/bundle/rslib.config.ts
+++ b/e2e/cases/dts/bundle/rslib.config.ts
@@ -1,8 +1,5 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
-import {
-  generateBundleCjsConfig,
-  generateBundleEsmConfig,
-} from '../../../scripts/shared';
 
 export default defineConfig({
   lib: [

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -4,8 +4,7 @@ import {
   mergeRsbuildConfig as mergeConfig,
 } from '@rsbuild/core';
 import type { LibConfig, RslibConfig } from '@rslib/core';
-import { build } from '../../packages/core/src/build';
-import { loadConfig } from '../../packages/core/src/config';
+import { build, loadConfig } from '@rslib/core';
 import { globContentJSON } from './helper';
 
 export function generateBundleEsmConfig(


### PR DESCRIPTION
## Summary

chore(infra/e2e): use package name rather than "../"

## Related Links

#59 
