### PR TITLE
perf: enable TypeScript isolatedDeclarations

### DIFF
--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -1,8 +1,12 @@
+import type { RsbuildInstance } from '@rsbuild/core';
 import type { BuildOptions } from './cli/commands';
 import { initRsbuild } from './config';
 import type { RslibConfig } from './types/config';
 
-export async function build(config: RslibConfig, options?: BuildOptions) {
+export async function build(
+  config: RslibConfig,
+  options?: BuildOptions,
+): Promise<RsbuildInstance> {
   const rsbuildInstance = await initRsbuild(config);
 
   await rsbuildInstance.build({

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -31,7 +31,7 @@ const applyCommonOptions = (command: Command) => {
     );
 };
 
-export function runCli() {
+export function runCli(): void {
   program.name('rslib').usage('<command> [options]').version(RSLIB_VERSION);
 
   const buildCommand = program.command('build');

--- a/packages/core/src/cli/prepare.ts
+++ b/packages/core/src/cli/prepare.ts
@@ -9,7 +9,7 @@ function initNodeEnv() {
   }
 }
 
-export function prepareCli() {
+export function prepareCli(): void {
   initNodeEnv();
 
   // Print a blank line to keep the greet log nice.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path, { dirname, isAbsolute, join } from 'node:path';
 import {
   type RsbuildConfig,
+  type RsbuildInstance,
   createRsbuild,
   defineConfig as defineRsbuildConfig,
   loadConfig as loadRsbuildConfig,
@@ -473,7 +474,9 @@ export async function composeCreateRsbuildConfig(
   return composedRsbuildConfig;
 }
 
-export async function initRsbuild(rslibConfig: RslibConfig) {
+export async function initRsbuild(
+  rslibConfig: RslibConfig,
+): Promise<RsbuildInstance> {
   const rsbuildConfigObject = await composeCreateRsbuildConfig(rslibConfig);
   const environments: RsbuildConfig['environments'] = {};
   const formatCount: Record<Format, number> = rsbuildConfigObject.reduce(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,4 +8,4 @@ export * from './utils/helper';
 
 export * from './types/config';
 
-export const version = RSLIB_VERSION;
+export const version: string = RSLIB_VERSION;

--- a/packages/core/src/utils/extension.ts
+++ b/packages/core/src/utils/extension.ts
@@ -7,7 +7,11 @@ export const getDefaultExtension = (options: {
   format: Format;
   root: string;
   autoExtension: boolean;
-}) => {
+}): {
+  jsExtension: string;
+  dtsExtension: string;
+  isModule?: boolean;
+} => {
   const { format, root, autoExtension } = options;
 
   let jsExtension = '.js';

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -5,7 +5,7 @@ import color from 'picocolors';
  * Node.js built-in modules.
  * Copied from https://github.com/webpack/webpack/blob/dd44b206a9c50f4b4cb4d134e1a0bd0387b159a3/lib/node/NodeTargetPlugin.js#L12-L72
  */
-export const nodeBuiltInModules = [
+export const nodeBuiltInModules: Array<string | RegExp> = [
   'assert',
   'assert/strict',
   'async_hooks',

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -6,7 +6,7 @@ if (process.env.DEBUG) {
   logger.level = 'verbose';
 }
 
-export const isDebug = () => {
+export const isDebug = (): boolean => {
   if (!process.env.DEBUG) {
     return false;
   }
@@ -27,7 +27,7 @@ function getTime() {
   return `${hours}:${minutes}:${seconds}`;
 }
 
-export const debug = (message: string | (() => string)) => {
+export const debug = (message: string | (() => string)): void => {
   if (isDebug()) {
     const result = typeof message === 'string' ? message : message();
     const time = color.gray(`${getTime()}`);

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src",
     "declaration": true,
     "declarationDir": "./dist-types",
+    "isolatedDeclarations": true,
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/packages/plugin-dts/src/apiExtractor.ts
+++ b/packages/plugin-dts/src/apiExtractor.ts
@@ -13,7 +13,7 @@ export type BundleOptions = {
   tsconfigPath?: string;
 };
 
-export function bundleDts(options: BundleOptions) {
+export function bundleDts(options: BundleOptions): void {
   const {
     cwd,
     outDir,

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -5,7 +5,7 @@ import * as ts from 'typescript';
 import { emitDts } from './tsc';
 import { ensureTempDeclarationDir, loadTsconfig } from './utils';
 
-export async function generateDts(data: DtsGenOptions) {
+export async function generateDts(data: DtsGenOptions): Promise<void> {
   logger.start('Generating DTS...');
   const { options: pluginOptions, cwd, isWatch } = data;
   const { tsconfigPath, distPath, bundle, entryPath } = pluginOptions;

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -13,7 +13,7 @@ export function emitDts(
   options: emitDtsOptions,
   onComplete: (isSuccess: boolean) => void,
   isWatch = false,
-) {
+): void {
   const start = Date.now();
   const getTimeCost = () => {
     return `${Math.floor(Date.now() - start)}ms`;

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -14,7 +14,7 @@ export function loadTsconfig(tsconfigPath: string): ts.ParsedCommandLine {
 }
 
 export const TEMP_FOLDER = '.rslib';
-export const TEMP_DTS_DIR = `${TEMP_FOLDER}/declarations`;
+export const TEMP_DTS_DIR: string = `${TEMP_FOLDER}/declarations`;
 
 export function ensureTempDeclarationDir(cwd: string): string {
   const dirPath = path.join(cwd, TEMP_DTS_DIR);

--- a/packages/plugin-dts/tsconfig.json
+++ b/packages/plugin-dts/tsconfig.json
@@ -5,6 +5,7 @@
     "baseUrl": "./",
     "rootDir": "src",
     "declaration": true,
+    "isolatedDeclarations": true,
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Bundler"

--- a/scripts/tsconfig/base.json
+++ b/scripts/tsconfig/base.json
@@ -2,9 +2,10 @@
   "extends": "@tsconfig/strictest/tsconfig",
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
-    "target": "ES2019",
+    "target": "ES2021",
     "lib": ["DOM", "ESNext"],
-    "allowJs": true,
+    "allowJs": false,
+    "checkJs": false,
     "module": "ES2020",
     "strict": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary

Enable TypeScript isolatedDeclarations, this allows us to speed up DTS generation.

## Related Links

https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#using-isolateddeclarations

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
