### PR TITLE
feat: support dts.abortOnError

### DIFF
--- a/e2e/cases/dts/bundle-false/abortOnError.config.ts
+++ b/e2e/cases/dts/bundle-false/abortOnError.config.ts
@@ -1,0 +1,24 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig(__dirname, {
+      bundle: false,
+      dts: {
+        bundle: false,
+        distPath: './dist/error',
+        abortOnError: false,
+      },
+    }),
+    generateBundleCjsConfig(__dirname, {
+      bundle: false,
+    }),
+  ],
+  source: {
+    entry: {
+      main: ['./src-error/**'],
+    },
+    tsconfigPath: 'tsconfig-error.json',
+  },
+});

--- a/e2e/cases/dts/bundle-false/src-error/const.ts
+++ b/e2e/cases/dts/bundle-false/src-error/const.ts
@@ -1,0 +1,3 @@
+export interface A {
+  a: number;
+}

--- a/e2e/cases/dts/bundle-false/src-error/index.ts
+++ b/e2e/cases/dts/bundle-false/src-error/index.ts
@@ -1,0 +1,6 @@
+import type { A } from './const';
+
+export const getA = (item: A) => {
+  item.a = '0';
+  return item;
+};

--- a/e2e/cases/dts/bundle-false/tsconfig-error.json
+++ b/e2e/cases/dts/bundle-false/tsconfig-error.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src-error"
+  },
+  "include": ["src-error"]
+}

--- a/e2e/cases/dts/bundle/abortOnError.config.ts
+++ b/e2e/cases/dts/bundle/abortOnError.config.ts
@@ -1,0 +1,21 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig(__dirname, {
+      dts: {
+        bundle: true,
+        distPath: './dist/error',
+        abortOnError: false,
+      },
+    }),
+    generateBundleCjsConfig(__dirname),
+  ],
+  source: {
+    entry: {
+      main: './src-error/index.ts',
+    },
+    tsconfigPath: 'tsconfig-error.json',
+  },
+});

--- a/e2e/cases/dts/bundle/src-error/const.ts
+++ b/e2e/cases/dts/bundle/src-error/const.ts
@@ -1,0 +1,3 @@
+export interface A {
+  a: number;
+}

--- a/e2e/cases/dts/bundle/src-error/index.ts
+++ b/e2e/cases/dts/bundle/src-error/index.ts
@@ -1,0 +1,6 @@
+import type { A } from './const';
+
+export const getA = (item: A) => {
+  item.a = '0';
+  return item;
+};

--- a/e2e/cases/dts/bundle/tsconfig-error.json
+++ b/e2e/cases/dts/bundle/tsconfig-error.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src-error"
+  },
+  "include": ["src-error"]
+}

--- a/e2e/cases/dts/index.test.ts
+++ b/e2e/cases/dts/index.test.ts
@@ -37,6 +37,17 @@ describe('dts when bundle: false', () => {
     expect(files.esm?.length).toBe(4);
     expect(files.esm?.[0]!.startsWith('./dist/custom')).toEqual(true);
   });
+
+  test('abortOnError: false', async () => {
+    const fixturePath = join(__dirname, 'bundle-false');
+    const { isSuccess } = await buildAndGetResults(
+      fixturePath,
+      'abortOnError.config.ts',
+      'dts',
+    );
+
+    expect(isSuccess).toBe(true);
+  });
 });
 
 describe('dts when bundle: true', () => {
@@ -72,5 +83,16 @@ describe('dts when bundle: true', () => {
     );
 
     expect(entryFiles.esm!.startsWith('./dist/custom')).toEqual(true);
+  });
+
+  test('abortOnError: false', async () => {
+    const fixturePath = join(__dirname, 'bundle');
+    const { isSuccess } = await buildAndGetResults(
+      fixturePath,
+      'abortOnError.config.ts',
+      'dts',
+    );
+
+    expect(isSuccess).toBe(true);
   });
 });

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -113,6 +113,7 @@ export const buildAndGetResults = async (
   entryFiles: Record<string, string>;
   rspackConfig: InspectConfigResult['origin']['bundlerConfigs'];
   rsbuildConfig: InspectConfigResult['origin']['rsbuildConfig'];
+  isSuccess: boolean;
 }> => {
   const rslibConfig = await loadConfig(join(fixturePath, configFile));
   process.chdir(fixturePath);
@@ -129,5 +130,6 @@ export const buildAndGetResults = async (
     entryFiles: results.entryFiles,
     rspackConfig: bundlerConfigs,
     rsbuildConfig: rsbuildConfig,
+    isSuccess: Boolean(rsbuildInstance),
   };
 };

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -336,6 +336,7 @@ const composeDtsConfig = async (
       pluginDts({
         bundle: dts?.bundle ?? bundle,
         distPath: dts?.distPath ?? output?.distPath?.root ?? './dist',
+        abortOnError: dts?.abortOnError ?? true,
       }),
     ],
   };

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -27,6 +27,7 @@ export type Dts =
   | {
       bundle: boolean;
       distPath?: string;
+      abortOnError?: boolean;
     }
   | false;
 

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -1,10 +1,11 @@
 import { fork } from 'node:child_process';
 import { extname, join } from 'node:path';
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { type RsbuildPlugin, logger } from '@rsbuild/core';
 
 export type PluginDtsOptions = {
   bundle?: boolean;
   distPath?: string;
+  abortOnError?: boolean;
 };
 
 export type DtsGenOptions = PluginDtsOptions & {
@@ -26,7 +27,11 @@ export const pluginDts = (options: PluginDtsOptions): RsbuildPlugin => ({
   name: PLUGIN_DTS_NAME,
 
   setup(api) {
-    const dtsPromises: Promise<void>[] = [];
+    options.bundle = options.bundle ?? false;
+    options.abortOnError = options.abortOnError ?? true;
+
+    const dtsPromises: Promise<string>[] = [];
+    let promisesResult: string[] = [];
 
     api.onBeforeEnvironmentCompile(
       ({ isWatch, isFirstCompile, environment }) => {
@@ -36,7 +41,6 @@ export const pluginDts = (options: PluginDtsOptions): RsbuildPlugin => ({
 
         const { config } = environment;
 
-        options.bundle = options.bundle ?? false;
         options.distPath = options.distPath ?? config.output?.distPath?.root;
 
         const jsExtension = extname(__filename);
@@ -57,16 +61,12 @@ export const pluginDts = (options: PluginDtsOptions): RsbuildPlugin => ({
         childProcess.send(dtsGenOptions);
 
         dtsPromises.push(
-          new Promise((resolve, reject) => {
+          new Promise<string>((resolve) => {
             childProcess.on('message', (message) => {
               if (message === 'success') {
-                resolve();
+                resolve('Success');
               } else if (message === 'error') {
-                reject(
-                  new Error(
-                    `Error occurred in ${environment.name} dts generation`,
-                  ),
-                );
+                resolve(`Error occurred in ${environment.name} DTS generation`);
               }
             });
           }),
@@ -79,7 +79,28 @@ export const pluginDts = (options: PluginDtsOptions): RsbuildPlugin => ({
         return;
       }
 
-      await Promise.all(dtsPromises);
+      promisesResult = await Promise.all(dtsPromises);
+    });
+
+    api.onAfterBuild({
+      handler: ({ isFirstCompile }) => {
+        if (!isFirstCompile) {
+          return;
+        }
+
+        for (const result of promisesResult) {
+          if (result.startsWith('Error')) {
+            if (options.abortOnError) {
+              throw new Error(result);
+            }
+            logger.error(result);
+            logger.warn(
+              'With the `abortOnError` configuration currently turned off, type errors do not cause build failures, but they do not guarantee proper type file output.',
+            );
+          }
+        }
+      },
+      order: 'post',
     });
   },
 });


### PR DESCRIPTION
## Summary

support `dts.abortOnError` option to control whether to exit process when dts build error.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
