### PR TITLE
feat: enable autoExtension by default

### DIFF
--- a/e2e/cases/autoExtension/index.test.ts
+++ b/e2e/cases/autoExtension/index.test.ts
@@ -1,17 +1,41 @@
 import { extname, join } from 'node:path';
 import { buildAndGetResults } from '@e2e/helper';
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
-test('autoExtension generate .mjs in build artifacts with esm format when type is commonjs', async () => {
-  const fixturePath = join(__dirname, 'type-commonjs');
-  const { entryFiles } = await buildAndGetResults(fixturePath);
-  expect(extname(entryFiles.esm!)).toEqual('.mjs');
-  expect(extname(entryFiles.cjs!)).toEqual('.js');
+describe('autoExtension: true', () => {
+  test('generate .mjs in build artifacts with esm format when type is commonjs', async () => {
+    const fixturePath = join(__dirname, 'type-commonjs');
+    const { entryFiles } = await buildAndGetResults(fixturePath);
+    expect(extname(entryFiles.esm!)).toEqual('.mjs');
+    expect(extname(entryFiles.cjs!)).toEqual('.js');
+  });
+
+  test('generate .cjs in build artifacts with cjs format when type is module', async () => {
+    const fixturePath = join(__dirname, 'type-module');
+    const { entryFiles } = await buildAndGetResults(fixturePath);
+    expect(extname(entryFiles.esm!)).toEqual('.js');
+    expect(extname(entryFiles.cjs!)).toEqual('.cjs');
+  });
 });
 
-test('autoExtension generate .cjs in build artifacts with cjs format when type is module', async () => {
-  const fixturePath = join(__dirname, 'type-module');
-  const { entryFiles } = await buildAndGetResults(fixturePath);
-  expect(extname(entryFiles.esm!)).toEqual('.js');
-  expect(extname(entryFiles.cjs!)).toEqual('.cjs');
+describe('autoExtension: false', () => {
+  test('generate .js in both cjs and esm build artifacts when type is commonjs', async () => {
+    const fixturePath = join(__dirname, 'type-commonjs');
+    const { entryFiles } = await buildAndGetResults(
+      fixturePath,
+      'autoExtension.false.config.ts',
+    );
+    expect(extname(entryFiles.esm!)).toEqual('.js');
+    expect(extname(entryFiles.cjs!)).toEqual('.js');
+  });
+
+  test('generate .js in both cjs and esm build artifacts when type is module', async () => {
+    const fixturePath = join(__dirname, 'type-module');
+    const { entryFiles } = await buildAndGetResults(
+      fixturePath,
+      'autoExtension.false.config.ts',
+    );
+    expect(extname(entryFiles.esm!)).toEqual('.js');
+    expect(extname(entryFiles.cjs!)).toEqual('.js');
+  });
 });

--- a/e2e/cases/autoExtension/type-commonjs/autoExtension.false.config.ts
+++ b/e2e/cases/autoExtension/type-commonjs/autoExtension.false.config.ts
@@ -2,7 +2,14 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  lib: [
+    generateBundleEsmConfig(__dirname, {
+      autoExtension: false,
+    }),
+    generateBundleCjsConfig(__dirname, {
+      autoExtension: false,
+    }),
+  ],
   source: {
     entry: {
       main: './src/index.ts',

--- a/e2e/cases/autoExtension/type-module/autoExtension.false.config.ts
+++ b/e2e/cases/autoExtension/type-module/autoExtension.false.config.ts
@@ -2,7 +2,14 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  lib: [
+    generateBundleEsmConfig(__dirname, {
+      autoExtension: false,
+    }),
+    generateBundleCjsConfig(__dirname, {
+      autoExtension: false,
+    }),
+  ],
   source: {
     entry: {
       main: './src/index.ts',

--- a/e2e/cases/autoExtension/type-module/rslib.config.ts
+++ b/e2e/cases/autoExtension/type-module/rslib.config.ts
@@ -2,14 +2,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [
-    generateBundleEsmConfig(__dirname, {
-      autoExtension: true,
-    }),
-    generateBundleCjsConfig(__dirname, {
-      autoExtension: true,
-    }),
-  ],
+  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
   source: {
     entry: {
       main: './src/index.ts',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -387,7 +387,7 @@ async function composeLibRsbuildConfig(
 ) {
   const config = mergeRsbuildConfig<LibConfig>(rsbuildConfig, libConfig);
 
-  const { format, autoExtension = false } = config;
+  const { format, autoExtension = true } = config;
   const formatConfig = composeFormatConfig(format!);
   const autoExtensionConfig = composeAutoExtensionConfig(
     format!,


### PR DESCRIPTION
## Summary

Enable `autoExtension` by default when build js.

- generate `.mjs` in build artifacts with esm format when type is `commonjs`
- generate .`cjs` in build artifacts with cjs format when type is `module`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
