### PR TITLE
feat: preserve import.meta.url in ESM

### DIFF
--- a/e2e/cases/shims/esm/rslib.config.ts
+++ b/e2e/cases/shims/esm/rslib.config.ts
@@ -1,0 +1,14 @@
+import { generateBundleEsmConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig(__dirname)],
+  output: {
+    target: 'node',
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+});

--- a/e2e/cases/shims/esm/src/index.ts
+++ b/e2e/cases/shims/esm/src/index.ts
@@ -1,0 +1,7 @@
+export const foo = () => {
+  const d1 = __dirname;
+  const d2 = __dirname;
+  const f1 = __filename;
+  const f2 = __filename;
+  const importMetaUrl = import.meta.url;
+};

--- a/e2e/cases/shims/index.test.ts
+++ b/e2e/cases/shims/index.test.ts
@@ -1,0 +1,19 @@
+import { join } from 'node:path';
+import { buildAndGetResults } from '@e2e/helper';
+import { expect, test } from 'vitest';
+
+test('shims for __dirname and __filename in ESM', async () => {
+  const fixturePath = join(__dirname, 'esm');
+  const { entries } = await buildAndGetResults(fixturePath);
+  for (const shim of [
+    'import {fileURLToPath as __webpack_fileURLToPath__} from "url";',
+    "var src_dirname = __webpack_fileURLToPath__(import.meta.url + '/..').slice(0, -1);",
+    'var src_filename = __webpack_fileURLToPath__(import.meta.url);',
+    // import.meta.url should not be substituted
+    'const importMetaUrl = import.meta.url;',
+  ]) {
+    expect(entries.esm).toContain(shim);
+  }
+});
+
+test.todo('shims for import.meta.url in CJS', async () => {});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -186,6 +186,13 @@ const composeFormatConfig = (format: Format): RsbuildConfig => {
                 type: 'modern-module',
               },
             },
+            module: {
+              parser: {
+                javascript: {
+                  importMeta: false,
+                },
+              },
+            },
             optimization: {
               concatenateModules: true,
             },
@@ -430,6 +437,9 @@ const composeTargetConfig = (target = 'web'): RsbuildConfig => {
         tools: {
           rspack: {
             target: ['node'],
+            // "__dirname" and "__filename" shims will automatically be enabled when `output.module` is `true`,
+            // and leave them as-is in the rest of the cases.
+            // { node: { __dirname: ..., __filename: ... } }
           },
         },
         output: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,5 +3,6 @@ export { runCli } from './cli/commands';
 export { defineConfig, loadConfig } from './config';
 export { build } from './build';
 export { logger } from './utils/logger';
+export type * from './types';
 
 export const version: string = RSLIB_VERSION;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,2 +1,2 @@
-export * from './config';
-export * from './utils';
+export type * from './config';
+export type * from './utils';

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -43,6 +43,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
               "outputModule": true,
             },
             "externalsType": "module-import",
+            "module": {
+              "parser": {
+                "javascript": {
+                  "importMeta": false,
+                },
+              },
+            },
             "optimization": {
               "concatenateModules": true,
             },


### PR DESCRIPTION
## Summary

- don't touch `import.meta.abc` in ESM
- add shims test

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
