### PR TITLE
refactor(core/loadConfig): loadConfig({ cwd, path})

### DIFF
--- a/e2e/cases/alias/rslib.config.ts
+++ b/e2e/cases/alias/rslib.config.ts
@@ -2,7 +2,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
   source: {
     entry: {
       index: './src/index.ts',

--- a/e2e/cases/auto-extension/type-commonjs/default/rslib.config.ts
+++ b/e2e/cases/auto-extension/type-commonjs/default/rslib.config.ts
@@ -2,7 +2,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
   source: {
     entry: {
       index: '../../__fixtures__/src/index.ts',

--- a/e2e/cases/auto-extension/type-commonjs/false/rslib.config.ts
+++ b/e2e/cases/auto-extension/type-commonjs/false/rslib.config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       autoExtension: false,
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       autoExtension: false,
     }),
   ],

--- a/e2e/cases/auto-extension/type-module/default/rslib.config.ts
+++ b/e2e/cases/auto-extension/type-module/default/rslib.config.ts
@@ -2,7 +2,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
   source: {
     entry: {
       index: '../../__fixtures__/src/index.ts',

--- a/e2e/cases/auto-extension/type-module/false/rslib.config.ts
+++ b/e2e/cases/auto-extension/type-module/false/rslib.config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       autoExtension: false,
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       autoExtension: false,
     }),
   ],

--- a/e2e/cases/auto-external/default/rslib.config.ts
+++ b/e2e/cases/auto-external/default/rslib.config.ts
@@ -3,12 +3,12 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       dts: {
         bundle: true,
       },
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       dts: {
         bundle: true,
       },

--- a/e2e/cases/auto-external/external-sub-path/rslib.config.ts
+++ b/e2e/cases/auto-external/external-sub-path/rslib.config.ts
@@ -2,7 +2,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
   source: {
     entry: {
       index: './src/index.ts',

--- a/e2e/cases/auto-external/false/rslib.config.ts
+++ b/e2e/cases/auto-external/false/rslib.config.ts
@@ -3,13 +3,13 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       autoExternal: false,
       dts: {
         bundle: true,
       },
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       autoExternal: false,
       dts: {
         bundle: true,

--- a/e2e/cases/auto-external/with-externals/rslib.config.ts
+++ b/e2e/cases/auto-external/with-externals/rslib.config.ts
@@ -2,7 +2,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
   output: {
     externals: {
       react: 'react1',

--- a/e2e/cases/bundle-false/basic/rslib.config.ts
+++ b/e2e/cases/bundle-false/basic/rslib.config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       bundle: false,
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       bundle: false,
     }),
   ],

--- a/e2e/cases/bundle-false/relative-import/rslib.config.ts
+++ b/e2e/cases/bundle-false/relative-import/rslib.config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       bundle: false,
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       bundle: false,
     }),
   ],

--- a/e2e/cases/bundle-false/single-file/rslib.config.ts
+++ b/e2e/cases/bundle-false/single-file/rslib.config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       bundle: false,
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       bundle: false,
     }),
   ],

--- a/e2e/cases/cli/rslib.config.ts
+++ b/e2e/cases/cli/rslib.config.ts
@@ -2,5 +2,5 @@ import { generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname)],
+  lib: [generateBundleEsmConfig()],
 });

--- a/e2e/cases/define/rslib.config.ts
+++ b/e2e/cases/define/rslib.config.ts
@@ -2,7 +2,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
   source: {
     entry: {
       index: './src/index.ts',

--- a/e2e/cases/dts/bundle-false/abort-on-error/rslib.config.ts
+++ b/e2e/cases/dts/bundle-false/abort-on-error/rslib.config.ts
@@ -3,14 +3,14 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       bundle: false,
       dts: {
         bundle: false,
         abortOnError: false,
       },
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       bundle: false,
     }),
   ],

--- a/e2e/cases/dts/bundle-false/auto-extension/rslib.config.ts
+++ b/e2e/cases/dts/bundle-false/auto-extension/rslib.config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       bundle: false,
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       bundle: false,
       dts: {
         bundle: false,

--- a/e2e/cases/dts/bundle-false/basic/rslib.config.ts
+++ b/e2e/cases/dts/bundle-false/basic/rslib.config.ts
@@ -3,13 +3,13 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       bundle: false,
       dts: {
         bundle: false,
       },
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       bundle: false,
     }),
   ],

--- a/e2e/cases/dts/bundle-false/dist-path/rslib.config.ts
+++ b/e2e/cases/dts/bundle-false/dist-path/rslib.config.ts
@@ -3,14 +3,14 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       bundle: false,
       dts: {
         bundle: false,
         distPath: './dist/custom',
       },
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       bundle: false,
     }),
   ],

--- a/e2e/cases/dts/bundle-false/false/rslib.config.ts
+++ b/e2e/cases/dts/bundle-false/false/rslib.config.ts
@@ -3,11 +3,11 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       bundle: false,
       dts: false,
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       bundle: false,
     }),
   ],

--- a/e2e/cases/dts/bundle/abort-on-error/rslib.config.ts
+++ b/e2e/cases/dts/bundle/abort-on-error/rslib.config.ts
@@ -3,13 +3,13 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       dts: {
         bundle: true,
         abortOnError: false,
       },
     }),
-    generateBundleCjsConfig(__dirname),
+    generateBundleCjsConfig(),
   ],
   source: {
     entry: {

--- a/e2e/cases/dts/bundle/auto-extension/rslib.config.ts
+++ b/e2e/cases/dts/bundle/auto-extension/rslib.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleEsmConfig(),
+    generateBundleCjsConfig({
       dts: {
         bundle: true,
       },

--- a/e2e/cases/dts/bundle/basic/rslib.config.ts
+++ b/e2e/cases/dts/bundle/basic/rslib.config.ts
@@ -3,12 +3,12 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       dts: {
         bundle: true,
       },
     }),
-    generateBundleCjsConfig(__dirname),
+    generateBundleCjsConfig(),
   ],
   source: {
     entry: {

--- a/e2e/cases/dts/bundle/bundle-name/rslib.config.ts
+++ b/e2e/cases/dts/bundle/bundle-name/rslib.config.ts
@@ -3,12 +3,12 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       dts: {
         bundle: true,
       },
     }),
-    generateBundleCjsConfig(__dirname),
+    generateBundleCjsConfig(),
   ],
   source: {
     entry: {

--- a/e2e/cases/dts/bundle/dist-path/rslib.config.ts
+++ b/e2e/cases/dts/bundle/dist-path/rslib.config.ts
@@ -3,13 +3,13 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       dts: {
         bundle: true,
         distPath: './dist/custom',
       },
     }),
-    generateBundleCjsConfig(__dirname),
+    generateBundleCjsConfig(),
   ],
   source: {
     entry: {

--- a/e2e/cases/dts/bundle/false/rslib.config.ts
+++ b/e2e/cases/dts/bundle/false/rslib.config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       dts: false,
     }),
-    generateBundleCjsConfig(__dirname),
+    generateBundleCjsConfig(),
   ],
   source: {
     entry: {

--- a/e2e/cases/externals/browser/rslib.config.ts
+++ b/e2e/cases/externals/browser/rslib.config.ts
@@ -2,7 +2,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
   source: {
     entry: {
       index: './src/index.ts',

--- a/e2e/cases/externals/node/rslib.config.ts
+++ b/e2e/cases/externals/node/rslib.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, { output: { target: 'node' } }),
-    generateBundleCjsConfig(__dirname, { output: { target: 'node' } }),
+    generateBundleEsmConfig({ output: { target: 'node' } }),
+    generateBundleCjsConfig({ output: { target: 'node' } }),
   ],
   source: {
     entry: {

--- a/e2e/cases/shims/esm/rslib.config.ts
+++ b/e2e/cases/shims/esm/rslib.config.ts
@@ -2,7 +2,7 @@ import { generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname)],
+  lib: [generateBundleEsmConfig()],
   output: {
     target: 'node',
   },

--- a/e2e/cases/syntax/config/rslib.config.ts
+++ b/e2e/cases/syntax/config/rslib.config.ts
@@ -3,12 +3,12 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(__dirname, {
+    generateBundleEsmConfig({
       output: {
         syntax: 'es2015',
       },
     }),
-    generateBundleCjsConfig(__dirname, {
+    generateBundleCjsConfig({
       output: {
         syntax: ['node 20'],
       },

--- a/e2e/cases/syntax/default/rslib.config.ts
+++ b/e2e/cases/syntax/default/rslib.config.ts
@@ -2,7 +2,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(__dirname), generateBundleCjsConfig(__dirname)],
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
   source: {
     entry: {
       index: '../__fixtures__/src/index.ts',

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -1,4 +1,3 @@
-import { isAbsolute, join } from 'node:path';
 import {
   type InspectConfigResult,
   mergeRsbuildConfig as mergeConfig,
@@ -7,15 +6,12 @@ import type { LibConfig, RslibConfig } from '@rslib/core';
 import { build, loadConfig } from '@rslib/core';
 import { globContentJSON } from './helper';
 
-export function generateBundleEsmConfig(
-  cwd: string,
-  config: LibConfig = {},
-): LibConfig {
+export function generateBundleEsmConfig(config: LibConfig = {}): LibConfig {
   const esmBasicConfig: LibConfig = {
     format: 'esm',
     output: {
       distPath: {
-        root: join(cwd, './dist/esm'),
+        root: './dist/esm',
       },
     },
   };
@@ -23,15 +19,12 @@ export function generateBundleEsmConfig(
   return mergeConfig(esmBasicConfig, config)!;
 }
 
-export function generateBundleCjsConfig(
-  cwd: string,
-  config: LibConfig = {},
-): LibConfig {
+export function generateBundleCjsConfig(config: LibConfig = {}): LibConfig {
   const cjsBasicConfig: LibConfig = {
     format: 'cjs',
     output: {
       distPath: {
-        root: join(cwd, './dist/cjs'),
+        root: './dist/cjs',
       },
     },
   };
@@ -125,7 +118,9 @@ export async function buildAndGetResults(
   fixturePath: string,
   type: 'js' | 'dts' | 'all' = 'js',
 ) {
-  const rslibConfig = await loadConfig(join(fixturePath, 'rslib.config.ts'));
+  const rslibConfig = await loadConfig({
+    cwd: fixturePath,
+  });
   process.chdir(fixturePath);
   const rsbuildInstance = await build(rslibConfig);
   const {

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -44,7 +44,10 @@ export function runCli(): void {
     .description('build the library for production')
     .action(async (options: BuildOptions) => {
       try {
-        const rslibConfig = await loadConfig(options.config, options.envMode);
+        const rslibConfig = await loadConfig({
+          path: options.config,
+          envMode: options.envMode,
+        });
         await build(rslibConfig, options);
       } catch (err) {
         logger.error('Failed to build.');
@@ -61,7 +64,10 @@ export function runCli(): void {
     .action(async (options: InspectOptions) => {
       try {
         // TODO: inspect should output Rslib's config
-        const rslibConfig = await loadConfig(options.config, options.envMode);
+        const rslibConfig = await loadConfig({
+          path: options.config,
+          envMode: options.envMode,
+        });
         const rsbuildInstance = await initRsbuild(rslibConfig);
         await rsbuildInstance.inspectConfig({
           mode: options.mode,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -65,7 +65,7 @@ const resolveConfigPath = (root: string, customConfig?: string): string => {
     return configFilePath;
   }
 
-  throw new Error(`${DEFAULT_CONFIG_NAME} not found`);
+  throw new Error(`${DEFAULT_CONFIG_NAME} not found in ${root}`);
 };
 
 export async function loadConfig({

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -48,7 +48,7 @@ const findConfig = (basePath: string): string | undefined => {
   return DEFAULT_EXTENSIONS.map((ext) => basePath + ext).find(fs.existsSync);
 };
 
-const resolveConfigPath = (root: string, customConfig?: string) => {
+const resolveConfigPath = (root: string, customConfig?: string): string => {
   if (customConfig) {
     const customConfigPath = isAbsolute(customConfig)
       ? customConfig
@@ -65,15 +65,19 @@ const resolveConfigPath = (root: string, customConfig?: string) => {
     return configFilePath;
   }
 
-  return undefined;
+  throw new Error(`${DEFAULT_CONFIG_NAME} not found`);
 };
 
-export async function loadConfig(
-  customConfig?: string,
-  envMode?: string,
-): Promise<RslibConfig> {
-  const root = process.cwd();
-  const configFilePath = resolveConfigPath(root, customConfig)!;
+export async function loadConfig({
+  cwd = process.cwd(),
+  path,
+  envMode,
+}: {
+  cwd?: string;
+  path?: string;
+  envMode?: string;
+}): Promise<RslibConfig> {
+  const configFilePath = resolveConfigPath(cwd, path);
   const { content } = await loadRsbuildConfig({
     cwd: dirname(configFilePath),
     path: configFilePath,

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -108,7 +108,7 @@ export async function calcLongestCommonPath(
 }
 
 export const readPackageJson = (rootPath: string): undefined | PkgJson => {
-  const pkgJsonPath = path.resolve(rootPath, './package.json');
+  const pkgJsonPath = path.join(rootPath, './package.json');
 
   if (!fs.existsSync(pkgJsonPath)) {
     logger.warn(`package.json does not exist in the ${rootPath} directory`);

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -8,8 +8,8 @@ vi.mock('rslog');
 describe('Should load config file correctly', () => {
   test('Load config.js in cjs project', async () => {
     const fixtureDir = join(__dirname, 'fixtures/config/cjs');
-    const configDir = join(fixtureDir, 'rslib.config.js');
-    const config = await loadConfig(configDir);
+    const configFilePath = join(fixtureDir, 'rslib.config.js');
+    const config = await loadConfig({ path: configFilePath });
     expect(config).toEqual({
       lib: [],
       source: {
@@ -18,15 +18,15 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
-        configFilePath: configDir,
+        configFilePath,
       },
     });
   });
 
   test('Load config.mjs in cjs project', async () => {
     const fixtureDir = join(__dirname, 'fixtures/config/cjs');
-    const configDir = join(fixtureDir, 'rslib.config.mjs');
-    const config = await loadConfig(configDir);
+    const configFilePath = join(fixtureDir, 'rslib.config.mjs');
+    const config = await loadConfig({ path: configFilePath });
     expect(config).toEqual({
       lib: [],
       source: {
@@ -35,15 +35,15 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
-        configFilePath: configDir,
+        configFilePath,
       },
     });
   });
 
   test('Load config.ts in cjs project', async () => {
     const fixtureDir = join(__dirname, 'fixtures/config/cjs');
-    const configDir = join(fixtureDir, 'rslib.config.ts');
-    const config = await loadConfig(configDir);
+    const configFilePath = join(fixtureDir, 'rslib.config.ts');
+    const config = await loadConfig({ path: configFilePath });
     expect(config).toEqual({
       lib: [],
       source: {
@@ -52,15 +52,15 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
-        configFilePath: configDir,
+        configFilePath,
       },
     });
   });
 
   test('Load config.cjs with defineConfig in cjs project', async () => {
     const fixtureDir = join(__dirname, 'fixtures/config/cjs');
-    const configDir = join(fixtureDir, 'rslib.config.cjs');
-    const config = await loadConfig(configDir);
+    const configFilePath = join(fixtureDir, 'rslib.config.cjs');
+    const config = await loadConfig({ path: configFilePath });
     expect(config).toEqual({
       lib: [],
       source: {
@@ -69,15 +69,15 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
-        configFilePath: configDir,
+        configFilePath,
       },
     });
   });
 
   test('Load config.js in esm project', async () => {
     const fixtureDir = join(__dirname, 'fixtures/config/esm');
-    const configDir = join(fixtureDir, 'rslib.config.js');
-    const config = await loadConfig(configDir);
+    const configFilePath = join(fixtureDir, 'rslib.config.js');
+    const config = await loadConfig({ path: configFilePath });
     expect(config).toEqual({
       lib: [],
       source: {
@@ -86,15 +86,15 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
-        configFilePath: configDir,
+        configFilePath,
       },
     });
   });
 
   test('Load config.cjs in esm project', async () => {
     const fixtureDir = join(__dirname, 'fixtures/config/esm');
-    const configDir = join(fixtureDir, 'rslib.config.cjs');
-    const config = await loadConfig(configDir);
+    const configFilePath = join(fixtureDir, 'rslib.config.cjs');
+    const config = await loadConfig({ path: configFilePath });
     expect(config).toEqual({
       lib: [],
       source: {
@@ -103,15 +103,15 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
-        configFilePath: configDir,
+        configFilePath,
       },
     });
   });
 
   test('Load config.ts in esm project', async () => {
     const fixtureDir = join(__dirname, 'fixtures/config/esm');
-    const configDir = join(fixtureDir, 'rslib.config.ts');
-    const config = await loadConfig(configDir);
+    const configFilePath = join(fixtureDir, 'rslib.config.ts');
+    const config = await loadConfig({ path: configFilePath });
     expect(config).toEqual({
       lib: [],
       source: {
@@ -120,16 +120,16 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
-        configFilePath: configDir,
+        configFilePath,
       },
     });
   });
 
   test('Load config.mjs with defineConfig in esm project', async () => {
     const fixtureDir = join(__dirname, 'fixtures/config/esm');
-    const configDir = join(fixtureDir, 'rslib.config.mjs');
-    const config = await loadConfig(configDir);
-    expect(config).toEqual({
+    const configFilePath = join(fixtureDir, 'rslib.config.mjs');
+    const config = await loadConfig({ path: configFilePath });
+    expect(config).toMatchObject({
       lib: [],
       source: {
         entry: {
@@ -137,7 +137,7 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
-        configFilePath: configDir,
+        configFilePath,
       },
     });
   });


### PR DESCRIPTION
## Summary

1. refactor `loadConfig`

```typescript
// before
export async function loadConfig(
  customConfig?: string,
  envMode?: string,
): Promise<RslibConfig> 

// after  https://github.com/web-infra-dev/rsbuild/blob/080a0d856f6743fe1e9570638448a3d629f91dea/packages/core/src/config.ts#L347
export async function loadConfig({
  cwd = process.cwd(),
  path,
  envMode,
}: {
  cwd?: string;
  path?: string;
  envMode?: string;
}): Promise<RslibConfig> 
```

2. remove the first arg of generateEsmConfig 