### PR TITLE
feat: align the time log format with Rsbuild

### DIFF
--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -74,8 +74,8 @@ export async function emitDts(
       throw new Error('DTS generation failed');
     }
 
-    logger.info(
-      `DTS generation succeeded in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+    logger.ready(
+      `DTS generated in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
     );
   } else {
     const createProgram = ts.createSemanticDiagnosticsBuilderProgram;

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -48,8 +48,25 @@ export function getFileLoc(diagnostic: ts.Diagnostic): string {
   return '';
 }
 
+export const prettyTime = (seconds: number): string => {
+  const format = (time: string) => color.bold(time);
+
+  if (seconds < 10) {
+    const digits = seconds >= 0.01 ? 2 : 3;
+    return `${format(seconds.toFixed(digits))} s`;
+  }
+
+  if (seconds < 60) {
+    return `${format(seconds.toFixed(1))} s`;
+  }
+
+  const minutes = seconds / 60;
+  return `${format(minutes.toFixed(2))} m`;
+};
+
 export function getTimeCost(start: number): string {
-  return `${Math.floor(Date.now() - start)}ms`;
+  const second = (Date.now() - start) / 1000;
+  return prettyTime(second);
 }
 
 export async function processDtsFiles(


### PR DESCRIPTION
## Summary

Align the time log format with Rsbuild.

- before:

<img width="515" alt="Screenshot 2024-08-13 at 12 58 16" src="https://github.com/user-attachments/assets/bb56a064-1481-41a7-ba7d-b10644785fc9">

- after:

<img width="428" alt="Screenshot 2024-08-13 at 13 03 04" src="https://github.com/user-attachments/assets/07a068d9-9654-440e-8362-a1f46ae10860">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
