### PR TITLE
feat: add warn when request type bail from "module-import"

### DIFF
--- a/e2e/cases/auto-external/module-import-warn/package.json
+++ b/e2e/cases/auto-external/module-import-warn/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "module-import-warn",
+  "dependencies": {
+    "react": "^18.3.1"
+  }
+}

--- a/e2e/cases/auto-external/module-import-warn/rslib.config.ts
+++ b/e2e/cases/auto-external/module-import-warn/rslib.config.ts
@@ -1,0 +1,11 @@
+import { generateBundleEsmConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig()],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+});

--- a/e2e/cases/auto-external/module-import-warn/src/index.ts
+++ b/e2e/cases/auto-external/module-import-warn/src/index.ts
@@ -1,0 +1,4 @@
+export const foo = () => {
+  const React = require('react');
+  return React.version;
+};

--- a/e2e/cases/externals/index.test.ts
+++ b/e2e/cases/externals/index.test.ts
@@ -1,6 +1,8 @@
 import { join } from 'node:path';
-import { buildAndGetResults } from '@e2e/helper';
+import { buildAndGetResults, proxyConsole } from '@e2e/helper';
+import stripAnsi from 'strip-ansi';
 import { expect, test } from 'vitest';
+import { composeModuleImportWarn } from '../../../packages/core/src/config';
 
 test('should fail to build when `output.target` is not "node"', async () => {
   const fixturePath = join(__dirname, 'browser');
@@ -16,6 +18,8 @@ test('auto externalize Node.js built-in modules when `output.target` is "node"',
     'import * as __WEBPACK_EXTERNAL_MODULE_fs__ from "fs"',
     'import * as __WEBPACK_EXTERNAL_MODULE_node_assert__ from "node:assert"',
     'import * as __WEBPACK_EXTERNAL_MODULE_react__ from "react"',
+    'import * as __WEBPACK_EXTERNAL_MODULE_bar__ from "bar"',
+    'module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("foo");',
   ]) {
     expect(entries.esm).toContain(external);
   }
@@ -24,7 +28,33 @@ test('auto externalize Node.js built-in modules when `output.target` is "node"',
     'var external_fs_namespaceObject = require("fs");',
     'var external_node_assert_namespaceObject = require("node:assert");',
     'var external_react_namespaceObject = require("react");',
+    'module.exports = require("bar");',
+    'module.exports = require("foo");',
   ]) {
     expect(entries.cjs).toContain(external);
   }
+});
+
+test('should get warn when use require in ESM', async () => {
+  const { logs, restore } = proxyConsole();
+  const fixturePath = join(__dirname, 'module-import-warn');
+  const { entries } = await buildAndGetResults(fixturePath);
+  const logStrings = logs.map((log) => stripAnsi(log));
+
+  for (const external of [
+    'import * as __WEBPACK_EXTERNAL_MODULE_bar__ from "bar";',
+    'import * as __WEBPACK_EXTERNAL_MODULE_foo__ from "foo";',
+  ]) {
+    expect(entries.esm).toContain(external);
+  }
+
+  for (const external of ['foo', 'bar']) {
+    expect(
+      logStrings.some((l) =>
+        l.includes(stripAnsi(composeModuleImportWarn(external))),
+      ),
+    ).toBe(true);
+  }
+
+  restore();
 });

--- a/e2e/cases/externals/module-import-warn/rslib.config.ts
+++ b/e2e/cases/externals/module-import-warn/rslib.config.ts
@@ -1,0 +1,20 @@
+import { generateBundleEsmConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      output: {
+        externals: { foo: 'foo' },
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+  output: {
+    externals: ['bar'],
+  },
+});

--- a/e2e/cases/externals/module-import-warn/src/index.ts
+++ b/e2e/cases/externals/module-import-warn/src/index.ts
@@ -1,0 +1,6 @@
+export const baz = () => {
+  const foo = require('foo');
+  const bar = require('bar');
+  foo();
+  bar();
+};

--- a/e2e/cases/externals/node/rslib.config.ts
+++ b/e2e/cases/externals/node/rslib.config.ts
@@ -3,8 +3,15 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig({ output: { target: 'node' } }),
-    generateBundleCjsConfig({ output: { target: 'node' } }),
+    generateBundleEsmConfig({
+      output: {
+        target: 'node',
+        externals: { foo: 'node-commonjs foo' },
+      },
+    }),
+    generateBundleCjsConfig({
+      output: { target: 'node', externals: { foo: 'foo' } },
+    }),
   ],
   source: {
     entry: {
@@ -12,6 +19,6 @@ export default defineConfig({
     },
   },
   output: {
-    externals: { react: 'react' },
+    externals: { react: 'react', bar: 'bar' },
   },
 });

--- a/e2e/cases/externals/node/src/index.ts
+++ b/e2e/cases/externals/node/src/index.ts
@@ -5,4 +5,8 @@ import React from 'react'; // works with the externals option in rslib.config.ts
 export const foo = () => {
   assert(fs, 'fs exists');
   assert(React.version);
+  const foo = require('foo'); // ESM: specified externals type
+  const bar = require('bar'); // ESM: fallback to "module" when not specify externals type
+  foo();
+  bar();
 };

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -19,6 +19,7 @@
     "@types/react": "^18.3.3",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
-    "path-serializer": "0.0.6"
+    "path-serializer": "0.0.6",
+    "strip-ansi": "^7.1.0"
   }
 }

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -32,3 +32,32 @@ export const globContentJSON = async (
 
   return ret;
 };
+
+type LogLevel = 'error' | 'warn' | 'info' | 'log';
+export const proxyConsole = (
+  types: LogLevel | LogLevel[] = ['log', 'warn', 'info', 'error'],
+) => {
+  const logs: string[] = [];
+  const restores: Array<() => void> = [];
+
+  for (const type of Array.isArray(types) ? types : [types]) {
+    const method = console[type];
+
+    restores.push(() => {
+      console[type] = method;
+    });
+
+    console[type] = (log) => {
+      logs.push(log);
+    };
+  }
+
+  return {
+    logs,
+    restore: () => {
+      for (const restore of restores) {
+        restore();
+      }
+    },
+  };
+};

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -12,6 +12,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
         "distPath": {
           "js": "./",
         },
+        "externals": [
+          [Function],
+        ],
         "filename": {
           "js": "[name].js",
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       path-serializer:
         specifier: 0.0.6
         version: 0.0.6
+      strip-ansi:
+        specifier: ^7.1.0
+        version: 7.1.0
 
   e2e/cases/auto-extension/type-commonjs/config-override: {}
 
@@ -126,6 +129,12 @@ importers:
       ora:
         specifier: 8.0.1
         version: 8.0.1
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+
+  e2e/cases/auto-external/module-import-warn:
+    dependencies:
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Summary

When using `require` to load an external module in ESM output, the `require` statement will adopt the `module` external type (the behavior of `"module-import"` external type). However, it can be challenging to identify the desired external type for the `require` statement. As a result, a warning will prompt the user to explicitly specify the correct external type.

<img width="590" alt="Code 2024-08-26 12 54 20" src="https://github.com/user-attachments/assets/5e1be321-feb4-43cf-ba06-9ede3e4d6647">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
