### PR TITLE
feat: support default extensionAlias

### DIFF
--- a/e2e/cases/extension-alias/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/extension-alias/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`should resolve .ts first 1`] = `
+exports[`resolve.extensionAlias should work 1`] = `
 "\\"use strict\\";
 var __webpack_exports__ = {};
 
@@ -23,7 +23,7 @@ if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target
 "
 `;
 
-exports[`should resolve .ts first 2`] = `
+exports[`resolve.extensionAlias should work 2`] = `
 "
 ;// CONCATENATED MODULE: ./src/bar.js
 const bar = 'bar';

--- a/e2e/cases/extension-alias/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/extension-alias/__snapshots__/index.test.ts.snap
@@ -1,0 +1,42 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should resolve .ts first 1`] = `
+"\\"use strict\\";
+var __webpack_exports__ = {};
+
+;// CONCATENATED MODULE: ./src/bar.js
+const bar = 'bar';
+
+;// CONCATENATED MODULE: ./src/foo.ts
+const foo = 'foo';
+
+;// CONCATENATED MODULE: ./src/index.ts
+// Relative import paths need explicit file extensions in ECMAScript imports
+// when '--moduleResolution' is 'node16' or 'nodenext'.
+
+
+console.log(foo + bar);
+
+var __webpack_export_target__ = exports;
+for(var i in __webpack_exports__) __webpack_export_target__[i] = __webpack_exports__[i];
+if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, '__esModule', { value: true });
+"
+`;
+
+exports[`should resolve .ts first 2`] = `
+"
+;// CONCATENATED MODULE: ./src/bar.js
+const bar = 'bar';
+
+;// CONCATENATED MODULE: ./src/foo.ts
+const foo = 'foo';
+
+;// CONCATENATED MODULE: ./src/index.ts
+// Relative import paths need explicit file extensions in ECMAScript imports
+// when '--moduleResolution' is 'node16' or 'nodenext'.
+
+
+console.log(foo + bar);
+
+"
+`;

--- a/e2e/cases/extension-alias/index.test.ts
+++ b/e2e/cases/extension-alias/index.test.ts
@@ -1,0 +1,10 @@
+import { buildAndGetResults } from '@e2e/helper';
+import { expect, test } from 'vitest';
+
+test('resolve.extensionAlias should work', async () => {
+  const fixturePath = __dirname;
+  const { entries } = await buildAndGetResults(fixturePath);
+
+  expect(entries.cjs).toMatchSnapshot();
+  expect(entries.esm).toMatchSnapshot();
+});

--- a/e2e/cases/extension-alias/package.json
+++ b/e2e/cases/extension-alias/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "extension-alias-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/extension-alias/rslib.config.ts
+++ b/e2e/cases/extension-alias/rslib.config.ts
@@ -1,0 +1,14 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+    alias: {
+      '@src': 'src',
+    },
+  },
+});

--- a/e2e/cases/extension-alias/src/bar.js
+++ b/e2e/cases/extension-alias/src/bar.js
@@ -1,0 +1,1 @@
+export const bar = 'bar';

--- a/e2e/cases/extension-alias/src/foo.ts
+++ b/e2e/cases/extension-alias/src/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/e2e/cases/extension-alias/src/index.ts
+++ b/e2e/cases/extension-alias/src/index.ts
@@ -1,0 +1,6 @@
+// Relative import paths need explicit file extensions in ECMAScript imports
+// when '--moduleResolution' is 'node16' or 'nodenext'.
+import { bar } from './bar.js';
+import { foo } from './foo.js';
+
+console.log(foo + bar);

--- a/e2e/cases/extension-alias/tsconfig.json
+++ b/e2e/cases/extension-alias/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  },
+  "include": ["src"]
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -164,6 +164,16 @@ export async function createInternalRsbuildConfig(): Promise<RsbuildConfig> {
             },
           },
         },
+        // TypeScript-specific behavior: if the extension is ".js" or ".jsx", try replacing it with ".ts" or ".tsx"
+        // see https://github.com/web-infra-dev/rslib/issues/41
+        resolve: {
+          extensionAlias: {
+            '.js': ['.ts', '.tsx', '.js', '.jsx'],
+            '.jsx': ['.tsx', '.jsx'],
+            '.mjs': ['.mts', '.mjs'],
+            '.cjs': ['.cts', '.cjs'],
+          },
+        },
       },
     },
     output: {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -81,6 +81,28 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             "optimization": {
               "moduleIds": "named",
             },
+            "resolve": {
+              "extensionAlias": {
+                ".cjs": [
+                  ".cts",
+                  ".cjs",
+                ],
+                ".js": [
+                  ".ts",
+                  ".tsx",
+                  ".js",
+                  ".jsx",
+                ],
+                ".jsx": [
+                  ".tsx",
+                  ".jsx",
+                ],
+                ".mjs": [
+                  ".mts",
+                  ".mjs",
+                ],
+              },
+            },
           },
         ],
       },
@@ -154,6 +176,28 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             "optimization": {
               "moduleIds": "named",
             },
+            "resolve": {
+              "extensionAlias": {
+                ".cjs": [
+                  ".cts",
+                  ".cjs",
+                ],
+                ".js": [
+                  ".ts",
+                  ".tsx",
+                  ".js",
+                  ".jsx",
+                ],
+                ".jsx": [
+                  ".tsx",
+                  ".jsx",
+                ],
+                ".mjs": [
+                  ".mts",
+                  ".mjs",
+                ],
+              },
+            },
           },
         ],
       },
@@ -220,6 +264,28 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             },
             "optimization": {
               "moduleIds": "named",
+            },
+            "resolve": {
+              "extensionAlias": {
+                ".cjs": [
+                  ".cts",
+                  ".cjs",
+                ],
+                ".js": [
+                  ".ts",
+                  ".tsx",
+                  ".js",
+                  ".jsx",
+                ],
+                ".jsx": [
+                  ".tsx",
+                  ".jsx",
+                ],
+                ".mjs": [
+                  ".mts",
+                  ".mjs",
+                ],
+              },
             },
           },
         ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,8 @@ importers:
 
   e2e/cases/dts/bundle/false: {}
 
+  e2e/cases/extension-alias: {}
+
   e2e/scripts: {}
 
   examples/express-plugin:

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -61,6 +61,7 @@ mjsx
 modularly
 mtsx
 napi
+nodenext
 nolyfill
 ntqry
 onclosetag


### PR DESCRIPTION
## Summary

closes: #41 

We add builtin `resolve.extensionAlias` to align with the TypeScript specific behavior: if the extension is ".js" or ".jsx", try replacing it with ".ts" or ".tsx"

```ts
resolve: {
  extensionAlias: {
    '.js': ['.ts', '.tsx', '.js', '.jsx'],
    '.jsx': ['.tsx', '.jsx'],
    '.mjs': ['.mts', '.mjs'],
    '.cjs': ['.cts', '.cjs'],
  },
},
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
