### PR TITLE
chore: add package.json for tests

### DIFF
--- a/e2e/cases/bundle-false/basic/package.json
+++ b/e2e/cases/bundle-false/basic/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bundle-false-basic-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/bundle-false/index.test.ts
+++ b/e2e/cases/bundle-false/index.test.ts
@@ -16,10 +16,10 @@ test('basic', async () => {
   `);
   expect(files.cjs).toMatchInlineSnapshot(`
     [
-      "<ROOT>/e2e/cases/bundle-false/basic/dist/cjs/index.js",
-      "<ROOT>/e2e/cases/bundle-false/basic/dist/cjs/sum.js",
-      "<ROOT>/e2e/cases/bundle-false/basic/dist/cjs/utils/numbers.js",
-      "<ROOT>/e2e/cases/bundle-false/basic/dist/cjs/utils/strings.js",
+      "<ROOT>/e2e/cases/bundle-false/basic/dist/cjs/index.cjs",
+      "<ROOT>/e2e/cases/bundle-false/basic/dist/cjs/sum.cjs",
+      "<ROOT>/e2e/cases/bundle-false/basic/dist/cjs/utils/numbers.cjs",
+      "<ROOT>/e2e/cases/bundle-false/basic/dist/cjs/utils/strings.cjs",
     ]
   `);
 });
@@ -35,7 +35,7 @@ test('single file', async () => {
   `);
   expect(files.cjs).toMatchInlineSnapshot(`
     [
-      "<ROOT>/e2e/cases/bundle-false/single-file/dist/cjs/index.js",
+      "<ROOT>/e2e/cases/bundle-false/single-file/dist/cjs/index.cjs",
     ]
   `);
 });

--- a/e2e/cases/bundle-false/single-file/package.json
+++ b/e2e/cases/bundle-false/single-file/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bundle-false-single-file-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/cli/package.json
+++ b/e2e/cases/cli/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cli-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/define/package.json
+++ b/e2e/cases/define/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "define-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/dts/bundle-false/abort-on-error/package.json
+++ b/e2e/cases/dts/bundle-false/abort-on-error/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-bundle-false-abort-on-error-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/dts/bundle-false/basic/package.json
+++ b/e2e/cases/dts/bundle-false/basic/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-bundle-false-basic-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/dts/bundle-false/dist-path/package.json
+++ b/e2e/cases/dts/bundle-false/dist-path/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-bundle-false-dist-path-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/dts/bundle-false/false/package.json
+++ b/e2e/cases/dts/bundle-false/false/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-false-bundle-false-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/externals/browser/package.json
+++ b/e2e/cases/externals/browser/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "externals-browser-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/externals/module-import-warn/package.json
+++ b/e2e/cases/externals/module-import-warn/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "externals-module-import-warn-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/externals/node/package.json
+++ b/e2e/cases/externals/node/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "externals-node-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/shims/esm/package.json
+++ b/e2e/cases/shims/esm/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "shims-esm-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/syntax/config/package.json
+++ b/e2e/cases/syntax/config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "syntax-config-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/syntax/default/package.json
+++ b/e2e/cases/syntax/default/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "syntax-default-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,9 +145,25 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
 
+  e2e/cases/bundle-false/basic: {}
+
   e2e/cases/bundle-false/relative-import: {}
 
+  e2e/cases/bundle-false/single-file: {}
+
+  e2e/cases/cli: {}
+
+  e2e/cases/define: {}
+
+  e2e/cases/dts/bundle-false/abort-on-error: {}
+
   e2e/cases/dts/bundle-false/auto-extension: {}
+
+  e2e/cases/dts/bundle-false/basic: {}
+
+  e2e/cases/dts/bundle-false/dist-path: {}
+
+  e2e/cases/dts/bundle-false/false: {}
 
   e2e/cases/dts/bundle/abort-on-error: {}
 
@@ -164,6 +180,18 @@ importers:
   e2e/cases/dts/bundle/false: {}
 
   e2e/cases/extension-alias: {}
+
+  e2e/cases/externals/browser: {}
+
+  e2e/cases/externals/module-import-warn: {}
+
+  e2e/cases/externals/node: {}
+
+  e2e/cases/shims/esm: {}
+
+  e2e/cases/syntax/config: {}
+
+  e2e/cases/syntax/default: {}
 
   e2e/scripts: {}
 


### PR DESCRIPTION
## Summary

add `package.json` for all tests, `autoExtension` and `autoExternal` should work correctly when running all tests.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
