### PR TITLE
chore: explicit tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "^5.5.4",
     "vitest": "^2.0.5"
   },
-  "packageManager": "pnpm@9.5.0",
+  "packageManager": "pnpm@9.9.0",
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=9.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,11 +296,7 @@ importers:
         specifier: ^5.5.4
         version: 5.5.4
 
-  scripts/tsconfig:
-    dependencies:
-      '@tsconfig/strictest':
-        specifier: ^2.0.5
-        version: 2.0.5
+  scripts/tsconfig: {}
 
 packages:
 
@@ -928,9 +924,6 @@ packages:
 
   '@swc/helpers@0.5.11':
     resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
-
-  '@tsconfig/strictest@2.0.5':
-    resolution: {integrity: sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -3223,8 +3216,6 @@ snapshots:
   '@swc/helpers@0.5.11':
     dependencies:
       tslib: 2.6.3
-
-  '@tsconfig/strictest@2.0.5': {}
 
   '@types/argparse@1.0.38': {}
 

--- a/scripts/tsconfig/base.json
+++ b/scripts/tsconfig/base.json
@@ -1,5 +1,4 @@
 {
-  "extends": "@tsconfig/strictest/tsconfig",
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
     "target": "ES2021",
@@ -17,7 +16,13 @@
     "resolveJsonModule": true,
     "moduleResolution": "Bundler",
     "useDefineForClassFields": true,
-    "noPropertyAccessFromIndexSignature": false
+    "noPropertyAccessFromIndexSignature": false,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true
   },
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Base"

--- a/scripts/tsconfig/package.json
+++ b/scripts/tsconfig/package.json
@@ -2,8 +2,5 @@
   "name": "@rslib/tsconfig",
   "version": "0.0.1",
   "private": true,
-  "type": "module",
-  "dependencies": {
-    "@tsconfig/strictest": "^2.0.5"
-  }
+  "type": "module"
 }


### PR DESCRIPTION
## Summary

- upgrade pnpm to `9.9.0`
- remove `@tsconfig/strictest` and explicitly declare tsconfig to avoid some bugs from resolver

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
