### PR TITLE
feat: modify merge config order

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -660,7 +660,15 @@ export async function composeCreateRsbuildConfig(
 
     return {
       format: libConfig.format!,
+      // The merge order represents the priority of the configuration
+      // The priorities from high to low are as follows:
+      // 1 - userConfig: users can configure any Rsbuild and Rspack config
+      // 2 - libRsbuildConfig: the configuration that we compose from Rslib unique config and userConfig from 1
+      // 3 - internalRsbuildConfig: the built-in best practice Rsbuild configuration we provide in Rslib
+      // We should state in the document that the built-in configuration should not be changed optionally
       config: mergeRsbuildConfig(
+        internalRsbuildConfig,
+        libRsbuildConfig,
         omitDeep(userConfig, [
           'bundle',
           'format',
@@ -669,10 +677,6 @@ export async function composeCreateRsbuildConfig(
           'syntax',
           'dts',
         ]),
-        libRsbuildConfig,
-        // Merge order matters, keep `internalRsbuildConfig` at the last position
-        // to ensure that the internal config is not overridden by user's config.
-        internalRsbuildConfig,
       ),
     };
   });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -666,6 +666,8 @@ export async function composeCreateRsbuildConfig(
       // 2 - libRsbuildConfig: the configuration that we compose from Rslib unique config and userConfig from 1
       // 3 - internalRsbuildConfig: the built-in best practice Rsbuild configuration we provide in Rslib
       // We should state in the document that the built-in configuration should not be changed optionally
+      // In compose process of 2, we may read some config from 1, and reassemble the related config,
+      // so before final mergeRsbuildConfig, we reset some specified fields
       config: mergeRsbuildConfig(
         internalRsbuildConfig,
         libRsbuildConfig,

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -122,6 +122,16 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
               "web",
             ],
           },
+          {
+            "resolve": {
+              "extensionAlias": {
+                ".js": [
+                  ".ts",
+                  ".tsx",
+                ],
+              },
+            },
+          },
         ],
       },
     },
@@ -235,6 +245,16 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
               "web",
             ],
           },
+          {
+            "resolve": {
+              "extensionAlias": {
+                ".js": [
+                  ".ts",
+                  ".tsx",
+                ],
+              },
+            },
+          },
         ],
       },
     },
@@ -341,6 +361,16 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             "target": [
               "web",
             ],
+          },
+          {
+            "resolve": {
+              "extensionAlias": {
+                ".js": [
+                  ".ts",
+                  ".tsx",
+                ],
+              },
+            },
           },
         ],
       },

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -61,35 +61,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
         "rspack": [
           {
             "experiments": {
-              "outputModule": true,
-            },
-            "externalsType": "module-import",
-            "module": {
-              "parser": {
-                "javascript": {
-                  "importMeta": false,
-                },
-              },
-            },
-            "optimization": {
-              "concatenateModules": true,
-            },
-            "output": {
-              "chunkFormat": "module",
-              "library": {
-                "type": "modern-module",
-              },
-              "module": true,
-            },
-          },
-          [Function],
-          {
-            "target": [
-              "web",
-            ],
-          },
-          {
-            "experiments": {
               "rspackFuture": {
                 "bundlerInfo": {
                   "force": false,
@@ -121,6 +92,35 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
                 ],
               },
             },
+          },
+          {
+            "experiments": {
+              "outputModule": true,
+            },
+            "externalsType": "module-import",
+            "module": {
+              "parser": {
+                "javascript": {
+                  "importMeta": false,
+                },
+              },
+            },
+            "optimization": {
+              "concatenateModules": true,
+            },
+            "output": {
+              "chunkFormat": "module",
+              "library": {
+                "type": "modern-module",
+              },
+              "module": true,
+            },
+          },
+          [Function],
+          {
+            "target": [
+              "web",
+            ],
           },
         ],
       },
@@ -186,22 +186,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
         "htmlPlugin": false,
         "rspack": [
           {
-            "externalsType": "commonjs",
-            "output": {
-              "chunkFormat": "commonjs",
-              "iife": false,
-              "library": {
-                "type": "commonjs",
-              },
-            },
-          },
-          [Function],
-          {
-            "target": [
-              "web",
-            ],
-          },
-          {
             "experiments": {
               "rspackFuture": {
                 "bundlerInfo": {
@@ -234,6 +218,22 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
                 ],
               },
             },
+          },
+          {
+            "externalsType": "commonjs",
+            "output": {
+              "chunkFormat": "commonjs",
+              "iife": false,
+              "library": {
+                "type": "commonjs",
+              },
+            },
+          },
+          [Function],
+          {
+            "target": [
+              "web",
+            ],
           },
         ],
       },
@@ -295,20 +295,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
         "htmlPlugin": false,
         "rspack": [
           {
-            "externalsType": "umd",
-            "output": {
-              "library": {
-                "type": "umd",
-              },
-            },
-          },
-          [Function],
-          {
-            "target": [
-              "web",
-            ],
-          },
-          {
             "experiments": {
               "rspackFuture": {
                 "bundlerInfo": {
@@ -341,6 +327,20 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
                 ],
               },
             },
+          },
+          {
+            "externalsType": "umd",
+            "output": {
+              "library": {
+                "type": "umd",
+              },
+            },
+          },
+          [Function],
+          {
+            "target": [
+              "web",
+            ],
           },
         ],
       },

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -178,7 +178,6 @@ describe('Should compose create Rsbuild config correctly', () => {
       },
       output: {
         filenameHash: false,
-        minify: true,
       },
     };
     const composedRsbuildConfig = await composeCreateRsbuildConfig(

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -179,6 +179,15 @@ describe('Should compose create Rsbuild config correctly', () => {
       output: {
         filenameHash: false,
       },
+      tools: {
+        rspack: {
+          resolve: {
+            extensionAlias: {
+              '.js': ['.ts', '.tsx'],
+            },
+          },
+        },
+      },
     };
     const composedRsbuildConfig = await composeCreateRsbuildConfig(
       rslibConfig,


### PR DESCRIPTION
## Summary

The priorities from high to low are as follows:

1. `userConfig`: users can configure any Rsbuild and Rspack config
2. `libRsbuildConfig`: the configuration that we compose from Rslib unique config and userConfig from 1
3. `internalRsbuildConfig`: the built-in best practice Rsbuild configuration we provide in Rslib

We should state in the document that the built-in configuration should not be changed optionally

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
