### PR TITLE
feat!: move config `output.syntax` to `syntax`

### DIFF
--- a/e2e/cases/syntax/config/rslib.config.ts
+++ b/e2e/cases/syntax/config/rslib.config.ts
@@ -4,27 +4,27 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     generateBundleEsmConfig({
+      syntax: 'es2015',
       output: {
         distPath: { root: 'dist/esm/0' },
-        syntax: 'es2015',
       },
     }),
     generateBundleEsmConfig({
+      syntax: ['es2022'],
       output: {
         distPath: { root: 'dist/esm/1' },
-        syntax: ['es2022'],
       },
     }),
     generateBundleCjsConfig({
+      syntax: ['node 20'],
       output: {
         distPath: { root: 'dist/cjs/0' },
-        syntax: ['node 20'],
       },
     }),
     generateBundleCjsConfig({
+      syntax: ['node 20', 'es5'],
       output: {
         distPath: { root: 'dist/cjs/1' },
-        syntax: ['node 20', 'es5'],
       },
     }),
   ],

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -4,9 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      output: {
-        syntax: ['node 16'],
-      },
+      syntax: ['node 16'],
       dts: {
         bundle: false,
         distPath: './dist-types',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -686,7 +686,7 @@ async function composeLibRsbuildConfig(config: LibConfig, configPath: string) {
   const bundleConfig = composeBundleConfig(jsExtension, config.bundle);
   const targetConfig = composeTargetConfig(config.output?.target);
   const syntaxConfig = composeSyntaxConfig(
-    config.output?.syntax,
+    config?.syntax,
     config.output?.target,
   );
   const autoExternalConfig = composeAutoExternalConfig({

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -44,10 +44,8 @@ export interface LibConfig extends RsbuildConfig {
   format?: Format;
   autoExtension?: boolean;
   autoExternal?: AutoExternal;
-  output?: RsbuildConfig['output'] & {
-    /** Support esX and browserslist query */
-    syntax?: Syntax;
-  };
+  /** Support esX and browserslist query */
+  syntax?: Syntax;
   dts?: Dts;
 }
 

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -288,9 +288,7 @@ describe('syntax', () => {
     const rslibConfig: RslibConfig = {
       lib: [
         {
-          output: {
-            syntax: 'es2015',
-          },
+          syntax: 'es2015',
           format: 'esm',
         },
       ],


### PR DESCRIPTION
## Summary

We try to flatten the fields under `lib` as much as possible instead of nesting them.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
