### PR TITLE
feat: support `externalHelpers`

### DIFF
--- a/e2e/cases/external-helpers/__fixtures__/src/index.ts
+++ b/e2e/cases/external-helpers/__fixtures__/src/index.ts
@@ -1,0 +1,5 @@
+export default class FOO {
+  get bar() {
+    return;
+  }
+}

--- a/e2e/cases/external-helpers/__fixtures__/tsconfig.json
+++ b/e2e/cases/external-helpers/__fixtures__/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "include": ["src"]
+}

--- a/e2e/cases/external-helpers/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/external-helpers/__snapshots__/index.test.ts.snap
@@ -1,0 +1,137 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should external @swc/helpers when externalHelpers is true 1`] = `
+"import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__ from \\"@swc/helpers/_/_class_call_check\\";
+import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__ from \\"@swc/helpers/_/_create_class\\";
+var _class_call_check_namespaceObject = __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__;
+var _create_class_namespaceObject = __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__;
+var src_FOO = /*#__PURE__*/ function() {
+    \\"use strict\\";
+    function FOO() {
+        (0, _class_call_check_namespaceObject._)(this, FOO);
+    }
+    (0, _create_class_namespaceObject._)(FOO, [
+        {
+            key: \\"bar\\",
+            get: function() {}
+        }
+    ]);
+    return FOO;
+}();
+export { src_FOO as default };
+"
+`;
+
+exports[`should external @swc/helpers when externalHelpers is true 2`] = `
+"import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__ from \\"@swc/helpers/_/_class_call_check\\";
+import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__ from \\"@swc/helpers/_/_create_class\\";
+var _class_call_check_namespaceObject = __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__;
+var _create_class_namespaceObject = __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__;
+var src_FOO = /*#__PURE__*/ function() {
+    \\"use strict\\";
+    function FOO() {
+        (0, _class_call_check_namespaceObject._)(this, FOO);
+    }
+    (0, _create_class_namespaceObject._)(FOO, [
+        {
+            key: \\"bar\\",
+            get: function() {}
+        }
+    ]);
+    return FOO;
+}();
+export { src_FOO as default };
+"
+`;
+
+exports[`should not external @swc/helpers by default 1`] = `
+"function _class_call_check(instance, Constructor) {
+    if (!(instance instanceof Constructor)) throw new TypeError(\\"Cannot call a class as a function\\");
+}
+function _defineProperties(target, props) {
+    for(var i = 0; i < props.length; i++){
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if (\\"value\\" in descriptor) descriptor.writable = true;
+        Object.defineProperty(target, descriptor.key, descriptor);
+    }
+}
+function _create_class(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) _defineProperties(Constructor, staticProps);
+    return Constructor;
+}
+var src_FOO = /*#__PURE__*/ function() {
+    \\"use strict\\";
+    function FOO() {
+        _class_call_check(this, FOO);
+    }
+    _create_class(FOO, [
+        {
+            key: \\"bar\\",
+            get: function() {}
+        }
+    ]);
+    return FOO;
+}();
+export { src_FOO as default };
+"
+`;
+
+exports[`should respect user override externalHelpers config 1`] = `
+"function _class_call_check(instance, Constructor) {
+    if (!(instance instanceof Constructor)) throw new TypeError(\\"Cannot call a class as a function\\");
+}
+function _defineProperties(target, props) {
+    for(var i = 0; i < props.length; i++){
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if (\\"value\\" in descriptor) descriptor.writable = true;
+        Object.defineProperty(target, descriptor.key, descriptor);
+    }
+}
+function _create_class(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) _defineProperties(Constructor, staticProps);
+    return Constructor;
+}
+var src_FOO = /*#__PURE__*/ function() {
+    \\"use strict\\";
+    function FOO() {
+        _class_call_check(this, FOO);
+    }
+    _create_class(FOO, [
+        {
+            key: \\"bar\\",
+            get: function() {}
+        }
+    ]);
+    return FOO;
+}();
+export { src_FOO as default };
+"
+`;
+
+exports[`should respect user override externalHelpers config 2`] = `
+"import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__ from \\"@swc/helpers/_/_class_call_check\\";
+import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__ from \\"@swc/helpers/_/_create_class\\";
+var _class_call_check_namespaceObject = __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__;
+var _create_class_namespaceObject = __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__;
+var src_FOO = /*#__PURE__*/ function() {
+    \\"use strict\\";
+    function FOO() {
+        (0, _class_call_check_namespaceObject._)(this, FOO);
+    }
+    (0, _create_class_namespaceObject._)(FOO, [
+        {
+            key: \\"bar\\",
+            get: function() {}
+        }
+    ]);
+    return FOO;
+}();
+export { src_FOO as default };
+"
+`;

--- a/e2e/cases/external-helpers/config-override/package.json
+++ b/e2e/cases/external-helpers/config-override/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "external-helpers-config-override-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@swc/helpers": "0.5.13"
+  }
+}

--- a/e2e/cases/external-helpers/config-override/rslib.config.ts
+++ b/e2e/cases/external-helpers/config-override/rslib.config.ts
@@ -1,0 +1,43 @@
+import { generateBundleEsmConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      syntax: 'es5',
+      externalHelpers: true,
+      tools: {
+        swc: {
+          jsc: {
+            externalHelpers: false,
+          },
+        },
+      },
+      output: {
+        distPath: {
+          root: './dist/1',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      syntax: 'es5',
+      tools: {
+        swc: {
+          jsc: {
+            externalHelpers: true,
+          },
+        },
+      },
+      output: {
+        distPath: {
+          root: './dist/2',
+        },
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src/index.ts',
+    },
+  },
+});

--- a/e2e/cases/external-helpers/default/package.json
+++ b/e2e/cases/external-helpers/default/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "external-helpers-default-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/external-helpers/default/rslib.config.ts
+++ b/e2e/cases/external-helpers/default/rslib.config.ts
@@ -1,0 +1,15 @@
+import { generateBundleEsmConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      syntax: 'es5',
+    }),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src/index.ts',
+    },
+  },
+});

--- a/e2e/cases/external-helpers/index.test.ts
+++ b/e2e/cases/external-helpers/index.test.ts
@@ -1,0 +1,50 @@
+import { join } from 'node:path';
+import { buildAndGetResults, proxyConsole } from '@e2e/helper';
+import stripAnsi from 'strip-ansi';
+import { expect, test } from 'vitest';
+
+test('should not external @swc/helpers by default', async () => {
+  const fixturePath = join(__dirname, 'default');
+  const { entries } = await buildAndGetResults(fixturePath);
+
+  expect(entries.esm).toMatchSnapshot();
+});
+
+test('should throw error when @swc/helpers is not be installed when externalHelpers is true', async () => {
+  const { logs, restore } = proxyConsole();
+
+  const fixturePath = join(__dirname, 'no-deps');
+  try {
+    await buildAndGetResults(fixturePath);
+  } catch {}
+
+  const logStrings = logs.map((log) => stripAnsi(log));
+
+  expect(logStrings).toMatchInlineSnapshot(`
+    [
+      "error   externalHelpers is enabled, but the @swc/helpers dependency declaration was not found in package.json.",
+    ]
+  `);
+
+  restore();
+});
+
+test('should external @swc/helpers when externalHelpers is true', async () => {
+  const fixturePath = join(__dirname, 'true');
+  const { entries } = await buildAndGetResults(fixturePath);
+
+  // autoExternal is true
+  expect(entries.esm0).toMatchSnapshot();
+  // autoExternal is false
+  expect(entries.esm1).toMatchSnapshot();
+});
+
+test('should respect user override externalHelpers config', async () => {
+  const fixturePath = join(__dirname, 'config-override');
+  const { entries } = await buildAndGetResults(fixturePath);
+
+  // override externalHelpers false
+  expect(entries.esm0).toMatchSnapshot();
+  // override externalHelpers true
+  expect(entries.esm1).toMatchSnapshot();
+});

--- a/e2e/cases/external-helpers/no-deps/package.json
+++ b/e2e/cases/external-helpers/no-deps/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "external-helpers-no-deps-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/external-helpers/no-deps/rslib.config.ts
+++ b/e2e/cases/external-helpers/no-deps/rslib.config.ts
@@ -1,0 +1,16 @@
+import { generateBundleEsmConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      syntax: 'es5',
+      externalHelpers: true,
+    }),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src/index.ts',
+    },
+  },
+});

--- a/e2e/cases/external-helpers/true/package.json
+++ b/e2e/cases/external-helpers/true/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "external-helpers-true-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@swc/helpers": "0.5.13"
+  }
+}

--- a/e2e/cases/external-helpers/true/rslib.config.ts
+++ b/e2e/cases/external-helpers/true/rslib.config.ts
@@ -1,0 +1,31 @@
+import { generateBundleEsmConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      syntax: 'es5',
+      externalHelpers: true,
+      output: {
+        distPath: {
+          root: './dist/1',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      syntax: 'es5',
+      externalHelpers: true,
+      autoExternal: false,
+      output: {
+        distPath: {
+          root: './dist/2',
+        },
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src/index.ts',
+    },
+  },
+});

--- a/e2e/cases/syntax/__snapshots__/index.test.ts.snap
+++ b/e2e/cases/syntax/__snapshots__/index.test.ts.snap
@@ -12,12 +12,12 @@ export { Foo };
 `;
 
 exports[`should downgrade class private method with output.syntax config 1`] = `
-"function _class_private_method_get(receiver, privateSet, fn) {
+"function _check_private_redeclaration(obj, privateCollection) {
+    if (privateCollection.has(obj)) throw new TypeError(\\"Cannot initialize the same private elements twice on an object\\");
+}
+function _class_private_method_get(receiver, privateSet, fn) {
     if (!privateSet.has(receiver)) throw new TypeError(\\"attempted to get private field on non-instance\\");
     return fn;
-}
-function _check_private_redeclaration(obj, privateCollection) {
-    if (privateCollection.has(obj)) throw new TypeError(\\"Cannot initialize the same private elements twice on an object\\");
 }
 function _class_private_method_init(obj, privateSet) {
     _check_private_redeclaration(obj, privateSet);

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -8,3 +8,5 @@ export const DEFAULT_EXTENSIONS = [
   '.cjs',
   '.cts',
 ] as const;
+
+export const SWC_HELPERS = '@swc/helpers';

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -46,6 +46,7 @@ export interface LibConfig extends RsbuildConfig {
   autoExternal?: AutoExternal;
   /** Support esX and browserslist query */
   syntax?: Syntax;
+  externalHelpers?: boolean;
   dts?: Dts;
 }
 

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -133,6 +133,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             },
           },
         ],
+        "swc": {
+          "jsc": {
+            "externalHelpers": false,
+          },
+        },
       },
     },
     "format": "esm",
@@ -256,6 +261,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             },
           },
         ],
+        "swc": {
+          "jsc": {
+            "externalHelpers": false,
+          },
+        },
       },
     },
     "format": "cjs",
@@ -373,6 +383,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             },
           },
         ],
+        "swc": {
+          "jsc": {
+            "externalHelpers": false,
+          },
+        },
       },
     },
     "format": "umd",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,22 @@ importers:
 
   e2e/cases/extension-alias: {}
 
+  e2e/cases/external-helpers/config-override:
+    dependencies:
+      '@swc/helpers':
+        specifier: 0.5.13
+        version: 0.5.13
+
+  e2e/cases/external-helpers/default: {}
+
+  e2e/cases/external-helpers/no-deps: {}
+
+  e2e/cases/external-helpers/true:
+    dependencies:
+      '@swc/helpers':
+        specifier: 0.5.13
+        version: 0.5.13
+
   e2e/cases/externals/browser: {}
 
   e2e/cases/externals/module-import-warn: {}
@@ -992,8 +1008,8 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
-  '@swc/helpers@0.5.12':
-    resolution: {integrity: sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==}
+  '@swc/helpers@0.5.13':
+    resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
@@ -3200,9 +3216,9 @@ snapshots:
 
   '@rsbuild/core@1.0.1-rc.0':
     dependencies:
-      '@rspack/core': 1.0.0(@swc/helpers@0.5.12)
+      '@rspack/core': 1.0.0(@swc/helpers@0.5.13)
       '@rspack/lite-tapable': 1.0.0
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.13
       caniuse-lite: 1.0.30001655
       core-js: 3.38.1
     optionalDependencies:
@@ -3210,9 +3226,9 @@ snapshots:
 
   '@rsbuild/core@1.0.1-rc.2':
     dependencies:
-      '@rspack/core': 1.0.0(@swc/helpers@0.5.12)
+      '@rspack/core': 1.0.0(@swc/helpers@0.5.13)
       '@rspack/lite-tapable': 1.0.0
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.13
       caniuse-lite: 1.0.30001655
       core-js: 3.38.1
     optionalDependencies:
@@ -3271,14 +3287,14 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.0.0
       '@rspack/binding-win32-x64-msvc': 1.0.0
 
-  '@rspack/core@1.0.0(@swc/helpers@0.5.12)':
+  '@rspack/core@1.0.0(@swc/helpers@0.5.13)':
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
       '@rspack/binding': 1.0.0
       '@rspack/lite-tapable': 1.0.0
       caniuse-lite: 1.0.30001655
     optionalDependencies:
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.13
 
   '@rspack/lite-tapable@1.0.0': {}
 
@@ -3325,7 +3341,7 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@swc/helpers@0.5.12':
+  '@swc/helpers@0.5.13':
     dependencies:
       tslib: 2.6.3
 


### PR DESCRIPTION
## Summary

support `externalHelpers` config to control whether to externalize `@swc/helpers`, default is false in Rslib, this is different from Rsbuild's default value.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
