### PR TITLE
chore: not use recursive omit

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -31,7 +31,7 @@ import {
   color,
   isObject,
   nodeBuiltInModules,
-  omitDeep,
+  omit,
   readPackageJson,
 } from './utils/helper';
 import { logger } from './utils/logger';
@@ -825,12 +825,13 @@ export async function composeCreateRsbuildConfig(
       config: mergeRsbuildConfig(
         constantRsbuildConfig,
         libRsbuildConfig,
-        omitDeep(userConfig, [
+        omit(userConfig, [
           'bundle',
           'format',
           'autoExtension',
           'autoExternal',
           'syntax',
+          'externalHelpers',
           'dts',
         ]),
       ),

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -126,36 +126,19 @@ export const readPackageJson = (rootPath: string): undefined | PkgJson => {
 export const isObject = (obj: unknown): obj is Record<string, any> =>
   Object.prototype.toString.call(obj) === '[object Object]';
 
-type OmitDeep<T, K extends string[]> = T extends (infer U)[]
-  ? OmitDeep<U, K>[]
-  : T extends Record<any, any>
-    ? { [P in keyof T as P extends K[number] ? never : P]: OmitDeep<T[P], K> }
-    : T;
-
-export function omitDeep<T extends object, K extends string[]>(
+export function omit<T extends object, U extends keyof T>(
   obj: T,
-  keys: K,
-): OmitDeep<T, K> {
-  if (typeof obj === 'string' || typeof obj !== 'object' || obj === null)
-    return obj as any;
-
-  if (Array.isArray(obj)) {
-    return obj.map((item) => omitDeep(item, keys)) as any;
-  }
-
-  const clone: any = {};
-  for (const property in obj) {
-    if (keys.includes(property as string)) {
-      continue;
-    }
-    const value = obj[property];
-    if (value && typeof value === 'object') {
-      clone[property] = omitDeep(value, keys);
-    } else {
-      clone[property] = value;
-    }
-  }
-  return clone;
+  keys: ReadonlyArray<U>,
+): Omit<T, U> {
+  return Object.keys(obj).reduce(
+    (ret, key) => {
+      if (!keys.includes(key as U)) {
+        ret[key as keyof Omit<T, U>] = obj[key as keyof Omit<T, U>];
+      }
+      return ret;
+    },
+    {} as Omit<T, U>,
+  );
 }
 
 export { color };


### PR DESCRIPTION
## Summary

`omitDeep` will break some element like 
```TS
tools: {
  rspack: {
    plugins: [
      new rspack.BannerPlugin({
        banner: 'hello world',
        footer: true,
        stage: 10000,
      }),
    ],
  },
},
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
