### PR TITLE
fix: should remain process.env.NODE_ENV as is by default

### DIFF
--- a/e2e/cases/auto-external/index.test.ts
+++ b/e2e/cases/auto-external/index.test.ts
@@ -54,7 +54,6 @@ test('auto external false should works', async () => {
 
   // dts should bundled
   expect(dts.entries.esm).toContain('export declare function oraPromise');
-
   expect(dts.entries.cjs).toContain('export declare function oraPromise');
 });
 

--- a/e2e/cases/define/index.test.ts
+++ b/e2e/cases/define/index.test.ts
@@ -5,9 +5,15 @@ test('source.define', async () => {
   const fixturePath = __dirname;
   const { entries } = await buildAndGetResults(fixturePath);
 
-  expect(entries.esm).not.toContain('console.info(VERSION)');
-  expect(entries.esm).toContain('1.0.0');
+  expect(entries.esm0).not.toContain('console.info(VERSION)');
+  expect(entries.esm0).toContain('console.info("1.0.0")');
+  expect(entries.esm0).toContain('console.info(process.env.NODE_ENV)');
+
+  expect(entries.esm1).not.toContain('console.info(VERSION)');
+  expect(entries.esm1).toContain('console.info("1.0.0")');
+  expect(entries.esm1).toContain('console.info(process.ENV.MY_CUSTOM_ENV)');
 
   expect(entries.cjs).not.toContain('console.info(VERSION)');
-  expect(entries.cjs).toContain('1.0.0');
+  expect(entries.cjs).toContain('console.info("1.0.0")');
+  expect(entries.cjs).toContain('console.info(process.env.NODE_ENV)');
 });

--- a/e2e/cases/define/rslib.config.ts
+++ b/e2e/cases/define/rslib.config.ts
@@ -2,13 +2,48 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
+  lib: [
+    generateBundleEsmConfig({
+      source: {
+        define: {
+          VERSION: JSON.stringify('1.0.0'),
+        },
+      },
+      output: {
+        distPath: {
+          root: './dist/esm/0',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      source: {
+        define: {
+          VERSION: JSON.stringify('1.0.0'),
+          'process.env.NODE_ENV': 'process.ENV.MY_CUSTOM_ENV',
+        },
+      },
+      output: {
+        distPath: {
+          root: './dist/esm/1',
+        },
+      },
+    }),
+    generateBundleCjsConfig({
+      source: {
+        define: {
+          VERSION: JSON.stringify('1.0.0'),
+        },
+      },
+      output: {
+        distPath: {
+          root: './dist/cjs/0',
+        },
+      },
+    }),
+  ],
   source: {
     entry: {
       index: './src/index.ts',
-    },
-    define: {
-      VERSION: JSON.stringify('1.0.0'),
     },
   },
 });

--- a/e2e/cases/define/src/index.ts
+++ b/e2e/cases/define/src/index.ts
@@ -1,1 +1,2 @@
 console.info(VERSION);
+console.info(process.env.NODE_ENV); // Should remain as is.

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -111,9 +111,16 @@ export async function getResults(
     }
 
     // Only applied in bundle mode, a shortcut to get single entry result
-    if (libConfig.bundle !== false && fileSet.length === 1) {
-      entries[key] = content[fileSet[0]!]!;
-      entryFiles[key] = fileSet[0]!;
+    if (libConfig.bundle !== false && fileSet.length) {
+      let entryFile = '';
+      if (fileSet.length === 1) {
+        entryFile = fileSet[0]!;
+      } else {
+        entryFile = fileSet.find((file) => file.includes('index'))!;
+      }
+
+      entries[key] = content[entryFile]!;
+      entryFiles[key] = entryFile;
     }
   }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -297,6 +297,7 @@ export async function createConstantRsbuildConfig(): Promise<RsbuildConfig> {
       rspack: {
         optimization: {
           moduleIds: 'named',
+          nodeEnv: false,
         },
         experiments: {
           rspackFuture: {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -69,6 +69,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             },
             "optimization": {
               "moduleIds": "named",
+              "nodeEnv": false,
             },
             "resolve": {
               "extensionAlias": {
@@ -210,6 +211,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             },
             "optimization": {
               "moduleIds": "named",
+              "nodeEnv": false,
             },
             "resolve": {
               "extensionAlias": {
@@ -334,6 +336,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             },
             "optimization": {
               "moduleIds": "named",
+              "nodeEnv": false,
             },
             "resolve": {
               "extensionAlias": {


### PR DESCRIPTION
## Summary

https://webpack.js.org/configuration/optimization/#optimizationnodeenv.

Previously, it will be `"production"` that uses `mode` by default. We usually leave this as-is in library and replace it by app.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
