### PR TITLE
feat: support `banner` and `footer`

### DIFF
--- a/.changeset/nice-hotels-cheer.md
+++ b/.changeset/nice-hotels-cheer.md
@@ -1,0 +1,6 @@
+---
+'rsbuild-plugin-dts': patch
+'@rslib/core': patch
+---
+
+release 0.0.5

--- a/e2e/cases/banner-footer/index.test.ts
+++ b/e2e/cases/banner-footer/index.test.ts
@@ -18,6 +18,12 @@ test('banner and footer should work in js, css and dts', async () => {
   const cssContents = Object.values(css.contents);
   const dtsContents = Object.values(dts.contents);
 
+  // There are 5 cases included:
+  // 1. bundle esm
+  // 2. bundle cjs
+  // 3. bundleless esm
+  // 4. bundleless cjs
+  // 5. bundle esm with minify enabled
   const checkBannerAndFooter = (
     contents: Record<string, string>[],
     type: 'js' | 'css' | 'dts',

--- a/e2e/cases/banner-footer/index.test.ts
+++ b/e2e/cases/banner-footer/index.test.ts
@@ -1,0 +1,51 @@
+import { buildAndGetResults } from '@e2e/helper';
+import { expect, test } from 'vitest';
+
+enum BannerFooter {
+  JS_BANNER = '/*! hello banner js */',
+  JS_FOOTER = '/*! hello footer js */',
+  CSS_BANNER = '/*! hello banner css */',
+  CSS_FOOTER = '/*! hello footer css */',
+  DTS_BANNER = '/*! hello banner dts */',
+  DTS_FOOTER = '/*! hello footer dts */',
+}
+
+test('banner and footer should work in js, css and dts', async () => {
+  const fixturePath = __dirname;
+  const { js, css, dts } = await buildAndGetResults(fixturePath, 'all');
+
+  const jsContents = Object.values(js.contents);
+  const cssContents = Object.values(css.contents);
+  const dtsContents = Object.values(dts.contents);
+
+  const checkBannerAndFooter = (
+    contents: Record<string, string>[],
+    type: 'js' | 'css' | 'dts',
+  ) => {
+    for (const content of Object.values(contents)) {
+      if (content) {
+        const expectedBanner =
+          type === 'js'
+            ? BannerFooter.JS_BANNER
+            : type === 'css'
+              ? BannerFooter.CSS_BANNER
+              : BannerFooter.DTS_BANNER;
+        const expectedFooter =
+          type === 'js'
+            ? BannerFooter.JS_FOOTER
+            : type === 'css'
+              ? BannerFooter.CSS_FOOTER
+              : BannerFooter.DTS_FOOTER;
+
+        for (const value of Object.values(content)) {
+          expect(value).toContain(expectedBanner);
+          expect(value).toContain(expectedFooter);
+        }
+      }
+    }
+  };
+
+  checkBannerAndFooter(jsContents, 'js');
+  checkBannerAndFooter(cssContents, 'css');
+  checkBannerAndFooter(dtsContents, 'dts');
+});

--- a/e2e/cases/banner-footer/package.json
+++ b/e2e/cases/banner-footer/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "banner-footer-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/banner-footer/rslib.config.ts
+++ b/e2e/cases/banner-footer/rslib.config.ts
@@ -1,0 +1,83 @@
+import { generateBundleCjsConfig, generateBundleEsmConfig } from '@e2e/helper';
+import { type LibConfig, defineConfig } from '@rslib/core';
+
+const bannerFooterConfig: LibConfig = {
+  banner: {
+    js: 'hello banner js',
+    css: 'hello banner css',
+    dts: 'hello banner dts',
+  },
+  footer: {
+    js: 'hello footer js',
+    css: 'hello footer css',
+    dts: 'hello footer dts',
+  },
+};
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      output: {
+        distPath: {
+          root: './dist/esm/bundle',
+        },
+      },
+      dts: {
+        bundle: true,
+      },
+      ...bannerFooterConfig,
+    }),
+    generateBundleCjsConfig({
+      output: {
+        distPath: {
+          root: './dist/cjs/bundle',
+        },
+      },
+      dts: {
+        bundle: true,
+      },
+      ...bannerFooterConfig,
+    }),
+    generateBundleEsmConfig({
+      output: {
+        distPath: {
+          root: './dist/esm/bundleless',
+        },
+      },
+      bundle: false,
+      dts: {
+        bundle: false,
+      },
+      // TODO: bundleless css
+      source: {
+        entry: {
+          index: ['./src/**/*.ts'],
+        },
+      },
+      ...bannerFooterConfig,
+    }),
+    generateBundleCjsConfig({
+      output: {
+        distPath: {
+          root: './dist/cjs/bundleless',
+        },
+      },
+      bundle: false,
+      dts: {
+        bundle: false,
+      },
+      // TODO: bundleless css
+      source: {
+        entry: {
+          index: ['./src/**/*.ts'],
+        },
+      },
+      ...bannerFooterConfig,
+    }),
+  ],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+});

--- a/e2e/cases/banner-footer/rslib.config.ts
+++ b/e2e/cases/banner-footer/rslib.config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
         distPath: {
           root: './dist/esm/bundle-minify',
         },
+        minify: true,
       },
       dts: {
         bundle: true,

--- a/e2e/cases/banner-footer/rslib.config.ts
+++ b/e2e/cases/banner-footer/rslib.config.ts
@@ -3,14 +3,14 @@ import { type LibConfig, defineConfig } from '@rslib/core';
 
 const bannerFooterConfig: LibConfig = {
   banner: {
-    js: 'hello banner js',
-    css: 'hello banner css',
-    dts: 'hello banner dts',
+    js: '/*! hello banner js */',
+    css: '/*! hello banner css */',
+    dts: '/*! hello banner dts */',
   },
   footer: {
-    js: 'hello footer js',
-    css: 'hello footer css',
-    dts: 'hello footer dts',
+    js: '/*! hello footer js */',
+    css: '/*! hello footer css */',
+    dts: '/*! hello footer dts */',
   },
 };
 

--- a/e2e/cases/banner-footer/rslib.config.ts
+++ b/e2e/cases/banner-footer/rslib.config.ts
@@ -16,6 +16,7 @@ const bannerFooterConfig: LibConfig = {
 
 export default defineConfig({
   lib: [
+    // bundle esm
     generateBundleEsmConfig({
       output: {
         distPath: {
@@ -27,6 +28,7 @@ export default defineConfig({
       },
       ...bannerFooterConfig,
     }),
+    // bundle cjs
     generateBundleCjsConfig({
       output: {
         distPath: {
@@ -38,6 +40,7 @@ export default defineConfig({
       },
       ...bannerFooterConfig,
     }),
+    // bundleless esm
     generateBundleEsmConfig({
       output: {
         distPath: {
@@ -56,6 +59,7 @@ export default defineConfig({
       },
       ...bannerFooterConfig,
     }),
+    // bundleless cjs
     generateBundleCjsConfig({
       output: {
         distPath: {
@@ -71,6 +75,18 @@ export default defineConfig({
         entry: {
           index: ['./src/**/*.ts'],
         },
+      },
+      ...bannerFooterConfig,
+    }),
+    // bundle esm with minify enabled
+    generateBundleEsmConfig({
+      output: {
+        distPath: {
+          root: './dist/esm/bundle-minify',
+        },
+      },
+      dts: {
+        bundle: true,
       },
       ...bannerFooterConfig,
     }),

--- a/e2e/cases/banner-footer/src/foo.ts
+++ b/e2e/cases/banner-footer/src/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/e2e/cases/banner-footer/src/index.css
+++ b/e2e/cases/banner-footer/src/index.css
@@ -1,0 +1,3 @@
+.a {
+  color: black;
+}

--- a/e2e/cases/banner-footer/src/index.ts
+++ b/e2e/cases/banner-footer/src/index.ts
@@ -1,0 +1,4 @@
+import './index.css';
+import { foo } from './foo';
+
+export const text = foo;

--- a/e2e/cases/banner-footer/tsconfig.json
+++ b/e2e/cases/banner-footer/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "include": ["src"]
+}

--- a/e2e/cases/extension-alias/rslib.config.ts
+++ b/e2e/cases/extension-alias/rslib.config.ts
@@ -7,8 +7,5 @@ export default defineConfig({
     entry: {
       index: './src/index.ts',
     },
-    alias: {
-      '@src': 'src',
-    },
   },
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -309,6 +309,7 @@ export function composeBannerFooterConfig(
         new rspack.BannerPlugin({
           banner: bannerConfig.js,
           stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+          raw: true,
           include: /\.(js|mjs|cjs)$/,
         }),
       );
@@ -318,6 +319,7 @@ export function composeBannerFooterConfig(
         new rspack.BannerPlugin({
           banner: bannerConfig.css,
           stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+          raw: true,
           include: /\.(css)$/,
         }),
       );
@@ -330,6 +332,7 @@ export function composeBannerFooterConfig(
         new rspack.BannerPlugin({
           banner: footerConfig.js,
           stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+          raw: true,
           footer: true,
           include: /\.(js|mjs|cjs)$/,
         }),
@@ -340,6 +343,7 @@ export function composeBannerFooterConfig(
         new rspack.BannerPlugin({
           banner: footerConfig.css,
           stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+          raw: true,
           footer: true,
           include: /\.(css)$/,
         }),

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -308,7 +308,7 @@ export function composeBannerFooterConfig(
       plugins.push(
         new rspack.BannerPlugin({
           banner: bannerConfig.js,
-          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE + 1,
           raw: true,
           include: /\.(js|mjs|cjs)$/,
         }),
@@ -318,7 +318,7 @@ export function composeBannerFooterConfig(
       plugins.push(
         new rspack.BannerPlugin({
           banner: bannerConfig.css,
-          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE + 1,
           raw: true,
           include: /\.(css)$/,
         }),
@@ -331,7 +331,7 @@ export function composeBannerFooterConfig(
       plugins.push(
         new rspack.BannerPlugin({
           banner: footerConfig.js,
-          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE + 1,
           raw: true,
           footer: true,
           include: /\.(js|mjs|cjs)$/,
@@ -342,7 +342,7 @@ export function composeBannerFooterConfig(
       plugins.push(
         new rspack.BannerPlugin({
           banner: footerConfig.css,
-          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE + 1,
           raw: true,
           footer: true,
           include: /\.(css)$/,

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -39,6 +39,12 @@ export type AutoExternal =
       peerDependencies?: boolean;
     };
 
+export type BannerAndFooter = {
+  js?: string;
+  css?: string;
+  dts?: string;
+};
+
 export interface LibConfig extends RsbuildConfig {
   bundle?: boolean;
   format?: Format;
@@ -47,6 +53,8 @@ export interface LibConfig extends RsbuildConfig {
   /** Support esX and browserslist query */
   syntax?: Syntax;
   externalHelpers?: boolean;
+  banner?: BannerAndFooter;
+  footer?: BannerAndFooter;
   dts?: Dts;
 }
 

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -126,6 +126,25 @@ export const readPackageJson = (rootPath: string): undefined | PkgJson => {
 export const isObject = (obj: unknown): obj is Record<string, any> =>
   Object.prototype.toString.call(obj) === '[object Object]';
 
+export const isEmptyObject = (obj: object): boolean => {
+  return Object.keys(obj).length === 0;
+};
+
+export function pick<T, U extends keyof T>(
+  obj: T,
+  keys: ReadonlyArray<U>,
+): Pick<T, U> {
+  return keys.reduce(
+    (ret, key) => {
+      if (obj[key] !== undefined) {
+        ret[key] = obj[key];
+      }
+      return ret;
+    },
+    {} as Pick<T, U>,
+  );
+}
+
 export function omit<T extends object, U extends keyof T>(
   obj: T,
   keys: ReadonlyArray<U>,

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "fast-glob": "^3.3.2",
+    "magic-string": "^0.30.1",
     "picocolors": "1.0.1"
   },
   "devDependencies": {

--- a/packages/plugin-dts/src/apiExtractor.ts
+++ b/packages/plugin-dts/src/apiExtractor.ts
@@ -7,13 +7,15 @@ import {
 import { logger } from '@rsbuild/core';
 import color from 'picocolors';
 import type { DtsEntry } from './index';
-import { getTimeCost } from './utils';
+import { addBannerAndFooter, getTimeCost } from './utils';
 
 export type BundleOptions = {
   name: string;
   cwd: string;
   outDir: string;
   dtsExtension: string;
+  banner?: string;
+  footer?: string;
   dtsEntry: DtsEntry;
   tsconfigPath?: string;
   bundledPackages?: string[];
@@ -25,6 +27,8 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
     cwd,
     outDir,
     dtsExtension,
+    banner,
+    footer,
     dtsEntry = {
       name: 'index',
       path: 'index.d.ts',
@@ -68,6 +72,8 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
     if (!extractorResult.succeeded) {
       throw new Error(`API Extractor error. ${color.gray(`(${name})`)}`);
     }
+
+    await addBannerAndFooter(untrimmedFilePath, banner, footer);
 
     logger.info(
       `API Extractor bundle DTS succeeded: ${color.cyan(untrimmedFilePath)} in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -112,6 +112,8 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
     dtsExtension = '.d.ts',
     autoExternal = true,
     userExternals,
+    banner,
+    footer,
   } = data;
   logger.start(`Generating DTS... ${color.gray(`(${name})`)}`);
   const configPath = ts.findConfigFile(cwd, ts.sys.fileExists, tsconfigPath);
@@ -168,6 +170,8 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
         },
         tsconfigPath,
         dtsExtension,
+        banner,
+        footer,
         bundledPackages: calcBundledPackages({
           autoExternal,
           cwd,
@@ -190,6 +194,8 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
       configPath,
       declarationDir,
       dtsExtension,
+      banner,
+      footer,
     },
     onComplete,
     bundle,

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -15,6 +15,8 @@ export type PluginDtsOptions = {
         devDependencies?: boolean;
         peerDependencies?: boolean;
       };
+  banner?: string;
+  footer?: string;
 };
 
 export type DtsEntry = {

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -14,6 +14,8 @@ export type EmitDtsOptions = {
   configPath: string;
   declarationDir: string;
   dtsExtension: string;
+  banner?: string;
+  footer?: string;
 };
 
 export async function emitDts(
@@ -23,7 +25,8 @@ export async function emitDts(
   isWatch = false,
 ): Promise<void> {
   const start = Date.now();
-  const { configPath, declarationDir, name, dtsExtension } = options;
+  const { configPath, declarationDir, name, dtsExtension, banner, footer } =
+    options;
   const { options: rawCompilerOptions, fileNames } = loadTsconfig(configPath);
 
   const compilerOptions = {
@@ -60,7 +63,7 @@ export async function emitDts(
       diagnosticMessages.push(message);
     }
 
-    await processDtsFiles(bundle, declarationDir, dtsExtension);
+    await processDtsFiles(bundle, declarationDir, dtsExtension, banner, footer);
 
     if (diagnosticMessages.length) {
       logger.error(
@@ -122,13 +125,25 @@ export async function emitDts(
         } else {
           logger.error(message);
         }
-        await processDtsFiles(bundle, declarationDir, dtsExtension);
+        await processDtsFiles(
+          bundle,
+          declarationDir,
+          dtsExtension,
+          banner,
+          footer,
+        );
       }
 
       // 6193: 1 error
       if (diagnostic.code === 6193) {
         logger.error(message);
-        await processDtsFiles(bundle, declarationDir, dtsExtension);
+        await processDtsFiles(
+          bundle,
+          declarationDir,
+          dtsExtension,
+          banner,
+          footer,
+        );
       }
     };
 

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -94,8 +94,8 @@ export async function addBannerAndFooter(
   const content = await fsP.readFile(file, 'utf-8');
   const code = new MagicString(content);
 
-  banner && code.prepend(`/*! ${banner} */\n`);
-  footer && code.append(`\n/*! ${footer} */`);
+  banner && code.prepend(`${banner}\n`);
+  footer && code.append(`\n${footer}\n`);
 
   await fsP.writeFile(file, code.toString());
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
 
+  e2e/cases/banner-footer: {}
+
   e2e/cases/bundle-false/basic: {}
 
   e2e/cases/bundle-false/relative-import: {}
@@ -345,6 +347,9 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
+      magic-string:
+        specifier: ^0.30.1
+        version: 0.30.10
       picocolors:
         specifier: 1.0.1
         version: 1.0.1


### PR DESCRIPTION
## Summary

This PR implements the `banner` and `footer` feature.

We use [bannerPlugin](https://rspack.dev/zh/plugins/webpack/banner-plugin#bannerplugin) of Rspack to add banner and footer in js/css build. 

Notice: 

1. only `string` type is supported and will not be wrapped in a comment. 
2. The default stage is `PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE + 1` to prevent avoid influence of minimizers
3. If you have further demand on banner and footer, you can directly use [bannerPlugin](https://rspack.dev/zh/plugins/webpack/banner-plugin#bannerplugin).

```ts
type BannerAndFooter = {
  js?: string;
  css?: string;
  dts?: string;
};

interface LibConfig extends RsbuildConfig {
  banner?: BannerAndFooter;
  footer?: BannerAndFooter;
}
```

Since support of css of bundleless mode is not ready, we ignore css banner and footer tests in bundleless mode.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
