### PR TITLE
ci: only trigger docs preview on demand

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF website package.json pnpm-lock.yaml netlify.toml .npmrc"


### PR DESCRIPTION
## Summary

Don't create preview documents for every pull request, it's noisy and wastes resources. Only trigger them when the documentation is relevant.

https://docs.netlify.com/configure-builds/ignore-builds/#mimic-default-behavior:~:text=The%20following%20ignore%20command%20example%20adapts%20the%20default%20behavior%20so%20that%20the%20build%20proceeds%20only%20if%20there%20are%20changes%20within%20the%20blog%2D1%20or%20common%20directories.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
