### PR TITLE
fix: derive `rspack.target` from `libConfig.syntax`

### DIFF
--- a/e2e/cases/syntax/index.test.ts
+++ b/e2e/cases/syntax/index.test.ts
@@ -23,5 +23,7 @@ test('should downgrade class private method with output.syntax config', async ()
   expect(entries.esm1).toContain('#bar');
 
   expect(entries.cjs0).toContain('#bar');
+  expect(entries.cjs0).toContain('()=>{'); // test webpack runtime arrow function
   expect(entries.cjs1).not.toContain('#bar');
+  expect(entries.cjs1).not.toContain('()=>{'); // test webpack runtime arrow function
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -560,18 +560,17 @@ const composeSyntaxConfig = (
   // Defaults to ESNext, Rslib will assume all of the latest JavaScript and CSS features are supported.
 
   if (syntax) {
+    const resolvedBrowserslist = transformSyntaxToBrowserslist(syntax, target);
     return {
       tools: {
         rspack: (config) => {
-          // TODO: Rspack should could resolve `browserslist:{query}` like webpack.
-          // https://webpack.js.org/configuration/target/#browserslist
-          // Using 'es5' as a temporary solution for compatibility.
-          config.target = ['es5'];
-          return config;
+          config.target = resolvedBrowserslist.map(
+            (item) => `browserslist:${item}` as const,
+          );
         },
       },
       output: {
-        overrideBrowserslist: transformSyntaxToBrowserslist(syntax, target),
+        overrideBrowserslist: resolvedBrowserslist,
       },
     };
   }
@@ -725,6 +724,11 @@ const composeTargetConfig = (
         tools: {
           rspack: {
             target: ['web'],
+            output: {
+              chunkLoading: 'import',
+              workerChunkLoading: 'import',
+              wasmLoading: 'fetch',
+            },
           },
         },
       };
@@ -736,6 +740,11 @@ const composeTargetConfig = (
             // "__dirname" and "__filename" shims will automatically be enabled when `output.module` is `true`,
             // and leave them as-is in the rest of the cases.
             // { node: { __dirname: ..., __filename: ... } }
+            output: {
+              chunkLoading: 'require',
+              workerChunkLoading: 'async-node',
+              wasmLoading: 'async-node',
+            },
           },
         },
         output: {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -119,6 +119,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           },
           [Function],
           {
+            "output": {
+              "chunkLoading": "import",
+              "wasmLoading": "fetch",
+              "workerChunkLoading": "import",
+            },
             "target": [
               "web",
             ],
@@ -248,6 +253,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           },
           [Function],
           {
+            "output": {
+              "chunkLoading": "import",
+              "wasmLoading": "fetch",
+              "workerChunkLoading": "import",
+            },
             "target": [
               "web",
             ],
@@ -371,6 +381,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           },
           [Function],
           {
+            "output": {
+              "chunkLoading": "import",
+              "wasmLoading": "fetch",
+              "workerChunkLoading": "import",
+            },
             "target": [
               "web",
             ],


### PR DESCRIPTION
## Summary

Fix https://github.com/web-infra-dev/rslib/issues/209.

- only webpack runtime related code will be affected.
- need to manually assign `{type}loading` as it derive the value from `target` by default, which will lead to unimpelmented `universal` type.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
