### PR TITLE
feat: support `import.meta.url` shim for CJS

### DIFF
--- a/e2e/cases/shims/cjs/package.json
+++ b/e2e/cases/shims/cjs/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "shims-cjs-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/e2e/cases/shims/cjs/rslib.config.ts
+++ b/e2e/cases/shims/cjs/rslib.config.ts
@@ -1,0 +1,14 @@
+import { generateBundleCjsConfig } from '@e2e/helper';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [generateBundleCjsConfig()],
+  output: {
+    target: 'node',
+  },
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+});

--- a/e2e/cases/shims/cjs/src/index.ts
+++ b/e2e/cases/shims/cjs/src/index.ts
@@ -1,0 +1,3 @@
+export const foo = () => {
+  console.log(import.meta.url);
+};

--- a/e2e/cases/shims/index.test.ts
+++ b/e2e/cases/shims/index.test.ts
@@ -16,4 +16,15 @@ test('shims for __dirname and __filename in ESM', async () => {
   }
 });
 
-test.todo('shims for import.meta.url in CJS', async () => {});
+test('shims for import.meta.url in CJS', async () => {
+  const fixturePath = join(__dirname, 'cjs');
+  const { entries } = await buildAndGetResults(fixturePath);
+  for (const shim of [
+    `var __rslib_import_meta_url__ = /*#__PURE__*/ function() {
+    'undefined' == typeof document ? new (require('url'.replace('', ''))).URL('file:' + __filename).href : document.currentScript && document.currentScript.src || new URL('main.js', document.baseURI).href;
+}();`,
+    'console.log(__rslib_import_meta_url__);',
+  ]) {
+    expect(entries.cjs).toContain(shim);
+  }
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_EXTENSIONS,
   SWC_HELPERS,
 } from './constant';
+import { pluginCjsShim } from './plugins/cjsShim';
 import type {
   AutoExternal,
   BannerAndFooter,
@@ -456,8 +457,16 @@ const composeFormatConfig = (format: Format): RsbuildConfig => {
       };
     case 'cjs':
       return {
+        plugins: [pluginCjsShim()],
         tools: {
           rspack: {
+            module: {
+              parser: {
+                javascript: {
+                  importMeta: false,
+                },
+              },
+            },
             output: {
               iife: false,
               chunkFormat: 'commonjs',
@@ -472,6 +481,13 @@ const composeFormatConfig = (format: Format): RsbuildConfig => {
       return {
         tools: {
           rspack: {
+            module: {
+              parser: {
+                javascript: {
+                  importMeta: false,
+                },
+              },
+            },
             output: {
               library: {
                 type: 'umd',

--- a/packages/core/src/plugins/cjsShim.ts
+++ b/packages/core/src/plugins/cjsShim.ts
@@ -1,0 +1,41 @@
+import { type RsbuildPlugin, rspack } from '@rsbuild/core';
+
+const importMetaUrlShim = `var __rslib_import_meta_url__ = /*#__PURE__*/ (function () {
+  typeof document === 'undefined'
+    ? new (require('url'.replace('', '')).URL)('file:' + __filename).href
+    : (document.currentScript && document.currentScript.src) ||
+      new URL('main.js', document.baseURI).href;
+})();
+`;
+
+// This Rsbuild plugin will shim `import.meta.url` for CommonJS modules.
+// - Replace `import.meta.url` with `importMetaUrl`.
+// - Inject `importMetaUrl` to the end of the module (can't inject at the beginning because of `"use strict";`).
+// This is a short-term solution, and we hope to provide built-in polyfills like `node.__filename` on Rspack side.
+export const pluginCjsShim = (): RsbuildPlugin => ({
+  name: 'rsbuild-plugin-cjs-shim',
+
+  setup(api) {
+    api.modifyRsbuildConfig((config) => {
+      config.source ||= {};
+      config.source.define = {
+        ...config.source.define,
+        'import.meta.url': '__rslib_import_meta_url__',
+      };
+    });
+
+    api.modifyRspackConfig((config) => {
+      config.plugins ??= [];
+      config.plugins.push(
+        new rspack.BannerPlugin({
+          banner: importMetaUrlShim,
+          // Just before minify stage, to perform tree shaking.
+          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE - 1,
+          raw: true,
+          footer: true,
+          include: /\.(js|cjs)$/,
+        }),
+      );
+    });
+  },
+});

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -191,6 +191,12 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           "not dead",
         ],
       },
+      "plugins": [
+        {
+          "name": "rsbuild-plugin-cjs-shim",
+          "setup": [Function],
+        },
+      ],
       "source": {
         "alias": {
           "bar": "bar/cjs",
@@ -243,6 +249,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           },
           {
             "externalsType": "commonjs",
+            "module": {
+              "parser": {
+                "javascript": {
+                  "importMeta": false,
+                },
+              },
+            },
             "output": {
               "chunkFormat": "commonjs",
               "iife": false,
@@ -373,6 +386,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           },
           {
             "externalsType": "umd",
+            "module": {
+              "parser": {
+                "javascript": {
+                  "importMeta": false,
+                },
+              },
+            },
             "output": {
               "library": {
                 "type": "umd",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,8 @@ importers:
 
   e2e/cases/resolve/with-main-fields: {}
 
+  e2e/cases/shims/cjs: {}
+
   e2e/cases/shims/esm: {}
 
   e2e/cases/sourcemap/default: {}


### PR DESCRIPTION
## Summary

This Rsbuild plugin will shim `import.meta.url` for CommonJS modules.
- Replace `import.meta.url` with `importMetaUrl`.
- Inject `importMetaUrl` to the end of the module (can't inject at the beginning because of `"use strict";`).
This is a short-term solution, and we hope to provide built-in polyfills like `node.__filename` on Rspack side.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
