### PR TITLE
fix: do not transform esX for rspack.target field

### DIFF
--- a/e2e/cases/shims/esm/rslib.config.ts
+++ b/e2e/cases/shims/esm/rslib.config.ts
@@ -3,9 +3,20 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
-    generateBundleEsmConfig(),
+    generateBundleEsmConfig({
+      output: {
+        distPath: {
+          root: './dist/normal',
+        },
+      },
+    }),
     generateBundleEsmConfig({
       syntax: 'esnext',
+      output: {
+        distPath: {
+          root: './dist/with-syntax',
+        },
+      },
     }),
   ],
   output: {

--- a/e2e/cases/shims/esm/rslib.config.ts
+++ b/e2e/cases/shims/esm/rslib.config.ts
@@ -2,7 +2,12 @@ import { generateBundleEsmConfig } from '@e2e/helper';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [generateBundleEsmConfig()],
+  lib: [
+    generateBundleEsmConfig(),
+    generateBundleEsmConfig({
+      syntax: 'esnext',
+    }),
+  ],
   output: {
     target: 'node',
   },

--- a/e2e/cases/shims/index.test.ts
+++ b/e2e/cases/shims/index.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'vitest';
 test('shims for __dirname and __filename in ESM', async () => {
   const fixturePath = join(__dirname, 'esm');
   const { entries } = await buildAndGetResults(fixturePath);
+
   for (const shim of [
     'import { fileURLToPath as __webpack_fileURLToPath__ } from "url";',
     'var src_dirname = __webpack_dirname__(__webpack_fileURLToPath__(import.meta.url));',
@@ -12,8 +13,9 @@ test('shims for __dirname and __filename in ESM', async () => {
     // import.meta.url should not be substituted
     'const importMetaUrl = import.meta.url;',
   ]) {
-    expect(entries.esm).toContain(shim);
+    expect(entries.esm0).toContain(shim);
   }
+  expect(entries.esm0).toBe(entries.esm1);
 });
 
 describe('shims for `import.meta.url` in CJS', () => {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:e2e": "cd e2e && pnpm run test",
     "test:unit": "vitest run --project unit*",
     "test:unit:watch": "vitest --project unit*",
+    "testu": "pnpm run test:unit -u && pnpm run test:artifact -u",
     "update:rsbuild": "npx taze minor --include /rsbuild/ -w -r -l",
     "watch": "pnpm build --watch"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -46,6 +46,7 @@ import { logger } from './utils/logger';
 import {
   ESX_TO_BROWSERSLIST,
   transformSyntaxToBrowserslist,
+  transformSyntaxToRspackTarget,
 } from './utils/syntax';
 import { loadTsconfig } from './utils/tsconfig';
 
@@ -578,19 +579,15 @@ const composeSyntaxConfig = (
   target?: RsbuildConfigOutputTarget,
 ): RsbuildConfig => {
   // Defaults to ESNext, Rslib will assume all of the latest JavaScript and CSS features are supported.
-
   if (syntax) {
-    const resolvedBrowserslist = transformSyntaxToBrowserslist(syntax, target);
     return {
       tools: {
         rspack: (config) => {
-          config.target = resolvedBrowserslist.map(
-            (item) => `browserslist:${item}` as const,
-          );
+          config.target = transformSyntaxToRspackTarget(syntax);
         },
       },
       output: {
-        overrideBrowserslist: resolvedBrowserslist,
+        overrideBrowserslist: transformSyntaxToBrowserslist(syntax, target),
       },
     };
   }

--- a/packages/core/src/utils/syntax.ts
+++ b/packages/core/src/utils/syntax.ts
@@ -166,7 +166,6 @@ export const ESX_TO_BROWSERSLIST: Record<
 
 export function transformSyntaxToRspackTarget(
   syntax: Syntax,
-  // target?: NonNullable<RsbuildConfig['output']>['target'],
 ): Rspack.Configuration['target'] {
   const handleSyntaxItem = (syntaxItem: EcmaScriptVersion | string): string => {
     const normalizedSyntaxItem = syntaxItem.toLowerCase();

--- a/packages/core/tests/syntax.test.ts
+++ b/packages/core/tests/syntax.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from 'vitest';
-import { transformSyntaxToBrowserslist } from '../src/utils/syntax';
+import {
+  transformSyntaxToBrowserslist,
+  transformSyntaxToRspackTarget,
+} from '../src/utils/syntax';
 
-describe('Correctly resolve syntax', () => {
-  test('esX', async () => {
+describe('transformSyntaxToBrowserslist', () => {
+  test('esX', () => {
     expect(transformSyntaxToBrowserslist('es6')).toMatchInlineSnapshot(`
       [
         "Chrome >= 63.0.0",
@@ -56,7 +59,7 @@ describe('Correctly resolve syntax', () => {
     );
   });
 
-  test('browserslist', async () => {
+  test('browserslist', () => {
     expect(
       transformSyntaxToBrowserslist(['fully supports es6-module']),
     ).toMatchInlineSnapshot(`
@@ -75,7 +78,7 @@ describe('Correctly resolve syntax', () => {
     `);
   });
 
-  test('combined', async () => {
+  test('combined', () => {
     expect(
       transformSyntaxToBrowserslist(['Chrome 123', 'es5']),
     ).toMatchInlineSnapshot(`
@@ -95,5 +98,43 @@ describe('Correctly resolve syntax', () => {
     expect(transformSyntaxToBrowserslist(['es5'])).toEqual(
       transformSyntaxToBrowserslist('es5'),
     );
+  });
+});
+
+describe('transformSyntaxToRspackTarget', () => {
+  test('esX', () => {
+    const es2023 = transformSyntaxToRspackTarget('es2023');
+    const es2024 = transformSyntaxToRspackTarget('es2024');
+    const esnext = transformSyntaxToRspackTarget('esnext');
+
+    expect(es2023).toEqual(es2024);
+    expect(es2023).toEqual(esnext);
+
+    expect(es2023).toMatchInlineSnapshot(
+      `
+      [
+        "es2022",
+      ]
+    `,
+    );
+
+    expect(transformSyntaxToRspackTarget('es2015')).toMatchInlineSnapshot(
+      `
+      [
+        "es2015",
+      ]
+    `,
+    );
+  });
+
+  test('combined', () => {
+    expect(
+      transformSyntaxToRspackTarget(['Chrome 123', 'es2023']),
+    ).toMatchInlineSnapshot(`
+      [
+        "browserslist:Chrome 123",
+        "es2022",
+      ]
+    `);
   });
 });


### PR DESCRIPTION
## Summary

Fix #236.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
