### PR TITLE
chore: update renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,40 +5,40 @@
   packageRules: [
     // Use chore as semantic commit type for commit messages
     {
-      matchPackagePatterns: ['*'],
+      matchPackageNames: ['**'],
       semanticCommitType: 'chore',
       // always bump package.json
       rangeStrategy: 'bump',
     },
     {
       groupName: 'babel',
-      packagePatterns: ['babel'],
+      matchPackageNames: ['**babel**'],
       groupSlug: 'babel',
     },
     {
       groupName: 'rsbuild',
-      packagePatterns: ['rsbuild'],
+      matchPackageNames: ['@rsbuild/**'],
       groupSlug: 'rsbuild',
     },
     {
       groupName: 'rspress',
-      packagePatterns: ['rspress'],
+      matchPackageNames: ['@rspress/**'],
       groupSlug: 'rspress',
     },
     {
       groupName: 'modern-js',
-      packagePatterns: ['modern-js'],
+      matchPackageNames: ['@modern-js/**'],
       groupSlug: 'modern-js',
     },
     {
       groupName: 'types',
-      packagePatterns: ['^@types/'],
+      matchPackageNames: ['@types/**'],
       groupSlug: 'types',
     },
     {
       groupName: 'all patch dependencies',
       groupSlug: 'all-patch',
-      matchPackagePatterns: ['*'],
+      matchPackageNames: ['**'],
       matchUpdateTypes: ['patch'],
     },
     // manually update peer dependencies


### PR DESCRIPTION
## Summary

`matchPackageNames` is no longer on https://docs.renovatebot.com/configuration-options/#matchpackagenames.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
