### PR TITLE
fix(dts): disable autoExtension for dts by default

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -746,7 +746,7 @@ const composeDtsConfig = async (
         bundle: dts?.bundle ?? bundle,
         distPath: dts?.distPath ?? output?.distPath?.root ?? './dist',
         abortOnError: dts?.abortOnError ?? true,
-        dtsExtension,
+        dtsExtension: dts?.autoExtension ? dtsExtension : '.d.ts',
         autoExternal,
         banner: banner?.dts,
         footer: footer?.dts,

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -1,4 +1,5 @@
 import type { RsbuildConfig } from '@rsbuild/core';
+import type { PluginDtsOptions } from 'rsbuild-plugin-dts';
 
 export type Format = 'esm' | 'cjs' | 'umd';
 
@@ -28,11 +29,9 @@ export type Syntax =
   | string[];
 
 export type Dts =
-  | {
-      bundle: boolean;
-      distPath?: string;
-      abortOnError?: boolean;
-    }
+  | (Pick<PluginDtsOptions, 'bundle' | 'distPath' | 'abortOnError'> & {
+      autoExtension?: boolean;
+    })
   | false;
 
 export type AutoExternal =

--- a/tests/integration/dts/__snapshots__/index.test.ts.snap
+++ b/tests/integration/dts/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`dts when bundle: false > basic 2`] = `
+exports[`dts when bundle: false > basic 3`] = `
 {
   "<ROOT>/tests/integration/dts/bundle-false/basic/dist/esm/index.d.ts": "export * from './utils/numbers';
 export * from './utils/strings';
@@ -20,8 +20,26 @@ export declare const str3 = "str3";
 }
 `;
 
-exports[`dts when bundle: true > basic 2`] = `
+exports[`dts when bundle: true > basic 3`] = `
 {
+  "cjs": "export declare const num1 = 1;
+
+export declare const num2 = 2;
+
+export declare const num3 = 3;
+
+export declare const numSum: number;
+
+export declare const str1 = "str1";
+
+export declare const str2 = "str2";
+
+export declare const str3 = "str3";
+
+export declare const strSum: string;
+
+export { }
+",
   "esm": "export declare const num1 = 1;
 
 export declare const num2 = 2;

--- a/tests/integration/dts/bundle-false/auto-extension/rslib.config.ts
+++ b/tests/integration/dts/bundle-false/auto-extension/rslib.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     generateBundleCjsConfig({
       bundle: false,
       dts: {
+        autoExtension: true,
         bundle: false,
       },
     }),

--- a/tests/integration/dts/bundle-false/basic/rslib.config.ts
+++ b/tests/integration/dts/bundle-false/basic/rslib.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     }),
     generateBundleCjsConfig({
       bundle: false,
+      dts: {
+        bundle: false,
+      },
     }),
   ],
   source: {

--- a/tests/integration/dts/bundle/auto-extension/rslib.config.ts
+++ b/tests/integration/dts/bundle/auto-extension/rslib.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     generateBundleCjsConfig({
       dts: {
         bundle: true,
+        autoExtension: true,
       },
     }),
   ],

--- a/tests/integration/dts/bundle/basic/rslib.config.ts
+++ b/tests/integration/dts/bundle/basic/rslib.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
         bundle: true,
       },
     }),
-    generateBundleCjsConfig(),
+    generateBundleCjsConfig({
+      dts: {
+        bundle: true,
+      },
+    }),
   ],
   source: {
     entry: {

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -15,6 +15,16 @@ describe('dts when bundle: false', () => {
         "<ROOT>/tests/integration/dts/bundle-false/basic/dist/esm/utils/strings.d.ts",
       ]
     `);
+
+    expect(files.cjs).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle-false/basic/dist/cjs/index.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/basic/dist/cjs/sum.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/basic/dist/cjs/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/basic/dist/cjs/utils/strings.d.ts",
+      ]
+    `);
+
     expect(contents.esm).toMatchSnapshot();
   });
 
@@ -72,6 +82,11 @@ describe('dts when bundle: true', () => {
     expect(entryFiles.esm).toMatchInlineSnapshot(
       `"<ROOT>/tests/integration/dts/bundle/basic/dist/esm/index.d.ts"`,
     );
+
+    expect(entryFiles.cjs).toMatchInlineSnapshot(
+      `"<ROOT>/tests/integration/dts/bundle/basic/dist/cjs/index.d.ts"`,
+    );
+
     expect(entries).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## Summary

For common usage, using `.d.ts` is sufficient for most cases. `autoExtension` is broken for non module type package now (see https://github.com/web-infra-dev/rslib/issues/263). This PR disable it by default, we might switch it back in the future.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
