### PR TITLE
ci: clean up and lock benchmark node version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Install Pnpm
         run: corepack enable
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 18
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 18
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js 18
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 18
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js 18
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 18
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -16,12 +16,14 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # ======== ut ========
-  ut-ubuntu:
+  # ======== caculate changes ========
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -44,27 +46,45 @@ jobs:
               - "!**/_meta.json"
               - "!**/dictionary.txt"
 
+  # ======== ut ========
+  ut-ubuntu:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.changed == 'true' }}
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+
+      - name: Install Pnpm
+        run: corepack enable
+
       - name: Setup Node.js ${{ matrix.node-version }}
-        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
       - name: Install Dependencies
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm install
 
       - name: Unit Test
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm run test:unit
 
   # ======== integration && e2e ========
   integration-e2e-ubuntu:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18, 20, 22]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -76,40 +96,53 @@ jobs:
       - name: Install Pnpm
         run: corepack enable
 
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!**/_meta.json"
-              - "!**/dictionary.txt"
-
       - name: Setup Node.js ${{ matrix.node-version }}
-        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
       - name: Install Dependencies
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm install && cd ./tests && npx playwright install
 
       - name: Integration Test (Vitest)
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm run test:integration
 
       - name: E2E Test (Playwright)
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm run test:e2e
+
+  # ======== benchmark ========
+  benchemark-ubuntu:
+    # Only Ubuntu 20.04 and 22.04 are supported at the moment.
+    # See https://github.com/CodSpeedHQ/action/blob/016456b513677f9d4a1c509c7f8a38d8dd55b2b0/.github/workflows/ci.yml#L19.
+    runs-on: ubuntu-22.04
+    needs: [integration-e2e-ubuntu]
+    strategy:
+      matrix:
+        node-version: [20]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+
+      - name: Install Pnpm
+        run: corepack enable
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install && cd ./tests && npx playwright install
 
       # only run benchmark in Ubuntu
       - name: Benchmarks (Vitest)
         uses: CodSpeedHQ/action@v3
-        if: steps.changes.outputs.changed == 'true'
         with:
           run: pnpm run test:benchmark
           # token retrieved from the CodSpeed app at the previous step

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -16,12 +16,44 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  # ======== caculate changes ========
+  changes:
+    runs-on: windows-latest
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
+    strategy:
+      matrix:
+        node-version: [18]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+
+      - name: Install Pnpm
+        run: corepack enable
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            changed:
+              - "!**/*.md"
+              - "!**/*.mdx"
+              - "!**/_meta.json"
+              - "!**/dictionary.txt"
+
   # ======== ut ========
   ut-windows:
     runs-on: windows-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -38,38 +70,26 @@ jobs:
       - name: Install Pnpm
         run: corepack enable
 
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!**/_meta.json"
-              - "!**/dictionary.txt"
-
       - name: Setup Node.js ${{ matrix.node-version }}
-        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
       - name: Install Dependencies
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm install
 
       - name: Unit Test
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm run test:unit
 
-  # # ======== integration && e2e ========
+  # ======== integration && e2e ========
   integration-e2e-windows:
     runs-on: windows-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -86,31 +106,17 @@ jobs:
       - name: Install Pnpm
         run: corepack enable
 
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!**/_meta.json"
-              - "!**/dictionary.txt"
-
       - name: Setup Node.js ${{ matrix.node-version }}
-        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+
       - name: Install Dependencies
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm install && cd ./tests && npx playwright install
 
       - name: Integration Test (Vitest)
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm run test:integration
 
       - name: E2E Test (Playwright)
-        if: steps.changes.outputs.changed == 'true'
         run: pnpm run test:e2e


### PR DESCRIPTION
## Summary

Ref: https://github.com/web-infra-dev/rslib/pull/266#issuecomment-2404134989

- lock benchmark node version
- run integration tests on 18 20 22
- clean ci

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
