### PR TITLE
fix: inline `import.meta.url` shims in CJS

### DIFF
--- a/packages/core/src/plugins/cjsShim.ts
+++ b/packages/core/src/plugins/cjsShim.ts
@@ -1,12 +1,11 @@
-import { type RsbuildPlugin, rspack } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
-const importMetaUrlShim = `var __rslib_import_meta_url__ = /*#__PURE__*/ (function () {
+const importMetaUrlShim = `/*#__PURE__*/ (function () {
   return typeof document === 'undefined'
     ? new (require('url'.replace('', '')).URL)('file:' + __filename).href
     : (document.currentScript && document.currentScript.src) ||
       new URL('main.js', document.baseURI).href;
-})();
-`;
+})()`;
 
 // This Rsbuild plugin will shim `import.meta.url` for CommonJS modules.
 // - Replace `import.meta.url` with `importMetaUrl`.
@@ -19,22 +18,8 @@ export const pluginCjsShim = (): RsbuildPlugin => ({
     api.modifyEnvironmentConfig((config) => {
       config.source.define = {
         ...config.source.define,
-        'import.meta.url': '__rslib_import_meta_url__',
+        'import.meta.url': importMetaUrlShim,
       };
-    });
-
-    api.modifyRspackConfig((config) => {
-      config.plugins ??= [];
-      config.plugins.push(
-        new rspack.BannerPlugin({
-          banner: importMetaUrlShim,
-          // Just before minify stage, to perform tree shaking.
-          stage: rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE - 1,
-          raw: true,
-          footer: true,
-          include: /\.(js|cjs)$/,
-        }),
-      );
     });
   },
 });

--- a/tests/integration/require/index.test.ts
+++ b/tests/integration/require/index.test.ts
@@ -23,7 +23,7 @@ test('require.resolve', async () => {
   ];
 
   const cjsStatements = [
-    'const _require = (0, external_node_module_namespaceObject.createRequire)(__rslib_import_meta_url__)',
+    'const _require = (0, external_node_module_namespaceObject.createRequire)(',
   ];
 
   for (const statement of [...statements, ...esmStatements]) {
@@ -52,7 +52,7 @@ test('require dynamic', async () => {
   ];
 
   const cjsStatements = [
-    'const _require = (0, external_node_module_namespaceObject.createRequire)(__rslib_import_meta_url__)',
+    'const _require = (0, external_node_module_namespaceObject.createRequire)(',
   ];
 
   for (const statement of [...statements, ...esmStatements]) {

--- a/tests/integration/shims/cjs/src/index.ts
+++ b/tests/integration/shims/cjs/src/index.ts
@@ -1,3 +1,4 @@
-export const foo = () => {
-  console.log(import.meta.url);
-};
+const url = import.meta.url;
+const readUrl = url;
+
+export default readUrl;


### PR DESCRIPTION
## Summary

Fix https://github.com/web-infra-dev/rslib/issues/274.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
