### PR TITLE
fix(shim): use `module.require` to avoid variable collision

### DIFF
--- a/packages/core/src/plugins/cjsShim.ts
+++ b/packages/core/src/plugins/cjsShim.ts
@@ -2,7 +2,7 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 
 const importMetaUrlShim = `/*#__PURE__*/ (function () {
   return typeof document === 'undefined'
-    ? new (require('url'.replace('', '')).URL)('file:' + __filename).href
+    ? new (module.require('url'.replace('', '')).URL)('file:' + __filename).href
     : (document.currentScript && document.currentScript.src) ||
       new URL('main.js', document.baseURI).href;
 })()`;

--- a/tests/integration/shims/cjs/rslib.config.ts
+++ b/tests/integration/shims/cjs/rslib.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
   output: {
     target: 'node',
+    copy: [{ from: 'src/ok.cjs' }],
   },
   source: {
     entry: {

--- a/tests/integration/shims/cjs/src/index.ts
+++ b/tests/integration/shims/cjs/src/index.ts
@@ -1,4 +1,6 @@
-const url = import.meta.url;
-const readUrl = url;
+import { createRequire } from 'node:module';
+const importMetaUrl = import.meta.url;
+const require = createRequire(import.meta.url);
+const requiredModule = require('./ok.cjs');
 
-export default readUrl;
+export { importMetaUrl, requiredModule };

--- a/tests/integration/shims/cjs/src/ok.cjs
+++ b/tests/integration/shims/cjs/src/ok.cjs
@@ -1,0 +1,1 @@
+module.exports = 'ok';

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -9,7 +9,8 @@
     "integration/**/*.ts",
     "benchmark/**/*.ts",
     "playwright.config.ts",
-    "scripts"
+    "scripts",
+    "integration/shims/cjs/src/ok.cjs"
   ],
   "exclude": ["**/node_modules", "**/.*/"],
   "references": [


### PR DESCRIPTION
## Summary

Fix https://github.com/web-infra-dev/rslib/issues/274, again 😅.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
