### PR TITLE
ci: fix should publish on selected branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 25
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Install Pnpm
         run: corepack enable


### PR DESCRIPTION
## Summary

Previously, it will use the branch of `Use workflow from`. See https://github.com/web-infra-dev/rslib/actions/runs/11339996469/job/31535663657#step:6:19 still releasing on `main` branch although I've set `Release Branch` to another.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
