### PR TITLE
chore: bump Rslib 0.0.12 and adjust dirname/filename

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "memfs": "^4.14.0",
     "picocolors": "1.1.0",
     "prebundle": "1.2.2",
-    "rslib": "npm:@rslib/core@0.0.11",
+    "rslib": "npm:@rslib/core@0.0.12",
     "rslog": "^1.2.3",
     "tsconfck": "3.1.4",
     "typescript": "^5.6.3"

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -35,7 +35,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "~18.19.39",
     "fs-extra": "^11.2.0",
-    "rslib": "npm:@rslib/core@0.0.11",
+    "rslib": "npm:@rslib/core@0.0.12",
     "typescript": "^5.6.3"
   },
   "engines": {

--- a/packages/create-rslib/src/index.ts
+++ b/packages/create-rslib/src/index.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   type Argv,
   type ESLintTemplateName,
@@ -6,6 +7,8 @@ import {
   create,
   select,
 } from 'create-rstack';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function getTemplateName({ template }: Argv) {
   if (typeof template === 'string') {

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -37,7 +37,7 @@
     "@microsoft/api-extractor": "^7.47.9",
     "@rsbuild/core": "~1.0.14",
     "@rslib/tsconfig": "workspace:*",
-    "rslib": "npm:@rslib/core@0.0.11",
+    "rslib": "npm:@rslib/core@0.0.12",
     "typescript": "^5.6.3"
   },
   "peerDependencies": {

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -1,7 +1,11 @@
 import { fork } from 'node:child_process';
-import { extname, join } from 'node:path';
+import { dirname, extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { type RsbuildConfig, type RsbuildPlugin, logger } from '@rsbuild/core';
 import { processSourceEntry } from './utils';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export type PluginDtsOptions = {
   bundle?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,8 @@ importers:
         specifier: 1.2.2
         version: 1.2.2(typescript@5.6.3)
       rslib:
-        specifier: npm:@rslib/core@0.0.11
-        version: '@rslib/core@0.0.11(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(typescript@5.6.3)'
+        specifier: npm:@rslib/core@0.0.12
+        version: '@rslib/core@0.0.12(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(typescript@5.6.3)'
       rslog:
         specifier: ^1.2.3
         version: 1.2.3
@@ -182,8 +182,8 @@ importers:
         specifier: ^11.2.0
         version: 11.2.0
       rslib:
-        specifier: npm:@rslib/core@0.0.11
-        version: '@rslib/core@0.0.11(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(typescript@5.6.3)'
+        specifier: npm:@rslib/core@0.0.12
+        version: '@rslib/core@0.0.12(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(typescript@5.6.3)'
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -210,8 +210,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/tsconfig
       rslib:
-        specifier: npm:@rslib/core@0.0.11
-        version: '@rslib/core@0.0.11(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(typescript@5.6.3)'
+        specifier: npm:@rslib/core@0.0.12
+        version: '@rslib/core@0.0.12(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(typescript@5.6.3)'
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -1276,8 +1276,8 @@ packages:
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-rc.0
 
-  '@rslib/core@0.0.11':
-    resolution: {integrity: sha512-zVW8q5RuLLwNsp+ODqhmpogmQqMvNQepIrHQGP+XEt4nQ/HfhoHFVNscKCIb04EaQDxVWorEYchqIZ2FBWG6tg==}
+  '@rslib/core@0.0.12':
+    resolution: {integrity: sha512-vlrrPAASi7D5jlGfndnJFyG3Q2R0m15oPBBJHNUKCMlDQRb83KM/pU1ihYWIxvfTgO6dK8RnGL8cUmVK4NyZkA==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     peerDependencies:
@@ -3983,8 +3983,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rsbuild-plugin-dts@0.0.11:
-    resolution: {integrity: sha512-jC/tIdyEUCZK+DNQOtlgvULBLYWekb9c9qWl2peLVUl+FJfiiDtt1RJ7xGN5TfZzSwvD42nCt8EwgYvJWQMteQ==}
+  rsbuild-plugin-dts@0.0.12:
+    resolution: {integrity: sha512-MnU011hgc1vgBrD81e05ZTFOST2rIupGQfBLF+ibm+HnzcXUiC7eHFS34q9rx+59IgJcgxpdSCO2JUPNcpiYog==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -5596,10 +5596,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rslib/core@0.0.11(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(typescript@5.6.3)':
+  '@rslib/core@0.0.12(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(typescript@5.6.3)':
     dependencies:
-      '@rsbuild/core': 1.0.12
-      rsbuild-plugin-dts: 0.0.11(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(@rsbuild/core@1.0.12)(typescript@5.6.3)
+      '@rsbuild/core': 1.0.14
+      rsbuild-plugin-dts: 0.0.12(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(@rsbuild/core@1.0.14)(typescript@5.6.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.47.9(@types/node@18.19.39)
       typescript: 5.6.3
@@ -8766,9 +8766,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.18.1
       fsevents: 2.3.3
 
-  rsbuild-plugin-dts@0.0.11(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(@rsbuild/core@1.0.12)(typescript@5.6.3):
+  rsbuild-plugin-dts@0.0.12(@microsoft/api-extractor@7.47.9(@types/node@18.19.39))(@rsbuild/core@1.0.14)(typescript@5.6.3):
     dependencies:
-      '@rsbuild/core': 1.0.12
+      '@rsbuild/core': 1.0.14
       fast-glob: 3.3.2
       magic-string: 0.30.12
       picocolors: 1.1.0


### PR DESCRIPTION
## Summary

Bump Rslib 0.0.12 and adjust `__dirname` and `__filename`, since Rslib no longer inject shims by default for `__dirname` and `__filename`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
