### PR TITLE
chore: remove duplicated workspace definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,6 @@
 {
   "name": "rslib-monorepo",
   "private": true,
-  "workspaces": {
-    "packages": [
-      "packages/*",
-      "scripts/*",
-      "tests/**",
-      "examples/**",
-      "website"
-    ]
-  },
   "scripts": {
     "build": "cross-env NX_DAEMON=false nx run-many -t build --exclude @examples/* --parallel=10",
     "build:examples": "cross-env NX_DAEMON=false nx run-many -t build --projects @examples/* --parallel=10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,11 +413,7 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4(@rsbuild/core@1.0.14)(typescript@5.6.3)
 
-  tests/integration/cli:
-    devDependencies:
-      '@rslib/core':
-        specifier: workspace:*
-        version: link:../../../packages/core
+  tests/integration/cli: {}
 
   tests/integration/copy: {}
 

--- a/tests/integration/cli/index.test.ts
+++ b/tests/integration/cli/index.test.ts
@@ -8,7 +8,7 @@ test.todo('build command', async () => {});
 
 test('inspect command', async () => {
   await fse.remove(path.join(__dirname, 'dist'));
-  execSync('pnpm run inspect', {
+  execSync('npx rslib inspect', {
     cwd: __dirname,
   });
 

--- a/tests/integration/cli/package.json
+++ b/tests/integration/cli/package.json
@@ -2,11 +2,5 @@
   "name": "cli-test",
   "version": "1.0.0",
   "private": true,
-  "type": "module",
-  "scripts": {
-    "inspect": "rslib inspect"
-  },
-  "devDependencies": {
-    "@rslib/core": "workspace:*"
-  }
+  "type": "module"
 }


### PR DESCRIPTION
## Summary

This PR partially revert #302. After #302, we can't execute `npx rslib build` under any integrations tests cases.

This PR doesn't revert the goal of #302, just remove the `workspaces` field of the root package.json which is the monorepo field for npm(https://docs.npmjs.com/cli/v7/using-npm/workspaces), this also helps keep single source of truth of the monorepo definition (pnpm-workspace.yaml).

changesets uses https://github.com/Thinkmill/manypkg to find packages in a monorepo under the hood so it could correct resolve pnpm-workspace.yaml. check-dependency-version-consistency could also read it https://github.com/bmish/check-dependency-version-consistency#usage.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
