### PR TITLE
perf(deps): replace fast-glob with tinyglobby

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,14 +38,14 @@
   },
   "dependencies": {
     "@rsbuild/core": "~1.0.14",
-    "rsbuild-plugin-dts": "workspace:*"
+    "rsbuild-plugin-dts": "workspace:*",
+    "tinyglobby": "^0.2.9"
   },
   "devDependencies": {
     "@rslib/tsconfig": "workspace:*",
     "@rspack/core": "1.0.8",
     "@types/fs-extra": "^11.0.4",
     "commander": "^12.1.0",
-    "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
     "memfs": "^4.14.0",
     "picocolors": "1.1.0",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -13,7 +13,6 @@ export default {
   },
   dependencies: [
     'commander',
-    'fast-glob',
     {
       name: 'rslog',
       afterBundle(task) {

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -24,7 +24,6 @@ export default defineConfig({
     target: 'node',
     externals: {
       picocolors: '../compiled/picocolors/index.js',
-      'fast-glob': '../compiled/fast-glob/index.js',
       commander: '../compiled/commander/index.js',
       rslog: '../compiled/rslog/index.js',
     },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -9,7 +9,7 @@ import {
   mergeRsbuildConfig,
   rspack,
 } from '@rsbuild/core';
-import glob from 'fast-glob';
+import { glob } from 'tinyglobby';
 import {
   DEFAULT_CONFIG_EXTENSIONS,
   DEFAULT_CONFIG_NAME,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -748,6 +748,7 @@ const composeEntryConfig = async (
     // Turn entries in array into each separate entry.
     const globEntryFiles = await glob(entryFiles, {
       cwd: root,
+      absolute: true,
     });
 
     // Filter the glob resolved entry files based on the allowed extensions

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -13,7 +13,6 @@
     "paths": {
       "commander": ["./compiled/commander"],
       "picocolors": ["./compiled/picocolors"],
-      "fast-glob": ["./compiled/fast-glob"],
       "rslog": ["./compiled/rslog"]
     }
   },

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -29,9 +29,9 @@
     "dev": "rslib build --watch"
   },
   "dependencies": {
-    "fast-glob": "^3.3.2",
     "magic-string": "^0.30.12",
-    "picocolors": "1.1.0"
+    "picocolors": "1.1.0",
+    "tinyglobby": "^0.2.9"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.47.9",

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -3,13 +3,11 @@ import fsP from 'node:fs/promises';
 import { platform } from 'node:os';
 import path, { join } from 'node:path';
 import { type RsbuildConfig, logger } from '@rsbuild/core';
-import fg from 'fast-glob';
 import MagicString from 'magic-string';
 import color from 'picocolors';
+import { convertPathToPattern, glob } from 'tinyglobby';
 import ts from 'typescript';
 import type { DtsEntry } from './index';
-
-const { convertPathToPattern } = fg;
 
 export function loadTsconfig(tsconfigPath: string): ts.ParsedCommandLine {
   const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
@@ -68,8 +66,8 @@ export const prettyTime = (seconds: number): string => {
   return `${format(minutes.toFixed(2))} m`;
 };
 
-// fast-glob only accepts posix path
-// https://github.com/mrmlnc/fast-glob#convertpathtopatternpath
+// tinyglobby only accepts posix path
+// https://github.com/SuperchupuDev/tinyglobby?tab=readme-ov-file#api
 const convertPath = (path: string) => {
   if (platform() === 'win32') {
     return convertPathToPattern(path);
@@ -111,7 +109,7 @@ export async function processDtsFiles(
     return;
   }
 
-  const dtsFiles = await fg(convertPath(join(dir, '/**/*.d.ts')));
+  const dtsFiles = await glob(convertPath(join(dir, '/**/*.d.ts')));
 
   for (const file of dtsFiles) {
     try {

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -109,7 +109,9 @@ export async function processDtsFiles(
     return;
   }
 
-  const dtsFiles = await glob(convertPath(join(dir, '/**/*.d.ts')));
+  const dtsFiles = await glob(convertPath(join(dir, '/**/*.d.ts')), {
+    absolute: true,
+  });
 
   for (const file of dtsFiles) {
     try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
+      tinyglobby:
+        specifier: ^0.2.9
+        version: 0.2.9
     devDependencies:
       '@rslib/tsconfig':
         specifier: workspace:*
@@ -153,9 +156,6 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
@@ -208,15 +208,15 @@ importers:
 
   packages/plugin-dts:
     dependencies:
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       magic-string:
         specifier: ^0.30.12
         version: 0.30.12
       picocolors:
         specifier: 1.1.0
         version: 1.1.0
+      tinyglobby:
+        specifier: ^0.2.9
+        version: 0.2.9
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.47.9
@@ -281,9 +281,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.1
         version: 18.3.1
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
@@ -296,6 +293,9 @@ importers:
       test-helper:
         specifier: workspace:*
         version: link:scripts
+      tinyglobby:
+        specifier: ^0.2.9
+        version: 0.2.9
 
   tests/e2e/react-component:
     dependencies:
@@ -2601,6 +2601,14 @@ packages:
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
 
+  fdir@6.4.2:
+    resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -3706,6 +3714,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -4502,6 +4514,10 @@ packages:
 
   tinyexec@0.3.0:
     resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+
+  tinyglobby@0.2.9:
+    resolution: {integrity: sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.0.0:
     resolution: {integrity: sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==}
@@ -7036,6 +7052,10 @@ snapshots:
     dependencies:
       format: 0.2.2
 
+  fdir@6.4.2(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -8432,6 +8452,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pify@2.3.0: {}
 
   pify@4.0.1: {}
@@ -9292,6 +9314,11 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@0.3.0: {}
+
+  tinyglobby@0.2.9:
+    dependencies:
+      fdir: 6.4.2(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   tinypool@1.0.0: {}
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -119,6 +119,7 @@ systemjs
 tailwindcss
 taze
 templating
+tinyglobby
 transpiling
 treeshaking
 tsbuildinfo

--- a/tests/package.json
+++ b/tests/package.json
@@ -23,10 +23,10 @@
     "@types/node": "~18.19.39",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
-    "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
     "path-serializer": "0.1.3",
     "strip-ansi": "^7.1.0",
-    "test-helper": "workspace:*"
+    "test-helper": "workspace:*",
+    "tinyglobby": "^0.2.9"
   }
 }

--- a/tests/scripts/helper.ts
+++ b/tests/scripts/helper.ts
@@ -1,13 +1,10 @@
 import { platform } from 'node:os';
 import { join } from 'node:path';
-import fg, {
-  type Options as GlobOptions,
-  convertPathToPattern,
-} from 'fast-glob';
 import fse from 'fs-extra';
+import { type GlobOptions, convertPathToPattern, glob } from 'tinyglobby';
 
-// fast-glob only accepts posix path
-// https://github.com/mrmlnc/fast-glob#convertpathtopatternpath
+// tinyglobby only accepts posix path
+// https://github.com/SuperchupuDev/tinyglobby?tab=readme-ov-file#api
 const convertPath = (path: string) => {
   if (platform() === 'win32') {
     return convertPathToPattern(path);
@@ -19,7 +16,7 @@ export const globContentJSON = async (
   path: string,
   options?: GlobOptions,
 ): Promise<Record<string, string>> => {
-  const files = await fg(convertPath(join(path, '**/*')), options);
+  const files = await glob(convertPath(join(path, '**/*')), options);
   const ret: Record<string, string> = {};
 
   await Promise.all(

--- a/tests/scripts/helper.ts
+++ b/tests/scripts/helper.ts
@@ -16,7 +16,10 @@ export const globContentJSON = async (
   path: string,
   options?: GlobOptions,
 ): Promise<Record<string, string>> => {
-  const files = await glob(convertPath(join(path, '**/*')), options);
+  const files = await glob(convertPath(join(path, '**/*')), {
+    absolute: true,
+    ...options,
+  });
   const ret: Record<string, string> = {};
 
   await Promise.all(


### PR DESCRIPTION
## Summary

Tinyglobby is a fast and minimal alternative to globby and fast-glob, it is used by tsup, Vite and Nuxt.

- `tinyglobby` is now in `dependencies` of `@rslib/core` because `rsbuild-plugin-dts` also depends on it. If we prebundle it, there will be two copies of the code.
- Add `absolute: true` because `fast-glob` and `tinyglobby` use different relative formats, `fast-glob` will return `./path/to/file.js`, `tinyglobby` will return `path/to/file.js`. Also the absolute path is more friendly to the Node `fs` APIs.

This PR should reduce 15 sub-dependencies of Rslib:

![image](https://github.com/user-attachments/assets/4737f5de-48a0-413b-a88e-aff5c6993866)

## Related Links

https://github.com/SuperchupuDev/tinyglobby?tab=readme-ov-file#api

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
