### PR TITLE
chore: renovate ignore react-aliased

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,7 @@
       groupName: 'rsbuild',
       matchPackageNames: ['@rsbuild/**'],
       groupSlug: 'rsbuild',
+      extends: ['schedule:daily'],
     },
     {
       groupName: 'rslib',
@@ -30,6 +31,7 @@
       groupName: 'rspress',
       matchPackageNames: ['@rspress/**'],
       groupSlug: 'rspress',
+      extends: ['schedule:daily'],
     },
     {
       groupName: 'modern-js',
@@ -61,6 +63,8 @@
     // align Node.js version minimum requirements
     '@types/node',
     'node',
+    // umd tests need to lock this version
+    'react-aliased',
   ],
   postUpdateOptions: ['pnpmDedupe'],
 }


### PR DESCRIPTION
## Summary

renovate ignore react-aliased since umd globals test need a fixed version of react.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
