### PR TITLE
ci: required checks should always run

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -147,3 +147,12 @@ jobs:
           run: pnpm run test:benchmark
           # token retrieved from the CodSpeed app at the previous step
           token: ${{ secrets.CODSPEED_TOKEN }}
+
+  # ======== exit ========
+  pr-check-required:
+    if: (!cancelled() && !failure())
+    needs: [ut-ubuntu, integration-e2e-ubuntu, benchmark-ubuntu]
+    runs-on: ubuntu-latest
+    name: Test passed or skipped
+    steps:
+      - run: echo "All tests passed or skipped."

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -120,3 +120,12 @@ jobs:
 
       - name: E2E Test (Playwright)
         run: pnpm run test:e2e
+
+  # ======== exit ========
+  pr-check-required:
+    if: (!cancelled() && !failure())
+    needs: [ut-windows, integration-e2e-windows]
+    runs-on: ubuntu-latest
+    name: Test passed or skipped
+    steps:
+      - run: echo "All tests passed or skipped."


### PR DESCRIPTION
## Summary

Previously, if a PR only modify docs (*.md), the required jobs will skip directly as `if: ${{ needs.changes.outputs.changed == 'true' }}`. But the jobs are required for PRs in repository settings.

This PR adds a dedicated job to be the status check job. It will be success if the jobs passed, and pending when failed.

This could also simplify our required status check in repository settings and move it into code.

TODO: required jobs need to be updated after PR got merged.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
