### PR TITLE
fix: map syntax "es6" to "es2015"

### DIFF
--- a/packages/core/src/utils/syntax.ts
+++ b/packages/core/src/utils/syntax.ts
@@ -173,7 +173,10 @@ export function transformSyntaxToRspackTarget(
         ) {
           return 'es2022';
         }
-
+        // The es6 is the same as es2015, compatible with rspack API schema
+        if (normalizedSyntaxItem === 'es6') {
+          return 'es2015';
+        }
         return normalizedSyntaxItem;
       }
 

--- a/packages/core/tests/syntax.test.ts
+++ b/packages/core/tests/syntax.test.ts
@@ -153,12 +153,19 @@ describe('transformSyntaxToBrowserslist', () => {
 
 describe('transformSyntaxToRspackTarget', () => {
   test('esX', () => {
+    const es6 = transformSyntaxToRspackTarget('es6');
     const es2023 = transformSyntaxToRspackTarget('es2023');
     const es2024 = transformSyntaxToRspackTarget('es2024');
     const esnext = transformSyntaxToRspackTarget('esnext');
 
     expect(es2023).toEqual(es2024);
     expect(es2023).toEqual(esnext);
+
+    expect(es6).toMatchInlineSnapshot(`
+      [
+        "es2015",
+      ]
+    `);
 
     expect(es2023).toMatchInlineSnapshot(
       `
@@ -184,6 +191,15 @@ describe('transformSyntaxToRspackTarget', () => {
       [
         "browserslist:Chrome 123",
         "es2022",
+      ]
+    `);
+
+    expect(
+      transformSyntaxToRspackTarget(['Chrome 123', 'es6']),
+    ).toMatchInlineSnapshot(`
+      [
+        "browserslist:Chrome 123",
+        "es2015",
       ]
     `);
   });


### PR DESCRIPTION
## Summary

## Related Links
fix: #322 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
