### PR TITLE
feat: support set `dts: true` and dts default to bundleless

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -906,15 +906,25 @@ const composeDtsConfig = async (
   libConfig: LibConfig,
   dtsExtension: string,
 ): Promise<RsbuildConfig> => {
-  const { dts, bundle, output, autoExternal, banner, footer } = libConfig;
+  const { output, autoExternal, banner, footer } = libConfig;
+
+  let { dts } = libConfig;
 
   if (dts === false || dts === undefined) return {};
+
+  // DTS default to bundleless whether js is bundle or not
+  if (dts === true) {
+    dts = {
+      bundle: false,
+    };
+  }
 
   const { pluginDts } = await import('rsbuild-plugin-dts');
   return {
     plugins: [
       pluginDts({
-        bundle: dts?.bundle ?? bundle,
+        // only set dts.bundle to true can generate bundle DTS
+        bundle: dts?.bundle ?? false,
         distPath: dts?.distPath ?? output?.distPath?.root ?? './dist',
         abortOnError: dts?.abortOnError ?? true,
         dtsExtension: dts?.autoExtension ? dtsExtension : '.d.ts',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -923,7 +923,7 @@ const composeDtsConfig = async (
   return {
     plugins: [
       pluginDts({
-        // only set dts.bundle to true can generate bundle DTS
+        // Only setting ⁠dts.bundle to true will generate the bundled d.ts.
         bundle: dts?.bundle ?? false,
         distPath: dts?.distPath ?? output?.distPath?.root ?? './dist',
         abortOnError: dts?.abortOnError ?? true,

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -32,7 +32,7 @@ export type Dts =
   | (Pick<PluginDtsOptions, 'bundle' | 'distPath' | 'abortOnError'> & {
       autoExtension?: boolean;
     })
-  | false;
+  | boolean;
 
 export type AutoExternal =
   | boolean

--- a/packages/create-rslib/template-node-dual-ts/rslib.config.ts
+++ b/packages/create-rslib/template-node-dual-ts/rslib.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     {
       format: 'esm',
       syntax: 'es2021',
-      dts: {},
+      dts: true,
     },
     {
       format: 'cjs',

--- a/packages/create-rslib/template-node-esm-ts/rslib.config.ts
+++ b/packages/create-rslib/template-node-esm-ts/rslib.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     {
       format: 'esm',
       syntax: 'es2021',
-      dts: {},
+      dts: true,
     },
   ],
   output: { target: 'node' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,8 @@ importers:
 
   tests/integration/dts/bundle-false/false: {}
 
+  tests/integration/dts/bundle-false/true: {}
+
   tests/integration/dts/bundle/abort-on-error: {}
 
   tests/integration/dts/bundle/absolute-entry: {}
@@ -534,6 +536,8 @@ importers:
   tests/integration/dts/bundle/dist-path: {}
 
   tests/integration/dts/bundle/false: {}
+
+  tests/integration/dts/bundle/true: {}
 
   tests/integration/entry/glob: {}
 

--- a/tests/integration/dts/bundle-false/true/package.json
+++ b/tests/integration/dts/bundle-false/true/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-true-bundle-false-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/bundle-false/true/rslib.config.ts
+++ b/tests/integration/dts/bundle-false/true/rslib.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: true,
+    }),
+    generateBundleCjsConfig(),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src/index.ts',
+    },
+    tsconfigPath: '../__fixtures__/tsconfig.json',
+  },
+});

--- a/tests/integration/dts/bundle/true/package.json
+++ b/tests/integration/dts/bundle/true/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-true-bundle-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/bundle/true/rslib.config.ts
+++ b/tests/integration/dts/bundle/true/rslib.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      dts: true,
+    }),
+    generateBundleCjsConfig(),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src/index.ts',
+    },
+    tsconfigPath: '../__fixtures__/tsconfig.json',
+  },
+});

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -38,6 +38,20 @@ describe('dts when bundle: false', () => {
     expect(files.esm).toMatchInlineSnapshot('undefined');
   });
 
+  test('dts true', async () => {
+    const fixturePath = join(__dirname, 'bundle-false', 'true');
+    const { files } = await buildAndGetResults({ fixturePath, type: 'dts' });
+
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle-false/true/dist/esm/index.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/true/dist/esm/sum.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/true/dist/esm/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/true/dist/esm/utils/strings.d.ts",
+      ]
+    `);
+  });
+
   test('distPath', async () => {
     const fixturePath = join(__dirname, 'bundle-false', 'dist-path');
     const { files } = await buildAndGetResults({ fixturePath, type: 'dts' });
@@ -80,17 +94,25 @@ describe('dts when bundle: false', () => {
 describe('dts when bundle: true', () => {
   test('basic', async () => {
     const fixturePath = join(__dirname, 'bundle', 'basic');
-    const { entryFiles, entries } = await buildAndGetResults({
+    const { files, entries } = await buildAndGetResults({
       fixturePath,
       type: 'dts',
     });
 
-    expect(entryFiles.esm).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/dts/bundle/basic/dist/esm/index.d.ts"`,
+    expect(files.esm).toMatchInlineSnapshot(
+      `
+      [
+        "<ROOT>/tests/integration/dts/bundle/basic/dist/esm/index.d.ts",
+      ]
+    `,
     );
 
-    expect(entryFiles.cjs).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/dts/bundle/basic/dist/cjs/index.d.ts"`,
+    expect(files.cjs).toMatchInlineSnapshot(
+      `
+      [
+        "<ROOT>/tests/integration/dts/bundle/basic/dist/cjs/index.d.ts",
+      ]
+    `,
     );
 
     expect(entries).toMatchSnapshot();
@@ -98,23 +120,46 @@ describe('dts when bundle: true', () => {
 
   test('dts false', async () => {
     const fixturePath = join(__dirname, 'bundle', 'false');
-    const { entryFiles } = await buildAndGetResults({
+    const { files } = await buildAndGetResults({
       fixturePath,
       type: 'dts',
     });
 
-    expect(entryFiles.esm).toMatchInlineSnapshot('undefined');
+    expect(files.esm).toMatchInlineSnapshot('undefined');
+  });
+
+  test('dts true', async () => {
+    const fixturePath = join(__dirname, 'bundle', 'true');
+    const { files } = await buildAndGetResults({
+      fixturePath,
+      type: 'dts',
+    });
+
+    expect(files.esm).toMatchInlineSnapshot(
+      `
+      [
+        "<ROOT>/tests/integration/dts/bundle/true/dist/esm/index.d.ts",
+        "<ROOT>/tests/integration/dts/bundle/true/dist/esm/sum.d.ts",
+        "<ROOT>/tests/integration/dts/bundle/true/dist/esm/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts/bundle/true/dist/esm/utils/strings.d.ts",
+      ]
+    `,
+    );
   });
 
   test('distPath', async () => {
     const fixturePath = join(__dirname, 'bundle', 'dist-path');
-    const { entryFiles } = await buildAndGetResults({
+    const { files } = await buildAndGetResults({
       fixturePath,
       type: 'dts',
     });
 
-    expect(entryFiles.esm).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/dts/bundle/dist-path/dist/custom/index.d.ts"`,
+    expect(files.esm).toMatchInlineSnapshot(
+      `
+      [
+        "<ROOT>/tests/integration/dts/bundle/dist-path/dist/custom/index.d.ts",
+      ]
+    `,
     );
   });
 
@@ -130,37 +175,49 @@ describe('dts when bundle: true', () => {
 
   test('autoExtension: true', async () => {
     const fixturePath = join(__dirname, 'bundle', 'auto-extension');
-    const { entryFiles } = await buildAndGetResults({
+    const { files } = await buildAndGetResults({
       fixturePath,
       type: 'dts',
     });
 
-    expect(entryFiles.cjs).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/dts/bundle/auto-extension/dist/cjs/index.d.cts"`,
+    expect(files.cjs).toMatchInlineSnapshot(
+      `
+      [
+        "<ROOT>/tests/integration/dts/bundle/auto-extension/dist/cjs/index.d.cts",
+      ]
+    `,
     );
   });
 
   test('bundleName -- set source.entry', async () => {
     const fixturePath = join(__dirname, 'bundle', 'bundle-name');
-    const { entryFiles } = await buildAndGetResults({
+    const { files } = await buildAndGetResults({
       fixturePath,
       type: 'dts',
     });
 
-    expect(entryFiles.esm).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/dts/bundle/bundle-name/dist/esm/bundleName.d.ts"`,
+    expect(files.esm).toMatchInlineSnapshot(
+      `
+      [
+        "<ROOT>/tests/integration/dts/bundle/bundle-name/dist/esm/bundleName.d.ts",
+      ]
+    `,
     );
   });
 
   test('entry is an absolute path', async () => {
     const fixturePath = join(__dirname, 'bundle', 'absolute-entry');
-    const { entryFiles } = await buildAndGetResults({
+    const { files } = await buildAndGetResults({
       fixturePath,
       type: 'dts',
     });
 
-    expect(entryFiles.esm).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/dts/bundle/absolute-entry/dist/esm/index.d.ts"`,
+    expect(files.esm).toMatchInlineSnapshot(
+      `
+      [
+        "<ROOT>/tests/integration/dts/bundle/absolute-entry/dist/esm/index.d.ts",
+      ]
+    `,
     );
   });
 });

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -82,6 +82,7 @@ export async function getResults(
     esm: 0,
     cjs: 0,
     umd: 0,
+    mf: 0,
   };
   let key = '';
 
@@ -105,7 +106,9 @@ export async function getResults(
       globFolder = libConfig?.output?.distPath?.root!;
     } else if (type === 'dts' && libConfig.dts !== false) {
       globFolder =
-        libConfig.dts?.distPath! ?? libConfig?.output?.distPath?.root!;
+        libConfig.dts === true
+          ? libConfig?.output?.distPath?.root!
+          : (libConfig.dts?.distPath! ?? libConfig?.output?.distPath?.root!);
     }
 
     if (!globFolder) continue;


### PR DESCRIPTION
## Summary

- Support `dts: true` to default generate bundleless DTS
- Only generate bundle DTS when `dts.bundle` set to true

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
