### PR TITLE
fix: use global as mf format external type

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -656,7 +656,9 @@ const composeExternalsConfig = (
     esm: 'module-import',
     cjs: 'commonjs',
     umd: 'umd',
-    // if use 'var', when users use external package like '@pkg', this will cause syntax error like 'var pkg = @pkg'
+    // If use 'var', when projects import an external package like '@pkg', this will cause a syntax error such as 'var pkg = @pkg'.
+    // If use 'umd', the judgement conditions may be affected by other packages that define variables like 'define'.
+    // Therefore, we use 'global' to satisfy both web and node environments.
     mf: 'global',
   } as const;
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -656,7 +656,8 @@ const composeExternalsConfig = (
     esm: 'module-import',
     cjs: 'commonjs',
     umd: 'umd',
-    mf: 'var', // same as default value
+    // if use 'var', when users use external package like '@pkg', this will cause syntax error like 'var pkg = @pkg'
+    mf: 'global',
   } as const;
 
   switch (format) {


### PR DESCRIPTION
## Summary

vmok uses `global` by default.

When users use a external pkg like `'@xxx'`, this will be transform to 
```
var xxx = @xxx
```
which will cause syntax Error because there's no quotation marks. So set to global to avoid this
## Related Links
close: https://github.com/web-infra-dev/rslib/issues/330
