### PR TITLE
fix: should emit config file parsing diagnostics in DTS build

### DIFF
--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -38,7 +38,10 @@ export function ensureTempDeclarationDir(cwd: string): string {
   return dirPath;
 }
 
-export function getFileLoc(diagnostic: ts.Diagnostic): string {
+export function getFileLoc(
+  diagnostic: ts.Diagnostic,
+  configPath: string,
+): string {
   if (diagnostic.file) {
     const { line, character } = ts.getLineAndCharacterOfPosition(
       diagnostic.file,
@@ -47,7 +50,7 @@ export function getFileLoc(diagnostic: ts.Diagnostic): string {
     return `${color.cyan(diagnostic.file.fileName)}:${color.yellow(line + 1)}:${color.yellow(character + 1)}`;
   }
 
-  return '';
+  return `${color.cyan(configPath)}:`;
 }
 
 export const prettyTime = (seconds: number): string => {

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -50,7 +50,7 @@ export function getFileLoc(
     return `${color.cyan(diagnostic.file.fileName)}:${color.yellow(line + 1)}:${color.yellow(character + 1)}`;
   }
 
-  return `${color.cyan(configPath)}:`;
+  return `${color.cyan(configPath)}`;
 }
 
 export const prettyTime = (seconds: number): string => {


### PR DESCRIPTION
## Summary

Emit config file parsing diagnostics in DTS build.

If there is no fileLoc in diagnostics, it should be tsconfig file, align with [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/0fab463b21c6edc4d94834568a3f440241d57887/src/typescript/worker/lib/config.ts#L118-L128)

![image](https://github.com/user-attachments/assets/103c8376-6175-4720-acc2-19d79f0d9d62)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
