### PR TITLE
feat: support `tsc --build` to incremental build project references

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -930,6 +930,7 @@ const composeDtsConfig = async (
         // Only setting ⁠dts.bundle to true will generate the bundled d.ts.
         bundle: dts?.bundle ?? false,
         distPath: dts?.distPath ?? output?.distPath?.root ?? './dist',
+        build: dts?.build ?? false,
         abortOnError: dts?.abortOnError ?? true,
         dtsExtension: dts?.autoExtension ? dtsExtension : '.d.ts',
         autoExternal,

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -29,7 +29,10 @@ export type Syntax =
   | string[];
 
 export type Dts =
-  | (Pick<PluginDtsOptions, 'bundle' | 'distPath' | 'abortOnError'> & {
+  | (Pick<
+      PluginDtsOptions,
+      'bundle' | 'distPath' | 'abortOnError' | 'build'
+    > & {
       autoExtension?: boolean;
     })
   | boolean;

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -164,7 +164,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
       throw Error(
         `Please set ${info}: "${outDir}" in ${color.underline(
           configPath,
-        )} to keep it same as Lib config.`,
+        )} to keep it same as "dts.distPath" or "output.distPath" field in lib config.`,
       );
     }
   }

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -145,7 +145,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
   if (build) {
     // do not allow to use bundle DTS when 'build: true' since temp declarationDir should be set by user in tsconfig
     if (bundle) {
-      throw Error(`Can not set "dts.bundle: true" when "dts.build = true"`);
+      throw Error(`Can not set "dts.bundle: true" when "dts.build: true"`);
     }
 
     // can not set '--declarationDir' or '--outDir' when 'build: true'.

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -147,6 +147,14 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
       throw Error(`Can not set "dts.bundle: true" when "dts.build = true"`);
     }
 
+    console.log(
+      'rawCompilerOptions.declarationDir: ',
+      rawCompilerOptions.declarationDir,
+    );
+    console.log(
+      'resolve(dirname(configPath), outDir): ',
+      resolve(dirname(configPath), outDir),
+    );
     // can not set '--declarationDir' or '--outDir' when 'build: true'.
     if (
       (!rawCompilerOptions.outDir ||

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -4,6 +4,7 @@ import {
   dirname,
   isAbsolute,
   join,
+  normalize,
   relative,
   resolve,
 } from 'node:path';
@@ -147,21 +148,14 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
       throw Error(`Can not set "dts.bundle: true" when "dts.build = true"`);
     }
 
-    console.log(
-      'rawCompilerOptions.declarationDir: ',
-      rawCompilerOptions.declarationDir,
-    );
-    console.log(
-      'resolve(dirname(configPath), outDir): ',
-      resolve(dirname(configPath), outDir),
-    );
     // can not set '--declarationDir' or '--outDir' when 'build: true'.
     if (
       (!rawCompilerOptions.outDir ||
-        rawCompilerOptions.outDir !== resolve(dirname(configPath), outDir)) &&
+        normalize(rawCompilerOptions.outDir) !==
+          normalize(resolve(dirname(configPath), outDir))) &&
       (!rawCompilerOptions.declarationDir ||
-        rawCompilerOptions.declarationDir !==
-          resolve(dirname(configPath), outDir))
+        normalize(rawCompilerOptions.declarationDir) !==
+          normalize(resolve(dirname(configPath), outDir)))
     ) {
       const info =
         rawCompilerOptions.outDir && !rawCompilerOptions.declarationDir

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -55,7 +55,7 @@ export const pluginDts = (options: PluginDtsOptions): RsbuildPlugin => ({
   setup(api) {
     options.bundle = options.bundle ?? false;
     options.abortOnError = options.abortOnError ?? true;
-    options.build = options.build || false;
+    options.build = options.build ?? false;
 
     const dtsPromises: Promise<TaskResult>[] = [];
     let promisesResult: TaskResult[] = [];

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -10,6 +10,7 @@ const __dirname = dirname(__filename);
 export type PluginDtsOptions = {
   bundle?: boolean;
   distPath?: string;
+  build?: boolean;
   abortOnError?: boolean;
   dtsExtension?: string;
   autoExternal?:
@@ -33,6 +34,7 @@ export type DtsGenOptions = PluginDtsOptions & {
   cwd: string;
   isWatch: boolean;
   dtsEntry: DtsEntry;
+  build?: boolean;
   tsconfigPath?: string;
   userExternals?: NonNullable<RsbuildConfig['output']>['externals'];
 };
@@ -46,7 +48,6 @@ export const PLUGIN_DTS_NAME = 'rsbuild:dts';
 
 // use ts compiler API to generate bundleless dts
 // use ts compiler API and api-extractor to generate dts bundle
-// TODO: support incremental build, to build one or more projects and their dependencies
 // TODO: deal alias in dts
 export const pluginDts = (options: PluginDtsOptions): RsbuildPlugin => ({
   name: PLUGIN_DTS_NAME,
@@ -54,6 +55,7 @@ export const pluginDts = (options: PluginDtsOptions): RsbuildPlugin => ({
   setup(api) {
     options.bundle = options.bundle ?? false;
     options.abortOnError = options.abortOnError ?? true;
+    options.build = options.build || false;
 
     const dtsPromises: Promise<TaskResult>[] = [];
     let promisesResult: TaskResult[] = [];

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -23,6 +23,7 @@ export async function emitDts(
   onComplete: (isSuccess: boolean) => void,
   bundle = false,
   isWatch = false,
+  build = false,
 ): Promise<void> {
   const start = Date.now();
   const { configPath, declarationDir, name, dtsExtension, banner, footer } =
@@ -42,131 +43,199 @@ export async function emitDts(
     emitDeclarationOnly: true,
   };
 
-  if (!isWatch) {
-    const host: ts.CompilerHost = ts.createCompilerHost(compilerOptions);
+  const createProgram = ts.createSemanticDiagnosticsBuilderProgram;
+  const formatHost: ts.FormatDiagnosticsHost = {
+    getCanonicalFileName: (path) => path,
+    getCurrentDirectory: ts.sys.getCurrentDirectory,
+    getNewLine: () => ts.sys.newLine,
+  };
 
-    const program: ts.Program = ts.createProgram({
-      rootNames: fileNames,
-      options: compilerOptions,
-      projectReferences,
-      host,
-      configFileParsingDiagnostics: ts.getConfigFileParsingDiagnostics(
-        configFileParseResult,
-      ),
-    });
+  const reportDiagnostic = (diagnostic: ts.Diagnostic) => {
+    const fileLoc = getFileLoc(diagnostic, configPath);
 
-    const emitResult = program.emit();
-
-    const allDiagnostics = ts
-      .getPreEmitDiagnostics(program)
-      .concat(emitResult.diagnostics);
-
-    const diagnosticMessages: string[] = [];
-
-    for (const diagnostic of allDiagnostics) {
-      const fileLoc = getFileLoc(diagnostic, configPath);
-      const message = `${fileLoc} - ${color.red('error')} ${color.gray(`TS${diagnostic.code}:`)} ${ts.flattenDiagnosticMessageText(
+    logger.error(
+      `${fileLoc} - ${color.red('error')} ${color.gray(`TS${diagnostic.code}:`)}`,
+      ts.flattenDiagnosticMessageText(
         diagnostic.messageText,
-        host.getNewLine(),
-      )}`;
-      diagnosticMessages.push(message);
+        formatHost.getNewLine(),
+      ),
+    );
+  };
+
+  const reportWatchStatusChanged: ts.WatchStatusReporter = async (
+    diagnostic: ts.Diagnostic,
+    _newLine: string,
+    _options: ts.CompilerOptions,
+    errorCount?: number,
+  ) => {
+    const message = `${ts.flattenDiagnosticMessageText(
+      diagnostic.messageText,
+      formatHost.getNewLine(),
+    )} ${color.gray(`(${name})`)}`;
+
+    // 6031: File change detected. Starting incremental compilation...
+    // 6032: Starting compilation in watch mode...
+    if (diagnostic.code === 6031 || diagnostic.code === 6032) {
+      logger.info(message);
     }
 
-    await processDtsFiles(bundle, declarationDir, dtsExtension, banner, footer);
-
-    if (diagnosticMessages.length) {
-      logger.error(
-        `Failed to emit declaration files. ${color.gray(`(${name})`)}`,
-      );
-
-      for (const message of diagnosticMessages) {
+    // 6194: 0 errors or 2+ errors!
+    if (diagnostic.code === 6194) {
+      if (errorCount === 0 || !errorCount) {
+        logger.info(message);
+        onComplete(true);
+      } else {
         logger.error(message);
       }
+      await processDtsFiles(
+        bundle,
+        declarationDir,
+        dtsExtension,
+        banner,
+        footer,
+      );
+    }
 
-      throw new Error('DTS generation failed');
+    // 6193: 1 error
+    if (diagnostic.code === 6193) {
+      logger.error(message);
+      await processDtsFiles(
+        bundle,
+        declarationDir,
+        dtsExtension,
+        banner,
+        footer,
+      );
+    }
+  };
+
+  const system = { ...ts.sys };
+
+  if (!isWatch) {
+    // build mode
+    if (!build) {
+      const host: ts.CompilerHost = ts.createCompilerHost(compilerOptions);
+
+      const program: ts.Program = ts.createProgram({
+        rootNames: fileNames,
+        options: compilerOptions,
+        projectReferences,
+        host,
+        configFileParsingDiagnostics: ts.getConfigFileParsingDiagnostics(
+          configFileParseResult,
+        ),
+      });
+
+      const emitResult = program.emit();
+
+      const allDiagnostics = ts
+        .getPreEmitDiagnostics(program)
+        .concat(emitResult.diagnostics);
+
+      const diagnosticMessages: string[] = [];
+
+      for (const diagnostic of allDiagnostics) {
+        const fileLoc = getFileLoc(diagnostic, configPath);
+        const message = `${fileLoc} - ${color.red('error')} ${color.gray(`TS${diagnostic.code}:`)} ${ts.flattenDiagnosticMessageText(
+          diagnostic.messageText,
+          host.getNewLine(),
+        )}`;
+        diagnosticMessages.push(message);
+      }
+
+      await processDtsFiles(
+        bundle,
+        declarationDir,
+        dtsExtension,
+        banner,
+        footer,
+      );
+
+      if (diagnosticMessages.length) {
+        logger.error(
+          `Failed to emit declaration files. ${color.gray(`(${name})`)}`,
+        );
+
+        for (const message of diagnosticMessages) {
+          logger.error(message);
+        }
+
+        throw new Error('DTS generation failed');
+      }
+    } else {
+      // incremental build with project references
+      let errorNumber = 0;
+      const reportErrorSummary = (errorCount: number) => {
+        errorNumber = errorCount;
+      };
+
+      const host = ts.createSolutionBuilderHost(
+        system,
+        createProgram,
+        reportDiagnostic,
+        undefined,
+        reportErrorSummary,
+      );
+
+      const solutionBuilder = ts.createSolutionBuilder(
+        host,
+        [configPath],
+        compilerOptions,
+      );
+
+      solutionBuilder.build();
+
+      await processDtsFiles(
+        bundle,
+        declarationDir,
+        dtsExtension,
+        banner,
+        footer,
+      );
+
+      if (errorNumber > 0) {
+        logger.error(
+          `Failed to emit declaration files. ${color.gray(`(${name})`)}`,
+        );
+
+        throw new Error('DTS generation failed');
+      }
     }
 
     logger.ready(
       `DTS generated in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
     );
   } else {
-    const createProgram = ts.createSemanticDiagnosticsBuilderProgram;
-    const formatHost: ts.FormatDiagnosticsHost = {
-      getCanonicalFileName: (path) => path,
-      getCurrentDirectory: ts.sys.getCurrentDirectory,
-      getNewLine: () => ts.sys.newLine,
-    };
-
-    const reportDiagnostic = (diagnostic: ts.Diagnostic) => {
-      const fileLoc = getFileLoc(diagnostic, configPath);
-
-      logger.error(
-        `${fileLoc} - ${color.red('error')} ${color.gray(`TS${diagnostic.code}:`)}`,
-        ts.flattenDiagnosticMessageText(
-          diagnostic.messageText,
-          formatHost.getNewLine(),
-        ),
+    // watch mode
+    if (!build) {
+      const host = ts.createWatchCompilerHost(
+        configPath,
+        compilerOptions,
+        system,
+        createProgram,
+        reportDiagnostic,
+        reportWatchStatusChanged,
       );
-    };
 
-    const reportWatchStatusChanged: ts.WatchStatusReporter = async (
-      diagnostic: ts.Diagnostic,
-      _newLine: string,
-      _options: ts.CompilerOptions,
-      errorCount?: number,
-    ) => {
-      const message = `${ts.flattenDiagnosticMessageText(
-        diagnostic.messageText,
-        formatHost.getNewLine(),
-      )} ${color.gray(`(${name})`)}`;
+      ts.createWatchProgram(host);
+    } else {
+      // incremental build with project references
+      const host = ts.createSolutionBuilderWithWatchHost(
+        system,
+        createProgram,
+        reportDiagnostic,
+        undefined,
+        reportWatchStatusChanged,
+      );
 
-      // 6031: File change detected. Starting incremental compilation...
-      // 6032: Starting compilation in watch mode...
-      if (diagnostic.code === 6031 || diagnostic.code === 6032) {
-        logger.info(message);
-      }
+      const solutionBuilder = ts.createSolutionBuilderWithWatch(
+        host,
+        [configPath],
+        compilerOptions,
+        { watch: true },
+      );
 
-      // 6194: 0 errors or 2+ errors!
-      if (diagnostic.code === 6194) {
-        if (errorCount === 0) {
-          logger.info(message);
-          onComplete(true);
-        } else {
-          logger.error(message);
-        }
-        await processDtsFiles(
-          bundle,
-          declarationDir,
-          dtsExtension,
-          banner,
-          footer,
-        );
-      }
-
-      // 6193: 1 error
-      if (diagnostic.code === 6193) {
-        logger.error(message);
-        await processDtsFiles(
-          bundle,
-          declarationDir,
-          dtsExtension,
-          banner,
-          footer,
-        );
-      }
-    };
-
-    const system = { ...ts.sys };
-
-    const host = ts.createWatchCompilerHost(
-      configPath,
-      compilerOptions,
-      system,
-      createProgram,
-      reportDiagnostic,
-      reportWatchStatusChanged,
-    );
-
-    ts.createWatchProgram(host);
+      solutionBuilder.build();
+    }
   }
 }

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -95,10 +95,17 @@ export async function addBannerAndFooter(
   const content = await fsP.readFile(file, 'utf-8');
   const code = new MagicString(content);
 
-  banner && code.prepend(`${banner}\n`);
-  footer && code.append(`\n${footer}\n`);
+  if (banner && !content.trimStart().startsWith(banner.trim())) {
+    code.prepend(`${banner}\n`);
+  }
 
-  await fsP.writeFile(file, code.toString());
+  if (footer && !content.trimEnd().endsWith(footer.trim())) {
+    code.append(`\n${footer}\n`);
+  }
+
+  if (code.hasChanged()) {
+    await fsP.writeFile(file, code.toString());
+  }
 }
 
 export async function processDtsFiles(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,18 @@ importers:
 
   tests/integration/dts/bundle/true: {}
 
+  tests/integration/dts/composite/__references__: {}
+
+  tests/integration/dts/composite/abort-on-error: {}
+
+  tests/integration/dts/composite/basic: {}
+
+  tests/integration/dts/composite/dist-path: {}
+
+  tests/integration/dts/composite/process-files: {}
+
+  tests/integration/dts/composite/tsconfig: {}
+
   tests/integration/entry/glob: {}
 
   tests/integration/entry/multiple: {}

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,7 +20,7 @@ Rslib will try to cover the common scenarios in the [integration test cases of M
 | decorator       | 🟢     |                                                          |
 | define          | 🟢     |                                                          |
 | dts             | 🟢     |                                                          |
-| dts-composite   | ⚪️     |                                                          |
+| dts-composite   | 🟢     |                                                          |
 | esbuildOptions  | ⚫️    |                                                          |
 | externals       | 🟢     |                                                          |
 | format          | 🟢     |                                                          |

--- a/tests/integration/dts/composite/__references__/package.json
+++ b/tests/integration/dts/composite/__references__/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-composite-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/composite/__references__/src/index.ts
+++ b/tests/integration/dts/composite/__references__/src/index.ts
@@ -1,0 +1,1 @@
+export const b = 'hello world';

--- a/tests/integration/dts/composite/__references__/tsconfig.json
+++ b/tests/integration/dts/composite/__references__/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "rootDir": "src",
+    "baseUrl": "./",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src"]
+}

--- a/tests/integration/dts/composite/abort-on-error/package.json
+++ b/tests/integration/dts/composite/abort-on-error/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-composite-abort-on-error-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/composite/abort-on-error/rslib.config.ts
+++ b/tests/integration/dts/composite/abort-on-error/rslib.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+        build: true,
+        abortOnError: false,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['./src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/composite/abort-on-error/src/const.ts
+++ b/tests/integration/dts/composite/abort-on-error/src/const.ts
@@ -1,0 +1,3 @@
+export interface A {
+  a: number;
+}

--- a/tests/integration/dts/composite/abort-on-error/src/index.ts
+++ b/tests/integration/dts/composite/abort-on-error/src/index.ts
@@ -1,0 +1,6 @@
+import type { A } from './const';
+
+export const getA = (item: A) => {
+  item.a = '0';
+  return item;
+};

--- a/tests/integration/dts/composite/abort-on-error/tsconfig.json
+++ b/tests/integration/dts/composite/abort-on-error/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "./dist/esm"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../__references__"
+    }
+  ]
+}

--- a/tests/integration/dts/composite/basic/package.json
+++ b/tests/integration/dts/composite/basic/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-composite-basic-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/composite/basic/rslib.config.ts
+++ b/tests/integration/dts/composite/basic/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+        build: true,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['./src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/composite/basic/src/index.ts
+++ b/tests/integration/dts/composite/basic/src/index.ts
@@ -1,0 +1,1 @@
+export * from './sum';

--- a/tests/integration/dts/composite/basic/src/sum.ts
+++ b/tests/integration/dts/composite/basic/src/sum.ts
@@ -1,0 +1,10 @@
+export const num1 = 1;
+export const num2 = 2;
+export const num3 = 3;
+
+export const str1 = 'str1';
+export const str2 = 'str2';
+export const str3 = 'str3';
+
+export const numSum = num1 + num2 + num3;
+export const strSum = str1 + str2 + str3;

--- a/tests/integration/dts/composite/basic/tsconfig.json
+++ b/tests/integration/dts/composite/basic/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "./dist/esm"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../__references__"
+    }
+  ]
+}

--- a/tests/integration/dts/composite/dist-path/package.json
+++ b/tests/integration/dts/composite/dist-path/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-composite-dist-path-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/composite/dist-path/rslib.config.ts
+++ b/tests/integration/dts/composite/dist-path/rslib.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+        build: true,
+        distPath: './dist/custom',
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['./src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/composite/dist-path/src/index.ts
+++ b/tests/integration/dts/composite/dist-path/src/index.ts
@@ -1,0 +1,1 @@
+export const num1 = 1;

--- a/tests/integration/dts/composite/dist-path/tsconfig.json
+++ b/tests/integration/dts/composite/dist-path/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "./dist/custom"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../__references__"
+    }
+  ]
+}

--- a/tests/integration/dts/composite/process-files/package.json
+++ b/tests/integration/dts/composite/process-files/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dts-composite-process-files-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/dts/composite/process-files/rslib.config.ts
+++ b/tests/integration/dts/composite/process-files/rslib.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      banner: {
+        dts: '/*! hello banner dts composite*/',
+      },
+      footer: {
+        dts: '/*! hello banner dts composite*/',
+      },
+      dts: {
+        bundle: false,
+        build: true,
+        autoExtension: true,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['./src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/composite/process-files/src/index.ts
+++ b/tests/integration/dts/composite/process-files/src/index.ts
@@ -1,0 +1,1 @@
+export const num1 = 1;

--- a/tests/integration/dts/composite/process-files/tsconfig.json
+++ b/tests/integration/dts/composite/process-files/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "./dist/esm"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../__references__"
+    }
+  ]
+}

--- a/tests/integration/dts/composite/tsconfig/package.json
+++ b/tests/integration/dts/composite/tsconfig/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-composite-tsconfig-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/composite/tsconfig/rslib.config.ts
+++ b/tests/integration/dts/composite/tsconfig/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+        build: true,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['./src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/composite/tsconfig/src/index.ts
+++ b/tests/integration/dts/composite/tsconfig/src/index.ts
@@ -1,0 +1,1 @@
+export * from './sum';

--- a/tests/integration/dts/composite/tsconfig/src/sum.ts
+++ b/tests/integration/dts/composite/tsconfig/src/sum.ts
@@ -1,0 +1,10 @@
+export const num1 = 1;
+export const num2 = 2;
+export const num3 = 3;
+
+export const str1 = 'str1';
+export const str2 = 'str2';
+export const str3 = 'str3';
+
+export const numSum = num1 + num2 + num3;
+export const strSum = str1 + str2 + str3;

--- a/tests/integration/dts/composite/tsconfig/tsconfig.json
+++ b/tests/integration/dts/composite/tsconfig/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../__references__"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Support `tsc --build` to incremental build project references by using TypeScript compiler API.

This feature can be enabled by setting `dts.build: true`, now it only works when `dts.bundle: false`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
