### PR TITLE
perf(CLI): enable Node cache before loading modules

### DIFF
--- a/packages/core/bin/rslib.js
+++ b/packages/core/bin/rslib.js
@@ -1,7 +1,19 @@
 #!/usr/bin/env node
-import { logger, prepareCli, runCli } from '../dist/index.js';
+import nodeModule from 'node:module';
+
+// enable on-disk code caching of all modules loaded by Node.js
+// requires Nodejs >= 22.8.0
+const { enableCompileCache } = nodeModule;
+if (enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+  try {
+    enableCompileCache();
+  } catch {
+    // ignore errors
+  }
+}
 
 async function main() {
+  const { logger, prepareCli, runCli } = await import('../dist/index.js');
   prepareCli();
 
   try {

--- a/packages/core/bin/rslib.js
+++ b/packages/core/bin/rslib.js
@@ -4,7 +4,7 @@ import nodeModule from 'node:module';
 // enable on-disk code caching of all modules loaded by Node.js
 // requires Nodejs >= 22.8.0
 const { enableCompileCache } = nodeModule;
-if (enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+if (enableCompileCache) {
   try {
     enableCompileCache();
   } catch {


### PR DESCRIPTION
## Summary

Enable Node.js 22 new compile cache in Rslib CLI, this makes Node.js startup faster.

- before:

<img width="894" alt="Screenshot 2024-11-04 at 16 01 41" src="https://github.com/user-attachments/assets/afdcba2d-e684-46c5-9513-481809a11fd9">

- after:

<img width="882" alt="Screenshot 2024-11-04 at 16 01 46" src="https://github.com/user-attachments/assets/95df1251-acfe-49a0-b3ac-607b7226dabc">

## Related Links

- https://nodejs.org/id/blog/release/v22.8.0
- https://github.com/nodejs/node/pull/54501
- https://github.com/web-infra-dev/rsbuild/pull/3627
- https://github.com/web-infra-dev/rspack/pull/8331

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
