### PR TITLE
fix: rootDir calculation should ignore declaration files

### DIFF
--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -133,9 +133,17 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
     throw new Error();
   }
   const { options: rawCompilerOptions, fileNames } = loadTsconfig(configPath);
+
+  // The longest common path of all non-declaration input files.
+  // If composite is set, the default is instead the directory containing the tsconfig.json file.
+  // see https://www.typescriptlang.org/tsconfig/#rootDir
   const rootDir =
     rawCompilerOptions.rootDir ??
-    (await calcLongestCommonPath(fileNames)) ??
+    (rawCompilerOptions.composite
+      ? dirname(configPath)
+      : await calcLongestCommonPath(
+          fileNames.filter((fileName) => !/\.d\.(ts|mts|cts)$/.test(fileName)),
+        )) ??
     dirname(configPath);
 
   const outDir = distPath

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,6 +543,12 @@ importers:
 
   tests/integration/dts/bundle/false: {}
 
+  tests/integration/dts/bundle/rootdir:
+    devDependencies:
+      '@types/chromecast-caf-sender':
+        specifier: ^1.0.10
+        version: 1.0.10
+
   tests/integration/dts/bundle/true: {}
 
   tests/integration/dts/composite/__references__: {}
@@ -2072,6 +2078,12 @@ packages:
   '@types/body-parser@1.19.5':
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
 
+  '@types/chrome@0.0.280':
+    resolution: {integrity: sha512-AotSmZrL9bcZDDmSI1D9dE7PGbhOur5L0cKxXd7IqbVizQWCY4gcvupPUVsQ4FfDj3V2tt/iOpomT9EY0s+w1g==}
+
+  '@types/chromecast-caf-sender@1.0.10':
+    resolution: {integrity: sha512-B4iO+T4kMonmvIV+9xyWeIjxNWYVh6RyIQlFUeLk9fgQuXzHtFLnbnVwY7no5qshdUk9szKy0qbCWEMAjMkj4w==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -2090,8 +2102,17 @@ packages:
   '@types/express@5.0.0':
     resolution: {integrity: sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==}
 
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
@@ -7301,6 +7322,15 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 22.8.1
 
+  '@types/chrome@0.0.280':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+
+  '@types/chromecast-caf-sender@1.0.10':
+    dependencies:
+      '@types/chrome': 0.0.280
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.8.1
@@ -7329,10 +7359,18 @@ snapshots:
       '@types/qs': 6.9.15
       '@types/serve-static': 1.15.7
 
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
       '@types/node': 22.8.1
+
+  '@types/har-format@1.2.16': {}
 
   '@types/hast@2.3.10':
     dependencies:

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -93,6 +93,7 @@ pxtorem
 quxx
 rebranded
 rolldown
+rootdir
 rsbuild
 rsdoctor
 rsfamily

--- a/tests/integration/dts/__snapshots__/index.test.ts.snap
+++ b/tests/integration/dts/__snapshots__/index.test.ts.snap
@@ -60,3 +60,44 @@ export { }
 ",
 }
 `;
+
+exports[`dts when bundle: true > rootdir calculation should ignore declaration files 3`] = `
+{
+  "cjs": "export declare const num1 = 1;
+
+export declare const num2 = 2;
+
+export declare const num3 = 3;
+
+export declare const numSum: number;
+
+export declare const str1 = "str1";
+
+export declare const str2 = "str2";
+
+export declare const str3 = "str3";
+
+export declare const strSum: string;
+
+export { }
+",
+  "esm": "export declare const num1 = 1;
+
+export declare const num2 = 2;
+
+export declare const num3 = 3;
+
+export declare const numSum: number;
+
+export declare const str1 = "str1";
+
+export declare const str2 = "str2";
+
+export declare const str3 = "str3";
+
+export declare const strSum: string;
+
+export { }
+",
+}
+`;

--- a/tests/integration/dts/bundle/rootdir/package.json
+++ b/tests/integration/dts/bundle/rootdir/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dts-bundle-rootdir-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@types/chromecast-caf-sender": "^1.0.10"
+  }
+}

--- a/tests/integration/dts/bundle/rootdir/rslib.config.ts
+++ b/tests/integration/dts/bundle/rootdir/rslib.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      dts: {
+        bundle: true,
+      },
+    }),
+    generateBundleCjsConfig({
+      dts: {
+        bundle: true,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src/index.ts',
+    },
+  },
+});

--- a/tests/integration/dts/bundle/rootdir/tsconfig.json
+++ b/tests/integration/dts/bundle/rootdir/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "include": ["../__fixtures__/src", "node_modules/@types"]
+}

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -221,6 +221,28 @@ describe('dts when bundle: true', () => {
     `,
     );
   });
+
+  test('rootdir calculation should ignore declaration files', async () => {
+    const fixturePath = join(__dirname, 'bundle', 'rootdir');
+    const { files, entries } = await buildAndGetResults({
+      fixturePath,
+      type: 'dts',
+    });
+
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle/rootdir/dist/esm/index.d.ts",
+      ]
+    `);
+
+    expect(files.cjs).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle/rootdir/dist/cjs/index.d.ts",
+      ]
+    `);
+
+    expect(entries).toMatchSnapshot();
+  });
 });
 
 describe('dts when build: true', () => {


### PR DESCRIPTION
## Summary

rootDir calculation should ignore declaration files

see https://www.typescriptlang.org/tsconfig/#rootDir

## Related Links

closes: #385 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
