### PR TITLE
feat: support incremental build when composite is true

### DIFF
--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -260,7 +260,7 @@ export async function emitDts(
       `DTS generated in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
     );
   } else {
-    // watch mode
+    // watch mode, can also deal with incremental build
     if (!build) {
       const host = ts.createWatchCompilerHost(
         configPath,
@@ -273,7 +273,7 @@ export async function emitDts(
 
       ts.createWatchProgram(host);
     } else {
-      // incremental build with build project references
+      // incremental build watcher with build project references
       const host = ts.createSolutionBuilderWithWatchHost(
         system,
         createProgram,

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -18,6 +18,43 @@ export type EmitDtsOptions = {
   footer?: string;
 };
 
+async function handleDiagnosticsAndProcessFiles(
+  diagnostics: readonly ts.Diagnostic[],
+  configPath: string,
+  host: ts.CompilerHost,
+  bundle: boolean,
+  declarationDir: string,
+  dtsExtension: string,
+  banner?: string,
+  footer?: string,
+  name?: string,
+): Promise<void> {
+  const diagnosticMessages: string[] = [];
+
+  for (const diagnostic of diagnostics) {
+    const fileLoc = getFileLoc(diagnostic, configPath);
+    const message = `${fileLoc} - ${color.red('error')} ${color.gray(`TS${diagnostic.code}:`)} ${ts.flattenDiagnosticMessageText(
+      diagnostic.messageText,
+      host.getNewLine(),
+    )}`;
+    diagnosticMessages.push(message);
+  }
+
+  await processDtsFiles(bundle, declarationDir, dtsExtension, banner, footer);
+
+  if (diagnosticMessages.length) {
+    logger.error(
+      `Failed to emit declaration files. ${color.gray(`(${name})`)}`,
+    );
+
+    for (const message of diagnosticMessages) {
+      logger.error(message);
+    }
+
+    throw new Error('DTS generation failed');
+  }
+}
+
 export async function emitDts(
   options: EmitDtsOptions,
   onComplete: (isSuccess: boolean) => void,
@@ -37,6 +74,7 @@ export async function emitDts(
 
   const compilerOptions = {
     ...rawCompilerOptions,
+    configFilePath: configPath,
     noEmit: false,
     declaration: true,
     declarationDir,
@@ -111,9 +149,10 @@ export async function emitDts(
 
   const system = { ...ts.sys };
 
+  // build mode
   if (!isWatch) {
-    // build mode
-    if (!build) {
+    // normal build - npx tsc
+    if (!build && !compilerOptions.composite) {
       const host: ts.CompilerHost = ts.createCompilerHost(compilerOptions);
 
       const program: ts.Program = ts.createProgram({
@@ -132,38 +171,53 @@ export async function emitDts(
         .getPreEmitDiagnostics(program)
         .concat(emitResult.diagnostics);
 
-      const diagnosticMessages: string[] = [];
-
-      for (const diagnostic of allDiagnostics) {
-        const fileLoc = getFileLoc(diagnostic, configPath);
-        const message = `${fileLoc} - ${color.red('error')} ${color.gray(`TS${diagnostic.code}:`)} ${ts.flattenDiagnosticMessageText(
-          diagnostic.messageText,
-          host.getNewLine(),
-        )}`;
-        diagnosticMessages.push(message);
-      }
-
-      await processDtsFiles(
+      await handleDiagnosticsAndProcessFiles(
+        allDiagnostics,
+        configPath,
+        host,
         bundle,
         declarationDir,
         dtsExtension,
         banner,
         footer,
+        name,
       );
+    } else if (!build && compilerOptions.composite) {
+      // incremental build with composite true - npx tsc
+      const host: ts.CompilerHost =
+        ts.createIncrementalCompilerHost(compilerOptions);
 
-      if (diagnosticMessages.length) {
-        logger.error(
-          `Failed to emit declaration files. ${color.gray(`(${name})`)}`,
-        );
+      const program = ts.createIncrementalProgram({
+        rootNames: fileNames,
+        options: compilerOptions,
+        configFileParsingDiagnostics: ts.getConfigFileParsingDiagnostics(
+          configFileParseResult,
+        ),
+        projectReferences,
+        host,
+        createProgram,
+      });
 
-        for (const message of diagnosticMessages) {
-          logger.error(message);
-        }
+      program.emit();
 
-        throw new Error('DTS generation failed');
-      }
+      const allDiagnostics = program
+        .getSemanticDiagnostics()
+        .concat(program.getConfigFileParsingDiagnostics());
+
+      await handleDiagnosticsAndProcessFiles(
+        allDiagnostics,
+        configPath,
+        host,
+        bundle,
+        declarationDir,
+        dtsExtension,
+        banner,
+        footer,
+        name,
+      );
     } else {
-      // incremental build with project references
+      // incremental build with build project references
+      // The equivalent of the `--build` flag for the tsc command.
       let errorNumber = 0;
       const reportErrorSummary = (errorCount: number) => {
         errorNumber = errorCount;
@@ -219,7 +273,7 @@ export async function emitDts(
 
       ts.createWatchProgram(host);
     } else {
-      // incremental build with project references
+      // incremental build with build project references
       const host = ts.createSolutionBuilderWithWatchHost(
         system,
         createProgram,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,6 +570,14 @@ importers:
 
   tests/integration/dts/bundle/true: {}
 
+  tests/integration/dts/composite/abort-on-error: {}
+
+  tests/integration/dts/composite/basic: {}
+
+  tests/integration/dts/composite/dist-path: {}
+
+  tests/integration/dts/composite/process-files: {}
+
   tests/integration/entry/glob: {}
 
   tests/integration/entry/multiple: {}

--- a/tests/integration/dts/composite/__fixtures__/src/index.ts
+++ b/tests/integration/dts/composite/__fixtures__/src/index.ts
@@ -1,0 +1,3 @@
+export * from './utils/numbers';
+export * from './utils/strings';
+export * from './sum';

--- a/tests/integration/dts/composite/__fixtures__/src/sum.ts
+++ b/tests/integration/dts/composite/__fixtures__/src/sum.ts
@@ -1,0 +1,5 @@
+import { num1, num2, num3 } from './utils/numbers';
+import { str1, str2, str3 } from './utils/strings';
+
+export const numSum = num1 + num2 + num3;
+export const strSum = str1 + str2 + str3;

--- a/tests/integration/dts/composite/__fixtures__/src/utils/numbers.ts
+++ b/tests/integration/dts/composite/__fixtures__/src/utils/numbers.ts
@@ -1,0 +1,3 @@
+export const num1 = 1;
+export const num2 = 2;
+export const num3 = 3;

--- a/tests/integration/dts/composite/__fixtures__/src/utils/strings.ts
+++ b/tests/integration/dts/composite/__fixtures__/src/utils/strings.ts
@@ -1,0 +1,3 @@
+export const str1 = 'str1';
+export const str2 = 'str2';
+export const str3 = 'str3';

--- a/tests/integration/dts/composite/abort-on-error/package.json
+++ b/tests/integration/dts/composite/abort-on-error/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-composite-abort-on-error-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/composite/abort-on-error/rslib.config.ts
+++ b/tests/integration/dts/composite/abort-on-error/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+        abortOnError: false,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['./src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/composite/abort-on-error/src/const.ts
+++ b/tests/integration/dts/composite/abort-on-error/src/const.ts
@@ -1,0 +1,3 @@
+export interface A {
+  a: number;
+}

--- a/tests/integration/dts/composite/abort-on-error/src/index.ts
+++ b/tests/integration/dts/composite/abort-on-error/src/index.ts
@@ -1,0 +1,6 @@
+import type { A } from './const';
+
+export const getA = (item: A) => {
+  item.a = '0';
+  return item;
+};

--- a/tests/integration/dts/composite/abort-on-error/tsconfig.json
+++ b/tests/integration/dts/composite/abort-on-error/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"]
+}

--- a/tests/integration/dts/composite/basic/package.json
+++ b/tests/integration/dts/composite/basic/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-composite-basic-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/composite/basic/rslib.config.ts
+++ b/tests/integration/dts/composite/basic/rslib.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['../__fixtures__/src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/composite/basic/tsconfig.json
+++ b/tests/integration/dts/composite/basic/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "rootDir": "../__fixtures__/src",
+    "baseUrl": "./",
+    "composite": true
+  },
+  "include": ["../__fixtures__/src"]
+}

--- a/tests/integration/dts/composite/dist-path/package.json
+++ b/tests/integration/dts/composite/dist-path/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-composite-dist-path-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/composite/dist-path/rslib.config.ts
+++ b/tests/integration/dts/composite/dist-path/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+        distPath: './dist-types',
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['../__fixtures__/src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/composite/dist-path/tsconfig.json
+++ b/tests/integration/dts/composite/dist-path/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "rootDir": "../__fixtures__/src",
+    "baseUrl": "./",
+    "composite": true
+  },
+  "include": ["../__fixtures__/src"]
+}

--- a/tests/integration/dts/composite/process-files/package.json
+++ b/tests/integration/dts/composite/process-files/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dts-composite-process-files-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/dts/composite/process-files/rslib.config.ts
+++ b/tests/integration/dts/composite/process-files/rslib.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      banner: {
+        dts: '/*! hello banner dts composite*/',
+      },
+      footer: {
+        dts: '/*! hello banner dts composite*/',
+      },
+      dts: {
+        bundle: false,
+        autoExtension: true,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['../__fixtures__/src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/composite/process-files/tsconfig.json
+++ b/tests/integration/dts/composite/process-files/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "rootDir": "../__fixtures__/src",
+    "baseUrl": "./",
+    "composite": true
+  },
+  "include": ["../__fixtures__/src"]
+}

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -286,6 +286,9 @@ describe('dts when build: true', () => {
       '../__references__/dist/index.d.ts',
     );
     expect(existsSync(referenceDistPath)).toBeTruthy();
+
+    const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
+    expect(existsSync(buildInfoPath)).toBeTruthy();
   });
 
   test('distPath', async () => {
@@ -300,6 +303,9 @@ describe('dts when build: true', () => {
         "<ROOT>/tests/integration/dts/build/dist-path/dist/custom/index.d.ts",
       ]
     `);
+
+    const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
+    expect(existsSync(buildInfoPath)).toBeTruthy();
   });
 
   test('process files - auto extension and banner / footer', async () => {
@@ -318,6 +324,9 @@ describe('dts when build: true', () => {
       ",
       }
     `);
+
+    const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
+    expect(existsSync(buildInfoPath)).toBeTruthy();
   });
 
   test('abortOnError: false', async () => {
@@ -328,6 +337,9 @@ describe('dts when build: true', () => {
     });
 
     expect(isSuccess).toBe(true);
+
+    const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
+    expect(existsSync(buildInfoPath)).toBeTruthy();
   });
 
   test('tsconfig missing some fields - declarationDir or outDir', async () => {
@@ -341,5 +353,103 @@ describe('dts when build: true', () => {
       // not easy to proxy child process stdout
       expect(err.message).toBe('Error occurred in esm DTS generation');
     }
+  });
+});
+
+describe('dts when composite: true', () => {
+  test('basic', async () => {
+    const fixturePath = join(__dirname, 'composite', 'basic');
+    const { files } = await buildAndGetResults({
+      fixturePath,
+      type: 'dts',
+    });
+
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/composite/basic/dist/esm/index.d.ts",
+        "<ROOT>/tests/integration/dts/composite/basic/dist/esm/sum.d.ts",
+        "<ROOT>/tests/integration/dts/composite/basic/dist/esm/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts/composite/basic/dist/esm/utils/strings.d.ts",
+      ]
+    `);
+
+    const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
+    expect(existsSync(buildInfoPath)).toBeTruthy();
+  });
+
+  test('abortOnError: false', async () => {
+    const fixturePath = join(__dirname, 'composite', 'abort-on-error');
+    const { isSuccess } = await buildAndGetResults({
+      fixturePath,
+      type: 'dts',
+    });
+
+    expect(isSuccess).toBe(true);
+
+    const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
+    expect(existsSync(buildInfoPath)).toBeTruthy();
+  });
+
+  test('distPath', async () => {
+    const fixturePath = join(__dirname, 'composite', 'dist-path');
+    const { files } = await buildAndGetResults({
+      fixturePath,
+      type: 'dts',
+    });
+
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/composite/dist-path/dist-types/index.d.ts",
+        "<ROOT>/tests/integration/dts/composite/dist-path/dist-types/sum.d.ts",
+        "<ROOT>/tests/integration/dts/composite/dist-path/dist-types/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts/composite/dist-path/dist-types/utils/strings.d.ts",
+      ]
+    `);
+
+    const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
+    expect(existsSync(buildInfoPath)).toBeTruthy();
+  });
+
+  test('process files - auto extension and banner / footer', async () => {
+    const fixturePath = join(__dirname, 'composite', 'process-files');
+    const { contents } = await buildAndGetResults({
+      fixturePath,
+      type: 'dts',
+    });
+
+    expect(contents.esm).toMatchInlineSnapshot(`
+      {
+        "<ROOT>/tests/integration/dts/composite/process-files/dist/esm/index.d.mts": "/*! hello banner dts composite*/
+      export * from './utils/numbers';
+      export * from './utils/strings';
+      export * from './sum';
+
+      /*! hello banner dts composite*/
+      ",
+        "<ROOT>/tests/integration/dts/composite/process-files/dist/esm/sum.d.mts": "/*! hello banner dts composite*/
+      export declare const numSum: number;
+      export declare const strSum: string;
+
+      /*! hello banner dts composite*/
+      ",
+        "<ROOT>/tests/integration/dts/composite/process-files/dist/esm/utils/numbers.d.mts": "/*! hello banner dts composite*/
+      export declare const num1 = 1;
+      export declare const num2 = 2;
+      export declare const num3 = 3;
+
+      /*! hello banner dts composite*/
+      ",
+        "<ROOT>/tests/integration/dts/composite/process-files/dist/esm/utils/strings.d.mts": "/*! hello banner dts composite*/
+      export declare const str1 = "str1";
+      export declare const str2 = "str2";
+      export declare const str3 = "str3";
+
+      /*! hello banner dts composite*/
+      ",
+      }
+    `);
+
+    const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
+    expect(existsSync(buildInfoPath)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Our current logic using the [Typescript compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#writing-an-incremental-program-watcher) is:

### build mode

1. `dts.build: false`: [basic compiler](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#a-minimal-compiler) with `createCompilerHost` and `createProgram`
2. `dts.build: true`: incremental build with project references, using `createSolutionBuilderHost` and `createSolutionBuilder`

### watch mode

1. `dts.build: false`: [incremental program watcher](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#writing-an-incremental-program-watcher) with `createWatchCompilerHost` and `createWatchProgram`
2. `dts.build: true`: incremental build with project references, using `createSolutionBuilderWithWatchHost` and `createSolutionBuilderWithWatch`

In this PR, we add `createIncrementalCompilerHost` and `createIncrementalProgram` in build mode to support incremental and deal with projects that with `composite: true`(`incremental: true`) and do not to build references dependencies. The watch mode API originally support incremental, so we do not to deal with it in this scenerio.

Our logic is beyond what [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin) do

https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/0fab463b21c6edc4d94834568a3f440241d57887/src/typescript/worker/get-issues-worker.ts#L66-L73

For compiler API that not use `SolutionBuilder`, it seems the buildinfo not actually takes effect, it just generate buildinfo files. And for tsbuildinfo, due to various issues caused by buildinfo such as remove distPath and monorepo sceniro, we decide to delete buildinfo before generating dts in the next PR which is aligned with Modern.js Module. And our dts processing behaviour such as redirect alias, modify dts extensions and adding banner/footer are also not compatitle with ts cache.

For users who want to keep most align with the default behaviour with `tsc` in incremetal scenerio, they can enable `dts.build: true` but I think there's no need to do this if they do not want to build dependencies.

Hopefully there won’t be a day where we switch to using tsc bin files directly, and the ts compiler api will be easier to use with more extensive documentation and able to align related behaviors with tsc more easily.

## Related Links

<!--- Provide links of related issues or pages -->

close: #404 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
