### PR TITLE
fix: checkMFPlugin function support array plugins

### DIFF
--- a/.changeset/silver-pumas-tap.md
+++ b/.changeset/silver-pumas-tap.md
@@ -1,0 +1,5 @@
+---
+'@rslib/core': patch
+---
+
+fix: checkMFPlugin function support array plugins

--- a/packages/core/tests/helper.test.ts
+++ b/packages/core/tests/helper.test.ts
@@ -15,6 +15,7 @@ it('readPackageJson correctly', async () => {
 it('checkMFPlugin correctly', async () => {
   expect(
     checkMFPlugin({
+      format: 'mf',
       plugins: [
         { name: 'rsbuild:module-federation-enhanced', setup: () => {} },
       ],
@@ -23,6 +24,7 @@ it('checkMFPlugin correctly', async () => {
 
   expect(
     checkMFPlugin({
+      format: 'mf',
       plugins: [
         [
           { name: 'rsbuild:module-federation-enhanced', setup: () => {} },

--- a/packages/core/tests/helper.test.ts
+++ b/packages/core/tests/helper.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { expect, it, vi } from 'vitest';
-import { readPackageJson } from '../src/utils/helper';
+import { checkMFPlugin, readPackageJson } from '../src/utils/helper';
 
 vi.mock('rslog');
 
@@ -10,4 +10,25 @@ it('readPackageJson correctly', async () => {
   expect(readPackageJson(join(__dirname, 'fixtures/config/esm'))).toEqual({
     type: 'module',
   });
+});
+
+it('checkMFPlugin correctly', async () => {
+  expect(
+    checkMFPlugin({
+      plugins: [
+        { name: 'rsbuild:module-federation-enhanced', setup: () => {} },
+      ],
+    }),
+  ).toEqual(true);
+
+  expect(
+    checkMFPlugin({
+      plugins: [
+        [
+          { name: 'rsbuild:module-federation-enhanced', setup: () => {} },
+          { name: 'plugin-foo', setup: () => {} },
+        ],
+      ],
+    }),
+  ).toEqual(true);
 });


### PR DESCRIPTION
## Summary
plugins may pass array type like this: 

```ts
{
      format: 'mf',
      plugins: [
        [
          { name: 'rsbuild:module-federation-enhanced', setup: () => {} },
          { name: 'plugin-foo', setup: () => {} },
        ],
      ],
}
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or not required).
