### PR TITLE
fix: respect declarationDir if dts.distPath is not set

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -911,7 +911,7 @@ const composeDtsConfig = async (
   libConfig: LibConfig,
   dtsExtension: string,
 ): Promise<RsbuildConfig> => {
-  const { output, autoExternal, banner, footer } = libConfig;
+  const { autoExternal, banner, footer } = libConfig;
 
   let { dts } = libConfig;
 
@@ -929,10 +929,10 @@ const composeDtsConfig = async (
     plugins: [
       pluginDts({
         // Only setting ⁠dts.bundle to true will generate the bundled d.ts.
-        bundle: dts?.bundle ?? false,
-        distPath: dts?.distPath ?? output?.distPath?.root ?? './dist',
-        build: dts?.build ?? false,
-        abortOnError: dts?.abortOnError ?? true,
+        bundle: dts?.bundle,
+        distPath: dts?.distPath,
+        build: dts?.build,
+        abortOnError: dts?.abortOnError,
         dtsExtension: dts?.autoExtension ? dtsExtension : '.d.ts',
         autoExternal,
         banner: banner?.dts,

--- a/packages/plugin-dts/src/apiExtractor.ts
+++ b/packages/plugin-dts/src/apiExtractor.ts
@@ -12,7 +12,7 @@ import { addBannerAndFooter, getTimeCost } from './utils';
 export type BundleOptions = {
   name: string;
   cwd: string;
-  outDir: string;
+  distPath: string;
   dtsExtension: string;
   banner?: string;
   footer?: string;
@@ -25,7 +25,7 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
   const {
     name,
     cwd,
-    outDir,
+    distPath,
     dtsExtension,
     banner,
     footer,
@@ -40,7 +40,7 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
     const start = Date.now();
     const untrimmedFilePath = join(
       cwd,
-      relative(cwd, outDir),
+      relative(cwd, distPath),
       `${dtsEntry.name}${dtsExtension}`,
     );
     const mainEntryPointFilePath = dtsEntry.path!;

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -34,6 +34,7 @@ export type DtsGenOptions = PluginDtsOptions & {
   cwd: string;
   isWatch: boolean;
   dtsEntry: DtsEntry;
+  rootDistPath: string;
   build?: boolean;
   tsconfigPath?: string;
   userExternals?: NonNullable<RsbuildConfig['output']>['externals'];
@@ -68,8 +69,6 @@ export const pluginDts = (options: PluginDtsOptions): RsbuildPlugin => ({
 
         const { config } = environment;
 
-        options.distPath = options.distPath ?? config.output?.distPath?.root;
-
         const jsExtension = extname(__filename);
         const childProcess = fork(join(__dirname, `./dts${jsExtension}`), [], {
           stdio: 'inherit',
@@ -86,6 +85,7 @@ export const pluginDts = (options: PluginDtsOptions): RsbuildPlugin => ({
           ...options,
           dtsEntry,
           userExternals: config.output.externals,
+          rootDistPath: config.output?.distPath?.root,
           tsconfigPath: config.source.tsconfigPath,
           name: environment.name,
           cwd: api.context.rootPath,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,8 @@ importers:
 
   tests/integration/dts/bundle-false/basic: {}
 
+  tests/integration/dts/bundle-false/declaration-dir: {}
+
   tests/integration/dts/bundle-false/dist-path: {}
 
   tests/integration/dts/bundle-false/false: {}

--- a/tests/integration/dts/bundle-false/declaration-dir/package.json
+++ b/tests/integration/dts/bundle-false/declaration-dir/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-bundle-false-declaration-dir-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/bundle-false/declaration-dir/rslib.config.ts
+++ b/tests/integration/dts/bundle-false/declaration-dir/rslib.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['../__fixtures__/src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/bundle-false/declaration-dir/tsconfig.json
+++ b/tests/integration/dts/bundle-false/declaration-dir/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "declarationDir": "./dist-types"
+  },
+  "include": ["../__fixtures__/src"]
+}

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { buildAndGetResults } from 'test-helper';
+import { buildAndGetResults, globContentJSON } from 'test-helper';
 import { describe, expect, test } from 'vitest';
 
 describe('dts when bundle: false', () => {
@@ -87,6 +87,27 @@ describe('dts when bundle: false', () => {
         "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/cjs/sum.d.cts",
         "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/cjs/utils/numbers.d.cts",
         "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/cjs/utils/strings.d.cts",
+      ]
+    `);
+  });
+
+  test('should use declarationDir when not set dts.distPath', async () => {
+    const fixturePath = join(__dirname, 'bundle-false', 'declaration-dir');
+    const distTypesPath = join(fixturePath, 'dist-types');
+
+    await buildAndGetResults({ fixturePath, type: 'dts' });
+
+    const distTypeFiles = await globContentJSON(distTypesPath, {
+      absolute: true,
+    });
+    const distTypeFilePaths = Object.keys(distTypeFiles).sort();
+
+    expect(distTypeFilePaths).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle-false/declaration-dir/dist-types/index.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/declaration-dir/dist-types/sum.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/declaration-dir/dist-types/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/declaration-dir/dist-types/utils/strings.d.ts",
       ]
     `);
   });
@@ -309,7 +330,7 @@ describe('dts when build: true', () => {
     expect(isSuccess).toBe(true);
   });
 
-  test('tsconfig missing some fields', async () => {
+  test('tsconfig missing some fields - declarationDir or outDir', async () => {
     const fixturePath = join(__dirname, 'composite', 'tsconfig');
     try {
       await buildAndGetResults({


### PR DESCRIPTION
## Summary

The bundleless dts emit path should follow priority of:

1. `dts.distPath`
2. `declarationDir`
3. `output.distPath.root`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
