### PR TITLE
perf: enable compress minify option for node target

### DIFF
--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -80,12 +80,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           "js": true,
           "jsOptions": {
             "minimizerOptions": {
-              "compress": {
-                "dead_code": true,
-                "defaults": false,
-                "toplevel": true,
-                "unused": true,
-              },
+              "compress": true,
               "format": {
                 "comments": "all",
               },
@@ -292,12 +287,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           "js": true,
           "jsOptions": {
             "minimizerOptions": {
-              "compress": {
-                "dead_code": true,
-                "defaults": false,
-                "toplevel": true,
-                "unused": true,
-              },
+              "compress": true,
               "format": {
                 "comments": "all",
               },
@@ -502,12 +492,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           "js": true,
           "jsOptions": {
             "minimizerOptions": {
-              "compress": {
-                "dead_code": true,
-                "defaults": false,
-                "toplevel": true,
-                "unused": true,
-              },
+              "compress": true,
               "format": {
                 "comments": "all",
               },

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -332,12 +332,7 @@ describe('minify', () => {
         "js": true,
         "jsOptions": {
           "minimizerOptions": {
-            "compress": {
-              "dead_code": true,
-              "defaults": false,
-              "toplevel": true,
-              "unused": true,
-            },
+            "compress": true,
             "format": {
               "comments": "all",
             },

--- a/tests/integration/alias/__snapshots__/index.test.ts.snap
+++ b/tests/integration/alias/__snapshots__/index.test.ts.snap
@@ -1,20 +1,19 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`source.alias 1`] = `
-"const a = 'hello world';
-console.info(a);
+"console.info('hello world');
 "
 `;
 
 exports[`source.alias 2`] = `
 ""use strict";
 var __webpack_exports__ = {};
-const a = 'hello world';
-console.info(a);
+let a = 'hello world';
+console.info('hello world');
 var __webpack_export_target__ = exports;
 for(var i in __webpack_exports__)__webpack_export_target__[i] = __webpack_exports__[i];
-if (__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, '__esModule', {
-    value: true
+__webpack_exports__.__esModule && Object.defineProperty(__webpack_export_target__, '__esModule', {
+    value: !0
 });
 "
 `;

--- a/tests/integration/auto-extension/index.test.ts
+++ b/tests/integration/auto-extension/index.test.ts
@@ -40,7 +40,7 @@ describe('should respect output.filename.js to override builtin logic', () => {
     const { entryFiles } = await buildAndGetResults({ fixturePath });
     expect(extname(entryFiles.esm!)).toEqual('.mjs');
     expect(entryFiles.cjs).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs/index.d08e1bb3.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs/index.60cfaf97.js"`,
     );
   });
 
@@ -48,7 +48,7 @@ describe('should respect output.filename.js to override builtin logic', () => {
     const fixturePath = join(__dirname, 'type-module', 'config-override');
     const { entryFiles } = await buildAndGetResults({ fixturePath });
     expect(entryFiles.esm).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm/index.d2068839.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm/index.387ba858.js"`,
     );
     expect(extname(entryFiles.cjs!)).toEqual('.cjs');
   });

--- a/tests/integration/decorators/__snapshots__/index.test.ts.snap
+++ b/tests/integration/decorators/__snapshots__/index.test.ts.snap
@@ -1,312 +1,197 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`decorators default to 2022-03 1`] = `
-"function applyDecs2203RFactory() {
-    function createAddInitializerMethod(initializers, decoratorFinishedRef) {
-        return function(initializer) {
-            assertNotFinished(decoratorFinishedRef, "addInitializer");
-            assertCallable(initializer, "An initializer");
-            initializers.push(initializer);
-        };
-    }
-    function memberDec(dec, name, desc, initializers, kind, isStatic, isPrivate, metadata, value) {
-        var kindStr;
-        switch(kind){
-            case 1:
-                kindStr = "accessor";
-                break;
-            case 2:
-                kindStr = "method";
-                break;
-            case 3:
-                kindStr = "getter";
-                break;
-            case 4:
-                kindStr = "setter";
-                break;
-            default:
-                kindStr = "field";
-        }
-        var ctx = {
-            kind: kindStr,
-            name: isPrivate ? "#" + name : name,
-            static: isStatic,
-            private: isPrivate,
-            metadata: metadata
-        };
-        var decoratorFinishedRef = {
-            v: false
-        };
-        ctx.addInitializer = createAddInitializerMethod(initializers, decoratorFinishedRef);
-        var get, set;
-        if (0 === kind) {
-            if (isPrivate) {
-                get = desc.get;
-                set = desc.set;
-            } else {
-                get = function() {
-                    return this[name];
-                };
-                set = function(v) {
-                    this[name] = v;
-                };
-            }
-        } else if (2 === kind) get = function() {
-            return desc.value;
-        };
-        else {
-            if (1 === kind || 3 === kind) get = function() {
-                return desc.get.call(this);
-            };
-            if (1 === kind || 4 === kind) set = function(v) {
-                desc.set.call(this, v);
-            };
-        }
-        ctx.access = get && set ? {
-            get: get,
-            set: set
-        } : get ? {
-            get: get
-        } : {
-            set: set
-        };
-        try {
-            return dec(value, ctx);
-        } finally{
-            decoratorFinishedRef.v = true;
-        }
-    }
-    function assertNotFinished(decoratorFinishedRef, fnName) {
-        if (decoratorFinishedRef.v) throw new Error("attempted to call " + fnName + " after decoration was finished");
-    }
-    function assertCallable(fn, hint) {
-        if ("function" != typeof fn) throw new TypeError(hint + " must be a function");
-    }
-    function assertValidReturnValue(kind, value) {
-        var type = typeof value;
-        if (1 === kind) {
-            if ("object" !== type || null === value) throw new TypeError("accessor decorators must return an object with get, set, or init properties or void 0");
-            if (void 0 !== value.get) assertCallable(value.get, "accessor.get");
-            if (void 0 !== value.set) assertCallable(value.set, "accessor.set");
-            if (void 0 !== value.init) assertCallable(value.init, "accessor.init");
-        } else if ("function" !== type) {
-            var hint;
-            hint = 0 === kind ? "field" : 10 === kind ? "class" : "method";
-            throw new TypeError(hint + " decorators must return a function or void 0");
-        }
-    }
-    function applyMemberDec(ret, base, decInfo, name, kind, isStatic, isPrivate, initializers, metadata) {
-        var decs = decInfo[0];
-        var desc, init, value;
-        if (isPrivate) desc = 0 === kind || 1 === kind ? {
-            get: decInfo[3],
-            set: decInfo[4]
-        } : 3 === kind ? {
-            get: decInfo[3]
-        } : 4 === kind ? {
-            set: decInfo[3]
-        } : {
-            value: decInfo[3]
-        };
-        else if (0 !== kind) desc = Object.getOwnPropertyDescriptor(base, name);
-        if (1 === kind) value = {
-            get: desc.get,
-            set: desc.set
-        };
-        else if (2 === kind) value = desc.value;
-        else if (3 === kind) value = desc.get;
-        else if (4 === kind) value = desc.set;
-        var newValue, get, set;
-        if ("function" == typeof decs) {
-            newValue = memberDec(decs, name, desc, initializers, kind, isStatic, isPrivate, metadata, value);
-            if (void 0 !== newValue) {
-                assertValidReturnValue(kind, newValue);
-                if (0 === kind) init = newValue;
-                else if (1 === kind) {
-                    init = newValue.init;
-                    get = newValue.get || value.get;
-                    set = newValue.set || value.set;
-                    value = {
-                        get: get,
-                        set: set
-                    };
-                } else value = newValue;
-            }
-        } else for(var i = decs.length - 1; i >= 0; i--){
-            var dec = decs[i];
-            newValue = memberDec(dec, name, desc, initializers, kind, isStatic, isPrivate, metadata, value);
-            if (void 0 !== newValue) {
-                assertValidReturnValue(kind, newValue);
-                var newInit;
-                if (0 === kind) newInit = newValue;
-                else if (1 === kind) {
-                    newInit = newValue.init;
-                    get = newValue.get || value.get;
-                    set = newValue.set || value.set;
-                    value = {
-                        get: get,
-                        set: set
-                    };
-                } else value = newValue;
-                if (void 0 !== newInit) {
-                    if (void 0 === init) init = newInit;
-                    else if ("function" == typeof init) init = [
-                        init,
-                        newInit
-                    ];
-                    else init.push(newInit);
-                }
-            }
-        }
-        if (0 === kind || 1 === kind) {
-            if (void 0 === init) init = function(instance, init) {
-                return init;
-            };
-            else if ("function" != typeof init) {
-                var ownInitializers = init;
-                init = function(instance, init) {
-                    var value = init;
-                    for(var i = 0; i < ownInitializers.length; i++)value = ownInitializers[i].call(instance, value);
-                    return value;
-                };
-            } else {
-                var originalInitializer = init;
-                init = function(instance, init) {
-                    return originalInitializer.call(instance, init);
-                };
-            }
-            ret.push(init);
-        }
-        if (0 !== kind) {
-            if (1 === kind) {
-                desc.get = value.get;
-                desc.set = value.set;
-            } else if (2 === kind) desc.value = value;
-            else if (3 === kind) desc.get = value;
-            else if (4 === kind) desc.set = value;
-            if (isPrivate) {
-                if (1 === kind) {
-                    ret.push(function(instance, args) {
-                        return value.get.call(instance, args);
-                    });
-                    ret.push(function(instance, args) {
-                        return value.set.call(instance, args);
-                    });
-                } else if (2 === kind) ret.push(value);
-                else ret.push(function(instance, args) {
-                    return value.call(instance, args);
-                });
-            } else Object.defineProperty(base, name, desc);
-        }
-    }
-    function applyMemberDecs(Class, decInfos, metadata) {
-        var ret = [];
-        var protoInitializers;
-        var staticInitializers;
-        var existingProtoNonFields = new Map();
-        var existingStaticNonFields = new Map();
-        for(var i = 0; i < decInfos.length; i++){
-            var decInfo = decInfos[i];
-            if (!!Array.isArray(decInfo)) {
-                var kind = decInfo[1];
-                var name = decInfo[2];
-                var isPrivate = decInfo.length > 3;
-                var isStatic = kind >= 5;
-                var base;
-                var initializers;
-                if (isStatic) {
-                    base = Class;
-                    kind -= 5;
-                    staticInitializers = staticInitializers || [];
-                    initializers = staticInitializers;
-                } else {
-                    base = Class.prototype;
-                    protoInitializers = protoInitializers || [];
-                    initializers = protoInitializers;
-                }
-                if (0 !== kind && !isPrivate) {
-                    var existingNonFields = isStatic ? existingStaticNonFields : existingProtoNonFields;
-                    var existingKind = existingNonFields.get(name) || 0;
-                    if (true === existingKind || 3 === existingKind && 4 !== kind || 4 === existingKind && 3 !== kind) throw new Error("Attempted to decorate a public method/accessor that has the same name as a previously decorated public method/accessor. This is not currently supported by the decorators plugin. Property name was: " + name);
-                    if (!existingKind && kind > 2) existingNonFields.set(name, kind);
-                    else existingNonFields.set(name, true);
-                }
-                applyMemberDec(ret, base, decInfo, name, kind, isStatic, isPrivate, initializers, metadata);
-            }
-        }
-        pushInitializers(ret, protoInitializers);
-        pushInitializers(ret, staticInitializers);
-        return ret;
-    }
-    function pushInitializers(ret, initializers) {
-        if (initializers) ret.push(function(instance) {
-            for(var i = 0; i < initializers.length; i++)initializers[i].call(instance);
-            return instance;
-        });
-    }
-    function applyClassDecs(targetClass, classDecs, metadata) {
-        if (classDecs.length > 0) {
-            var initializers = [];
-            var newClass = targetClass;
-            var name = targetClass.name;
-            for(var i = classDecs.length - 1; i >= 0; i--){
-                var decoratorFinishedRef = {
-                    v: false
-                };
-                try {
-                    var nextNewClass = classDecs[i](newClass, {
-                        kind: "class",
-                        name: name,
-                        addInitializer: createAddInitializerMethod(initializers, decoratorFinishedRef),
-                        metadata
-                    });
-                } finally{
-                    decoratorFinishedRef.v = true;
-                }
-                if (void 0 !== nextNewClass) {
-                    assertValidReturnValue(10, nextNewClass);
-                    newClass = nextNewClass;
-                }
-            }
-            return [
-                defineMetadata(newClass, metadata),
-                function() {
-                    for(var i = 0; i < initializers.length; i++)initializers[i].call(newClass);
-                }
-            ];
-        }
-    }
-    function defineMetadata(Class, metadata) {
-        return Object.defineProperty(Class, Symbol.metadata || Symbol.for("Symbol.metadata"), {
-            configurable: true,
-            enumerable: true,
-            value: metadata
-        });
-    }
-    return function(targetClass, memberDecs, classDecs, parentClass) {
-        if (void 0 !== parentClass) var parentMetadata = parentClass[Symbol.metadata || Symbol.for("Symbol.metadata")];
-        var metadata = Object.create(void 0 === parentMetadata ? null : parentMetadata);
-        var e = applyMemberDecs(targetClass, memberDecs, metadata);
-        if (!classDecs.length) defineMetadata(targetClass, metadata);
-        return {
-            e: e,
-            get c () {
-                return applyClassDecs(targetClass, classDecs, metadata);
-            }
-        };
-    };
-}
-function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
-    return (_apply_decs_2203_r = applyDecs2203RFactory())(targetClass, memberDecs, classDecs, parentClass);
-}
-var _dec, _initClass;
-function src_enhancer(name) {
-    return function(target) {
-        target.prototype.name = name;
-    };
-}
+"var _dec, _initClass;
 let _Person;
-_dec = src_enhancer('rslib');
+function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
+    return (_apply_decs_2203_r = function() {
+        function createAddInitializerMethod(initializers, decoratorFinishedRef) {
+            return function(initializer) {
+                (function(decoratorFinishedRef, fnName) {
+                    if (decoratorFinishedRef.v) throw Error("attempted to call " + fnName + " after decoration was finished");
+                })(decoratorFinishedRef, "addInitializer"), assertCallable(initializer, "An initializer"), initializers.push(initializer);
+            };
+        }
+        function memberDec(dec, name, desc, initializers, kind, isStatic, isPrivate, metadata, value) {
+            switch(kind){
+                case 1:
+                    kindStr = "accessor";
+                    break;
+                case 2:
+                    kindStr = "method";
+                    break;
+                case 3:
+                    kindStr = "getter";
+                    break;
+                case 4:
+                    kindStr = "setter";
+                    break;
+                default:
+                    kindStr = "field";
+            }
+            var kindStr, get, set, ctx = {
+                kind: kindStr,
+                name: isPrivate ? "#" + name : name,
+                static: isStatic,
+                private: isPrivate,
+                metadata: metadata
+            }, decoratorFinishedRef = {
+                v: !1
+            };
+            ctx.addInitializer = createAddInitializerMethod(initializers, decoratorFinishedRef), 0 === kind ? isPrivate ? (get = desc.get, set = desc.set) : (get = function() {
+                return this[name];
+            }, set = function(v) {
+                this[name] = v;
+            }) : 2 === kind ? get = function() {
+                return desc.value;
+            } : ((1 === kind || 3 === kind) && (get = function() {
+                return desc.get.call(this);
+            }), (1 === kind || 4 === kind) && (set = function(v) {
+                desc.set.call(this, v);
+            })), ctx.access = get && set ? {
+                get: get,
+                set: set
+            } : get ? {
+                get: get
+            } : {
+                set: set
+            };
+            try {
+                return dec(value, ctx);
+            } finally{
+                decoratorFinishedRef.v = !0;
+            }
+        }
+        function assertCallable(fn, hint) {
+            if ("function" != typeof fn) throw TypeError(hint + " must be a function");
+        }
+        function assertValidReturnValue(kind, value) {
+            var hint, type = typeof value;
+            if (1 === kind) {
+                if ("object" !== type || null === value) throw TypeError("accessor decorators must return an object with get, set, or init properties or void 0");
+                void 0 !== value.get && assertCallable(value.get, "accessor.get"), void 0 !== value.set && assertCallable(value.set, "accessor.set"), void 0 !== value.init && assertCallable(value.init, "accessor.init");
+            } else if ("function" !== type) throw TypeError((hint = 0 === kind ? "field" : 10 === kind ? "class" : "method") + " decorators must return a function or void 0");
+        }
+        function pushInitializers(ret, initializers) {
+            initializers && ret.push(function(instance) {
+                for(var i = 0; i < initializers.length; i++)initializers[i].call(instance);
+                return instance;
+            });
+        }
+        function defineMetadata(Class, metadata) {
+            return Object.defineProperty(Class, Symbol.metadata || Symbol.for("Symbol.metadata"), {
+                configurable: !0,
+                enumerable: !0,
+                value: metadata
+            });
+        }
+        return function(targetClass, memberDecs, classDecs, parentClass) {
+            if (void 0 !== parentClass) var parentMetadata = parentClass[Symbol.metadata || Symbol.for("Symbol.metadata")];
+            var metadata = Object.create(void 0 === parentMetadata ? null : parentMetadata), e = function(Class, decInfos, metadata) {
+                for(var ret = [], existingProtoNonFields = new Map(), existingStaticNonFields = new Map(), i = 0; i < decInfos.length; i++){
+                    var protoInitializers, staticInitializers, base, initializers, decInfo = decInfos[i];
+                    if (Array.isArray(decInfo)) {
+                        var kind = decInfo[1], name = decInfo[2], isPrivate = decInfo.length > 3, isStatic = kind >= 5;
+                        if (isStatic ? (base = Class, kind -= 5, initializers = staticInitializers = staticInitializers || []) : (base = Class.prototype, initializers = protoInitializers = protoInitializers || []), 0 !== kind && !isPrivate) {
+                            var existingNonFields = isStatic ? existingStaticNonFields : existingProtoNonFields, existingKind = existingNonFields.get(name) || 0;
+                            if (!0 === existingKind || 3 === existingKind && 4 !== kind || 4 === existingKind && 3 !== kind) throw Error("Attempted to decorate a public method/accessor that has the same name as a previously decorated public method/accessor. This is not currently supported by the decorators plugin. Property name was: " + name);
+                            !existingKind && kind > 2 ? existingNonFields.set(name, kind) : existingNonFields.set(name, !0);
+                        }
+                        !function(ret, base, decInfo, name, kind, isStatic, isPrivate, initializers, metadata) {
+                            var desc, init, value, newValue, get, set, newInit, decs = decInfo[0];
+                            if (isPrivate ? desc = 0 === kind || 1 === kind ? {
+                                get: decInfo[3],
+                                set: decInfo[4]
+                            } : 3 === kind ? {
+                                get: decInfo[3]
+                            } : 4 === kind ? {
+                                set: decInfo[3]
+                            } : {
+                                value: decInfo[3]
+                            } : 0 !== kind && (desc = Object.getOwnPropertyDescriptor(base, name)), 1 === kind ? value = {
+                                get: desc.get,
+                                set: desc.set
+                            } : 2 === kind ? value = desc.value : 3 === kind ? value = desc.get : 4 === kind && (value = desc.set), "function" == typeof decs) void 0 !== (newValue = memberDec(decs, name, desc, initializers, kind, isStatic, isPrivate, metadata, value)) && (assertValidReturnValue(kind, newValue), 0 === kind ? init = newValue : 1 === kind ? (init = newValue.init, get = newValue.get || value.get, value = {
+                                get: get,
+                                set: set = newValue.set || value.set
+                            }) : value = newValue);
+                            else for(var i = decs.length - 1; i >= 0; i--){
+                                ;
+                                void 0 !== (newValue = memberDec(decs[i], name, desc, initializers, kind, isStatic, isPrivate, metadata, value)) && (assertValidReturnValue(kind, newValue), 0 === kind ? newInit = newValue : 1 === kind ? (newInit = newValue.init, get = newValue.get || value.get, value = {
+                                    get: get,
+                                    set: set = newValue.set || value.set
+                                }) : value = newValue, void 0 !== newInit && (void 0 === init ? init = newInit : "function" == typeof init ? init = [
+                                    init,
+                                    newInit
+                                ] : init.push(newInit)));
+                            }
+                            if (0 === kind || 1 === kind) {
+                                if (void 0 === init) init = function(instance, init) {
+                                    return init;
+                                };
+                                else if ("function" != typeof init) {
+                                    var ownInitializers = init;
+                                    init = function(instance, init) {
+                                        for(var value = init, i = 0; i < ownInitializers.length; i++)value = ownInitializers[i].call(instance, value);
+                                        return value;
+                                    };
+                                } else {
+                                    var originalInitializer = init;
+                                    init = function(instance, init) {
+                                        return originalInitializer.call(instance, init);
+                                    };
+                                }
+                                ret.push(init);
+                            }
+                            0 !== kind && (1 === kind ? (desc.get = value.get, desc.set = value.set) : 2 === kind ? desc.value = value : 3 === kind ? desc.get = value : 4 === kind && (desc.set = value), isPrivate ? 1 === kind ? (ret.push(function(instance, args) {
+                                return value.get.call(instance, args);
+                            }), ret.push(function(instance, args) {
+                                return value.set.call(instance, args);
+                            })) : 2 === kind ? ret.push(value) : ret.push(function(instance, args) {
+                                return value.call(instance, args);
+                            }) : Object.defineProperty(base, name, desc));
+                        }(ret, base, decInfo, name, kind, isStatic, isPrivate, initializers, metadata);
+                    }
+                }
+                return pushInitializers(ret, protoInitializers), pushInitializers(ret, staticInitializers), ret;
+            }(targetClass, memberDecs, metadata);
+            return !classDecs.length && defineMetadata(targetClass, metadata), {
+                e: e,
+                get c () {
+                    return function(targetClass, classDecs, metadata) {
+                        if (classDecs.length > 0) {
+                            for(var initializers = [], newClass = targetClass, name = targetClass.name, i = classDecs.length - 1; i >= 0; i--){
+                                var decoratorFinishedRef = {
+                                    v: !1
+                                };
+                                try {
+                                    var nextNewClass = classDecs[i](newClass, {
+                                        kind: "class",
+                                        name: name,
+                                        addInitializer: createAddInitializerMethod(initializers, decoratorFinishedRef),
+                                        metadata
+                                    });
+                                } finally{
+                                    decoratorFinishedRef.v = !0;
+                                }
+                                void 0 !== nextNewClass && (assertValidReturnValue(10, nextNewClass), newClass = nextNewClass);
+                            }
+                            return [
+                                defineMetadata(newClass, metadata),
+                                function() {
+                                    for(var i = 0; i < initializers.length; i++)initializers[i].call(newClass);
+                                }
+                            ];
+                        }
+                    }(targetClass, classDecs, metadata);
+                }
+            };
+        };
+    }())(targetClass, memberDecs, classDecs, parentClass);
+}
+_dec = function(target) {
+    target.prototype.name = 'rslib';
+};
 class Person {
     static{
         ({ c: [_Person, _initClass] } = _apply_decs_2203_r(this, [], [
@@ -326,27 +211,23 @@ export { _Person as Person };
 `;
 
 exports[`decorators with experimentalDecorators in tsconfig 1`] = `
-"function _ts_decorate(decorators, target, key, desc) {
-    var c = arguments.length, r = c < 3 ? target : null === desc ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-    if ("object" == typeof Reflect && "function" == typeof Reflect.decorate) r = Reflect.decorate(decorators, target, key, desc);
-    else for(var i = decorators.length - 1; i >= 0; i--)if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
-    return c > 3 && r && Object.defineProperty(target, key, r), r;
-}
-function _ts_metadata(k, v) {
+"function _ts_metadata(k, v) {
     if ("object" == typeof Reflect && "function" == typeof Reflect.metadata) return Reflect.metadata(k, v);
-}
-function src_enhancer(name) {
-    return function(target) {
-        target.prototype.name = name;
-    };
 }
 class Person {
     constructor(){
         this.version = '1.0.0';
     }
 }
-Person = _ts_decorate([
-    src_enhancer('rslib'),
+Person = function(decorators, target, key, desc) {
+    var d, c = arguments.length, r = c < 3 ? target : null === desc ? desc = Object.getOwnPropertyDescriptor(target, key) : desc;
+    if ("object" == typeof Reflect && "function" == typeof Reflect.decorate) r = Reflect.decorate(decorators, target, key, desc);
+    else for(var i = decorators.length - 1; i >= 0; i--)(d = decorators[i]) && (r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r);
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+}([
+    function(target) {
+        target.prototype.name = 'rslib';
+    },
     _ts_metadata("design:type", Function),
     _ts_metadata("design:paramtypes", [])
 ], Person);
@@ -355,312 +236,197 @@ export { Person };
 `;
 
 exports[`decorators with experimentalDecorators in tsconfig 2`] = `
-"function applyDecs2203RFactory() {
-    function createAddInitializerMethod(initializers, decoratorFinishedRef) {
-        return function(initializer) {
-            assertNotFinished(decoratorFinishedRef, "addInitializer");
-            assertCallable(initializer, "An initializer");
-            initializers.push(initializer);
-        };
-    }
-    function memberDec(dec, name, desc, initializers, kind, isStatic, isPrivate, metadata, value) {
-        var kindStr;
-        switch(kind){
-            case 1:
-                kindStr = "accessor";
-                break;
-            case 2:
-                kindStr = "method";
-                break;
-            case 3:
-                kindStr = "getter";
-                break;
-            case 4:
-                kindStr = "setter";
-                break;
-            default:
-                kindStr = "field";
-        }
-        var ctx = {
-            kind: kindStr,
-            name: isPrivate ? "#" + name : name,
-            static: isStatic,
-            private: isPrivate,
-            metadata: metadata
-        };
-        var decoratorFinishedRef = {
-            v: false
-        };
-        ctx.addInitializer = createAddInitializerMethod(initializers, decoratorFinishedRef);
-        var get, set;
-        if (0 === kind) {
-            if (isPrivate) {
-                get = desc.get;
-                set = desc.set;
-            } else {
-                get = function() {
-                    return this[name];
-                };
-                set = function(v) {
-                    this[name] = v;
-                };
-            }
-        } else if (2 === kind) get = function() {
-            return desc.value;
-        };
-        else {
-            if (1 === kind || 3 === kind) get = function() {
-                return desc.get.call(this);
-            };
-            if (1 === kind || 4 === kind) set = function(v) {
-                desc.set.call(this, v);
-            };
-        }
-        ctx.access = get && set ? {
-            get: get,
-            set: set
-        } : get ? {
-            get: get
-        } : {
-            set: set
-        };
-        try {
-            return dec(value, ctx);
-        } finally{
-            decoratorFinishedRef.v = true;
-        }
-    }
-    function assertNotFinished(decoratorFinishedRef, fnName) {
-        if (decoratorFinishedRef.v) throw new Error("attempted to call " + fnName + " after decoration was finished");
-    }
-    function assertCallable(fn, hint) {
-        if ("function" != typeof fn) throw new TypeError(hint + " must be a function");
-    }
-    function assertValidReturnValue(kind, value) {
-        var type = typeof value;
-        if (1 === kind) {
-            if ("object" !== type || null === value) throw new TypeError("accessor decorators must return an object with get, set, or init properties or void 0");
-            if (void 0 !== value.get) assertCallable(value.get, "accessor.get");
-            if (void 0 !== value.set) assertCallable(value.set, "accessor.set");
-            if (void 0 !== value.init) assertCallable(value.init, "accessor.init");
-        } else if ("function" !== type) {
-            var hint;
-            hint = 0 === kind ? "field" : 10 === kind ? "class" : "method";
-            throw new TypeError(hint + " decorators must return a function or void 0");
-        }
-    }
-    function applyMemberDec(ret, base, decInfo, name, kind, isStatic, isPrivate, initializers, metadata) {
-        var decs = decInfo[0];
-        var desc, init, value;
-        if (isPrivate) desc = 0 === kind || 1 === kind ? {
-            get: decInfo[3],
-            set: decInfo[4]
-        } : 3 === kind ? {
-            get: decInfo[3]
-        } : 4 === kind ? {
-            set: decInfo[3]
-        } : {
-            value: decInfo[3]
-        };
-        else if (0 !== kind) desc = Object.getOwnPropertyDescriptor(base, name);
-        if (1 === kind) value = {
-            get: desc.get,
-            set: desc.set
-        };
-        else if (2 === kind) value = desc.value;
-        else if (3 === kind) value = desc.get;
-        else if (4 === kind) value = desc.set;
-        var newValue, get, set;
-        if ("function" == typeof decs) {
-            newValue = memberDec(decs, name, desc, initializers, kind, isStatic, isPrivate, metadata, value);
-            if (void 0 !== newValue) {
-                assertValidReturnValue(kind, newValue);
-                if (0 === kind) init = newValue;
-                else if (1 === kind) {
-                    init = newValue.init;
-                    get = newValue.get || value.get;
-                    set = newValue.set || value.set;
-                    value = {
-                        get: get,
-                        set: set
-                    };
-                } else value = newValue;
-            }
-        } else for(var i = decs.length - 1; i >= 0; i--){
-            var dec = decs[i];
-            newValue = memberDec(dec, name, desc, initializers, kind, isStatic, isPrivate, metadata, value);
-            if (void 0 !== newValue) {
-                assertValidReturnValue(kind, newValue);
-                var newInit;
-                if (0 === kind) newInit = newValue;
-                else if (1 === kind) {
-                    newInit = newValue.init;
-                    get = newValue.get || value.get;
-                    set = newValue.set || value.set;
-                    value = {
-                        get: get,
-                        set: set
-                    };
-                } else value = newValue;
-                if (void 0 !== newInit) {
-                    if (void 0 === init) init = newInit;
-                    else if ("function" == typeof init) init = [
-                        init,
-                        newInit
-                    ];
-                    else init.push(newInit);
-                }
-            }
-        }
-        if (0 === kind || 1 === kind) {
-            if (void 0 === init) init = function(instance, init) {
-                return init;
-            };
-            else if ("function" != typeof init) {
-                var ownInitializers = init;
-                init = function(instance, init) {
-                    var value = init;
-                    for(var i = 0; i < ownInitializers.length; i++)value = ownInitializers[i].call(instance, value);
-                    return value;
-                };
-            } else {
-                var originalInitializer = init;
-                init = function(instance, init) {
-                    return originalInitializer.call(instance, init);
-                };
-            }
-            ret.push(init);
-        }
-        if (0 !== kind) {
-            if (1 === kind) {
-                desc.get = value.get;
-                desc.set = value.set;
-            } else if (2 === kind) desc.value = value;
-            else if (3 === kind) desc.get = value;
-            else if (4 === kind) desc.set = value;
-            if (isPrivate) {
-                if (1 === kind) {
-                    ret.push(function(instance, args) {
-                        return value.get.call(instance, args);
-                    });
-                    ret.push(function(instance, args) {
-                        return value.set.call(instance, args);
-                    });
-                } else if (2 === kind) ret.push(value);
-                else ret.push(function(instance, args) {
-                    return value.call(instance, args);
-                });
-            } else Object.defineProperty(base, name, desc);
-        }
-    }
-    function applyMemberDecs(Class, decInfos, metadata) {
-        var ret = [];
-        var protoInitializers;
-        var staticInitializers;
-        var existingProtoNonFields = new Map();
-        var existingStaticNonFields = new Map();
-        for(var i = 0; i < decInfos.length; i++){
-            var decInfo = decInfos[i];
-            if (!!Array.isArray(decInfo)) {
-                var kind = decInfo[1];
-                var name = decInfo[2];
-                var isPrivate = decInfo.length > 3;
-                var isStatic = kind >= 5;
-                var base;
-                var initializers;
-                if (isStatic) {
-                    base = Class;
-                    kind -= 5;
-                    staticInitializers = staticInitializers || [];
-                    initializers = staticInitializers;
-                } else {
-                    base = Class.prototype;
-                    protoInitializers = protoInitializers || [];
-                    initializers = protoInitializers;
-                }
-                if (0 !== kind && !isPrivate) {
-                    var existingNonFields = isStatic ? existingStaticNonFields : existingProtoNonFields;
-                    var existingKind = existingNonFields.get(name) || 0;
-                    if (true === existingKind || 3 === existingKind && 4 !== kind || 4 === existingKind && 3 !== kind) throw new Error("Attempted to decorate a public method/accessor that has the same name as a previously decorated public method/accessor. This is not currently supported by the decorators plugin. Property name was: " + name);
-                    if (!existingKind && kind > 2) existingNonFields.set(name, kind);
-                    else existingNonFields.set(name, true);
-                }
-                applyMemberDec(ret, base, decInfo, name, kind, isStatic, isPrivate, initializers, metadata);
-            }
-        }
-        pushInitializers(ret, protoInitializers);
-        pushInitializers(ret, staticInitializers);
-        return ret;
-    }
-    function pushInitializers(ret, initializers) {
-        if (initializers) ret.push(function(instance) {
-            for(var i = 0; i < initializers.length; i++)initializers[i].call(instance);
-            return instance;
-        });
-    }
-    function applyClassDecs(targetClass, classDecs, metadata) {
-        if (classDecs.length > 0) {
-            var initializers = [];
-            var newClass = targetClass;
-            var name = targetClass.name;
-            for(var i = classDecs.length - 1; i >= 0; i--){
-                var decoratorFinishedRef = {
-                    v: false
-                };
-                try {
-                    var nextNewClass = classDecs[i](newClass, {
-                        kind: "class",
-                        name: name,
-                        addInitializer: createAddInitializerMethod(initializers, decoratorFinishedRef),
-                        metadata
-                    });
-                } finally{
-                    decoratorFinishedRef.v = true;
-                }
-                if (void 0 !== nextNewClass) {
-                    assertValidReturnValue(10, nextNewClass);
-                    newClass = nextNewClass;
-                }
-            }
-            return [
-                defineMetadata(newClass, metadata),
-                function() {
-                    for(var i = 0; i < initializers.length; i++)initializers[i].call(newClass);
-                }
-            ];
-        }
-    }
-    function defineMetadata(Class, metadata) {
-        return Object.defineProperty(Class, Symbol.metadata || Symbol.for("Symbol.metadata"), {
-            configurable: true,
-            enumerable: true,
-            value: metadata
-        });
-    }
-    return function(targetClass, memberDecs, classDecs, parentClass) {
-        if (void 0 !== parentClass) var parentMetadata = parentClass[Symbol.metadata || Symbol.for("Symbol.metadata")];
-        var metadata = Object.create(void 0 === parentMetadata ? null : parentMetadata);
-        var e = applyMemberDecs(targetClass, memberDecs, metadata);
-        if (!classDecs.length) defineMetadata(targetClass, metadata);
-        return {
-            e: e,
-            get c () {
-                return applyClassDecs(targetClass, classDecs, metadata);
-            }
-        };
-    };
-}
-function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
-    return (_apply_decs_2203_r = applyDecs2203RFactory())(targetClass, memberDecs, classDecs, parentClass);
-}
-var _dec, _initClass;
-function src_enhancer(name) {
-    return function(target) {
-        target.prototype.name = name;
-    };
-}
+"var _dec, _initClass;
 let _Person;
-_dec = src_enhancer('rslib');
+function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
+    return (_apply_decs_2203_r = function() {
+        function createAddInitializerMethod(initializers, decoratorFinishedRef) {
+            return function(initializer) {
+                (function(decoratorFinishedRef, fnName) {
+                    if (decoratorFinishedRef.v) throw Error("attempted to call " + fnName + " after decoration was finished");
+                })(decoratorFinishedRef, "addInitializer"), assertCallable(initializer, "An initializer"), initializers.push(initializer);
+            };
+        }
+        function memberDec(dec, name, desc, initializers, kind, isStatic, isPrivate, metadata, value) {
+            switch(kind){
+                case 1:
+                    kindStr = "accessor";
+                    break;
+                case 2:
+                    kindStr = "method";
+                    break;
+                case 3:
+                    kindStr = "getter";
+                    break;
+                case 4:
+                    kindStr = "setter";
+                    break;
+                default:
+                    kindStr = "field";
+            }
+            var kindStr, get, set, ctx = {
+                kind: kindStr,
+                name: isPrivate ? "#" + name : name,
+                static: isStatic,
+                private: isPrivate,
+                metadata: metadata
+            }, decoratorFinishedRef = {
+                v: !1
+            };
+            ctx.addInitializer = createAddInitializerMethod(initializers, decoratorFinishedRef), 0 === kind ? isPrivate ? (get = desc.get, set = desc.set) : (get = function() {
+                return this[name];
+            }, set = function(v) {
+                this[name] = v;
+            }) : 2 === kind ? get = function() {
+                return desc.value;
+            } : ((1 === kind || 3 === kind) && (get = function() {
+                return desc.get.call(this);
+            }), (1 === kind || 4 === kind) && (set = function(v) {
+                desc.set.call(this, v);
+            })), ctx.access = get && set ? {
+                get: get,
+                set: set
+            } : get ? {
+                get: get
+            } : {
+                set: set
+            };
+            try {
+                return dec(value, ctx);
+            } finally{
+                decoratorFinishedRef.v = !0;
+            }
+        }
+        function assertCallable(fn, hint) {
+            if ("function" != typeof fn) throw TypeError(hint + " must be a function");
+        }
+        function assertValidReturnValue(kind, value) {
+            var hint, type = typeof value;
+            if (1 === kind) {
+                if ("object" !== type || null === value) throw TypeError("accessor decorators must return an object with get, set, or init properties or void 0");
+                void 0 !== value.get && assertCallable(value.get, "accessor.get"), void 0 !== value.set && assertCallable(value.set, "accessor.set"), void 0 !== value.init && assertCallable(value.init, "accessor.init");
+            } else if ("function" !== type) throw TypeError((hint = 0 === kind ? "field" : 10 === kind ? "class" : "method") + " decorators must return a function or void 0");
+        }
+        function pushInitializers(ret, initializers) {
+            initializers && ret.push(function(instance) {
+                for(var i = 0; i < initializers.length; i++)initializers[i].call(instance);
+                return instance;
+            });
+        }
+        function defineMetadata(Class, metadata) {
+            return Object.defineProperty(Class, Symbol.metadata || Symbol.for("Symbol.metadata"), {
+                configurable: !0,
+                enumerable: !0,
+                value: metadata
+            });
+        }
+        return function(targetClass, memberDecs, classDecs, parentClass) {
+            if (void 0 !== parentClass) var parentMetadata = parentClass[Symbol.metadata || Symbol.for("Symbol.metadata")];
+            var metadata = Object.create(void 0 === parentMetadata ? null : parentMetadata), e = function(Class, decInfos, metadata) {
+                for(var ret = [], existingProtoNonFields = new Map(), existingStaticNonFields = new Map(), i = 0; i < decInfos.length; i++){
+                    var protoInitializers, staticInitializers, base, initializers, decInfo = decInfos[i];
+                    if (Array.isArray(decInfo)) {
+                        var kind = decInfo[1], name = decInfo[2], isPrivate = decInfo.length > 3, isStatic = kind >= 5;
+                        if (isStatic ? (base = Class, kind -= 5, initializers = staticInitializers = staticInitializers || []) : (base = Class.prototype, initializers = protoInitializers = protoInitializers || []), 0 !== kind && !isPrivate) {
+                            var existingNonFields = isStatic ? existingStaticNonFields : existingProtoNonFields, existingKind = existingNonFields.get(name) || 0;
+                            if (!0 === existingKind || 3 === existingKind && 4 !== kind || 4 === existingKind && 3 !== kind) throw Error("Attempted to decorate a public method/accessor that has the same name as a previously decorated public method/accessor. This is not currently supported by the decorators plugin. Property name was: " + name);
+                            !existingKind && kind > 2 ? existingNonFields.set(name, kind) : existingNonFields.set(name, !0);
+                        }
+                        !function(ret, base, decInfo, name, kind, isStatic, isPrivate, initializers, metadata) {
+                            var desc, init, value, newValue, get, set, newInit, decs = decInfo[0];
+                            if (isPrivate ? desc = 0 === kind || 1 === kind ? {
+                                get: decInfo[3],
+                                set: decInfo[4]
+                            } : 3 === kind ? {
+                                get: decInfo[3]
+                            } : 4 === kind ? {
+                                set: decInfo[3]
+                            } : {
+                                value: decInfo[3]
+                            } : 0 !== kind && (desc = Object.getOwnPropertyDescriptor(base, name)), 1 === kind ? value = {
+                                get: desc.get,
+                                set: desc.set
+                            } : 2 === kind ? value = desc.value : 3 === kind ? value = desc.get : 4 === kind && (value = desc.set), "function" == typeof decs) void 0 !== (newValue = memberDec(decs, name, desc, initializers, kind, isStatic, isPrivate, metadata, value)) && (assertValidReturnValue(kind, newValue), 0 === kind ? init = newValue : 1 === kind ? (init = newValue.init, get = newValue.get || value.get, value = {
+                                get: get,
+                                set: set = newValue.set || value.set
+                            }) : value = newValue);
+                            else for(var i = decs.length - 1; i >= 0; i--){
+                                ;
+                                void 0 !== (newValue = memberDec(decs[i], name, desc, initializers, kind, isStatic, isPrivate, metadata, value)) && (assertValidReturnValue(kind, newValue), 0 === kind ? newInit = newValue : 1 === kind ? (newInit = newValue.init, get = newValue.get || value.get, value = {
+                                    get: get,
+                                    set: set = newValue.set || value.set
+                                }) : value = newValue, void 0 !== newInit && (void 0 === init ? init = newInit : "function" == typeof init ? init = [
+                                    init,
+                                    newInit
+                                ] : init.push(newInit)));
+                            }
+                            if (0 === kind || 1 === kind) {
+                                if (void 0 === init) init = function(instance, init) {
+                                    return init;
+                                };
+                                else if ("function" != typeof init) {
+                                    var ownInitializers = init;
+                                    init = function(instance, init) {
+                                        for(var value = init, i = 0; i < ownInitializers.length; i++)value = ownInitializers[i].call(instance, value);
+                                        return value;
+                                    };
+                                } else {
+                                    var originalInitializer = init;
+                                    init = function(instance, init) {
+                                        return originalInitializer.call(instance, init);
+                                    };
+                                }
+                                ret.push(init);
+                            }
+                            0 !== kind && (1 === kind ? (desc.get = value.get, desc.set = value.set) : 2 === kind ? desc.value = value : 3 === kind ? desc.get = value : 4 === kind && (desc.set = value), isPrivate ? 1 === kind ? (ret.push(function(instance, args) {
+                                return value.get.call(instance, args);
+                            }), ret.push(function(instance, args) {
+                                return value.set.call(instance, args);
+                            })) : 2 === kind ? ret.push(value) : ret.push(function(instance, args) {
+                                return value.call(instance, args);
+                            }) : Object.defineProperty(base, name, desc));
+                        }(ret, base, decInfo, name, kind, isStatic, isPrivate, initializers, metadata);
+                    }
+                }
+                return pushInitializers(ret, protoInitializers), pushInitializers(ret, staticInitializers), ret;
+            }(targetClass, memberDecs, metadata);
+            return !classDecs.length && defineMetadata(targetClass, metadata), {
+                e: e,
+                get c () {
+                    return function(targetClass, classDecs, metadata) {
+                        if (classDecs.length > 0) {
+                            for(var initializers = [], newClass = targetClass, name = targetClass.name, i = classDecs.length - 1; i >= 0; i--){
+                                var decoratorFinishedRef = {
+                                    v: !1
+                                };
+                                try {
+                                    var nextNewClass = classDecs[i](newClass, {
+                                        kind: "class",
+                                        name: name,
+                                        addInitializer: createAddInitializerMethod(initializers, decoratorFinishedRef),
+                                        metadata
+                                    });
+                                } finally{
+                                    decoratorFinishedRef.v = !0;
+                                }
+                                void 0 !== nextNewClass && (assertValidReturnValue(10, nextNewClass), newClass = nextNewClass);
+                            }
+                            return [
+                                defineMetadata(newClass, metadata),
+                                function() {
+                                    for(var i = 0; i < initializers.length; i++)initializers[i].call(newClass);
+                                }
+                            ];
+                        }
+                    }(targetClass, classDecs, metadata);
+                }
+            };
+        };
+    }())(targetClass, memberDecs, classDecs, parentClass);
+}
+_dec = function(target) {
+    target.prototype.name = 'rslib';
+};
 class Person {
     static{
         ({ c: [_Person, _initClass] } = _apply_decs_2203_r(this, [], [

--- a/tests/integration/extension-alias/__snapshots__/index.test.ts.snap
+++ b/tests/integration/extension-alias/__snapshots__/index.test.ts.snap
@@ -3,24 +3,21 @@
 exports[`resolve.extensionAlias should work 1`] = `
 ""use strict";
 var __webpack_exports__ = {};
-const bar = 'bar';
-const foo = 'foo';
+let bar = 'bar', foo = 'foo';
 // Relative import paths need explicit file extensions in ECMAScript imports
 // when '--moduleResolution' is 'node16' or 'nodenext'.
-console.log(foo + bar);
+console.log("foobar");
 var __webpack_export_target__ = exports;
 for(var i in __webpack_exports__)__webpack_export_target__[i] = __webpack_exports__[i];
-if (__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, '__esModule', {
-    value: true
+__webpack_exports__.__esModule && Object.defineProperty(__webpack_export_target__, '__esModule', {
+    value: !0
 });
 "
 `;
 
 exports[`resolve.extensionAlias should work 2`] = `
-"const bar = 'bar';
-const foo = 'foo';
-// Relative import paths need explicit file extensions in ECMAScript imports
+"// Relative import paths need explicit file extensions in ECMAScript imports
 // when '--moduleResolution' is 'node16' or 'nodenext'.
-console.log(foo + bar);
+console.log("foobar");
 "
 `;

--- a/tests/integration/external-helpers/__snapshots__/index.test.ts.snap
+++ b/tests/integration/external-helpers/__snapshots__/index.test.ts.snap
@@ -8,13 +8,12 @@ var src_FOO = /*#__PURE__*/ function() {
     function FOO() {
         (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__._)(this, FOO);
     }
-    (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__._)(FOO, [
+    return (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__._)(FOO, [
         {
             key: "bar",
             get: function() {}
         }
-    ]);
-    return FOO;
+    ]), FOO;
 }();
 export { src_FOO as default };
 "
@@ -28,83 +27,64 @@ var src_FOO = /*#__PURE__*/ function() {
     function FOO() {
         (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__._)(this, FOO);
     }
-    (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__._)(FOO, [
+    return (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__._)(FOO, [
         {
             key: "bar",
             get: function() {}
         }
-    ]);
-    return FOO;
+    ]), FOO;
 }();
 export { src_FOO as default };
 "
 `;
 
 exports[`should not external @swc/helpers by default 1`] = `
-"function _class_call_check(instance, Constructor) {
-    if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
-}
-function _defineProperties(target, props) {
+"function _defineProperties(target, props) {
     for(var i = 0; i < props.length; i++){
         var descriptor = props[i];
-        descriptor.enumerable = descriptor.enumerable || false;
-        descriptor.configurable = true;
-        if ("value" in descriptor) descriptor.writable = true;
-        Object.defineProperty(target, descriptor.key, descriptor);
+        descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
-}
-function _create_class(Constructor, protoProps, staticProps) {
-    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
-    if (staticProps) _defineProperties(Constructor, staticProps);
-    return Constructor;
 }
 var src_FOO = /*#__PURE__*/ function() {
     "use strict";
+    var Constructor, protoProps, staticProps;
     function FOO() {
-        _class_call_check(this, FOO);
+        !function(instance, Constructor) {
+            if (!(instance instanceof Constructor)) throw TypeError("Cannot call a class as a function");
+        }(this, FOO);
     }
-    _create_class(FOO, [
+    return Constructor = FOO, protoProps = [
         {
             key: "bar",
             get: function() {}
         }
-    ]);
-    return FOO;
+    ], _defineProperties(Constructor.prototype, protoProps), FOO;
 }();
 export { src_FOO as default };
 "
 `;
 
 exports[`should respect user override externalHelpers config 1`] = `
-"function _class_call_check(instance, Constructor) {
-    if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
-}
-function _defineProperties(target, props) {
+"function _defineProperties(target, props) {
     for(var i = 0; i < props.length; i++){
         var descriptor = props[i];
-        descriptor.enumerable = descriptor.enumerable || false;
-        descriptor.configurable = true;
-        if ("value" in descriptor) descriptor.writable = true;
-        Object.defineProperty(target, descriptor.key, descriptor);
+        descriptor.enumerable = descriptor.enumerable || !1, descriptor.configurable = !0, "value" in descriptor && (descriptor.writable = !0), Object.defineProperty(target, descriptor.key, descriptor);
     }
-}
-function _create_class(Constructor, protoProps, staticProps) {
-    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
-    if (staticProps) _defineProperties(Constructor, staticProps);
-    return Constructor;
 }
 var src_FOO = /*#__PURE__*/ function() {
     "use strict";
+    var Constructor, protoProps, staticProps;
     function FOO() {
-        _class_call_check(this, FOO);
+        !function(instance, Constructor) {
+            if (!(instance instanceof Constructor)) throw TypeError("Cannot call a class as a function");
+        }(this, FOO);
     }
-    _create_class(FOO, [
+    return Constructor = FOO, protoProps = [
         {
             key: "bar",
             get: function() {}
         }
-    ]);
-    return FOO;
+    ], _defineProperties(Constructor.prototype, protoProps), FOO;
 }();
 export { src_FOO as default };
 "
@@ -118,13 +98,12 @@ var src_FOO = /*#__PURE__*/ function() {
     function FOO() {
         (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__._)(this, FOO);
     }
-    (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__._)(FOO, [
+    return (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__._)(FOO, [
         {
             key: "bar",
             get: function() {}
         }
-    ]);
-    return FOO;
+    ]), FOO;
 }();
 export { src_FOO as default };
 "

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -6,7 +6,7 @@ test('tree shaking is enabled by default, bar and baz should be shaken', async (
   const fixturePath = join(__dirname, 'default');
   const { entries } = await buildAndGetResults({ fixturePath });
   expect(entries.esm).toMatchInlineSnapshot(`
-    "const foo = ()=>{};
+    "let foo = ()=>{};
     export { foo };
     "
   `);

--- a/tests/integration/require/import-dynamic/index.ts
+++ b/tests/integration/require/import-dynamic/index.ts
@@ -1,5 +1,5 @@
 const i1 = import(`${process.env.DIR}./other`);
 const i2 = import(process.env.DIR!);
-const condition = 1 > 0;
+const condition = Math.random() > 0.5;
 const i3 = import(condition ? './other1' : './other2');
 export { i1, i2, i3 };

--- a/tests/integration/require/index.test.ts
+++ b/tests/integration/require/index.test.ts
@@ -7,23 +7,21 @@ test('require.resolve', async () => {
   const { entries } = await buildAndGetResults({ fixturePath });
 
   const statements = [
-    "const cjs1 = require.resolve('./other')",
-    'const cjs2 = require.resolve(`${process.env.DIR}./other`)',
-    'const assignedResolve = require.resolve',
-    "const cjs3 = assignedResolve('./other')",
-    "const cr1 = _require.resolve('./other')",
-    'const cr2 = _require.resolve(`${process.env.DIR}./other`)',
-    'const assignedResolve2 = _require.resolve',
-    "const cr3 = assignedResolve2('./other')",
+    "let cjs1 = require.resolve('./other')",
+    'cjs2 = require.resolve(`${process.env.DIR}./other`)',
+    "cjs3 = (0, require.resolve)('./other')",
+    "cr1 = _require.resolve('./other')",
+    'cr2 = _require.resolve(`${process.env.DIR}./other`)',
+    "cr3 = (0, _require.resolve)('./other')",
   ];
 
   const esmStatements = [
     'import * as __WEBPACK_EXTERNAL_MODULE_node_module__ from "node:module"',
-    'const _require = (0, __WEBPACK_EXTERNAL_MODULE_node_module__.createRequire)(import.meta.url)',
+    '_require = (0, __WEBPACK_EXTERNAL_MODULE_node_module__.createRequire)(import.meta.url)',
   ];
 
   const cjsStatements = [
-    'const _require = (0, external_node_module_namespaceObject.createRequire)(',
+    '_require = (0, external_node_module_namespaceObject.createRequire)(',
   ];
 
   for (const statement of [...statements, ...esmStatements]) {
@@ -48,11 +46,11 @@ test('require dynamic', async () => {
 
   const esmStatements = [
     'import * as __WEBPACK_EXTERNAL_MODULE_node_module__ from "node:module"',
-    'const _require = (0, __WEBPACK_EXTERNAL_MODULE_node_module__.createRequire)(import.meta.url)',
+    '_require = (0, __WEBPACK_EXTERNAL_MODULE_node_module__.createRequire)(import.meta.url)',
   ];
 
   const cjsStatements = [
-    'const _require = (0, external_node_module_namespaceObject.createRequire)(',
+    '_require = (0, external_node_module_namespaceObject.createRequire)(',
   ];
 
   for (const statement of [...statements, ...esmStatements]) {
@@ -69,9 +67,9 @@ test('import dynamic', async () => {
   const { entries } = await buildAndGetResults({ fixturePath });
 
   const statements = [
-    'const i1 = import(`${process.env.DIR}./other`)',
-    'const i2 = import(process.env.DIR)',
-    "const i3 = import(condition ? './other1' : './other2')",
+    'let i1 = import(`${process.env.DIR}./other`)',
+    'i2 = import(process.env.DIR)',
+    "i3 = import(Math.random() > 0.5 ? './other1' : './other2')",
   ];
 
   for (const statement of [...statements]) {
@@ -87,14 +85,12 @@ test('require as expression', async () => {
   const fixturePath = join(__dirname, 'require-as-expression');
   const { entries } = await buildAndGetResults({ fixturePath });
 
+  expect(entries.esm).toContain(`console.log('./other.js', require);`);
+
   const statements = [
-    'const lazyFn = (module, requireFn)=>{}',
+    'let lazyFn = (module, requireFn)=>{',
     "lazyFn('./other.js', require)",
   ];
-
-  for (const statement of [...statements]) {
-    expect(entries.esm).toContain(statement);
-  }
 
   for (const statement of [...statements]) {
     expect(entries.cjs).toContain(statement);

--- a/tests/integration/require/require-as-expression/index.js
+++ b/tests/integration/require/require-as-expression/index.js
@@ -1,2 +1,4 @@
-const lazyFn = (module, requireFn) => {};
+const lazyFn = (module, requireFn) => {
+  requireFn(module);
+};
 lazyFn('./other.js', require);

--- a/tests/integration/resolve/index.test.ts
+++ b/tests/integration/resolve/index.test.ts
@@ -8,8 +8,7 @@ test('resolve data url', async () => {
 
   expect(isSuccess).toBeTruthy();
   expect(entries.esm).toMatchInlineSnapshot(`
-    "/* ESM default export */ const javascript_export_default_42 = 42;
-    console.log('x:', javascript_export_default_42);
+    "console.log('x:', 42);
     "
   `);
 });
@@ -31,7 +30,7 @@ test('resolve node protocol', async () => {
   expect(isSuccess).toBeTruthy();
   expect(entries.esm).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_node_path__ from "node:path";
-    const { join } = __WEBPACK_EXTERNAL_MODULE_node_path__["default"];
+    let { join } = __WEBPACK_EXTERNAL_MODULE_node_path__.default;
     export { join };
     "
   `);
@@ -63,8 +62,7 @@ test('resolve with js extensions', async () => {
 
   expect(isSuccess).toBeTruthy();
   expect(entries.esm).toMatchInlineSnapshot(`
-    "const value = 1;
-    console.log(value);
+    "console.log(1);
     "
   `);
 });
@@ -76,8 +74,7 @@ test('resolve with main fields', async () => {
 
   expect(isSuccess).toBeTruthy();
   expect(Object.values(results[0]!)[0]).toMatchInlineSnapshot(`
-    "const value = 1;
-    console.log(value);
+    "console.log(1);
     "
   `);
   expect(Object.values(results[1]!)[0]).toContain('main');

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -12,7 +12,7 @@ describe('ESM shims', async () => {
   test('__dirname', async () => {
     for (const shim of [
       'import { fileURLToPath as __webpack_fileURLToPath__ } from "url";',
-      'var src_dirname = __webpack_dirname__(__webpack_fileURLToPath__(import.meta.url));',
+      'var src_dirname = __webpack_dirname__(__webpack_fileURLToPath__(import.meta.url)),',
     ]) {
       expect(entries.esm0).toContain(shim);
     }
@@ -25,7 +25,7 @@ describe('ESM shims', async () => {
   test('__filename', async () => {
     for (const shim of [
       'import { fileURLToPath as __webpack_fileURLToPath__ } from "url";',
-      'var src_filename = __webpack_fileURLToPath__(import.meta.url);',
+      'src_filename = __webpack_fileURLToPath__(import.meta.url);',
     ]) {
       expect(entries.esm0).toContain(shim);
     }
@@ -38,7 +38,7 @@ describe('ESM shims', async () => {
   test('import.meta.url', async () => {
     for (const shouldPreserve of [
       // import.meta.url should not be substituted
-      'const importMetaUrl = import.meta.url;',
+      'importMetaUrl: import.meta.url',
     ]) {
       expect(entries.esm0).toContain(shouldPreserve);
     }
@@ -103,9 +103,7 @@ describe('CJS shims', () => {
     expect(entries.esm).toMatchInlineSnapshot(`
       "import * as __WEBPACK_EXTERNAL_MODULE_node_module__ from "node:module";
       // import.meta.url
-      const importMetaUrl = import.meta.url;
-      const src_require = (0, __WEBPACK_EXTERNAL_MODULE_node_module__.createRequire)(import.meta.url);
-      const requiredModule = src_require('./ok.cjs');
+      let importMetaUrl = import.meta.url, requiredModule = (0, __WEBPACK_EXTERNAL_MODULE_node_module__.createRequire)(import.meta.url)('./ok.cjs');
       export { importMetaUrl, requiredModule };
       "
     `);

--- a/tests/integration/syntax/__snapshots__/index.test.ts.snap
+++ b/tests/integration/syntax/__snapshots__/index.test.ts.snap
@@ -15,22 +15,16 @@ export { Foo, foo };
 `;
 
 exports[`should downgrade class private method with output.syntax config 1`] = `
-"function _check_private_redeclaration(obj, privateCollection) {
-    if (privateCollection.has(obj)) throw new TypeError("Cannot initialize the same private elements twice on an object");
-}
-function _class_private_method_get(receiver, privateSet, fn) {
-    if (!privateSet.has(receiver)) throw new TypeError("attempted to get private field on non-instance");
-    return fn;
-}
-function _class_private_method_init(obj, privateSet) {
-    _check_private_redeclaration(obj, privateSet);
-    privateSet.add(obj);
-}
-var _bar = /*#__PURE__*/ new WeakSet();
+"var _bar = /*#__PURE__*/ new WeakSet();
 class Foo {
     constructor(){
-        _class_private_method_init(this, _bar);
-        _class_private_method_get(this, _bar, bar).call(this);
+        var obj, privateSet;
+        obj = this, !function(obj, privateCollection) {
+            if (privateCollection.has(obj)) throw TypeError("Cannot initialize the same private elements twice on an object");
+        }(obj, privateSet = _bar), privateSet.add(obj), (function(receiver, privateSet, fn) {
+            if (!privateSet.has(receiver)) throw TypeError("attempted to get private field on non-instance");
+            return fn;
+        })(this, _bar, bar).call(this);
     }
 }
 function bar() {}

--- a/tests/integration/syntax/index.test.ts
+++ b/tests/integration/syntax/index.test.ts
@@ -23,7 +23,5 @@ test('should downgrade class private method with output.syntax config', async ()
   expect(entries.esm1).toContain('#bar');
 
   expect(entries.cjs0).toContain('#bar');
-  expect(entries.cjs0).toContain('()=>{'); // test webpack runtime arrow function
   expect(entries.cjs1).not.toContain('#bar');
-  expect(entries.cjs1).not.toContain('()=>{'); // test webpack runtime arrow function
 });

--- a/tests/integration/transform-import/index.test.ts
+++ b/tests/integration/transform-import/index.test.ts
@@ -11,7 +11,7 @@ test('transformImport with arco-design', async () => {
     expect(Object.values(contents[format]!)[0]).toContain(
       format.startsWith('esm')
         ? 'import * as __WEBPACK_EXTERNAL_MODULE__arco_design_web_react_es_button__ from "@arco-design/web-react/es/button"'
-        : 'const button_namespaceObject = require("@arco-design/web-react/es/button")',
+        : 'button_namespaceObject = require("@arco-design/web-react/es/button");',
     );
     expect(Object.values(contents[format]!)[0]).toContain(
       format.startsWith('esm')
@@ -30,12 +30,12 @@ test('transformImport with lodash', async () => {
     expect(Object.values(contents[format]!)[0]).toContain(
       format.startsWith('esm')
         ? 'import * as __WEBPACK_EXTERNAL_MODULE_lodash_get__ from "lodash/get"'
-        : 'const get_namespaceObject = require("lodash/get")',
+        : 'let get_namespaceObject = require("lodash/get")',
     );
     expect(Object.values(contents[format]!)[0]).toContain(
       format.startsWith('esm')
         ? 'import * as __WEBPACK_EXTERNAL_MODULE_lodash_fp_add__ from "lodash/fp/add"'
-        : 'const add_namespaceObject = require("lodash/fp/add")',
+        : 'let add_namespaceObject = require("lodash/fp/add")',
     );
   }
 });


### PR DESCRIPTION
## Summary

For the Node target, keep output bundles as small as possible while retaining the necessary information for debugging, as Node outputs usually executed directly at runtime rather than being built again.

See https://github.com/web-infra-dev/rsbuild/pull/3966 for more.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
