### PR TITLE
chore(deps): remove unnecessary rspack/core devDeps

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "@rslib/tsconfig": "workspace:*",
-    "@rspack/core": "1.0.8",
     "@types/fs-extra": "^11.0.4",
     "commander": "^12.1.0",
     "fs-extra": "^11.2.0",

--- a/packages/core/src/css/RemoveCssExtractAssetPlugin.ts
+++ b/packages/core/src/css/RemoveCssExtractAssetPlugin.ts
@@ -1,4 +1,4 @@
-import type { Compiler, RspackPluginInstance } from '@rspack/core';
+import type { Rspack } from '@rsbuild/core';
 
 const pluginName = 'REMOVE_CSS_EXTRACT_ASSET_PLUGIN';
 
@@ -6,14 +6,14 @@ type Options = {
   include: RegExp;
 };
 
-class RemoveCssExtractAssetPlugin implements RspackPluginInstance {
+class RemoveCssExtractAssetPlugin implements Rspack.RspackPluginInstance {
   readonly name: string = pluginName;
   options: Options;
   constructor(options: Options) {
     this.options = options;
   }
 
-  apply(compiler: Compiler): void {
+  apply(compiler: Rspack.Compiler): void {
     const include = this.options.include;
     compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
       compilation.hooks.chunkAsset.tap(pluginName, (_chunk, filename) => {

--- a/packages/core/src/css/libCssExtractLoader.ts
+++ b/packages/core/src/css/libCssExtractLoader.ts
@@ -6,7 +6,7 @@
  * 3. add `import './[name].css';`
  */
 import path, { extname } from 'node:path';
-import type { LoaderDefinition } from '@rspack/core';
+import type { Rspack } from '@rsbuild/core';
 
 interface DependencyDescription {
   identifier: string;
@@ -35,7 +35,7 @@ function stringifyLocal(value: any) {
   return typeof value === 'function' ? value.toString() : JSON.stringify(value);
 }
 
-const loader: LoaderDefinition = function loader(content) {
+const loader: Rspack.LoaderDefinition = function loader(content) {
   if (
     this._compiler?.options?.experiments?.css &&
     this._module &&
@@ -49,7 +49,11 @@ const loader: LoaderDefinition = function loader(content) {
   return;
 };
 
-export const pitch: LoaderDefinition['pitch'] = function (request, _, _data) {
+export const pitch: Rspack.LoaderDefinition['pitch'] = function (
+  request,
+  _,
+  _data,
+) {
   if (
     this._compiler?.options?.experiments?.css &&
     this._module &&

--- a/packages/core/src/plugins/entryModuleLoader.ts
+++ b/packages/core/src/plugins/entryModuleLoader.ts
@@ -1,4 +1,4 @@
-import type { LoaderDefinition } from '@rspack/core';
+import type { Rspack } from '@rsbuild/core';
 import {
   REACT_DIRECTIVE_REGEX,
   RSLIB_ENTRY_QUERY,
@@ -14,7 +14,7 @@ function splitFromFirstLine(text: string): [string, string] {
   return [text.slice(0, match.index), text.slice(match.index)];
 }
 
-const loader: LoaderDefinition = function loader(source) {
+const loader: Rspack.LoaderDefinition = function loader(source) {
   let result = source;
 
   if (this.resourceQuery === `?${RSLIB_ENTRY_QUERY}`) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,9 +241,6 @@ importers:
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
-      '@rspack/core':
-        specifier: 1.0.8
-        version: 1.0.8(@swc/helpers@0.5.15)
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -1753,11 +1750,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.0.8':
-    resolution: {integrity: sha512-1l8/eg3HNz53DHQO3fy5O5QKdYh8hSMZaWGtm3NR5IfdrTm2TaLL9tuR8oL2iHHtd87LEvVKHXdjlcuLV5IPNQ==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@1.1.0':
     resolution: {integrity: sha512-02YmzmtKMNHCSMzVT5sgbJuPDn+HunkrtWq0D95Fh9sGKYap9cs0JOpzTfyAL3KXJ9JzVfOAZA3VgVQOBaQNWQ==}
     cpu: [arm64]
@@ -1765,11 +1757,6 @@ packages:
 
   '@rspack/binding-darwin-x64@1.0.14':
     resolution: {integrity: sha512-q4Da1Bn/4xTLhhnOkT+fjP2STsSCfp4z03/J/h8tCVG/UYz56Ud3q1UEOK33c5Fxw1C4GlhEh5yYOlSAdxFQLQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.0.8':
-    resolution: {integrity: sha512-7BbG8gXVWjtqJegDpsObzM/B90Eig1piEtcahvPdvlC92uZz3/IwtKPpMaywGBrf5RSI3U0nQMSekwz0cO1SOw==}
     cpu: [x64]
     os: [darwin]
 
@@ -1783,11 +1770,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@1.0.8':
-    resolution: {integrity: sha512-QnqCL0wmwYqT/IFx5q0aw7DsIOr8oYUa4+7JI8iiqRf3RuuRJExesVW9VuWr0jS2UvChKgmb8PvRtDy/0tshFw==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rspack/binding-linux-arm64-gnu@1.1.0':
     resolution: {integrity: sha512-Q/i50Pieii3akdv5Q6my6QelV5Dpc8O/Ir4udpjYl0pbSdKamdI8M85fxrMxGAGcoNSD+X52fDvxJujXWMcP0w==}
     cpu: [arm64]
@@ -1795,11 +1777,6 @@ packages:
 
   '@rspack/binding-linux-arm64-musl@1.0.14':
     resolution: {integrity: sha512-qgybhxI/nnoa8CUz7zKTC0Oh37NZt9uRxsSV7+ZYrfxqbrVCoNVuutPpY724uUHy1M6W34kVEm1uT1N4Ka5cZg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.0.8':
-    resolution: {integrity: sha512-Ns9TsE7zdUjimW5HURRW08BaMyAh16MDh97PPsGEMeRPx9plnRO9aXvuUG6t+0gy4KwlQdeq3BvUsbBpIo5Tow==}
     cpu: [arm64]
     os: [linux]
 
@@ -1813,11 +1790,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.0.8':
-    resolution: {integrity: sha512-lfqUuKCoyRN/gGeokhX/oNYqB6OpbtgQb57b0QuD8IaiH2a1ee0TtEVvRbyQNEDwht6lW4RTNg0RfMYu52LgXg==}
-    cpu: [x64]
-    os: [linux]
-
   '@rspack/binding-linux-x64-gnu@1.1.0':
     resolution: {integrity: sha512-dIZSutPo2z/OaO2f6SVlcYA6lGBH+4TrRtWmMyPshpTNPrkCGGfDhC43fZ4jCiUj2PO/Hcn8jyKhci4leBsVBA==}
     cpu: [x64]
@@ -1825,11 +1797,6 @@ packages:
 
   '@rspack/binding-linux-x64-musl@1.0.14':
     resolution: {integrity: sha512-4U6QD9xVS1eGme52DuJr6Fg/KdcUfJ+iKwH49Up460dZ/fLvGylnVGA+V0mzPlKi8gfy7NwFuYXZdu3Pwi1YYg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.0.8':
-    resolution: {integrity: sha512-MgbHJWV5utVa1/U9skrXClydZ/eZw001++v4B6nb8myU6Ck1D02aMl9ESefb/sSA8TatLLxEXQ2VENG9stnPwQ==}
     cpu: [x64]
     os: [linux]
 
@@ -1843,11 +1810,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@1.0.8':
-    resolution: {integrity: sha512-3NN5VisnSOzhgqX77O/7NvcjPUueg1oIdMKoc5vElJCEu5FEXPqDhwZmr1PpBovaXshAcgExF3j54+20pwdg5g==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rspack/binding-win32-arm64-msvc@1.1.0':
     resolution: {integrity: sha512-opo6XR4iXh/QkHiauVQBlU2xR2JyjDmSwgkION27oszu81nr+IajTSXQX96x5I6Bq48GQLU4rItHse/doctQDA==}
     cpu: [arm64]
@@ -1855,11 +1817,6 @@ packages:
 
   '@rspack/binding-win32-ia32-msvc@1.0.14':
     resolution: {integrity: sha512-m1gUiVyz3Z3VYIK/Ayo5CVHBjnEeRk9a+KIpKSsq1yhZItnMgjtr4bKabU9vjxalO4UoaSmVzODJI8lJBlnn5Q==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.0.8':
-    resolution: {integrity: sha512-17VQNC7PSygzsipSVoukDM/SOcVueVNsk9bZiB0Swl20BaqrlBts2Dvlmo+L+ZGsxOYI97WvA/zomMDv860usg==}
     cpu: [ia32]
     os: [win32]
 
@@ -1873,11 +1830,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.0.8':
-    resolution: {integrity: sha512-Vtjt74Soh09XUsV5Nw0YjZVSk/qtsjtPnzbSZluncSAVUs8l+X1ALcM6n1Jrt3TLTfcqf7a+VIsWOXAMqkCGUg==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@1.1.0':
     resolution: {integrity: sha512-H/6Glp1nZvxWAD5+2hRrp1kBs9f+pLb/un2TdFSUNd2tyXq5GyHCe70+N9psbe/jjGxD8e1vPNQtN/VvkuR0Zg==}
     cpu: [x64]
@@ -1886,23 +1838,11 @@ packages:
   '@rspack/binding@1.0.14':
     resolution: {integrity: sha512-0wWqFvr9hkF4LgNPgWfkTU0hhkZAMvOytoCs2p+wDX1Up1E/SgJ1U1JAsCxsl1XtUKm7mRvdWHzJmHbza3y89Q==}
 
-  '@rspack/binding@1.0.8':
-    resolution: {integrity: sha512-abRirbrjobcllLAamyeiWxT6Rb0wELUnITynQdqRbSweWm2lvnhm9YBv4BcOjvJBzhJtvRJo5JBtbKXjDTarug==}
-
   '@rspack/binding@1.1.0':
     resolution: {integrity: sha512-zLduWacrw/bBYiFvhjN70f+AJxXnTzevywXp54vso8d0Nz7z4KIycdz/Ua5AGRUkG2ZuQw6waypN5pXf48EBcA==}
 
   '@rspack/core@1.0.14':
     resolution: {integrity: sha512-xHl23lxJZNjItGc5YuE9alz3yjb56y7EgJmAcBMPHMqgjtUt8rBu4xd/cSUjbr9/lLF9N4hdyoJiPJOFs9LEjw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.0.8':
-    resolution: {integrity: sha512-pbXwXYb4WQwb0l35P5v3l/NpDJXy1WiVE4IcQ/6LxZYU5NyZuqtsK0trR88xIVRZb9qU0JUeCdQq7Xa6Q+c3Xw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -7385,16 +7325,10 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.0.14':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.0.8':
-    optional: true
-
   '@rspack/binding-darwin-arm64@1.1.0':
     optional: true
 
   '@rspack/binding-darwin-x64@1.0.14':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.0.8':
     optional: true
 
   '@rspack/binding-darwin-x64@1.1.0':
@@ -7403,16 +7337,10 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.0.14':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.0.8':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@1.1.0':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.0.14':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.0.8':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.1.0':
@@ -7421,16 +7349,10 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.0.14':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.0.8':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@1.1.0':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.0.14':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.0.8':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.1.0':
@@ -7439,25 +7361,16 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.0.14':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.0.8':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@1.1.0':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.0.14':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.0.8':
-    optional: true
-
   '@rspack/binding-win32-ia32-msvc@1.1.0':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.0.14':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.0.8':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.1.0':
@@ -7475,18 +7388,6 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.0.14
       '@rspack/binding-win32-x64-msvc': 1.0.14
 
-  '@rspack/binding@1.0.8':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.0.8
-      '@rspack/binding-darwin-x64': 1.0.8
-      '@rspack/binding-linux-arm64-gnu': 1.0.8
-      '@rspack/binding-linux-arm64-musl': 1.0.8
-      '@rspack/binding-linux-x64-gnu': 1.0.8
-      '@rspack/binding-linux-x64-musl': 1.0.8
-      '@rspack/binding-win32-arm64-msvc': 1.0.8
-      '@rspack/binding-win32-ia32-msvc': 1.0.8
-      '@rspack/binding-win32-x64-msvc': 1.0.8
-
   '@rspack/binding@1.1.0':
     optionalDependencies:
       '@rspack/binding-darwin-arm64': 1.1.0
@@ -7503,15 +7404,6 @@ snapshots:
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
       '@rspack/binding': 1.0.14
-      '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001663
-    optionalDependencies:
-      '@swc/helpers': 0.5.15
-
-  '@rspack/core@1.0.8(@swc/helpers@0.5.15)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.5.1
-      '@rspack/binding': 1.0.8
       '@rspack/lite-tapable': 1.0.1
       caniuse-lite: 1.0.30001663
     optionalDependencies:


### PR DESCRIPTION
## Summary

remove unnecessary rspack/core devDeps to avoid rspack multiple versions.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
