### PR TITLE
feat(create-rslib): add prepublishOnly script for templates

### DIFF
--- a/packages/create-rslib/template-[node-dual]-[]-js/package.json
+++ b/packages/create-rslib/template-[node-dual]-[]-js/package.json
@@ -15,7 +15,8 @@
   ],
   "scripts": {
     "build": "rslib build",
-    "dev": "rslib build --watch"
+    "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build"
   },
   "devDependencies": {
     "@rslib/core": "workspace:*"

--- a/packages/create-rslib/template-[node-dual]-[]-ts/package.json
+++ b/packages/create-rslib/template-[node-dual]-[]-ts/package.json
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "rslib build",
-    "dev": "rslib build --watch"
+    "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build"
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",

--- a/packages/create-rslib/template-[node-dual]-[vitest]-js/package.json
+++ b/packages/create-rslib/template-[node-dual]-[vitest]-js/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-[node-dual]-[vitest]-ts/package.json
+++ b/packages/create-rslib/template-[node-dual]-[vitest]-ts/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-[node-esm]-[]-js/package.json
+++ b/packages/create-rslib/template-[node-esm]-[]-js/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "build": "rslib build",
-    "dev": "rslib build --watch"
+    "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build"
   },
   "devDependencies": {
     "@rslib/core": "workspace:*"

--- a/packages/create-rslib/template-[node-esm]-[]-ts/package.json
+++ b/packages/create-rslib/template-[node-esm]-[]-ts/package.json
@@ -15,7 +15,8 @@
   ],
   "scripts": {
     "build": "rslib build",
-    "dev": "rslib build --watch"
+    "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build"
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",

--- a/packages/create-rslib/template-[node-esm]-[vitest]-js/package.json
+++ b/packages/create-rslib/template-[node-esm]-[vitest]-js/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-[node-esm]-[vitest]-ts/package.json
+++ b/packages/create-rslib/template-[node-esm]-[vitest]-ts/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-[react]-[]-js/package.json
+++ b/packages/create-rslib/template-[react]-[]-js/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "build": "rslib build",
-    "dev": "rslib build --watch"
+    "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build"
   },
   "devDependencies": {
     "@rsbuild/plugin-react": "^1.0.7",

--- a/packages/create-rslib/template-[react]-[]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[]-ts/package.json
@@ -15,7 +15,8 @@
   ],
   "scripts": {
     "build": "rslib build",
-    "dev": "rslib build --watch"
+    "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build"
   },
   "devDependencies": {
     "@rsbuild/plugin-react": "^1.0.7",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -15,6 +15,7 @@
     "build": "rslib build",
     "build:storybook": "storybook build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "storybook": "storybook dev",
     "test": "vitest run"
   },

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -17,6 +17,7 @@
     "build": "rslib build",
     "build:storybook": "storybook build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "storybook": "storybook dev",
     "test": "vitest run"
   },

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -15,6 +15,7 @@
     "build": "rslib build",
     "build:storybook": "storybook build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "storybook": "storybook dev"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -17,6 +17,7 @@
     "build": "rslib build",
     "build:storybook": "storybook build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "storybook": "storybook dev"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-[react]-[vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[vitest]-js/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-[react]-[vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[vitest]-ts/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -27,6 +27,7 @@ export const expectPackageJson = (
   expect(pkgJson.name).toBe(name);
   expect(pkgJson.scripts.dev).toBe('rslib build --watch');
   expect(pkgJson.scripts.build).toBe('rslib build');
+  expect(pkgJson.scripts.prepublishOnly).toBe('pnpm run build');
   expect(pkgJson.devDependencies['@rslib/core']).toBeTruthy();
 };
 
@@ -53,7 +54,6 @@ export const createAndValidate = (
   }
 
   execSync(command, { cwd });
-
   const pkgJson = fse.readJSONSync(path.join(dir, 'package.json'));
   expectPackageJson(pkgJson, path.basename(name));
 


### PR DESCRIPTION
## Summary
Automatically execute the `npm run build` command before executing the `npm publish` command

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
