### PR TITLE
feat!: use 'commonjs-import' as CJS external type by default

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.7.5",
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@rsbuild/plugin-react": "^1.0.7",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.7.5",
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@rsbuild/plugin-react": "^1.0.7",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   },
   "pnpm": {
     "overrides": {
-      "@rspack/core": "npm:@rspack/core-canary@1.1.2-canary-49a99741-20241115094711",
       "zx>@types/node": "-"
     }
   }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "pnpm": {
     "overrides": {
+      "@rspack/core": "npm:@rspack/core-canary@1.1.2-canary-49a99741-20241115094711",
       "zx>@types/node": "-"
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "prebundle": "prebundle"
   },
   "dependencies": {
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "rsbuild-plugin-dts": "workspace:*",
     "tinyglobby": "^0.2.10"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -685,7 +685,7 @@ const composeExternalsConfig = (
 
   const externalsTypeMap = {
     esm: 'module-import',
-    cjs: 'commonjs',
+    cjs: 'commonjs-import',
     umd: 'umd',
     // If use 'var', when projects import an external package like '@pkg', this will cause a syntax error such as 'var pkg = @pkg'.
     // If use 'umd', the judgement conditions may be affected by other packages that define variables like 'define'.

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -396,7 +396,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
             },
           },
           {
-            "externalsType": "commonjs",
+            "externalsType": "commonjs-import",
             "module": {
               "parser": {
                 "javascript": {

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@storybook/addon-essentials": "^8.4.4",
     "@storybook/addon-interactions": "^8.4.4",
     "@storybook/addon-links": "^8.4.4",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@storybook/addon-essentials": "^8.4.4",
     "@storybook/addon-interactions": "^8.4.4",
     "@storybook/addon-links": "^8.4.4",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -19,7 +19,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@rsbuild/plugin-react": "^1.0.7",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.4.4",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@rsbuild/plugin-react": "^1.0.7",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.4.4",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -18,7 +18,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@rsbuild/plugin-react": "^1.0.7",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.4.4",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@rsbuild/plugin-react": "^1.0.7",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.4.4",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.47.11",
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@rslib/tsconfig": "workspace:*",
     "rslib": "npm:@rslib/core@0.0.18",
     "typescript": "^5.6.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@rspack/core': npm:@rspack/core-canary@1.1.2-canary-49a99741-20241115094711
   zx>@types/node: '-'
 
 importers:
@@ -89,13 +88,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.7.5
-        version: 0.7.5(@module-federation/enhanced@0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0))(@rsbuild/core@1.1.3)
+        version: 0.7.5(@module-federation/enhanced@0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0))(@rsbuild/core@1.1.4)
       '@rsbuild/core':
-        specifier: ~1.1.3
-        version: 1.1.3
+        specifier: ~1.1.4
+        version: 1.1.4
       '@rsbuild/plugin-react':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.1.3)
+        version: 1.0.7(@rsbuild/core@1.1.4)
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.12
@@ -113,13 +112,13 @@ importers:
         version: 0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0)
       '@module-federation/rsbuild-plugin':
         specifier: ^0.7.5
-        version: 0.7.5(@module-federation/enhanced@0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0))(@rsbuild/core@1.1.3)
+        version: 0.7.5(@module-federation/enhanced@0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0))(@rsbuild/core@1.1.4)
       '@module-federation/storybook-addon':
         specifier: ^3.0.8
-        version: 3.0.8(@rsbuild/core@1.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack-virtual-modules@0.6.2)(webpack@5.94.0)
+        version: 3.0.8(@rsbuild/core@1.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack-virtual-modules@0.6.2)(webpack@5.94.0)
       '@rsbuild/plugin-react':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.1.3)
+        version: 1.0.7(@rsbuild/core@1.1.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -140,10 +139,10 @@ importers:
         version: 8.4.4(prettier@3.3.3)
       storybook-addon-rslib:
         specifier: ^0.1.4
-        version: 0.1.4(@rsbuild/core@1.1.3)(@rslib/core@packages+core)(storybook-builder-rsbuild@0.1.4(@rsbuild/core@1.1.3)(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3))(typescript@5.6.3)
+        version: 0.1.4(@rsbuild/core@1.1.4)(@rslib/core@packages+core)(storybook-builder-rsbuild@0.1.4(@rsbuild/core@1.1.4)(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3))(typescript@5.6.3)
       storybook-react-rsbuild:
         specifier: ^0.1.4
-        version: 0.1.4(@rsbuild/core@1.1.3)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.18.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3)(webpack@5.94.0)
+        version: 0.1.4(@rsbuild/core@1.1.4)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.18.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3)(webpack@5.94.0)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -156,13 +155,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.7.5
-        version: 0.7.5(@module-federation/enhanced@0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0))(@rsbuild/core@1.1.3)
+        version: 0.7.5(@module-federation/enhanced@0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0))(@rsbuild/core@1.1.4)
       '@rsbuild/core':
-        specifier: ~1.1.3
-        version: 1.1.3
+        specifier: ~1.1.4
+        version: 1.1.4
       '@rsbuild/plugin-react':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.1.3)
+        version: 1.0.7(@rsbuild/core@1.1.4)
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.12
@@ -177,10 +176,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.1.3)(preact@10.24.3)
+        version: 1.2.0(@rsbuild/core@1.1.4)(preact@10.24.3)
       '@rsbuild/plugin-sass':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.1.3)
+        version: 1.1.1(@rsbuild/core@1.1.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -192,10 +191,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.1.3)
+        version: 1.0.7(@rsbuild/core@1.1.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.1.3)
+        version: 1.1.1(@rsbuild/core@1.1.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -210,10 +209,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.1.3)
+        version: 1.0.7(@rsbuild/core@1.1.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.1.3)
+        version: 1.1.1(@rsbuild/core@1.1.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -228,10 +227,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.1.3)
+        version: 1.0.7(@rsbuild/core@1.1.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.1.3)
+        version: 1.1.1(@rsbuild/core@1.1.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -245,8 +244,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~1.1.3
-        version: 1.1.3
+        specifier: ~1.1.4
+        version: 1.1.4
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
@@ -335,8 +334,8 @@ importers:
         specifier: ^7.47.11
         version: 7.47.11(@types/node@22.8.1)
       '@rsbuild/core':
-        specifier: ~1.1.3
-        version: 1.1.3
+        specifier: ~1.1.4
+        version: 1.1.4
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -363,22 +362,22 @@ importers:
         version: 3.1.1(vite@5.3.3(@types/node@22.8.1)(terser@5.31.6))(vitest@2.1.5(@types/node@22.8.1)(terser@5.31.6))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.7.5
-        version: 0.7.5(@module-federation/enhanced@0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0))(@rsbuild/core@1.1.3)
+        version: 0.7.5(@module-federation/enhanced@0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0))(@rsbuild/core@1.1.4)
       '@playwright/test':
         specifier: 1.48.2
         version: 1.48.2
       '@rsbuild/core':
-        specifier: ~1.1.3
-        version: 1.1.3
+        specifier: ~1.1.4
+        version: 1.1.4
       '@rsbuild/plugin-less':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.3)
+        version: 1.1.0(@rsbuild/core@1.1.4)
       '@rsbuild/plugin-react':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.1.3)
+        version: 1.0.7(@rsbuild/core@1.1.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.1.3)
+        version: 1.1.1(@rsbuild/core@1.1.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -437,7 +436,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.1.3)
+        version: 1.0.7(@rsbuild/core@1.1.4)
 
   tests/integration/asset/path: {}
 
@@ -447,10 +446,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.1.3)
+        version: 1.0.7(@rsbuild/core@1.1.4)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.1.3)(typescript@5.6.3)
+        version: 1.0.5(@rsbuild/core@1.1.4)(typescript@5.6.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -520,10 +519,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.1.3)
+        version: 1.0.7(@rsbuild/core@1.1.4)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.1.3)(typescript@5.6.3)
+        version: 1.0.5(@rsbuild/core@1.1.4)(typescript@5.6.3)
 
   tests/integration/cli: {}
 
@@ -637,7 +636,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.1.3)
+        version: 1.2.0(@rsbuild/core@1.1.4)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -647,7 +646,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.1.3)
+        version: 1.2.0(@rsbuild/core@1.1.4)
 
   tests/integration/polyfill:
     dependencies:
@@ -657,7 +656,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.1.3)
+        version: 1.0.3(@rsbuild/core@1.1.4)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.11.0
         version: 0.11.0(@babel/core@7.26.0)
@@ -784,8 +783,8 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~1.1.3
-        version: 1.1.3
+        specifier: ~1.1.4
+        version: 1.1.4
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -809,7 +808,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.3
-        version: 1.0.3(@rsbuild/core@1.1.3)
+        version: 1.0.3(@rsbuild/core@1.1.4)
       rspress:
         specifier: 1.37.0
         version: 1.37.0(webpack@5.94.0)
@@ -1804,8 +1803,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.1.3':
-    resolution: {integrity: sha512-bl0bN56ZTIaZg8tuCWr48LcE72rF4nDAvSVGDJwpem2Nv3suQYsuwEVq2Mpt5wu6ZEuyEXsMu4owIVoA4JgWyw==}
+  '@rsbuild/core@1.1.4':
+    resolution: {integrity: sha512-fN13hH6Ag0WgCCDUJErNvGs39hSePr8MTaJu1TjUZbFAY3DtOsUHhEb2V5zCUiaeMLMz7ef+krj7+duAJkizog==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
@@ -1873,109 +1872,56 @@ packages:
       typescript:
         optional: true
 
-<<<<<<< HEAD
-  '@rspack/binding-darwin-arm64@1.1.0':
-    resolution: {integrity: sha512-02YmzmtKMNHCSMzVT5sgbJuPDn+HunkrtWq0D95Fh9sGKYap9cs0JOpzTfyAL3KXJ9JzVfOAZA3VgVQOBaQNWQ==}
+  '@rspack/binding-darwin-arm64@1.1.2':
+    resolution: {integrity: sha512-Ay4Srve6U3pDFCsmwVJ1PHHKyeURO/iNU1pjiH986Q30bHDozfHWxCjcy0BJnK4CI4HcSaMQi5YF6BMps3ayuQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.1.0':
-    resolution: {integrity: sha512-HtBh8p6hml7BWNtZaqWFtGbOFP/tvFDn1uPWmA3R32WTILUXNRWXIsLDY95U3Z2U1Gt3SL58SOpJjXlFIb6wZg==}
+  '@rspack/binding-darwin-x64@1.1.2':
+    resolution: {integrity: sha512-s/Mepgi8SHs75QNCtnHo/ua4fAsAz3JdJ6EfdkTmODCE2GwExXy43xl0qWhlzN1FDHnRFIZ0k6tWE0K+uCbKpQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.1.0':
-    resolution: {integrity: sha512-Q/i50Pieii3akdv5Q6my6QelV5Dpc8O/Ir4udpjYl0pbSdKamdI8M85fxrMxGAGcoNSD+X52fDvxJujXWMcP0w==}
+  '@rspack/binding-linux-arm64-gnu@1.1.2':
+    resolution: {integrity: sha512-x2JgHIAKY9CaCt5Q0EwlomyfhLYUOJ7PRUy85axROvMAPRnyRmcDr2OYQPa4KSQ+nDvF7m5SVmchHhepaORwaw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.1.0':
-    resolution: {integrity: sha512-H7Eu3xC7LWPpxrI47n8X361eEGGpQOjZIWTz8tLdn4oNS2D9kqsBYES7LsuuLTTH4ueHTDuEtDdfZpBsE+qesw==}
+  '@rspack/binding-linux-arm64-musl@1.1.2':
+    resolution: {integrity: sha512-kvikjjzErfJEGldJnBTRPSkXcoICaW1PUkicVZJGYcpS6AmXz9OdbHsBKhBvJFCP+BoAHRpK10L0DAydF9kSfg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.1.0':
-    resolution: {integrity: sha512-dIZSutPo2z/OaO2f6SVlcYA6lGBH+4TrRtWmMyPshpTNPrkCGGfDhC43fZ4jCiUj2PO/Hcn8jyKhci4leBsVBA==}
+  '@rspack/binding-linux-x64-gnu@1.1.2':
+    resolution: {integrity: sha512-wg5n7qTl0NRGL+7dzrZcKObM18GKMQDL5Ke7cEWmdHooH0rlyYK6ExIqzE5u/3GJ7KYBlDj/IgAMu5KLd8Ygjw==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.1.0':
-    resolution: {integrity: sha512-f6L2JWgbG9PKWnVw2YNZdntjzia1V2w2Xq458HkCQUDwhnEipWXaZ2zhfD9jcb4UYoMP8/2uD3B96sSFFNTdrQ==}
+  '@rspack/binding-linux-x64-musl@1.1.2':
+    resolution: {integrity: sha512-1705atWiL6mo0KVRUoRcn5SFirUAJhREENzsQSucIYyHOX5bKjPDrd+7SAOSLOGc/yGJSmWZv6NzEH/WvY8TeA==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-win32-arm64-msvc@1.1.0':
-    resolution: {integrity: sha512-opo6XR4iXh/QkHiauVQBlU2xR2JyjDmSwgkION27oszu81nr+IajTSXQX96x5I6Bq48GQLU4rItHse/doctQDA==}
+  '@rspack/binding-win32-arm64-msvc@1.1.2':
+    resolution: {integrity: sha512-DL9v6PAlC0dZnAjwNpdv5JyebidIctLTRCXO6q3bVL03i0jSyX5gRnd6YM5A9176M5HLBnSJjgujqhCffeFA3g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.1.0':
-    resolution: {integrity: sha512-FBcG+OPJokSE3nPi1+ZamLK2V4IWdNC+GMr0z7LUrBiKc5lO70y5VkldfyPV1Z+doSuroVINlhK+lRHdQgGwYg==}
+  '@rspack/binding-win32-ia32-msvc@1.1.2':
+    resolution: {integrity: sha512-RluX7GENVpophR5BB4v0XxqffpGpBLTJDwoQBY0LjfOTGpLv8A0zrGIOMUsJGKE10MOlNfTUQOyB+p6sxLJzcQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.1.0':
-    resolution: {integrity: sha512-H/6Glp1nZvxWAD5+2hRrp1kBs9f+pLb/un2TdFSUNd2tyXq5GyHCe70+N9psbe/jjGxD8e1vPNQtN/VvkuR0Zg==}
+  '@rspack/binding-win32-x64-msvc@1.1.2':
+    resolution: {integrity: sha512-fXg6y/IajuYyBy3oOsat20U+CLrDK/l4FLdg8ETfDPb5isD7jcmhyWXBeJVZVcwHT+Sj1LnLLUuhc+FGFk4aeA==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.1.0':
-    resolution: {integrity: sha512-zLduWacrw/bBYiFvhjN70f+AJxXnTzevywXp54vso8d0Nz7z4KIycdz/Ua5AGRUkG2ZuQw6waypN5pXf48EBcA==}
+  '@rspack/binding@1.1.2':
+    resolution: {integrity: sha512-HUE7EPvrgbabbhW635wSrthidZY1Kijk6+rvmTFuxzmxsBtZNcrhUFVw7Z1fwa2fykiOhbot61EDV9X1qoIa4g==}
 
-  '@rspack/core@1.1.0':
-    resolution: {integrity: sha512-+IYWSe9D3wB97VVBfaojuWLv3wGIBe9pfJkxNObkorN60Nj3UHYzBLuACrHn4hW2mZjAWrv06ReHXJUEGzQqaQ==}
-=======
-  '@rspack/binding-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-xbGzo930YmYcNvp3HQrZsnPkvWeTistmN1LWuZ5biVtIKxDFbCgihxZaUnvUUr7Yxu/9gqQ2MZgpmZp/AHmAtQ==}
-
-  '@rspack/binding-darwin-arm64-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-mCTbwBdbx6mh3CXVvIvZKNf4RCd3gFHbvMI49AN97FRtYluAAYfNIwg24dRe92IrfUfxcZv2huhoIaoIj60SQw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-Dn8B4lYgtT2mSk5Bxuc7iHmtbAs1+iuzJL1EVItED+b7QaEij979EIX4WonesXCFrinREq4D3NFkLPGAVlCo4Q==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-linux-arm64-gnu-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-uxfQw7BiC72XmW03ai0NXMzUmMFv5D3+yiAlRedo4KvtJ1pgEV0x2U6lFl0H5hb6ewPdo7/1IqXQeGwM9v+jqA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-qdrwSeQ0zIzpNhkUa/sJOihQfXQaMuTXgtTgjubc/lQ3gium2cQM7b4r5/jUjF6g6FZQ0ZkzgAd9FPFVVqQ4FQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-yqBSQXhfhLrAe/A84NA/znR3MY72aFzJI0Udq2ozRjaGYdIq9GNK5qYvMM61pTJwXlY9SIA/vA2C9KFsdfuEtw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-DnfBG2pf75MJFG595zRqUAiGJ2h+vyraKWdfBbrgHT2sB3ejDV0dlB3iPmocZomW8P/ORhWDzPREdqo8UVX7nA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-win32-arm64-msvc-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-JFUZdSW4lxEk0HgacaUTJ1ZT9XS3OKwqt/iE9w0/+iIrZWK7jS0gii/mBUmv+OGwB/mqaOm+RUExL7wCsmuhcQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-R1pNKfk/rJT7WJT46cRgXSWkYuGZeb23rubOari8fkl6Ctc3mEwc9dyivtUI7bDNaQLIPzI0OXFfU9qtzuG6dw==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-Qjv0Dah60DuzHoCi2Ngiv3fk5SEVHz5/y6R6svsUldsF8d925P+nmHUT1CDkZpxhKhvrrWJbuMPOZc+eKD/9jQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/core-canary@1.1.2-canary-49a99741-20241115094711':
-    resolution: {integrity: sha512-PThzk1tfa4UujoLnFc4is3qrRateXIsqs2mKfdCyHrEGVr+Y+KeUsxIUywyjEGB1WwG8T6gveGqagMTRqcIcLw==}
->>>>>>> 159f492 (feat!: use 'commonjs-import' as CJS external type by default)
+  '@rspack/core@1.1.2':
+    resolution: {integrity: sha512-cXYPImNpHl2nZmWcMv7WHsorkOaIZP9csPc2J8WxEJhOEotcgP33TKmRTAfJYszV4cqUuKbVjLMv0WgX1OeftQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -7257,11 +7203,11 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.7.5(@module-federation/enhanced@0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0))(@rsbuild/core@1.1.3)':
+  '@module-federation/rsbuild-plugin@0.7.5(@module-federation/enhanced@0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0))(@rsbuild/core@1.1.4)':
     dependencies:
       '@module-federation/enhanced': 0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0)
       '@module-federation/sdk': 0.7.5
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
 
   '@module-federation/rspack@0.7.5(typescript@5.6.3)':
     dependencies:
@@ -7304,12 +7250,12 @@ snapshots:
     dependencies:
       isomorphic-rslog: 0.0.6
 
-  '@module-federation/storybook-addon@3.0.8(@rsbuild/core@1.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack-virtual-modules@0.6.2)(webpack@5.94.0)':
+  '@module-federation/storybook-addon@3.0.8(@rsbuild/core@1.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack-virtual-modules@0.6.2)(webpack@5.94.0)':
     dependencies:
       '@module-federation/enhanced': 0.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.94.0)
       '@module-federation/sdk': 0.7.5
     optionalDependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       webpack: 5.94.0
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -7461,33 +7407,20 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.18.1':
     optional: true
 
-<<<<<<< HEAD
-  '@rsbuild/core@1.1.3':
-=======
-  '@rsbuild/core@1.0.19':
+  '@rsbuild/core@1.1.4':
     dependencies:
-      '@rspack/core': '@rspack/core-canary@1.1.2-canary-49a99741-20241115094711(@swc/helpers@0.5.15)'
-      '@rspack/lite-tapable': 1.0.1
-      '@swc/helpers': 0.5.15
-      core-js: 3.38.1
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  '@rsbuild/core@1.1.0':
->>>>>>> 159f492 (feat!: use 'commonjs-import' as CJS external type by default)
-    dependencies:
-      '@rspack/core': '@rspack/core-canary@1.1.2-canary-49a99741-20241115094711(@swc/helpers@0.5.15)'
+      '@rspack/core': 1.1.2(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.15
       core-js: 3.39.0
 
-  '@rsbuild/plugin-babel@1.0.3(@rsbuild/core@1.1.3)':
+  '@rsbuild/plugin-babel@1.0.3(@rsbuild/core@1.1.4)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.0.0
@@ -7495,13 +7428,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.1.0(@rsbuild/core@1.1.3)':
+  '@rsbuild/plugin-less@1.1.0(@rsbuild/core@1.1.4)':
     dependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       deepmerge: 4.3.1
       reduce-configs: 1.0.0
 
-  '@rsbuild/plugin-node-polyfill@1.2.0(@rsbuild/core@1.1.3)':
+  '@rsbuild/plugin-node-polyfill@1.2.0(@rsbuild/core@1.1.4)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -7527,43 +7460,43 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
 
-  '@rsbuild/plugin-preact@1.2.0(@rsbuild/core@1.1.3)(preact@10.24.3)':
+  '@rsbuild/plugin-preact@1.2.0(@rsbuild/core@1.1.4)(preact@10.24.3)':
     dependencies:
       '@prefresh/core': 1.5.3(preact@10.24.3)
       '@prefresh/utils': 1.2.0
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       '@rspack/plugin-preact-refresh': 1.1.1(@prefresh/core@1.5.3(preact@10.24.3))(@prefresh/utils@1.2.0)
       '@swc/plugin-prefresh': 5.0.0
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@1.0.6(@rsbuild/core@1.1.3)':
+  '@rsbuild/plugin-react@1.0.6(@rsbuild/core@1.1.4)':
     dependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
       react-refresh: 0.14.2
 
-  '@rsbuild/plugin-react@1.0.7(@rsbuild/core@1.1.3)':
+  '@rsbuild/plugin-react@1.0.7(@rsbuild/core@1.1.4)':
     dependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
       react-refresh: 0.14.2
 
-  '@rsbuild/plugin-sass@1.1.1(@rsbuild/core@1.1.3)':
+  '@rsbuild/plugin-sass@1.1.1(@rsbuild/core@1.1.4)':
     dependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.4.49
       reduce-configs: 1.0.0
       sass-embedded: 1.81.0
 
-  '@rsbuild/plugin-svgr@1.0.5(@rsbuild/core@1.1.3)(typescript@5.6.3)':
+  '@rsbuild/plugin-svgr@1.0.5(@rsbuild/core@1.1.4)(typescript@5.6.3)':
     dependencies:
-      '@rsbuild/core': 1.1.3
-      '@rsbuild/plugin-react': 1.0.6(@rsbuild/core@1.1.3)
+      '@rsbuild/core': 1.1.4
+      '@rsbuild/plugin-react': 1.0.6(@rsbuild/core@1.1.4)
       '@svgr/core': 8.1.0(typescript@5.6.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))(typescript@5.6.3)
@@ -7573,7 +7506,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.1.3)(typescript@5.6.3)':
+  '@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.1.4)(typescript@5.6.3)':
     dependencies:
       deepmerge: 4.3.1
       fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.6.3)(webpack@5.94.0)
@@ -7581,7 +7514,7 @@ snapshots:
       reduce-configs: 1.0.0
       webpack: 5.94.0
     optionalDependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -7591,102 +7524,56 @@ snapshots:
 
   '@rslib/core@0.0.18(@microsoft/api-extractor@7.47.11(@types/node@22.8.1))(typescript@5.6.3)':
     dependencies:
-      '@rsbuild/core': 1.1.3
-      rsbuild-plugin-dts: 0.0.18(@microsoft/api-extractor@7.47.11(@types/node@22.8.1))(@rsbuild/core@1.1.3)(typescript@5.6.3)
+      '@rsbuild/core': 1.1.4
+      rsbuild-plugin-dts: 0.0.18(@microsoft/api-extractor@7.47.11(@types/node@22.8.1))(@rsbuild/core@1.1.4)(typescript@5.6.3)
       tinyglobby: 0.2.10
     optionalDependencies:
       '@microsoft/api-extractor': 7.47.11(@types/node@22.8.1)
       typescript: 5.6.3
 
-<<<<<<< HEAD
-  '@rspack/binding-darwin-arm64@1.1.0':
+  '@rspack/binding-darwin-arm64@1.1.2':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.1.0':
+  '@rspack/binding-darwin-x64@1.1.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.1.0':
+  '@rspack/binding-linux-arm64-gnu@1.1.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.1.0':
+  '@rspack/binding-linux-arm64-musl@1.1.2':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.1.0':
+  '@rspack/binding-linux-x64-gnu@1.1.2':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.1.0':
+  '@rspack/binding-linux-x64-musl@1.1.2':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.1.0':
+  '@rspack/binding-win32-arm64-msvc@1.1.2':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.1.0':
+  '@rspack/binding-win32-ia32-msvc@1.1.2':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.1.0':
+  '@rspack/binding-win32-x64-msvc@1.1.2':
     optional: true
 
-  '@rspack/binding@1.1.0':
+  '@rspack/binding@1.1.2':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.1.0
-      '@rspack/binding-darwin-x64': 1.1.0
-      '@rspack/binding-linux-arm64-gnu': 1.1.0
-      '@rspack/binding-linux-arm64-musl': 1.1.0
-      '@rspack/binding-linux-x64-gnu': 1.1.0
-      '@rspack/binding-linux-x64-musl': 1.1.0
-      '@rspack/binding-win32-arm64-msvc': 1.1.0
-      '@rspack/binding-win32-ia32-msvc': 1.1.0
-      '@rspack/binding-win32-x64-msvc': 1.1.0
+      '@rspack/binding-darwin-arm64': 1.1.2
+      '@rspack/binding-darwin-x64': 1.1.2
+      '@rspack/binding-linux-arm64-gnu': 1.1.2
+      '@rspack/binding-linux-arm64-musl': 1.1.2
+      '@rspack/binding-linux-x64-gnu': 1.1.2
+      '@rspack/binding-linux-x64-musl': 1.1.2
+      '@rspack/binding-win32-arm64-msvc': 1.1.2
+      '@rspack/binding-win32-ia32-msvc': 1.1.2
+      '@rspack/binding-win32-x64-msvc': 1.1.2
 
-  '@rspack/core@1.1.0(@swc/helpers@0.5.15)':
+  '@rspack/core@1.1.2(@swc/helpers@0.5.15)':
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
-      '@rspack/binding': 1.1.0
-=======
-  '@rspack/binding-canary@1.1.2-canary-49a99741-20241115094711':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': '@rspack/binding-darwin-arm64-canary@1.1.2-canary-49a99741-20241115094711'
-      '@rspack/binding-darwin-x64': '@rspack/binding-darwin-x64-canary@1.1.2-canary-49a99741-20241115094711'
-      '@rspack/binding-linux-arm64-gnu': '@rspack/binding-linux-arm64-gnu-canary@1.1.2-canary-49a99741-20241115094711'
-      '@rspack/binding-linux-arm64-musl': '@rspack/binding-linux-arm64-musl-canary@1.1.2-canary-49a99741-20241115094711'
-      '@rspack/binding-linux-x64-gnu': '@rspack/binding-linux-x64-gnu-canary@1.1.2-canary-49a99741-20241115094711'
-      '@rspack/binding-linux-x64-musl': '@rspack/binding-linux-x64-musl-canary@1.1.2-canary-49a99741-20241115094711'
-      '@rspack/binding-win32-arm64-msvc': '@rspack/binding-win32-arm64-msvc-canary@1.1.2-canary-49a99741-20241115094711'
-      '@rspack/binding-win32-ia32-msvc': '@rspack/binding-win32-ia32-msvc-canary@1.1.2-canary-49a99741-20241115094711'
-      '@rspack/binding-win32-x64-msvc': '@rspack/binding-win32-x64-msvc-canary@1.1.2-canary-49a99741-20241115094711'
-
-  '@rspack/binding-darwin-arm64-canary@1.1.2-canary-49a99741-20241115094711':
-    optional: true
-
-  '@rspack/binding-darwin-x64-canary@1.1.2-canary-49a99741-20241115094711':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu-canary@1.1.2-canary-49a99741-20241115094711':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl-canary@1.1.2-canary-49a99741-20241115094711':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu-canary@1.1.2-canary-49a99741-20241115094711':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl-canary@1.1.2-canary-49a99741-20241115094711':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc-canary@1.1.2-canary-49a99741-20241115094711':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc-canary@1.1.2-canary-49a99741-20241115094711':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc-canary@1.1.2-canary-49a99741-20241115094711':
-    optional: true
-
-  '@rspack/core-canary@1.1.2-canary-49a99741-20241115094711(@swc/helpers@0.5.15)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.5.1
-      '@rspack/binding': '@rspack/binding-canary@1.1.2-canary-49a99741-20241115094711'
->>>>>>> 159f492 (feat!: use 'commonjs-import' as CJS external type by default)
+      '@rspack/binding': 1.1.2
       '@rspack/lite-tapable': 1.0.1
       caniuse-lite: 1.0.30001680
     optionalDependencies:
@@ -7713,10 +7600,10 @@ snapshots:
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
       '@modern-js/utils': 2.62.0
-      '@rsbuild/core': 1.1.3
-      '@rsbuild/plugin-less': 1.1.0(@rsbuild/core@1.1.3)
-      '@rsbuild/plugin-react': 1.0.7(@rsbuild/core@1.1.3)
-      '@rsbuild/plugin-sass': 1.1.1(@rsbuild/core@1.1.3)
+      '@rsbuild/core': 1.1.4
+      '@rsbuild/plugin-less': 1.1.0(@rsbuild/core@1.1.4)
+      '@rsbuild/plugin-react': 1.0.7(@rsbuild/core@1.1.4)
+      '@rsbuild/plugin-sass': 1.1.1(@rsbuild/core@1.1.4)
       '@rspress/mdx-rs': 0.6.3
       '@rspress/plugin-auto-nav-sidebar': 1.37.0
       '@rspress/plugin-container-syntax': 1.37.0
@@ -7823,7 +7710,7 @@ snapshots:
 
   '@rspress/shared@1.37.0':
     dependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       chalk: 5.3.0
       execa: 5.1.1
       fs-extra: 11.2.0
@@ -11773,9 +11660,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.18.1
       fsevents: 2.3.3
 
-  rsbuild-plugin-dts@0.0.18(@microsoft/api-extractor@7.47.11(@types/node@22.8.1))(@rsbuild/core@1.1.3)(typescript@5.6.3):
+  rsbuild-plugin-dts@0.0.18(@microsoft/api-extractor@7.47.11(@types/node@22.8.1))(@rsbuild/core@1.1.4)(typescript@5.6.3):
     dependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       magic-string: 0.30.12
       picocolors: 1.1.1
       tinyglobby: 0.2.10
@@ -11783,16 +11670,16 @@ snapshots:
       '@microsoft/api-extractor': 7.47.11(@types/node@22.8.1)
       typescript: 5.6.3
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.1.3):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.1.4):
     optionalDependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
 
-  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.1.3):
+  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.1.4):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
 
   rslog@1.2.3: {}
 
@@ -11804,7 +11691,7 @@ snapshots:
 
   rspress@1.37.0(webpack@5.94.0):
     dependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       '@rspress/core': 1.37.0(webpack@5.94.0)
       '@rspress/shared': 1.37.0
       cac: 6.7.14
@@ -12114,18 +12001,18 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@0.1.4(@rsbuild/core@1.1.3)(@rslib/core@packages+core)(storybook-builder-rsbuild@0.1.4(@rsbuild/core@1.1.3)(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3))(typescript@5.6.3):
+  storybook-addon-rslib@0.1.4(@rsbuild/core@1.1.4)(@rslib/core@packages+core)(storybook-builder-rsbuild@0.1.4(@rsbuild/core@1.1.4)(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3))(typescript@5.6.3):
     dependencies:
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 0.1.4(@rsbuild/core@1.1.3)(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 0.1.4(@rsbuild/core@1.1.4)(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3)
     optionalDependencies:
       typescript: 5.6.3
 
-  storybook-builder-rsbuild@0.1.4(@rsbuild/core@1.1.3)(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3):
+  storybook-builder-rsbuild@0.1.4(@rsbuild/core@1.1.4)(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3):
     dependencies:
-      '@rsbuild/core': 1.1.3
-      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.1.3)(typescript@5.6.3)
+      '@rsbuild/core': 1.1.4
+      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.1.4)(typescript@5.6.3)
       '@storybook/addon-docs': 8.4.2(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(webpack-sources@3.2.3)
       '@storybook/core-webpack': 8.4.2(storybook@8.4.4(prettier@3.3.3))
       browser-assert: 1.2.1
@@ -12137,7 +12024,7 @@ snapshots:
       magic-string: 0.30.12
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.1.3)
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.1.4)
       sirv: 2.0.4
       storybook: 8.4.4(prettier@3.3.3)
       ts-dedent: 2.2.0
@@ -12154,10 +12041,10 @@ snapshots:
       - webpack-cli
       - webpack-sources
 
-  storybook-react-rsbuild@0.1.4(@rsbuild/core@1.1.3)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.18.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3)(webpack@5.94.0):
+  storybook-react-rsbuild@0.1.4(@rsbuild/core@1.1.4)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.18.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3)(webpack@5.94.0):
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.18.1)
-      '@rsbuild/core': 1.1.3
+      '@rsbuild/core': 1.1.4
       '@storybook/react': 8.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.6.3)(webpack@5.94.0)
       '@types/node': 18.19.64
@@ -12168,7 +12055,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       storybook: 8.4.4(prettier@3.3.3)
-      storybook-builder-rsbuild: 0.1.4(@rsbuild/core@1.1.3)(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 0.1.4(@rsbuild/core@1.1.4)(@types/react@18.3.12)(storybook@8.4.4(prettier@3.3.3))(typescript@5.6.3)(webpack-sources@3.2.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.6.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@rspack/core': npm:@rspack/core-canary@1.1.2-canary-49a99741-20241115094711
   zx>@types/node: '-'
 
 importers:
@@ -1872,6 +1873,7 @@ packages:
       typescript:
         optional: true
 
+<<<<<<< HEAD
   '@rspack/binding-darwin-arm64@1.1.0':
     resolution: {integrity: sha512-02YmzmtKMNHCSMzVT5sgbJuPDn+HunkrtWq0D95Fh9sGKYap9cs0JOpzTfyAL3KXJ9JzVfOAZA3VgVQOBaQNWQ==}
     cpu: [arm64]
@@ -1922,6 +1924,58 @@ packages:
 
   '@rspack/core@1.1.0':
     resolution: {integrity: sha512-+IYWSe9D3wB97VVBfaojuWLv3wGIBe9pfJkxNObkorN60Nj3UHYzBLuACrHn4hW2mZjAWrv06ReHXJUEGzQqaQ==}
+=======
+  '@rspack/binding-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-xbGzo930YmYcNvp3HQrZsnPkvWeTistmN1LWuZ5biVtIKxDFbCgihxZaUnvUUr7Yxu/9gqQ2MZgpmZp/AHmAtQ==}
+
+  '@rspack/binding-darwin-arm64-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-mCTbwBdbx6mh3CXVvIvZKNf4RCd3gFHbvMI49AN97FRtYluAAYfNIwg24dRe92IrfUfxcZv2huhoIaoIj60SQw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-Dn8B4lYgtT2mSk5Bxuc7iHmtbAs1+iuzJL1EVItED+b7QaEij979EIX4WonesXCFrinREq4D3NFkLPGAVlCo4Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-uxfQw7BiC72XmW03ai0NXMzUmMFv5D3+yiAlRedo4KvtJ1pgEV0x2U6lFl0H5hb6ewPdo7/1IqXQeGwM9v+jqA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-qdrwSeQ0zIzpNhkUa/sJOihQfXQaMuTXgtTgjubc/lQ3gium2cQM7b4r5/jUjF6g6FZQ0ZkzgAd9FPFVVqQ4FQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-gnu-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-yqBSQXhfhLrAe/A84NA/znR3MY72aFzJI0Udq2ozRjaGYdIq9GNK5qYvMM61pTJwXlY9SIA/vA2C9KFsdfuEtw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-DnfBG2pf75MJFG595zRqUAiGJ2h+vyraKWdfBbrgHT2sB3ejDV0dlB3iPmocZomW8P/ORhWDzPREdqo8UVX7nA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-win32-arm64-msvc-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-JFUZdSW4lxEk0HgacaUTJ1ZT9XS3OKwqt/iE9w0/+iIrZWK7jS0gii/mBUmv+OGwB/mqaOm+RUExL7wCsmuhcQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-R1pNKfk/rJT7WJT46cRgXSWkYuGZeb23rubOari8fkl6Ctc3mEwc9dyivtUI7bDNaQLIPzI0OXFfU9qtzuG6dw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-Qjv0Dah60DuzHoCi2Ngiv3fk5SEVHz5/y6R6svsUldsF8d925P+nmHUT1CDkZpxhKhvrrWJbuMPOZc+eKD/9jQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/core-canary@1.1.2-canary-49a99741-20241115094711':
+    resolution: {integrity: sha512-PThzk1tfa4UujoLnFc4is3qrRateXIsqs2mKfdCyHrEGVr+Y+KeUsxIUywyjEGB1WwG8T6gveGqagMTRqcIcLw==}
+>>>>>>> 159f492 (feat!: use 'commonjs-import' as CJS external type by default)
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -7407,9 +7461,22 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.18.1':
     optional: true
 
+<<<<<<< HEAD
   '@rsbuild/core@1.1.3':
+=======
+  '@rsbuild/core@1.0.19':
     dependencies:
-      '@rspack/core': 1.1.0(@swc/helpers@0.5.15)
+      '@rspack/core': '@rspack/core-canary@1.1.2-canary-49a99741-20241115094711(@swc/helpers@0.5.15)'
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.15
+      core-js: 3.38.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  '@rsbuild/core@1.1.0':
+>>>>>>> 159f492 (feat!: use 'commonjs-import' as CJS external type by default)
+    dependencies:
+      '@rspack/core': '@rspack/core-canary@1.1.2-canary-49a99741-20241115094711(@swc/helpers@0.5.15)'
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.15
       core-js: 3.39.0
@@ -7531,6 +7598,7 @@ snapshots:
       '@microsoft/api-extractor': 7.47.11(@types/node@22.8.1)
       typescript: 5.6.3
 
+<<<<<<< HEAD
   '@rspack/binding-darwin-arm64@1.1.0':
     optional: true
 
@@ -7574,6 +7642,51 @@ snapshots:
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
       '@rspack/binding': 1.1.0
+=======
+  '@rspack/binding-canary@1.1.2-canary-49a99741-20241115094711':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': '@rspack/binding-darwin-arm64-canary@1.1.2-canary-49a99741-20241115094711'
+      '@rspack/binding-darwin-x64': '@rspack/binding-darwin-x64-canary@1.1.2-canary-49a99741-20241115094711'
+      '@rspack/binding-linux-arm64-gnu': '@rspack/binding-linux-arm64-gnu-canary@1.1.2-canary-49a99741-20241115094711'
+      '@rspack/binding-linux-arm64-musl': '@rspack/binding-linux-arm64-musl-canary@1.1.2-canary-49a99741-20241115094711'
+      '@rspack/binding-linux-x64-gnu': '@rspack/binding-linux-x64-gnu-canary@1.1.2-canary-49a99741-20241115094711'
+      '@rspack/binding-linux-x64-musl': '@rspack/binding-linux-x64-musl-canary@1.1.2-canary-49a99741-20241115094711'
+      '@rspack/binding-win32-arm64-msvc': '@rspack/binding-win32-arm64-msvc-canary@1.1.2-canary-49a99741-20241115094711'
+      '@rspack/binding-win32-ia32-msvc': '@rspack/binding-win32-ia32-msvc-canary@1.1.2-canary-49a99741-20241115094711'
+      '@rspack/binding-win32-x64-msvc': '@rspack/binding-win32-x64-msvc-canary@1.1.2-canary-49a99741-20241115094711'
+
+  '@rspack/binding-darwin-arm64-canary@1.1.2-canary-49a99741-20241115094711':
+    optional: true
+
+  '@rspack/binding-darwin-x64-canary@1.1.2-canary-49a99741-20241115094711':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu-canary@1.1.2-canary-49a99741-20241115094711':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl-canary@1.1.2-canary-49a99741-20241115094711':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu-canary@1.1.2-canary-49a99741-20241115094711':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl-canary@1.1.2-canary-49a99741-20241115094711':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc-canary@1.1.2-canary-49a99741-20241115094711':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc-canary@1.1.2-canary-49a99741-20241115094711':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc-canary@1.1.2-canary-49a99741-20241115094711':
+    optional: true
+
+  '@rspack/core-canary@1.1.2-canary-49a99741-20241115094711(@swc/helpers@0.5.15)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.5.1
+      '@rspack/binding': '@rspack/binding-canary@1.1.2-canary-49a99741-20241115094711'
+>>>>>>> 159f492 (feat!: use 'commonjs-import' as CJS external type by default)
       '@rspack/lite-tapable': 1.0.1
       caniuse-lite: 1.0.30001680
     optionalDependencies:

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -66,3 +66,11 @@ test('should get warn when use require in ESM', async () => {
 
   restore();
 });
+
+test('require ESM from CJS', async () => {
+  const fixturePath = join(__dirname, 'node');
+  const { entryFiles } = await buildAndGetResults({ fixturePath });
+  const baz = (await import(entryFiles.cjs)).baz;
+  const bazValue = await baz();
+  expect(bazValue).toBe('baz');
+});

--- a/tests/integration/externals/node/rslib.config.ts
+++ b/tests/integration/externals/node/rslib.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     },
   },
   output: {
-    externals: { react: 'react', bar: 'bar' },
+    externals: { react: 'react', bar: 'bar', './baz.mjs': './baz.mjs' },
+    copy: [{ from: './src/baz.mjs' }],
   },
 });

--- a/tests/integration/externals/node/src/baz.mjs
+++ b/tests/integration/externals/node/src/baz.mjs
@@ -1,0 +1,1 @@
+export const baz = 'baz';

--- a/tests/integration/externals/node/src/index.ts
+++ b/tests/integration/externals/node/src/index.ts
@@ -2,11 +2,20 @@ import fs from 'fs'; // handle bare node built-in modules
 import assert from 'node:assert'; // handle node built-in modules with node: protocol
 import React from 'react'; // works with the externals option in rslib.config.ts
 
-export const foo = () => {
+export const foo = async () => {
   assert(fs, 'fs exists');
+  const fooModule = require('foo'); // ESM: specified externals type
+  fooModule();
+};
+
+export const bar = async () => {
   assert(React.version);
-  const foo = require('foo'); // ESM: specified externals type
-  const bar = require('bar'); // ESM: fallback to "module" when not specify externals type
-  foo();
-  bar();
+  const barModule = require('bar'); // ESM: fallback to "module" when not specify externals type
+  barModule();
+};
+
+export const baz = async () => {
+  // @ts-ignore
+  const bazModule = await import('./baz.mjs'); // should be kept dynamic import by default
+  return bazModule.baz;
 };

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,7 @@
     "@codspeed/vitest-plugin": "^3.1.1",
     "@module-federation/rsbuild-plugin": "^0.7.5",
     "@playwright/test": "1.48.2",
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@rsbuild/plugin-less": "^1.1.0",
     "@rsbuild/plugin-react": "^1.0.7",
     "@rsbuild/plugin-sass": "^1.1.1",

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "rspress preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.3",
+    "@rsbuild/core": "~1.1.4",
     "@rslib/tsconfig": "workspace:*",
     "@rstack-dev/doc-ui": "1.5.4",
     "@types/node": "^22.8.1",


### PR DESCRIPTION
## Summary

It's hard to cover all cases of whether it's under node `13.2.0` without calling Browserslist API. Since Node 13.2 has reach EOL for years (https://endoflife.date/nodejs). I think it's fine to set `commonjs-import` as the default external type for Node.js and demonstrate the differences between the externals type on library build scenario next.

Also bump Rsbuild to `~1.1.4`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
