### PR TITLE
feat!: emit CSS files to `dist` instead of `dist/static/css`

### DIFF
--- a/examples/react-component-bundle/rslib.config.ts
+++ b/examples/react-component-bundle/rslib.config.ts
@@ -10,8 +10,6 @@ export default defineConfig({
       output: {
         distPath: {
           root: './dist/esm',
-          css: '.',
-          cssAsync: '.',
         },
       },
     },
@@ -21,8 +19,6 @@ export default defineConfig({
       output: {
         distPath: {
           root: './dist/cjs',
-          css: '.',
-          cssAsync: '.',
         },
       },
     },

--- a/examples/vue-component-bundle/rslib.config.ts
+++ b/examples/vue-component-bundle/rslib.config.ts
@@ -3,16 +3,7 @@ import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   plugins: [pluginVue()],
-  lib: [
-    {
-      format: 'esm',
-      output: {
-        distPath: {
-          css: '.',
-        },
-      },
-    },
-  ],
+  lib: [{ format: 'esm' }],
   output: {
     target: 'web',
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -463,6 +463,9 @@ export async function createConstantRsbuildConfig(): Promise<RsbuildConfig> {
       filenameHash: false,
       distPath: {
         js: './',
+        jsAsync: './',
+        css: './',
+        cssAsync: './',
       },
     },
   });

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -10,7 +10,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
       "mode": "production",
       "output": {
         "distPath": {
+          "css": "./",
+          "cssAsync": "./",
           "js": "./",
+          "jsAsync": "./",
         },
         "externals": [
           [Function],
@@ -239,7 +242,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
       "mode": "production",
       "output": {
         "distPath": {
+          "css": "./",
+          "cssAsync": "./",
           "js": "./",
+          "jsAsync": "./",
         },
         "externals": [
           "assert",
@@ -464,7 +470,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
       "mode": "production",
       "output": {
         "distPath": {
+          "css": "./",
+          "cssAsync": "./",
           "js": "./",
+          "jsAsync": "./",
         },
         "externals": [
           "assert",

--- a/tests/integration/style/css-modules/index.test.ts
+++ b/tests/integration/style/css-modules/index.test.ts
@@ -10,14 +10,14 @@ test('should extract css-modules successfully in bundle', async () => {
   const esmFiles = Object.keys(contents.esm);
   expect(esmFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/css-modules/bundle/dist/esm/static/css/index.css",
+      "<ROOT>/tests/integration/style/css-modules/bundle/dist/esm/index.css",
     ]
   `);
 
   const cjsFiles = Object.keys(contents.cjs);
   expect(cjsFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/css-modules/bundle/dist/cjs/static/css/index.css",
+      "<ROOT>/tests/integration/style/css-modules/bundle/dist/cjs/index.css",
     ]
   `);
 });

--- a/tests/integration/style/css/index.test.ts
+++ b/tests/integration/style/css/index.test.ts
@@ -11,13 +11,13 @@ test('should extract css successfully in bundle', async () => {
 
   expect(files.esm).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/css/bundle/dist/esm/static/css/index.css",
+      "<ROOT>/tests/integration/style/css/bundle/dist/esm/index.css",
     ]
   `);
 
   expect(contents.esm).toMatchInlineSnapshot(`
     {
-      "<ROOT>/tests/integration/style/css/bundle/dist/esm/static/css/index.css": "@import url(https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/1.1.0/modern-normalize.css);
+      "<ROOT>/tests/integration/style/css/bundle/dist/esm/index.css": "@import url(https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/1.1.0/modern-normalize.css);
     @import url(https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/1.0.0/modern-normalize.css);
     .lib1 {
       color: red;
@@ -37,13 +37,13 @@ test('should extract css successfully in bundle', async () => {
 
   expect(files.cjs).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/css/bundle/dist/cjs/static/css/index.css",
+      "<ROOT>/tests/integration/style/css/bundle/dist/cjs/index.css",
     ]
   `);
 
   expect(contents.cjs).toMatchInlineSnapshot(`
     {
-      "<ROOT>/tests/integration/style/css/bundle/dist/cjs/static/css/index.css": "@import url(https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/1.1.0/modern-normalize.css);
+      "<ROOT>/tests/integration/style/css/bundle/dist/cjs/index.css": "@import url(https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/1.1.0/modern-normalize.css);
     @import url(https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/1.0.0/modern-normalize.css);
     .lib1 {
       color: red;

--- a/tests/integration/style/less/index.test.ts
+++ b/tests/integration/style/less/index.test.ts
@@ -33,14 +33,14 @@ test('should extract css with pluginLess successfully in bundle', async () => {
   const esmFiles = Object.keys(contents.esm);
   expect(esmFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/less/bundle/dist/esm/static/css/index.css",
+      "<ROOT>/tests/integration/style/less/bundle/dist/esm/index.css",
     ]
   `);
 
   const cjsFiles = Object.keys(contents.cjs);
   expect(cjsFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/less/bundle/dist/cjs/static/css/index.css",
+      "<ROOT>/tests/integration/style/less/bundle/dist/cjs/index.css",
     ]
   `);
 });
@@ -52,7 +52,7 @@ test('should extract css with pluginLess successfully in import case', async () 
   const esmFiles = Object.keys(contents.esm);
   expect(esmFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/less/bundle-import/dist/esm/static/css/index.css",
+      "<ROOT>/tests/integration/style/less/bundle-import/dist/esm/index.css",
     ]
   `);
   expectFileContainContent(contents.esm, 'index.css', '.lib1 {');
@@ -60,7 +60,7 @@ test('should extract css with pluginLess successfully in import case', async () 
   const cjsFiles = Object.keys(contents.cjs);
   expect(cjsFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/less/bundle-import/dist/cjs/static/css/index.css",
+      "<ROOT>/tests/integration/style/less/bundle-import/dist/cjs/index.css",
     ]
   `);
   expectFileContainContent(contents.cjs, 'index.css', '.lib1 {');

--- a/tests/integration/style/lightningcss/index.test.ts
+++ b/tests/integration/style/lightningcss/index.test.ts
@@ -9,7 +9,7 @@ test('should extract css with lightningcss-loader successfully in bundle', async
   const esmFiles = Object.keys(contents.esm);
   expect(esmFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/lightningcss/bundle/dist/esm/static/css/index.css",
+      "<ROOT>/tests/integration/style/lightningcss/bundle/dist/esm/index.css",
     ]
   `);
   expectFileContainContent(
@@ -21,7 +21,7 @@ test('should extract css with lightningcss-loader successfully in bundle', async
   const cjsFiles = Object.keys(contents.cjs);
   expect(cjsFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/lightningcss/bundle/dist/cjs/static/css/index.css",
+      "<ROOT>/tests/integration/style/lightningcss/bundle/dist/cjs/index.css",
     ]
   `);
   expectFileContainContent(

--- a/tests/integration/style/postcss/index.test.ts
+++ b/tests/integration/style/postcss/index.test.ts
@@ -10,7 +10,7 @@ test('should extract css with postcss-loader successfully in bundle', async () =
   const esmFiles = Object.keys(contents.esm);
   expect(esmFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/postcss/bundle/dist/esm/static/css/index.css",
+      "<ROOT>/tests/integration/style/postcss/bundle/dist/esm/index.css",
     ]
   `);
   expectFileContainContent(contents.esm, 'index.css', 'font-size: 16px;');
@@ -18,7 +18,7 @@ test('should extract css with postcss-loader successfully in bundle', async () =
   const cjsFiles = Object.keys(contents.cjs);
   expect(cjsFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/postcss/bundle/dist/cjs/static/css/index.css",
+      "<ROOT>/tests/integration/style/postcss/bundle/dist/cjs/index.css",
     ]
   `);
   expectFileContainContent(contents.cjs, 'index.css', 'font-size: 16px;');

--- a/tests/integration/style/sass/index.test.ts
+++ b/tests/integration/style/sass/index.test.ts
@@ -8,14 +8,14 @@ test('should extract css with pluginSass in bundle', async () => {
   const esmFiles = Object.keys(contents.esm);
   expect(esmFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/sass/bundle/dist/esm/static/css/index.css",
+      "<ROOT>/tests/integration/style/sass/bundle/dist/esm/index.css",
     ]
   `);
 
   const cjsFiles = Object.keys(contents.cjs);
   expect(cjsFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/sass/bundle/dist/cjs/static/css/index.css",
+      "<ROOT>/tests/integration/style/sass/bundle/dist/cjs/index.css",
     ]
   `);
 });

--- a/tests/integration/style/tailwindcss/index.test.ts
+++ b/tests/integration/style/tailwindcss/index.test.ts
@@ -9,7 +9,7 @@ test('should extract css when using tailwindcss successfully in bundle', async (
   const esmFiles = Object.keys(contents.esm);
   expect(esmFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/tailwindcss/bundle/dist/esm/static/css/index.css",
+      "<ROOT>/tests/integration/style/tailwindcss/bundle/dist/esm/index.css",
     ]
   `);
   expectFileContainContent(contents.esm, 'index.css', [
@@ -21,7 +21,7 @@ test('should extract css when using tailwindcss successfully in bundle', async (
   const cjsFiles = Object.keys(contents.cjs);
   expect(cjsFiles).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/style/tailwindcss/bundle/dist/cjs/static/css/index.css",
+      "<ROOT>/tests/integration/style/tailwindcss/bundle/dist/cjs/index.css",
     ]
   `);
   expectFileContainContent(contents.cjs, 'index.css', [


### PR DESCRIPTION
## Summary

Emit CSS files and async files to `dist` instead of `dist/static/css`.

- Align with `distPath.js`.
- Usually library authors prefer flatter output instead of nested output.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
