### PR TITLE
fix: entry query should handle non-string entry

### DIFF
--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -24,6 +24,11 @@ export type RsbuildConfigWithLibInfo = {
   config: RsbuildConfig;
 };
 
+export type RsbuildConfigEntry = NonNullable<
+  NonNullable<RsbuildConfig['source']>['entry']
+>;
+export type RsbuildConfigEntryItem = RsbuildConfigEntry[string];
+
 export type RsbuildConfigOutputTarget = NonNullable<
   RsbuildConfig['output']
 >['target'];

--- a/packages/core/tests/entry.test.ts
+++ b/packages/core/tests/entry.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'vitest';
+import { appendEntryQuery } from '../src/config';
+
+describe('appendEntryQuery', () => {
+  test('string', () => {
+    expect(
+      appendEntryQuery({
+        index: 'src/index.js',
+        foo: 'src/foo.js',
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "foo": "src/foo.js?__rslib_entry__",
+        "index": "src/index.js?__rslib_entry__",
+      }
+    `);
+  });
+
+  test('string[]', () => {
+    expect(
+      appendEntryQuery({
+        index: ['src/index.ts', 'src/extra.ts'],
+        foo: ['src/foo.js'],
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "foo": [
+          "src/foo.js?__rslib_entry__",
+        ],
+        "index": [
+          "src/index.ts?__rslib_entry__",
+          "src/extra.ts?__rslib_entry__",
+        ],
+      }
+    `);
+  });
+
+  test('Rspack.EntryDescription', () => {
+    expect(
+      appendEntryQuery({
+        index: {
+          import: ['src/index.ts', 'src/extra.ts'],
+          layer: 'l1',
+        },
+        foo: {
+          import: ['src/foo.js'],
+          dependOn: ['src/dep.js'],
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "foo": {
+          "dependOn": [
+            "src/dep.js",
+          ],
+          "import": [
+            "src/foo.js?__rslib_entry__",
+          ],
+        },
+        "index": {
+          "import": [
+            "src/index.ts?__rslib_entry__",
+            "src/extra.ts?__rslib_entry__",
+          ],
+          "layer": "l1",
+        },
+      }
+    `);
+  });
+
+  test('combined', () => {
+    expect(
+      appendEntryQuery({
+        index: {
+          import: ['src/index.ts', 'src/extra.ts'],
+          layer: 'l1',
+        },
+        foo: {
+          import: ['src/foo.js'],
+          dependOn: ['src/dep.js'],
+        },
+        bar: 'src/bar.ts',
+        baz: ['src/baz.ts', 'src/bar.ts'],
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "bar": "src/bar.ts?__rslib_entry__",
+        "baz": [
+          "src/baz.ts?__rslib_entry__",
+          "src/bar.ts?__rslib_entry__",
+        ],
+        "foo": {
+          "dependOn": [
+            "src/dep.js",
+          ],
+          "import": [
+            "src/foo.js?__rslib_entry__",
+          ],
+        },
+        "index": {
+          "import": [
+            "src/index.ts?__rslib_entry__",
+            "src/extra.ts?__rslib_entry__",
+          ],
+          "layer": "l1",
+        },
+      }
+    `);
+  });
+});


### PR DESCRIPTION
## Summary

Correctly handle all possible entry types to add entry query. Previously, we can only handle `string` indeed.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
