### PR TITLE
test: multiple entries now do not affect each other

### DIFF
--- a/tests/integration/entry/index.test.ts
+++ b/tests/integration/entry/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { buildAndGetResults } from 'test-helper';
+import { buildAndGetResults, queryContent } from 'test-helper';
 import { expect, test } from 'vitest';
 
 test('single entry bundle', async () => {
@@ -20,19 +20,54 @@ test('single entry bundle', async () => {
 
 test('multiple entry bundle', async () => {
   const fixturePath = join(__dirname, 'multiple');
-  const { files } = await buildAndGetResults({ fixturePath });
+  const { files, contents } = await buildAndGetResults({ fixturePath });
 
   expect(files).toMatchInlineSnapshot(`
     {
       "cjs": [
         "<ROOT>/tests/integration/entry/multiple/dist/cjs/bar.cjs",
+        "<ROOT>/tests/integration/entry/multiple/dist/cjs/foo.cjs",
         "<ROOT>/tests/integration/entry/multiple/dist/cjs/index.cjs",
+        "<ROOT>/tests/integration/entry/multiple/dist/cjs/shared.cjs",
       ],
       "esm": [
         "<ROOT>/tests/integration/entry/multiple/dist/esm/bar.js",
+        "<ROOT>/tests/integration/entry/multiple/dist/esm/foo.js",
         "<ROOT>/tests/integration/entry/multiple/dist/esm/index.js",
+        "<ROOT>/tests/integration/entry/multiple/dist/esm/shared.js",
       ],
     }
+  `);
+
+  const index = queryContent(contents.esm, 'index.js', { basename: true });
+  expect(index).toMatchInlineSnapshot(`
+    "const shared = 'shared';
+    const foo = 'foo' + shared;
+    const src_rslib_entry_text = ()=>\`hello \${foo} \${shared}\`;
+    export { src_rslib_entry_text as text };
+    "
+  `);
+
+  const foo = queryContent(contents.esm, 'foo.js', { basename: true });
+  expect(foo).toMatchInlineSnapshot(`
+    "const shared = 'shared';
+    const foo = 'foo' + shared;
+    export { foo };
+    "
+  `);
+
+  const bar = queryContent(contents.esm, 'bar.js', { basename: true });
+  expect(bar).toMatchInlineSnapshot(`
+    "const bar = 'bar';
+    export { bar };
+    "
+  `);
+
+  const shared = queryContent(contents.esm, 'shared.js', { basename: true });
+  expect(shared).toMatchInlineSnapshot(`
+    "const shared = 'shared';
+    export { shared };
+    "
   `);
 });
 

--- a/tests/integration/entry/multiple/rslib.config.ts
+++ b/tests/integration/entry/multiple/rslib.config.ts
@@ -5,8 +5,10 @@ export default defineConfig({
   lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
   source: {
     entry: {
-      index: ['./src/index.ts'],
-      bar: ['./src/bar.ts'],
+      index: './src/index.ts',
+      foo: './src/foo.ts',
+      bar: './src/bar.ts',
+      shared: './src/shared.ts',
     },
   },
 });

--- a/tests/integration/entry/multiple/src/foo.ts
+++ b/tests/integration/entry/multiple/src/foo.ts
@@ -1,1 +1,3 @@
-export const foo = 'foo';
+import { shared } from './shared';
+
+export const foo = 'foo' + shared;

--- a/tests/integration/entry/multiple/src/index.ts
+++ b/tests/integration/entry/multiple/src/index.ts
@@ -1,3 +1,4 @@
 import { foo } from './foo';
+import { shared } from './shared';
 
-export const text = () => `hello ${foo}`;
+export const text = () => `hello ${foo} ${shared}`;

--- a/tests/integration/entry/multiple/src/shared.ts
+++ b/tests/integration/entry/multiple/src/shared.ts
@@ -1,0 +1,1 @@
+export const shared = 'shared';

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -166,6 +166,7 @@ export async function getResults(
       if (fileSet.length === 1) {
         entryFile = fileSet[0];
       } else {
+        // TODO: Do not support multiple entry files yet.
         entryFile = fileSet.find((file) => file.includes('index'));
         mfExposeFile = fileSet.find((file) => file.includes('expose'));
       }


### PR DESCRIPTION
## Summary

Finish the test of multiple entry, resolved by https://github.com/web-infra-dev/rslib/pull/399.

https://github.com/web-infra-dev/rslib/pull/399 fixed https://github.com/web-infra-dev/rslib/issues/316.
https://github.com/web-infra-dev/rslib/pull/399 fixed https://github.com/web-infra-dev/rslib/issues/452.

### Why it fixed

In #399, each entry is appended with a `?__rslib_entry__` query so importing `foo` from `index` will be distinguished as a different module from the entry module. Which will prevent `foo` from concatenation bailout.

FYI: `layer` could also distinguish the entry module, we might, could use `layer` if one day entry query is removed.

### It's not done.

Currently, chunk splitting of shared modules is not yet supported, but at least it works for now. We will track the progress of chunk splitting in a dedicated issue.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
