### PR TITLE
feat: clean dts files / buildinfo / .rslib temp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ coverage/
 doc_build/
 playwright-report/
 tsconfig.tsbuildinfo
+tsconfig.esm.tsbuildinfo
+tsconfig.cjs.tsbuildinfo
 test-temp-*
 test-results
 

--- a/packages/plugin-dts/src/apiExtractor.ts
+++ b/packages/plugin-dts/src/apiExtractor.ts
@@ -52,9 +52,7 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
         untrimmedFilePath,
       },
       compiler: {
-        tsconfigFilePath: tsconfigPath.includes(cwd)
-          ? tsconfigPath
-          : join(cwd, tsconfigPath),
+        tsconfigFilePath: tsconfigPath,
       },
       projectFolder: cwd,
     };

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -2,7 +2,14 @@ import { fork } from 'node:child_process';
 import { dirname, extname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { type RsbuildConfig, type RsbuildPlugin, logger } from '@rsbuild/core';
-import { processSourceEntry } from './utils';
+import ts from 'typescript';
+import {
+  cleanDtsFiles,
+  cleanTsBuildInfoFile,
+  clearTempDeclarationDir,
+  loadTsconfig,
+  processSourceEntry,
+} from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -34,9 +41,10 @@ export type DtsGenOptions = PluginDtsOptions & {
   cwd: string;
   isWatch: boolean;
   dtsEntry: DtsEntry;
-  rootDistPath: string;
+  dtsEmitPath: string;
   build?: boolean;
-  tsconfigPath?: string;
+  tsconfigPath: string;
+  tsConfigResult: ts.ParsedCommandLine;
   userExternals?: NonNullable<RsbuildConfig['output']>['externals'];
 };
 
@@ -62,17 +70,12 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
     let promisesResult: TaskResult[] = [];
 
     api.onBeforeEnvironmentCompile(
-      ({ isWatch, isFirstCompile, environment }) => {
+      async ({ isWatch, isFirstCompile, environment }) => {
         if (!isFirstCompile) {
           return;
         }
 
         const { config } = environment;
-
-        const jsExtension = extname(__filename);
-        const childProcess = fork(join(__dirname, `./dts${jsExtension}`), [], {
-          stdio: 'inherit',
-        });
 
         // TODO: @microsoft/api-extractor only support single entry to bundle DTS
         // use first element of Record<string, string> type entry config
@@ -81,14 +84,53 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
           config.source?.entry,
         );
 
+        const cwd = api.context.rootPath;
+        const tsconfigPath = ts.findConfigFile(
+          cwd,
+          ts.sys.fileExists,
+          config.source.tsconfigPath,
+        );
+
+        if (!tsconfigPath) {
+          logger.error(`tsconfig.json not found in ${cwd}`);
+          throw new Error();
+        }
+
+        const tsConfigResult = loadTsconfig(tsconfigPath);
+        const dtsEmitPath =
+          options.distPath ??
+          tsConfigResult.options.declarationDir ??
+          config.output?.distPath?.root;
+
+        const jsExtension = extname(__filename);
+        const childProcess = fork(join(__dirname, `./dts${jsExtension}`), [], {
+          stdio: 'inherit',
+        });
+
+        const { cleanDistPath } = config.output;
+
+        // clean dts files
+        if (cleanDistPath !== false) {
+          await cleanDtsFiles(dtsEmitPath);
+        }
+
+        // clean .rslib temp folder
+        if (options.bundle) {
+          await clearTempDeclarationDir(cwd);
+        }
+
+        // clean tsbuildinfo file
+        await cleanTsBuildInfoFile(tsconfigPath, tsConfigResult);
+
         const dtsGenOptions: DtsGenOptions = {
           ...options,
           dtsEntry,
+          dtsEmitPath,
           userExternals: config.output.externals,
-          rootDistPath: config.output?.distPath?.root,
-          tsconfigPath: config.source.tsconfigPath,
+          tsconfigPath,
+          tsConfigResult,
           name: environment.name,
-          cwd: api.context.rootPath,
+          cwd,
           isWatch,
         };
 

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -1,17 +1,13 @@
 import { logger } from '@rsbuild/core';
 import color from 'picocolors';
 import ts from 'typescript';
-import {
-  getFileLoc,
-  getTimeCost,
-  loadTsconfig,
-  processDtsFiles,
-} from './utils';
+import { getFileLoc, getTimeCost, processDtsFiles } from './utils';
 
 export type EmitDtsOptions = {
   name: string;
   cwd: string;
   configPath: string;
+  tsConfigResult: ts.ParsedCommandLine;
   declarationDir: string;
   dtsExtension: string;
   banner?: string;
@@ -63,14 +59,20 @@ export async function emitDts(
   build = false,
 ): Promise<void> {
   const start = Date.now();
-  const { configPath, declarationDir, name, dtsExtension, banner, footer } =
-    options;
-  const configFileParseResult = loadTsconfig(configPath);
+  const {
+    configPath,
+    tsConfigResult,
+    declarationDir,
+    name,
+    dtsExtension,
+    banner,
+    footer,
+  } = options;
   const {
     options: rawCompilerOptions,
     fileNames,
     projectReferences,
-  } = configFileParseResult;
+  } = tsConfigResult;
 
   const compilerOptions = {
     ...rawCompilerOptions,
@@ -160,9 +162,8 @@ export async function emitDts(
         options: compilerOptions,
         projectReferences,
         host,
-        configFileParsingDiagnostics: ts.getConfigFileParsingDiagnostics(
-          configFileParseResult,
-        ),
+        configFileParsingDiagnostics:
+          ts.getConfigFileParsingDiagnostics(tsConfigResult),
       });
 
       const emitResult = program.emit();
@@ -190,9 +191,8 @@ export async function emitDts(
       const program = ts.createIncrementalProgram({
         rootNames: fileNames,
         options: compilerOptions,
-        configFileParsingDiagnostics: ts.getConfigFileParsingDiagnostics(
-          configFileParseResult,
-        ),
+        configFileParsingDiagnostics:
+          ts.getConfigFileParsingDiagnostics(tsConfigResult),
         projectReferences,
         host,
         createProgram,

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import fsP from 'node:fs/promises';
 import { platform } from 'node:os';
-import path, { join } from 'node:path';
+import path, { basename, dirname, join, relative, resolve } from 'node:path';
 import { type RsbuildConfig, logger } from '@rsbuild/core';
 import MagicString from 'magic-string';
 import color from 'picocolors';
@@ -23,8 +23,8 @@ export function loadTsconfig(tsconfigPath: string): ts.ParsedCommandLine {
 export const TEMP_FOLDER = '.rslib';
 export const TEMP_DTS_DIR: string = `${TEMP_FOLDER}/declarations`;
 
-export function ensureTempDeclarationDir(cwd: string): string {
-  const dirPath = path.join(cwd, TEMP_DTS_DIR);
+export function ensureTempDeclarationDir(cwd: string, name: string): string {
+  const dirPath = path.join(cwd, TEMP_DTS_DIR, name);
 
   if (fs.existsSync(dirPath)) {
     return dirPath;
@@ -36,6 +36,16 @@ export function ensureTempDeclarationDir(cwd: string): string {
   fs.writeFileSync(gitIgnorePath, '**/*\n');
 
   return dirPath;
+}
+
+export async function clearTempDeclarationDir(cwd: string): Promise<void> {
+  const dirPath = path.join(cwd, TEMP_DTS_DIR);
+
+  try {
+    await fsP.rm(dirPath, { recursive: true, force: true });
+  } catch (error) {
+    logger.error(`Error clearing temporary directory ${dirPath}: ${error}`);
+  }
 }
 
 export function getFileLoc(
@@ -195,4 +205,42 @@ export async function calcLongestCommonPath(
   }
 
   return lca;
+}
+
+export async function cleanDtsFiles(dir: string): Promise<void> {
+  const patterns = ['/**/*.d.ts', '/**/*.d.cts', '/**/*.d.mts'];
+  const files = await Promise.all(
+    patterns.map((pattern) =>
+      glob(convertPath(join(dir, pattern)), { absolute: true }),
+    ),
+  );
+
+  const allFiles = files.flat();
+
+  await Promise.all(allFiles.map((file) => fsP.rm(file, { force: true })));
+}
+
+export async function cleanTsBuildInfoFile(
+  tsconfigPath: string,
+  tsConfigResult: ts.ParsedCommandLine,
+): Promise<void> {
+  const tsconfigDir = dirname(tsconfigPath);
+  const { outDir, rootDir, tsBuildInfoFile } = tsConfigResult.options;
+  let tsbuildInfoFilePath = `${basename(
+    tsconfigPath,
+    '.json',
+  )}${tsBuildInfoFile ?? '.tsbuildinfo'}`;
+  if (outDir) {
+    if (rootDir) {
+      tsbuildInfoFilePath = join(
+        outDir,
+        relative(resolve(tsconfigDir, rootDir), tsconfigDir),
+        tsbuildInfoFilePath,
+      );
+    } else {
+      tsbuildInfoFilePath = join(outDir, tsbuildInfoFilePath);
+    }
+  }
+
+  await fsP.rm(tsbuildInfoFilePath, { force: true });
 }

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -38,14 +38,35 @@ export function ensureTempDeclarationDir(cwd: string, name: string): string {
   return dirPath;
 }
 
+export async function pathExists(path: string): Promise<boolean> {
+  return fs.promises
+    .access(path)
+    .then(() => true)
+    .catch(() => false);
+}
+
+export async function emptyDir(dir: string): Promise<void> {
+  if (!(await pathExists(dir))) {
+    return;
+  }
+
+  try {
+    for (const file of await fs.promises.readdir(dir)) {
+      await fs.promises.rm(path.resolve(dir, file), {
+        recursive: true,
+        force: true,
+      });
+    }
+  } catch (err) {
+    logger.debug(`Failed to empty dir: ${dir}`);
+    logger.debug(err);
+  }
+}
+
 export async function clearTempDeclarationDir(cwd: string): Promise<void> {
   const dirPath = path.join(cwd, TEMP_DTS_DIR);
 
-  try {
-    await fsP.rm(dirPath, { recursive: true, force: true });
-  } catch (error) {
-    logger.error(`Error clearing temporary directory ${dirPath}: ${error}`);
-  }
+  await emptyDir(dirPath);
 }
 
 export function getFileLoc(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,6 +566,8 @@ importers:
 
   tests/integration/dts/build/basic: {}
 
+  tests/integration/dts/build/clean: {}
+
   tests/integration/dts/build/dist-path: {}
 
   tests/integration/dts/build/process-files: {}
@@ -577,6 +579,8 @@ importers:
   tests/integration/dts/bundle-false/auto-extension: {}
 
   tests/integration/dts/bundle-false/basic: {}
+
+  tests/integration/dts/bundle-false/clean: {}
 
   tests/integration/dts/bundle-false/declaration-dir: {}
 
@@ -596,6 +600,8 @@ importers:
 
   tests/integration/dts/bundle/bundle-name: {}
 
+  tests/integration/dts/bundle/clean: {}
+
   tests/integration/dts/bundle/dist-path: {}
 
   tests/integration/dts/bundle/false: {}
@@ -611,6 +617,8 @@ importers:
   tests/integration/dts/composite/abort-on-error: {}
 
   tests/integration/dts/composite/basic: {}
+
+  tests/integration/dts/composite/clean: {}
 
   tests/integration/dts/composite/dist-path: {}
 

--- a/tests/integration/dts/build/clean/package.json
+++ b/tests/integration/dts/build/clean/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-build-clean-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/build/clean/rslib.config.ts
+++ b/tests/integration/dts/build/clean/rslib.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        distPath: './dist-types/esm',
+        bundle: false,
+        build: true,
+      },
+      source: {
+        tsconfigPath: './tsconfig.esm.json',
+      },
+    }),
+    generateBundleCjsConfig({
+      bundle: false,
+      dts: {
+        distPath: './dist-types/cjs',
+        bundle: false,
+        build: true,
+      },
+      source: {
+        tsconfigPath: './tsconfig.cjs.json',
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['./src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/build/clean/src/index.ts
+++ b/tests/integration/dts/build/clean/src/index.ts
@@ -1,0 +1,1 @@
+export * from './sum';

--- a/tests/integration/dts/build/clean/src/sum.ts
+++ b/tests/integration/dts/build/clean/src/sum.ts
@@ -1,0 +1,10 @@
+export const num1 = 1;
+export const num2 = 2;
+export const num3 = 3;
+
+export const str1 = 'str1';
+export const str2 = 'str2';
+export const str3 = 'str3';
+
+export const numSum = num1 + num2 + num3;
+export const strSum = str1 + str2 + str3;

--- a/tests/integration/dts/build/clean/tsconfig.cjs.json
+++ b/tests/integration/dts/build/clean/tsconfig.cjs.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "./dist-types/cjs"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../__references__"
+    }
+  ]
+}

--- a/tests/integration/dts/build/clean/tsconfig.esm.json
+++ b/tests/integration/dts/build/clean/tsconfig.esm.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "./dist-types/esm"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../__references__"
+    }
+  ]
+}

--- a/tests/integration/dts/bundle-false/clean/package.json
+++ b/tests/integration/dts/bundle-false/clean/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-bundle-false-clean-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/bundle-false/clean/rslib.config.ts
+++ b/tests/integration/dts/bundle-false/clean/rslib.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+        distPath: './dist-types/esm',
+      },
+    }),
+    generateBundleCjsConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+        distPath: './dist-types/cjs',
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['../__fixtures__/src/**'],
+    },
+    tsconfigPath: '../__fixtures__/tsconfig.json',
+  },
+});

--- a/tests/integration/dts/bundle/clean/package.json
+++ b/tests/integration/dts/bundle/clean/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-bundle-clean-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/bundle/clean/rslib.config.ts
+++ b/tests/integration/dts/bundle/clean/rslib.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      dts: {
+        bundle: true,
+        distPath: './dist-types/esm',
+      },
+    }),
+    generateBundleCjsConfig({
+      dts: {
+        bundle: true,
+        distPath: './dist-types/cjs',
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src/index.ts',
+    },
+    tsconfigPath: '../__fixtures__/tsconfig.json',
+  },
+});

--- a/tests/integration/dts/composite/clean/package.json
+++ b/tests/integration/dts/composite/clean/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-composite-clean-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/composite/clean/rslib.config.ts
+++ b/tests/integration/dts/composite/clean/rslib.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+        distPath: 'dist-types/esm',
+      },
+    }),
+    generateBundleCjsConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+        distPath: 'dist-types/cjs',
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['../__fixtures__/src/**'],
+    },
+  },
+});

--- a/tests/integration/dts/composite/clean/tsconfig.json
+++ b/tests/integration/dts/composite/clean/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "rootDir": "../__fixtures__/src",
+    "baseUrl": "./",
+    "composite": true
+  },
+  "include": ["../__fixtures__/src"]
+}

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -1,6 +1,10 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { buildAndGetResults, globContentJSON } from 'test-helper';
+import {
+  buildAndGetResults,
+  createTempFiles,
+  globContentJSON,
+} from 'test-helper';
 import { describe, expect, test } from 'vitest';
 
 describe('dts when bundle: false', () => {
@@ -108,6 +112,36 @@ describe('dts when bundle: false', () => {
         "<ROOT>/tests/integration/dts/bundle-false/declaration-dir/dist-types/sum.d.ts",
         "<ROOT>/tests/integration/dts/bundle-false/declaration-dir/dist-types/utils/numbers.d.ts",
         "<ROOT>/tests/integration/dts/bundle-false/declaration-dir/dist-types/utils/strings.d.ts",
+      ]
+    `);
+  });
+
+  test('should clean dts dist files', async () => {
+    const fixturePath = join(__dirname, 'bundle-false', 'clean');
+
+    const checkFiles = await createTempFiles(fixturePath, false);
+
+    const { files } = await buildAndGetResults({ fixturePath, type: 'dts' });
+
+    for (const file of checkFiles) {
+      expect(existsSync(file)).toBe(false);
+    }
+
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle-false/clean/dist-types/esm/index.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/clean/dist-types/esm/sum.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/clean/dist-types/esm/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/clean/dist-types/esm/utils/strings.d.ts",
+      ]
+    `);
+
+    expect(files.cjs).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle-false/clean/dist-types/cjs/index.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/clean/dist-types/cjs/sum.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/clean/dist-types/cjs/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/clean/dist-types/cjs/utils/strings.d.ts",
       ]
     `);
   });
@@ -264,6 +298,30 @@ describe('dts when bundle: true', () => {
 
     expect(entries).toMatchSnapshot();
   });
+
+  test('should clean dts dist files and .rslib folder', async () => {
+    const fixturePath = join(__dirname, 'bundle', 'clean');
+
+    const checkFiles = await createTempFiles(fixturePath, true);
+
+    const { files } = await buildAndGetResults({ fixturePath, type: 'dts' });
+
+    for (const file of checkFiles) {
+      expect(existsSync(file)).toBe(false);
+    }
+
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle/clean/dist-types/esm/index.d.ts",
+      ]
+    `);
+
+    expect(files.cjs).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle/clean/dist-types/cjs/index.d.ts",
+      ]
+    `);
+  });
 });
 
 describe('dts when build: true', () => {
@@ -353,6 +411,44 @@ describe('dts when build: true', () => {
       // not easy to proxy child process stdout
       expect(err.message).toBe('Error occurred in esm DTS generation');
     }
+  });
+
+  test('should clean dts dist files', async () => {
+    const fixturePath = join(__dirname, 'build', 'clean');
+
+    const checkFiles = await createTempFiles(fixturePath, false);
+
+    const { files } = await buildAndGetResults({ fixturePath, type: 'dts' });
+
+    for (const file of checkFiles) {
+      expect(existsSync(file)).toBe(false);
+    }
+
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/build/clean/dist-types/esm/index.d.ts",
+        "<ROOT>/tests/integration/dts/build/clean/dist-types/esm/sum.d.ts",
+      ]
+    `);
+
+    expect(files.cjs).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/build/clean/dist-types/cjs/index.d.ts",
+        "<ROOT>/tests/integration/dts/build/clean/dist-types/cjs/sum.d.ts",
+      ]
+    `);
+
+    const referenceDistPath = join(
+      fixturePath,
+      '../__references__/dist/index.d.ts',
+    );
+    expect(existsSync(referenceDistPath)).toBeTruthy();
+
+    const cjsBuildInfoPath = join(fixturePath, 'tsconfig.cjs.tsbuildinfo');
+    expect(existsSync(cjsBuildInfoPath)).toBeTruthy();
+
+    const esmBuildInfoPath = join(fixturePath, 'tsconfig.esm.tsbuildinfo');
+    expect(existsSync(esmBuildInfoPath)).toBeTruthy();
   });
 });
 
@@ -447,6 +543,30 @@ describe('dts when composite: true', () => {
       /*! hello banner dts composite*/
       ",
       }
+    `);
+
+    const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
+    expect(existsSync(buildInfoPath)).toBeTruthy();
+  });
+
+  test('should clean dts dist files', async () => {
+    const fixturePath = join(__dirname, 'composite', 'clean');
+
+    const checkFiles = await createTempFiles(fixturePath, false);
+
+    const { files } = await buildAndGetResults({ fixturePath, type: 'dts' });
+
+    for (const file of checkFiles) {
+      expect(existsSync(file)).toBe(false);
+    }
+
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/composite/clean/dist-types/esm/index.d.ts",
+        "<ROOT>/tests/integration/dts/composite/clean/dist-types/esm/sum.d.ts",
+        "<ROOT>/tests/integration/dts/composite/clean/dist-types/esm/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts/composite/clean/dist-types/esm/utils/strings.d.ts",
+      ]
     `);
 
     const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -342,3 +342,46 @@ export function queryContent(
 
   return matched[1];
 }
+
+export async function createTempFiles(
+  fixturePath: string,
+  bundle: boolean,
+): Promise<string[]> {
+  const checkFile: string[] = [];
+
+  const tempDirCjs = join(fixturePath, 'dist-types', 'cjs');
+  const tempDirEsm = join(fixturePath, 'dist-types', 'esm');
+  const tempFileCjs = join(tempDirCjs, 'tempFile.d.ts');
+  const tempFileEsm = join(tempDirEsm, 'tempFile.d.ts');
+
+  await fs.promises.mkdir(tempDirCjs, { recursive: true });
+  await fs.promises.mkdir(tempDirEsm, { recursive: true });
+
+  await fs.promises.writeFile(tempFileCjs, 'console.log("temp file for cjs");');
+  await fs.promises.writeFile(tempFileEsm, 'console.log("temp file for esm");');
+
+  checkFile.push(tempFileCjs, tempFileEsm);
+
+  if (bundle) {
+    const tempDirRslib = join(fixturePath, '.rslib/declarations', 'cjs');
+    const tempDirRslibEsm = join(fixturePath, '.rslib/declarations', 'esm');
+    const tempFileRslibCjs = join(tempDirRslib, 'tempFile.d.ts');
+    const tempFileRslibEsm = join(tempDirRslibEsm, 'tempFile.d.ts');
+
+    await fs.promises.mkdir(tempDirRslib, { recursive: true });
+    await fs.promises.mkdir(tempDirRslibEsm, { recursive: true });
+
+    await fs.promises.writeFile(
+      tempFileRslibCjs,
+      'console.log("temp file for cjs");',
+    );
+    await fs.promises.writeFile(
+      tempFileRslibEsm,
+      'console.log("temp file for esm");',
+    );
+
+    checkFile.push(tempFileRslibCjs, tempFileRslibEsm);
+  }
+
+  return checkFile;
+}

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -363,8 +363,8 @@ export async function createTempFiles(
   checkFile.push(tempFileCjs, tempFileEsm);
 
   if (bundle) {
-    const tempDirRslib = join(fixturePath, '.rslib/declarations', 'cjs');
-    const tempDirRslibEsm = join(fixturePath, '.rslib/declarations', 'esm');
+    const tempDirRslib = join(fixturePath, '.rslib', 'declarations', 'cjs');
+    const tempDirRslibEsm = join(fixturePath, '.rslib', 'declarations', 'esm');
     const tempFileRslibCjs = join(tempDirRslib, 'tempFile.d.ts');
     const tempFileRslibEsm = join(tempDirRslibEsm, 'tempFile.d.ts');
 


### PR DESCRIPTION
## Summary

- Load tsconfig in plugin hook in main process instead of child process
- When using bundle DTS, temporary folders are distinguished by the environment name
- When `output.cleanDistPath` is not set to `false`, clean `.d.ts/mts/cts` files in dts distPath
- Always clean `.rslib` temp folder when `dts.bundle` set to `true`
- Always clean `tsconfig.buildinfo` file

## Related Links

closes: #405 
closes: #139 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
