### PR TITLE
fix: the moduleIds should be deterministic if the env is production and format is mf

### DIFF
--- a/.changeset/smooth-parents-pull.md
+++ b/.changeset/smooth-parents-pull.md
@@ -1,0 +1,5 @@
+---
+'@rslib/core': patch
+---
+
+fix: the moduleIds should be deterministic if the env is production and format is mf

--- a/packages/core/src/cli/mf.ts
+++ b/packages/core/src/cli/mf.ts
@@ -41,6 +41,7 @@ function changeEnvToDev(rsbuildConfig: RsbuildConfig) {
       rspack: {
         optimization: {
           nodeEnv: 'development',
+          moduleIds: 'named',
         },
       },
     },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -594,9 +594,9 @@ const composeFormatConfig = ({
             },
             // can not set nodeEnv to false, because mf format should build shared module.
             // If nodeEnv is false, the process.env.NODE_ENV in third-party packages's will not be replaced
-            // now we have not provide dev mode for users, so we can always set nodeEnv as 'production'
             optimization: {
               nodeEnv: 'production',
+              moduleIds: 'deterministic',
             },
           },
         },

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -141,3 +141,4 @@ vnode
 watchpack
 webm
 webp
+unstubAllEnvs

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -33,29 +33,28 @@ test('minify is enabled by default in mf format, bar and baz should be minified'
   const fixturePath = join(__dirname, 'mf/default');
   const { mfExposeEntry } = await buildAndGetResults({ fixturePath });
   // biome-ignore format: snapshot
-  expect(mfExposeEntry).toMatchInlineSnapshot(`""use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["249"],{"../../__fixtures__/src/index.ts":function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{foo:function(){return foo}});const foo=()=>{}}}]);"`);
+  expect(mfExposeEntry).toMatchInlineSnapshot(`""use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["249"],{163:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{foo:function(){return foo}});const foo=()=>{}}}]);"`);
 });
 
 test('minify is disabled by the user, bar and baz should not be minified', async () => {
   const fixturePath = join(__dirname, 'mf/config');
   const { mfExposeEntry } = await buildAndGetResults({ fixturePath });
-  expect(mfExposeEntry).toMatchInlineSnapshot(`
-    ""use strict";
-    (globalThis['disable_minify'] = globalThis['disable_minify'] || []).push([["249"], {
-    "../../__fixtures__/src/index.ts": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
-    __webpack_require__.r(__webpack_exports__);
-    __webpack_require__.d(__webpack_exports__, {
-      foo: function() { return foo; }
-    });
-    const foo = ()=>{};
-    const bar = ()=>{};
-    const baz = ()=>{
-        return bar();
-    };
+
+  expect(mfExposeEntry).toMatchInlineSnapshot(`""use strict";
+(globalThis['disable_minify'] = globalThis['disable_minify'] || []).push([["249"], {
+"163": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  foo: function() { return foo; }
+});
+const foo = ()=>{};
+const bar = ()=>{};
+const baz = ()=>{
+    return bar();
+};
 
 
-    }),
+}),
 
-    }]);"
-  `);
+}]);"`);
 });


### PR DESCRIPTION
## Summary

When format is mf , and env is production , the moduleIds should be deterministic for better cache and smaller size. 

And the named moduleIds may cause domain name leaked if the build env path has sensitive infomation

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
