### PR TITLE
perf: rm buildinfo on demand

### DIFF
--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -98,9 +98,10 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
         }
 
         const tsConfigResult = loadTsconfig(tsconfigPath);
+        const compilerOptions = tsConfigResult.options;
         const dtsEmitPath =
           options.distPath ??
-          tsConfigResult.options.declarationDir ??
+          compilerOptions.declarationDir ??
           config.output?.distPath?.root;
 
         const jsExtension = extname(__filename);
@@ -123,7 +124,13 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
         }
 
         // clean tsbuildinfo file
-        await cleanTsBuildInfoFile(tsconfigPath, tsConfigResult);
+        if (
+          compilerOptions.composite ||
+          compilerOptions.incremental ||
+          options.build
+        ) {
+          await cleanTsBuildInfoFile(tsconfigPath, tsConfigResult);
+        }
 
         const dtsGenOptions: DtsGenOptions = {
           ...options,

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -3,13 +3,7 @@ import { dirname, extname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { type RsbuildConfig, type RsbuildPlugin, logger } from '@rsbuild/core';
 import ts from 'typescript';
-import {
-  cleanDtsFiles,
-  cleanTsBuildInfoFile,
-  clearTempDeclarationDir,
-  loadTsconfig,
-  processSourceEntry,
-} from './utils';
+import { loadTsconfig, processSourceEntry } from './utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -41,10 +35,11 @@ export type DtsGenOptions = PluginDtsOptions & {
   cwd: string;
   isWatch: boolean;
   dtsEntry: DtsEntry;
-  dtsEmitPath: string;
   build?: boolean;
   tsconfigPath: string;
   tsConfigResult: ts.ParsedCommandLine;
+  rootDistPath: string;
+  cleanDistPath: NonNullable<RsbuildConfig['output']>['cleanDistPath'];
   userExternals?: NonNullable<RsbuildConfig['output']>['externals'];
 };
 
@@ -98,11 +93,6 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
         }
 
         const tsConfigResult = loadTsconfig(tsconfigPath);
-        const compilerOptions = tsConfigResult.options;
-        const dtsEmitPath =
-          options.distPath ??
-          compilerOptions.declarationDir ??
-          config.output?.distPath?.root;
 
         const jsExtension = extname(__filename);
         const childProcess = fork(join(__dirname, `./dts${jsExtension}`), [], {
@@ -111,34 +101,14 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
 
         childProcesses.push(childProcess);
 
-        const { cleanDistPath } = config.output;
-
-        // clean dts files
-        if (cleanDistPath !== false) {
-          await cleanDtsFiles(dtsEmitPath);
-        }
-
-        // clean .rslib temp folder
-        if (options.bundle) {
-          await clearTempDeclarationDir(cwd);
-        }
-
-        // clean tsbuildinfo file
-        if (
-          compilerOptions.composite ||
-          compilerOptions.incremental ||
-          options.build
-        ) {
-          await cleanTsBuildInfoFile(tsconfigPath, tsConfigResult);
-        }
-
         const dtsGenOptions: DtsGenOptions = {
           ...options,
           dtsEntry,
-          dtsEmitPath,
+          rootDistPath: config.output?.distPath?.root,
           userExternals: config.output.externals,
           tsconfigPath,
           tsConfigResult,
+          cleanDistPath: config.output.cleanDistPath,
           name: environment.name,
           cwd,
           isWatch,

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -263,5 +263,7 @@ export async function cleanTsBuildInfoFile(
     }
   }
 
-  await fsP.rm(tsbuildInfoFilePath, { force: true });
+  if (await pathExists(tsbuildInfoFilePath)) {
+    await fsP.rm(tsbuildInfoFilePath, { force: true });
+  }
 }

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -243,10 +243,10 @@ export async function cleanDtsFiles(dir: string): Promise<void> {
 
 export async function cleanTsBuildInfoFile(
   tsconfigPath: string,
-  tsConfigResult: ts.ParsedCommandLine,
+  compilerOptions: ts.CompilerOptions,
 ): Promise<void> {
   const tsconfigDir = dirname(tsconfigPath);
-  const { outDir, rootDir, tsBuildInfoFile } = tsConfigResult.options;
+  const { outDir, rootDir, tsBuildInfoFile } = compilerOptions;
   let tsbuildInfoFilePath = `${basename(
     tsconfigPath,
     '.json',


### PR DESCRIPTION
## Summary

only remove buildinfo when `composite` or `incremental` is set or `dts.build` is set to `true`

## Related Links

closes: #493 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
