### PR TITLE
chore: use `resolve.alias` instead of `source.alias`

### DIFF
--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -113,11 +113,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           "setup": [Function],
         },
       ],
-      "source": {
+      "resolve": {
         "alias": {
           "bar": "bar",
           "foo": "foo/esm",
         },
+      },
+      "source": {
         "entry": {},
         "preEntry": "./b.js",
       },
@@ -348,11 +350,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           "setup": [Function],
         },
       ],
-      "source": {
+      "resolve": {
         "alias": {
           "bar": "bar/cjs",
           "foo": "foo",
         },
+      },
+      "source": {
         "entry": {},
         "preEntry": [
           "./a.js",
@@ -572,11 +576,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
           "setup": [Function],
         },
       ],
-      "source": {
+      "resolve": {
         "alias": {
           "bar": "bar",
           "foo": "foo",
         },
+      },
+      "source": {
         "entry": {},
         "preEntry": "./a.js",
       },

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -154,19 +154,23 @@ describe('Should compose create Rsbuild config correctly', () => {
         {
           format: 'esm',
           source: {
+            preEntry: './b.js',
+          },
+          resolve: {
             alias: {
               foo: 'foo/esm',
             },
-            preEntry: './b.js',
           },
         },
         {
           format: 'cjs',
           source: {
+            preEntry: ['./c.js', './d.js'],
+          },
+          resolve: {
             alias: {
               bar: 'bar/cjs',
             },
-            preEntry: ['./c.js', './d.js'],
           },
         },
         {
@@ -174,11 +178,13 @@ describe('Should compose create Rsbuild config correctly', () => {
         },
       ],
       source: {
+        preEntry: './a.js',
+      },
+      resolve: {
         alias: {
           foo: 'foo',
           bar: 'bar',
         },
-        preEntry: './a.js',
       },
       output: {
         filenameHash: false,

--- a/tests/integration/alias/rslib.config.ts
+++ b/tests/integration/alias/rslib.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
     entry: {
       index: './src/index.ts',
     },
+  },
+  resolve: {
     alias: {
       '@src': 'src',
     },

--- a/tests/integration/style/less/bundle-false/rslib.config.ts
+++ b/tests/integration/style/less/bundle-false/rslib.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     entry: {
       index: ['../__fixtures__/basic/src/**', '!../__fixtures__/**/*.d.ts'],
     },
+  },
+  resolve: {
     alias: {
       '~': require('node:path').resolve(
         __dirname,

--- a/tests/integration/style/less/bundle/rslib.config.ts
+++ b/tests/integration/style/less/bundle/rslib.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     entry: {
       index: ['../__fixtures__/basic/src/index.less'],
     },
+  },
+  resolve: {
     alias: {
       '~': require('node:path').resolve(
         __dirname,


### PR DESCRIPTION
## Summary

We need to update docs in https://lib.rsbuild.dev/config/rsbuild/source#sourcealias in the future, the Rsbuild docs of `resolve.alias` and `resolve.aliasStrategy` is not ready now.

## Related Links

feat: add resolve.alias and deprecate source.alias by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4098

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
