### PR TITLE
fix:  catch error when killing DTS child process

### DIFF
--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -169,7 +169,7 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
         if (!childProcess.killed) {
           try {
             childProcess.kill();
-            // Temporary fix kill EPERM error on windows
+            // silent kill error, such as: kill EPERM error on windows
             // https://github.com/nodejs/node/issues/51766
           } catch (_err) {}
         }

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -169,7 +169,7 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
         if (!childProcess.killed) {
           try {
             childProcess.kill();
-            // silent kill error, such as: kill EPERM error on windows
+            // mute kill error, such as: kill EPERM error on windows
             // https://github.com/nodejs/node/issues/51766
           } catch (_err) {}
         }

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -167,7 +167,11 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
     const killProcesses = () => {
       for (const childProcess of childProcesses) {
         if (!childProcess.killed) {
-          childProcess.kill();
+          try {
+            childProcess.kill();
+            // Temporary fix kill EPERM error on windows
+            // https://github.com/nodejs/node/issues/51766
+          } catch (_err) {}
         }
       }
       childProcesses = [];


### PR DESCRIPTION
## Summary

silent dts kill error, such as: kill EPERM error on windows.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
