### PR TITLE
feat: do not preserve nodeEnv when format is umd

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -583,6 +583,9 @@ const composeFormatConfig = ({
                     type: 'umd',
                   },
             },
+            optimization: {
+              nodeEnv: process.env.NODE_ENV,
+            },
           },
         },
       };

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -640,6 +640,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
                 },
               },
             },
+            "optimization": {
+              "nodeEnv": "test",
+            },
             "output": {
               "asyncChunks": false,
               "library": {

--- a/tests/integration/umd/index.test.ts
+++ b/tests/integration/umd/index.test.ts
@@ -2,13 +2,15 @@ import { buildAndGetResults } from 'test-helper';
 import { expect, test } from 'vitest';
 
 test('read UMD value in CommonJS', async () => {
+  process.env.NODE_ENV = 'production';
   const fixturePath = __dirname;
   const { entryFiles } = await buildAndGetResults({
     fixturePath,
   });
 
   const fn = require(entryFiles.umd);
-  expect(fn('ok')).toBe('DEBUG:ok');
+  expect(fn('ok')).toBe('production: DEBUG:ok');
+  delete process.env.NODE_ENV;
 });
 
 test('throw error when using UMD with `bundle: false`', async () => {

--- a/tests/integration/umd/src/index.js
+++ b/tests/integration/umd/src/index.js
@@ -1,3 +1,3 @@
 const { addPrefix } = require('./utils');
 
-module.exports = (str) => addPrefix('DEBUG:', str);
+module.exports = (str) => addPrefix('DEBUG:', str, process.env.NODE_ENV);

--- a/tests/integration/umd/src/utils.js
+++ b/tests/integration/umd/src/utils.js
@@ -1,4 +1,4 @@
-const addPrefix = (prefix, str) => `${prefix}${str}`;
+const addPrefix = (prefix, str, env) => `${env}: ${prefix}${str}`;
 
 module.exports = {
   addPrefix,

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -53,7 +53,7 @@ You can see more details in [Environment Variables](https://rsbuild.dev/guide/ad
 
 ::: note
 
-`process.env.NODE_ENV` will be preserved in the build output when [format](/config/lib/format) is set to `esm` or `cjs`. For `mf` format, it will be preserved to make output directly usable.
+`process.env.NODE_ENV` will be preserved in the build output when [format](/config/lib/format) is set to `esm` or `cjs`. For `mf` or `umd` format, it will be preserved to make output directly usable.
 
 :::
 


### PR DESCRIPTION
## Summary

do not preserve nodeEnv when format is umd

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
