### PR TITLE
fix(minify): only preserve some comments and annotations by default

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.8.1",
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@rsbuild/plugin-react": "^1.1.0",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.8.1",
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@rsbuild/plugin-react": "^1.1.0",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "prebundle": "prebundle"
   },
   "dependencies": {
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "rsbuild-plugin-dts": "workspace:*",
     "tinyglobby": "^0.2.10"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -339,7 +339,8 @@ export function composeMinifyConfig(config: LibConfig): RsbuildConfig {
               toplevel: format !== 'mf',
             },
             format: {
-              comments: 'all',
+              comments: 'some',
+              preserve_annotations: true,
             },
           },
         },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -339,7 +339,7 @@ export function composeMinifyConfig(config: LibConfig): RsbuildConfig {
               toplevel: format !== 'mf',
             },
             format: {
-              comments: 'all',
+              comments: 'some',
               preserve_annotations: true,
             },
           },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -339,7 +339,7 @@ export function composeMinifyConfig(config: LibConfig): RsbuildConfig {
               toplevel: format !== 'mf',
             },
             format: {
-              comments: 'some',
+              comments: 'all',
               preserve_annotations: true,
             },
           },

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -90,7 +90,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
                 "unused": true,
               },
               "format": {
-                "comments": "all",
+                "comments": "some",
+                "preserve_annotations": true,
               },
               "mangle": false,
               "minify": false,
@@ -327,7 +328,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
                 "unused": true,
               },
               "format": {
-                "comments": "all",
+                "comments": "some",
+                "preserve_annotations": true,
               },
               "mangle": false,
               "minify": false,
@@ -557,7 +559,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config 1
                 "unused": true,
               },
               "format": {
-                "comments": "all",
+                "comments": "some",
+                "preserve_annotations": true,
               },
               "mangle": false,
               "minify": false,

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -331,7 +331,8 @@ describe('minify', () => {
               "unused": true,
             },
             "format": {
-              "comments": "all",
+              "comments": "some",
+              "preserve_annotations": true,
             },
             "mangle": false,
             "minify": false,

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@storybook/addon-essentials": "^8.4.7",
     "@storybook/addon-interactions": "^8.4.7",
     "@storybook/addon-links": "^8.4.7",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@storybook/addon-essentials": "^8.4.7",
     "@storybook/addon-interactions": "^8.4.7",
     "@storybook/addon-links": "^8.4.7",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -19,7 +19,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@rsbuild/plugin-react": "^1.0.7",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.4.7",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@rsbuild/plugin-react": "^1.0.7",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.4.7",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -18,7 +18,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@rsbuild/plugin-react": "^1.0.7",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.4.7",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@rsbuild/plugin-react": "^1.0.7",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.4.7",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.48.0",
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@rslib/tsconfig": "workspace:*",
     "rslib": "npm:@rslib/core@0.1.3",
     "typescript": "^5.6.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,13 +88,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.8.1
-        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1))(@rsbuild/core@1.1.9)
+        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1))(@rsbuild/core@1.1.10)
       '@rsbuild/core':
-        specifier: ~1.1.9
-        version: 1.1.9
+        specifier: ~1.1.10
+        version: 1.1.10
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
       '@types/react':
         specifier: ^19.0.1
         version: 19.0.1
@@ -109,16 +109,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.8.1
-        version: 0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1)
+        version: 0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1)
       '@module-federation/rsbuild-plugin':
         specifier: ^0.8.1
-        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1))(@rsbuild/core@1.1.9)
+        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1))(@rsbuild/core@1.1.10)
       '@module-federation/storybook-addon':
         specifier: ^3.0.12
-        version: 3.0.12(@rsbuild/core@1.1.9)(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack-virtual-modules@0.6.2)(webpack@5.96.1)
+        version: 3.0.12(@rsbuild/core@1.1.10)(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack-virtual-modules@0.6.2)(webpack@5.96.1)
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -139,10 +139,10 @@ importers:
         version: 8.4.7(prettier@3.4.2)
       storybook-addon-rslib:
         specifier: ^0.1.5
-        version: 0.1.5(@rsbuild/core@1.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@0.1.5(@rsbuild/core@1.1.9)(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3))(typescript@5.6.3)
+        version: 0.1.5(@rsbuild/core@1.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@0.1.5(@rsbuild/core@1.1.10)(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3))(typescript@5.6.3)
       storybook-react-rsbuild:
         specifier: ^0.1.5
-        version: 0.1.5(@rsbuild/core@1.1.9)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.18.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3)(webpack@5.96.1)
+        version: 0.1.5(@rsbuild/core@1.1.10)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.18.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3)(webpack@5.96.1)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -155,13 +155,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.8.1
-        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1))(@rsbuild/core@1.1.9)
+        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1))(@rsbuild/core@1.1.10)
       '@rsbuild/core':
-        specifier: ~1.1.9
-        version: 1.1.9
+        specifier: ~1.1.10
+        version: 1.1.10
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
       '@types/react':
         specifier: ^19.0.1
         version: 19.0.1
@@ -176,10 +176,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.1.9)(preact@10.25.1)
+        version: 1.2.0(@rsbuild/core@1.1.10)(preact@10.25.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@1.1.9)
+        version: 1.1.2(@rsbuild/core@1.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -191,10 +191,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
       '@rsbuild/plugin-sass':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@1.1.9)
+        version: 1.1.2(@rsbuild/core@1.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -209,10 +209,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
       '@rsbuild/plugin-sass':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@1.1.9)
+        version: 1.1.2(@rsbuild/core@1.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -227,10 +227,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
       '@rsbuild/plugin-sass':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@1.1.9)
+        version: 1.1.2(@rsbuild/core@1.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -245,7 +245,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.1.9)(vue@3.5.13(typescript@5.6.3))
+        version: 1.0.5(@rsbuild/core@1.1.10)(vue@3.5.13(typescript@5.6.3))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -262,8 +262,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~1.1.9
-        version: 1.1.9
+        specifier: ~1.1.10
+        version: 1.1.10
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
@@ -355,8 +355,8 @@ importers:
         specifier: ^7.48.0
         version: 7.48.0(@types/node@22.8.1)
       '@rsbuild/core':
-        specifier: ~1.1.9
-        version: 1.1.9
+        specifier: ~1.1.10
+        version: 1.1.10
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -383,22 +383,22 @@ importers:
         version: 3.1.1(vite@5.3.3(@types/node@22.8.1)(terser@5.31.6))(vitest@2.1.8(@types/node@22.8.1)(terser@5.31.6))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.8.1
-        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1))(@rsbuild/core@1.1.9)
+        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1))(@rsbuild/core@1.1.10)
       '@playwright/test':
         specifier: 1.49.0
         version: 1.49.0
       '@rsbuild/core':
-        specifier: ~1.1.9
-        version: 1.1.9
+        specifier: ~1.1.10
+        version: 1.1.10
       '@rsbuild/plugin-less':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
       '@rsbuild/plugin-sass':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@1.1.9)
+        version: 1.1.2(@rsbuild/core@1.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -457,7 +457,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
 
   tests/integration/asset/path: {}
 
@@ -467,10 +467,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@1.1.9)(typescript@5.6.3)
+        version: 1.0.6(@rsbuild/core@1.1.10)(typescript@5.6.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -540,10 +540,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.1.9)
+        version: 1.1.0(@rsbuild/core@1.1.10)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@1.1.9)(typescript@5.6.3)
+        version: 1.0.6(@rsbuild/core@1.1.10)(typescript@5.6.3)
 
   tests/integration/cli/build: {}
 
@@ -663,7 +663,9 @@ importers:
 
   tests/integration/format: {}
 
-  tests/integration/minify/config: {}
+  tests/integration/minify/config/disabled: {}
+
+  tests/integration/minify/config/enabled: {}
 
   tests/integration/minify/default: {}
 
@@ -675,7 +677,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.1.9)
+        version: 1.2.0(@rsbuild/core@1.1.10)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -685,7 +687,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.1.9)
+        version: 1.2.0(@rsbuild/core@1.1.10)
 
   tests/integration/polyfill:
     dependencies:
@@ -695,7 +697,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.1.9)
+        version: 1.0.3(@rsbuild/core@1.1.10)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.11.0
         version: 0.11.0(@babel/core@7.26.0)
@@ -822,8 +824,8 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~1.1.9
-        version: 1.1.9
+        specifier: ~1.1.10
+        version: 1.1.10
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -847,7 +849,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.3
-        version: 1.0.3(@rsbuild/core@1.1.9)
+        version: 1.0.3(@rsbuild/core@1.1.10)
       rspress:
         specifier: 1.38.0
         version: 1.38.0(webpack@5.96.1)
@@ -1834,8 +1836,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.1.9':
-    resolution: {integrity: sha512-mHZveEwlTtW9nxWa+T0xUm6ssm+HkDYZ0NENLfWMUmsL0LjMJrpQzRlbD+p5+9Uf+KXUo3Dbtv0ScA+p7cuGTg==}
+  '@rsbuild/core@1.1.10':
+    resolution: {integrity: sha512-G0aVnoMSIZ4PNcW07tKtsOSoID9M03EAnCThRmUWMj1RXDqhbGje6AFBwGun9uz63bdxYEbEp9C8wH7dGi8aYQ==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
@@ -1903,56 +1905,56 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.1.5':
-    resolution: {integrity: sha512-eEynmyPPl+OGYQ9LRFwiQosyRfcca3OQB73akqY4mqDRl39OyiBjq7347DLHJysgbm9z+B1bsiLuh2xc6mdclQ==}
+  '@rspack/binding-darwin-arm64@1.1.6':
+    resolution: {integrity: sha512-x9dxm2yyiMuL1FBwvWNNMs2/mEUJmRoSRgYb8pblR7HDaTRORrjBFCqhaYlGyAqtQaeUy7o2VAQlE0BavIiFYA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.1.5':
-    resolution: {integrity: sha512-I6HPRgogewU5v1OKe3noEzq2U1FCEYAbW+smy+lPvpTW+3X6PlVMzTT4oelhB0EXDQ+KxjXH9KpOKON1hg/JGg==}
+  '@rspack/binding-darwin-x64@1.1.6':
+    resolution: {integrity: sha512-o0seilveftGiDjy3VPxug20HmAgYyQbNEuagR3i93/t/PT/eWXHnik+C1jjwqcivZL1Zllqvy4tbZw393aROEQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.1.5':
-    resolution: {integrity: sha512-LQnqucNa6Dr6y3By+/M2ARO4jDR3AM+PuCsHgzlYT0RDRLS+Ow3f50WbNBf7eI/DhrEA0aucYL3sz1ljguB3EA==}
+  '@rspack/binding-linux-arm64-gnu@1.1.6':
+    resolution: {integrity: sha512-4atnoknJx/c3KaQElsMIxHMpPf2jcRRdWsH/SdqJIRSrkWWakMK9Yv4TFwH680I4HDTMf1XLboMVScHzW8e+Mg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.1.5':
-    resolution: {integrity: sha512-b9L/9HJxrWY4cezPWqgj28I9Xe2XxwLHu8x0CMGobwF2XKR0QQVLAst38RW/EusJ8TURdyvNEOuRZlWEIJuYOw==}
+  '@rspack/binding-linux-arm64-musl@1.1.6':
+    resolution: {integrity: sha512-7QMtwUtgFpt3/Y3/X18fSyN+kk4H8ZnZ8tDzQskVWc/j2AQYShZq56XQYqrhClzwujcCVAHauIQ2eiuJ2ASGag==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.1.5':
-    resolution: {integrity: sha512-0az52ZXTg/ErCGC1v/oFLWByKAiXvng4euv+prwMWF6p1pA7lfLRLzdibDFO4KgC16Zlfcg3hqs7YikLng4x+w==}
+  '@rspack/binding-linux-x64-gnu@1.1.6':
+    resolution: {integrity: sha512-MTjDEfPn4TwHoqs5d5Fck06kmXiTHZctGIcRVfrpg0RK0r1NLEHN+oosavRZ9c9H70f34+NmcHk+/qvV4c8lWg==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.1.5':
-    resolution: {integrity: sha512-EF/LJTtCTkuti2gJnCyvXHC5Q2L5M4+RXm5kj9Bfu/t0Zmmfe6Jd5QUsifgogioeL0ZsH/Pou5QiiVcOFcqFKQ==}
+  '@rspack/binding-linux-x64-musl@1.1.6':
+    resolution: {integrity: sha512-LqDw7PTVr/4ZuGA0izgDQfamfr72USFHltR1Qhy2YVC3JmDmhG/pQi13LHcOLVaGH1xoeyCmEPNJpVizzDxSjg==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-win32-arm64-msvc@1.1.5':
-    resolution: {integrity: sha512-VEqhK6HwIHby6gtOkxIx66SkqYndiaP1ddZ3X39RLE40TY3KlNgfG/SzbN9J5Qb+8jjq3ogV8n50+wLEGkhiWw==}
+  '@rspack/binding-win32-arm64-msvc@1.1.6':
+    resolution: {integrity: sha512-RHApLM93YN0WdHpS35u2cm7VCqZ8Yg3CrNRL16VJtyT9e6MBqeScoe4XIgIWKPm7edFyedYAjLX0wQOApwfjkg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.1.5':
-    resolution: {integrity: sha512-Yi2BwYehc5/sRVgI7zTGYJKjnV8UszAJt/stWdFHaq82chHiuuF/tQd1WcBUq0Iin9ylBMo16mRJAuFkFmJ74Q==}
+  '@rspack/binding-win32-ia32-msvc@1.1.6':
+    resolution: {integrity: sha512-Y6lx4q0eJawRfMPBo/AclTJAPTZ325DSPFBQJB3TnWh9Z2X7P7pQcYc8PHDmfDuYRIdg5WRsQRvVxihSvF7v8w==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.1.5':
-    resolution: {integrity: sha512-4UArXYqJO1Ni7TmCw1T11JnrwfpoThDdiQ9k1P1voBWK3bDahPEBOptk9ZPu2+ZuRX8hFrvumRKkLY3oy7fTMw==}
+  '@rspack/binding-win32-x64-msvc@1.1.6':
+    resolution: {integrity: sha512-UuCsfhC/yNuU7xLASOxNXcmsXi2ZvBX14GkxvcdChw6q7IIGNYUKXo1zgR8C1PE/6qDSxmLxbRMS+71d0H3HQg==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.1.5':
-    resolution: {integrity: sha512-RsSkgi56Q5XUXut0qweLSE1C4Ogcm7g/ueKoOgsbHAYVKrCs9/dTFlPHWSIAaI7QWh0GWEePR/MM2O2HIu+1rw==}
+  '@rspack/binding@1.1.6':
+    resolution: {integrity: sha512-vfeBEgGOYVwqj5cQjGyvdfrr/BEihAHlyIsobL98FZjTF0uig+bj2yJUH5Ib5F0BpIUKVG3Pw0IjlUBqcVpZsQ==}
 
-  '@rspack/core@1.1.5':
-    resolution: {integrity: sha512-/FmxDeMuW8fJkhz8fHuCu7OiJHFKW78xclEu7LkEujWl4PqJgdWjUL/6FWIj50spRwj6PRfuc31hFSL4hbNfCA==}
+  '@rspack/core@1.1.6':
+    resolution: {integrity: sha512-q0VLphOF5VW2FEG7Vbdq3Ke4I74FbELE/8xmKghSalFtULLZ44SoSz8lyotfMim9GXIRFhDokAaH8WICmPxG+g==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -7224,14 +7226,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1)':
+  '@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.8.1
       '@module-federation/data-prefetch': 0.8.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@module-federation/dts-plugin': 0.8.1(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))
       '@module-federation/managers': 0.8.1
       '@module-federation/manifest': 0.8.1(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))
-      '@module-federation/rspack': 0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))
+      '@module-federation/rspack': 0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))
       '@module-federation/runtime-tools': 0.8.1
       '@module-federation/sdk': 0.8.1
       btoa: 1.2.1
@@ -7272,13 +7274,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1))(@rsbuild/core@1.1.9)':
+  '@module-federation/rsbuild-plugin@0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1))(@rsbuild/core@1.1.10)':
     dependencies:
-      '@module-federation/enhanced': 0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1)
+      '@module-federation/enhanced': 0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1)
       '@module-federation/sdk': 0.8.1
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
 
-  '@module-federation/rspack@0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))':
+  '@module-federation/rspack@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.8.1
       '@module-federation/dts-plugin': 0.8.1(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))
@@ -7286,7 +7288,7 @@ snapshots:
       '@module-federation/manifest': 0.8.1(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))
       '@module-federation/runtime-tools': 0.8.1
       '@module-federation/sdk': 0.8.1
-      '@rspack/core': 1.1.5(@swc/helpers@0.5.15)
+      '@rspack/core': 1.1.6(@swc/helpers@0.5.15)
     optionalDependencies:
       typescript: 5.6.3
       vue-tsc: 2.1.10(typescript@5.6.3)
@@ -7321,12 +7323,12 @@ snapshots:
     dependencies:
       isomorphic-rslog: 0.0.6
 
-  '@module-federation/storybook-addon@3.0.12(@rsbuild/core@1.1.9)(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack-virtual-modules@0.6.2)(webpack@5.96.1)':
+  '@module-federation/storybook-addon@3.0.12(@rsbuild/core@1.1.10)(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack-virtual-modules@0.6.2)(webpack@5.96.1)':
     dependencies:
-      '@module-federation/enhanced': 0.8.1(@rspack/core@1.1.5(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1)
+      '@module-federation/enhanced': 0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)(vue-tsc@2.1.10(typescript@5.6.3))(webpack@5.96.1)
       '@module-federation/sdk': 0.8.1
     optionalDependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       webpack: 5.96.1
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -7479,20 +7481,20 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.18.1':
     optional: true
 
-  '@rsbuild/core@1.1.9':
+  '@rsbuild/core@1.1.10':
     dependencies:
-      '@rspack/core': 1.1.5(@swc/helpers@0.5.15)
+      '@rspack/core': 1.1.6(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.15
       core-js: 3.39.0
 
-  '@rsbuild/plugin-babel@1.0.3(@rsbuild/core@1.1.9)':
+  '@rsbuild/plugin-babel@1.0.3(@rsbuild/core@1.1.10)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -7500,13 +7502,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.1.0(@rsbuild/core@1.1.9)':
+  '@rsbuild/plugin-less@1.1.0(@rsbuild/core@1.1.10)':
     dependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
-  '@rsbuild/plugin-node-polyfill@1.2.0(@rsbuild/core@1.1.9)':
+  '@rsbuild/plugin-node-polyfill@1.2.0(@rsbuild/core@1.1.10)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -7532,37 +7534,37 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
 
-  '@rsbuild/plugin-preact@1.2.0(@rsbuild/core@1.1.9)(preact@10.25.1)':
+  '@rsbuild/plugin-preact@1.2.0(@rsbuild/core@1.1.10)(preact@10.25.1)':
     dependencies:
       '@prefresh/core': 1.5.3(preact@10.25.1)
       '@prefresh/utils': 1.2.0
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       '@rspack/plugin-preact-refresh': 1.1.1(@prefresh/core@1.5.3(preact@10.25.1))(@prefresh/utils@1.2.0)
       '@swc/plugin-prefresh': 5.0.0
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@1.1.0(@rsbuild/core@1.1.9)':
+  '@rsbuild/plugin-react@1.1.0(@rsbuild/core@1.1.10)':
     dependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.16.0)
       react-refresh: 0.16.0
 
-  '@rsbuild/plugin-sass@1.1.2(@rsbuild/core@1.1.9)':
+  '@rsbuild/plugin-sass@1.1.2(@rsbuild/core@1.1.10)':
     dependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.4.49
       reduce-configs: 1.1.0
       sass-embedded: 1.82.0
 
-  '@rsbuild/plugin-svgr@1.0.6(@rsbuild/core@1.1.9)(typescript@5.6.3)':
+  '@rsbuild/plugin-svgr@1.0.6(@rsbuild/core@1.1.10)(typescript@5.6.3)':
     dependencies:
-      '@rsbuild/core': 1.1.9
-      '@rsbuild/plugin-react': 1.1.0(@rsbuild/core@1.1.9)
+      '@rsbuild/core': 1.1.10
+      '@rsbuild/plugin-react': 1.1.0(@rsbuild/core@1.1.10)
       '@svgr/core': 8.1.0(typescript@5.6.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))(typescript@5.6.3)
@@ -7572,7 +7574,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.1.9)(typescript@5.6.3)':
+  '@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.1.10)(typescript@5.6.3)':
     dependencies:
       deepmerge: 4.3.1
       fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.6.3)(webpack@5.96.1)
@@ -7580,7 +7582,7 @@ snapshots:
       reduce-configs: 1.1.0
       webpack: 5.96.1
     optionalDependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -7588,9 +7590,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rsbuild/plugin-vue@1.0.5(@rsbuild/core@1.1.9)(vue@3.5.13(typescript@5.6.3))':
+  '@rsbuild/plugin-vue@1.0.5(@rsbuild/core@1.1.10)(vue@3.5.13(typescript@5.6.3))':
     dependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       vue-loader: 17.4.2(vue@3.5.13(typescript@5.6.3))(webpack@5.96.1)
       webpack: 5.96.1
     transitivePeerDependencies:
@@ -7603,56 +7605,56 @@ snapshots:
 
   '@rslib/core@0.1.3(@microsoft/api-extractor@7.48.0(@types/node@22.8.1))(typescript@5.6.3)':
     dependencies:
-      '@rsbuild/core': 1.1.9
-      rsbuild-plugin-dts: 0.1.3(@microsoft/api-extractor@7.48.0(@types/node@22.8.1))(@rsbuild/core@1.1.9)(typescript@5.6.3)
+      '@rsbuild/core': 1.1.10
+      rsbuild-plugin-dts: 0.1.3(@microsoft/api-extractor@7.48.0(@types/node@22.8.1))(@rsbuild/core@1.1.10)(typescript@5.6.3)
       tinyglobby: 0.2.10
     optionalDependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@22.8.1)
       typescript: 5.6.3
 
-  '@rspack/binding-darwin-arm64@1.1.5':
+  '@rspack/binding-darwin-arm64@1.1.6':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.1.5':
+  '@rspack/binding-darwin-x64@1.1.6':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.1.5':
+  '@rspack/binding-linux-arm64-gnu@1.1.6':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.1.5':
+  '@rspack/binding-linux-arm64-musl@1.1.6':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.1.5':
+  '@rspack/binding-linux-x64-gnu@1.1.6':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.1.5':
+  '@rspack/binding-linux-x64-musl@1.1.6':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.1.5':
+  '@rspack/binding-win32-arm64-msvc@1.1.6':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.1.5':
+  '@rspack/binding-win32-ia32-msvc@1.1.6':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.1.5':
+  '@rspack/binding-win32-x64-msvc@1.1.6':
     optional: true
 
-  '@rspack/binding@1.1.5':
+  '@rspack/binding@1.1.6':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.1.5
-      '@rspack/binding-darwin-x64': 1.1.5
-      '@rspack/binding-linux-arm64-gnu': 1.1.5
-      '@rspack/binding-linux-arm64-musl': 1.1.5
-      '@rspack/binding-linux-x64-gnu': 1.1.5
-      '@rspack/binding-linux-x64-musl': 1.1.5
-      '@rspack/binding-win32-arm64-msvc': 1.1.5
-      '@rspack/binding-win32-ia32-msvc': 1.1.5
-      '@rspack/binding-win32-x64-msvc': 1.1.5
+      '@rspack/binding-darwin-arm64': 1.1.6
+      '@rspack/binding-darwin-x64': 1.1.6
+      '@rspack/binding-linux-arm64-gnu': 1.1.6
+      '@rspack/binding-linux-arm64-musl': 1.1.6
+      '@rspack/binding-linux-x64-gnu': 1.1.6
+      '@rspack/binding-linux-x64-musl': 1.1.6
+      '@rspack/binding-win32-arm64-msvc': 1.1.6
+      '@rspack/binding-win32-ia32-msvc': 1.1.6
+      '@rspack/binding-win32-x64-msvc': 1.1.6
 
-  '@rspack/core@1.1.5(@swc/helpers@0.5.15)':
+  '@rspack/core@1.1.6(@swc/helpers@0.5.15)':
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
-      '@rspack/binding': 1.1.5
+      '@rspack/binding': 1.1.6
       '@rspack/lite-tapable': 1.0.1
       caniuse-lite: 1.0.30001680
     optionalDependencies:
@@ -7677,10 +7679,10 @@ snapshots:
       '@mdx-js/loader': 2.3.0(webpack@5.96.1)
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rsbuild/core': 1.1.9
-      '@rsbuild/plugin-less': 1.1.0(@rsbuild/core@1.1.9)
-      '@rsbuild/plugin-react': 1.1.0(@rsbuild/core@1.1.9)
-      '@rsbuild/plugin-sass': 1.1.2(@rsbuild/core@1.1.9)
+      '@rsbuild/core': 1.1.10
+      '@rsbuild/plugin-less': 1.1.0(@rsbuild/core@1.1.10)
+      '@rsbuild/plugin-react': 1.1.0(@rsbuild/core@1.1.10)
+      '@rsbuild/plugin-sass': 1.1.2(@rsbuild/core@1.1.10)
       '@rspress/mdx-rs': 0.6.4
       '@rspress/plugin-auto-nav-sidebar': 1.38.0
       '@rspress/plugin-container-syntax': 1.38.0
@@ -7776,7 +7778,7 @@ snapshots:
 
   '@rspress/shared@1.38.0':
     dependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       chalk: 5.3.0
       execa: 5.1.1
       fs-extra: 11.2.0
@@ -11718,9 +11720,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.18.1
       fsevents: 2.3.3
 
-  rsbuild-plugin-dts@0.1.3(@microsoft/api-extractor@7.48.0(@types/node@22.8.1))(@rsbuild/core@1.1.9)(typescript@5.6.3):
+  rsbuild-plugin-dts@0.1.3(@microsoft/api-extractor@7.48.0(@types/node@22.8.1))(@rsbuild/core@1.1.10)(typescript@5.6.3):
     dependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       magic-string: 0.30.14
       picocolors: 1.1.1
       tinyglobby: 0.2.10
@@ -11728,16 +11730,16 @@ snapshots:
       '@microsoft/api-extractor': 7.48.0(@types/node@22.8.1)
       typescript: 5.6.3
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.1.9):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.1.10):
     optionalDependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
 
-  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.1.9):
+  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.1.10):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
 
   rslog@1.2.3: {}
 
@@ -11749,7 +11751,7 @@ snapshots:
 
   rspress@1.38.0(webpack@5.96.1):
     dependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       '@rspress/core': 1.38.0(webpack@5.96.1)
       '@rspress/shared': 1.38.0
       cac: 6.7.14
@@ -12055,18 +12057,18 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@0.1.5(@rsbuild/core@1.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@0.1.5(@rsbuild/core@1.1.9)(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3))(typescript@5.6.3):
+  storybook-addon-rslib@0.1.5(@rsbuild/core@1.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@0.1.5(@rsbuild/core@1.1.10)(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3))(typescript@5.6.3):
     dependencies:
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 0.1.5(@rsbuild/core@1.1.9)(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 0.1.5(@rsbuild/core@1.1.10)(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3)
     optionalDependencies:
       typescript: 5.6.3
 
-  storybook-builder-rsbuild@0.1.5(@rsbuild/core@1.1.9)(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3):
+  storybook-builder-rsbuild@0.1.5(@rsbuild/core@1.1.10)(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3):
     dependencies:
-      '@rsbuild/core': 1.1.9
-      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.1.9)(typescript@5.6.3)
+      '@rsbuild/core': 1.1.10
+      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.1.10)(typescript@5.6.3)
       '@storybook/addon-docs': 8.4.2(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(webpack-sources@3.2.3)
       '@storybook/core-webpack': 8.4.2(storybook@8.4.7(prettier@3.4.2))
       browser-assert: 1.2.1
@@ -12078,7 +12080,7 @@ snapshots:
       magic-string: 0.30.14
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.1.9)
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.1.10)
       sirv: 2.0.4
       storybook: 8.4.7(prettier@3.4.2)
       ts-dedent: 2.2.0
@@ -12095,10 +12097,10 @@ snapshots:
       - webpack-cli
       - webpack-sources
 
-  storybook-react-rsbuild@0.1.5(@rsbuild/core@1.1.9)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.18.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3)(webpack@5.96.1):
+  storybook-react-rsbuild@0.1.5(@rsbuild/core@1.1.10)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.18.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3)(webpack@5.96.1):
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.18.1)
-      '@rsbuild/core': 1.1.9
+      '@rsbuild/core': 1.1.10
       '@storybook/react': 8.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.6.3)(webpack@5.96.1)
       '@types/node': 18.19.64
@@ -12109,7 +12111,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       resolve: 1.22.8
       storybook: 8.4.7(prettier@3.4.2)
-      storybook-builder-rsbuild: 0.1.5(@rsbuild/core@1.1.9)(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 0.1.5(@rsbuild/core@1.1.10)(@types/react@19.0.1)(storybook@8.4.7(prettier@3.4.2))(typescript@5.6.3)(webpack-sources@3.2.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.6.3

--- a/tests/integration/asset/__snapshots__/index.test.ts.snap
+++ b/tests/integration/asset/__snapshots__/index.test.ts.snap
@@ -24,7 +24,7 @@ const SvgLogo = (props)=>/*#__PURE__*/ (0, __WEBPACK_EXTERNAL_MODULE_react_jsx_r
             ]
         })
     });
-/* ESM default export */ const logoreact = SvgLogo;
+const logoreact = SvgLogo;
 console.log(logoreact);
 "
 `;
@@ -53,7 +53,7 @@ const SvgLogo = (props)=>/*#__PURE__*/ (0, __WEBPACK_EXTERNAL_MODULE_react_jsx_r
             ]
         })
     });
-/* ESM default export */ const logoreact = SvgLogo;
+const logoreact = SvgLogo;
 console.log(logoreact);
 "
 `;

--- a/tests/integration/bundle-false/__snapshots__/index.test.ts.snap
+++ b/tests/integration/bundle-false/__snapshots__/index.test.ts.snap
@@ -24,17 +24,15 @@ const SvgLogo = (props)=>/*#__PURE__*/ (0, __WEBPACK_EXTERNAL_MODULE_react_jsx_r
             ]
         })
     });
-/* ESM default export */ const logoreact = SvgLogo;
-/* ESM default export */ const src_rslib_entry_ = logoreact;
+const logoreact = SvgLogo;
+const src_rslib_entry_ = logoreact;
 export { src_rslib_entry_ as default };
 "
 `;
 
 exports[`svgr in bundleless 2`] = `
 ""use strict";
-// The require scope
 var __webpack_require__ = {};
-/************************************************************************/ // webpack/runtime/define_property_getters
 (()=>{
     __webpack_require__.d = function(exports1, definition) {
         for(var key in definition)if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
@@ -43,15 +41,12 @@ var __webpack_require__ = {};
         });
     };
 })();
-// webpack/runtime/has_own_property
 (()=>{
     __webpack_require__.o = function(obj, prop) {
         return Object.prototype.hasOwnProperty.call(obj, prop);
     };
 })();
-// webpack/runtime/make_namespace_object
 (()=>{
-    // define __esModule on exports
     __webpack_require__.r = function(exports1) {
         if ('undefined' != typeof Symbol && Symbol.toStringTag) Object.defineProperty(exports1, Symbol.toStringTag, {
             value: 'Module'
@@ -61,12 +56,10 @@ var __webpack_require__ = {};
         });
     };
 })();
-/************************************************************************/ var __webpack_exports__ = {};
-// ESM COMPAT FLAG
+var __webpack_exports__ = {};
 __webpack_require__.r(__webpack_exports__);
-// EXPORTS
 __webpack_require__.d(__webpack_exports__, {
-    default: ()=>/* binding */ src_rslib_entry_
+    default: ()=>src_rslib_entry_
 });
 const jsx_runtime_namespaceObject = require("react/jsx-runtime");
 require("react");
@@ -91,8 +84,8 @@ const SvgLogo = (props)=>/*#__PURE__*/ (0, jsx_runtime_namespaceObject.jsx)("svg
             ]
         })
     });
-/* ESM default export */ const logoreact = SvgLogo;
-/* ESM default export */ const src_rslib_entry_ = logoreact;
+const logoreact = SvgLogo;
+const src_rslib_entry_ = logoreact;
 var __webpack_export_target__ = exports;
 for(var __webpack_i__ in __webpack_exports__)__webpack_export_target__[__webpack_i__] = __webpack_exports__[__webpack_i__];
 if (__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, '__esModule', {

--- a/tests/integration/extension-alias/__snapshots__/index.test.ts.snap
+++ b/tests/integration/extension-alias/__snapshots__/index.test.ts.snap
@@ -5,8 +5,6 @@ exports[`resolve.extensionAlias should work 1`] = `
 var __webpack_exports__ = {};
 const bar = 'bar';
 const foo = 'foo';
-// Relative import paths need explicit file extensions in ECMAScript imports
-// when '--moduleResolution' is 'node16' or 'nodenext'.
 console.log(foo + bar);
 var __webpack_export_target__ = exports;
 for(var __webpack_i__ in __webpack_exports__)__webpack_export_target__[__webpack_i__] = __webpack_exports__[__webpack_i__];
@@ -19,8 +17,6 @@ if (__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_targe
 exports[`resolve.extensionAlias should work 2`] = `
 "const bar = 'bar';
 const foo = 'foo';
-// Relative import paths need explicit file extensions in ECMAScript imports
-// when '--moduleResolution' is 'node16' or 'nodenext'.
 console.log(foo + bar);
 "
 `;

--- a/tests/integration/minify/__fixtures__/src/index.ts
+++ b/tests/integration/minify/__fixtures__/src/index.ts
@@ -1,6 +1,12 @@
+/*! Legal Comment */
+import { jsx } from 'react/jsx-runtime';
+
 export const foo = () => {};
 
 const bar = () => {};
 const baz = () => {
   return bar();
 };
+
+// normal comment
+export const Button = () => /*#__PURE__*/ jsx('button', {});

--- a/tests/integration/minify/config/disabled/package.json
+++ b/tests/integration/minify/config/disabled/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "minify-config-test",
+  "name": "minify-diabled-config-test",
   "version": "1.0.0",
   "private": true,
   "type": "module"

--- a/tests/integration/minify/config/disabled/rslib.config.ts
+++ b/tests/integration/minify/config/disabled/rslib.config.ts
@@ -6,10 +6,11 @@ export default defineConfig({
   lib: [generateBundleEsmConfig()],
   output: {
     minify: false,
+    externals: ['react/jsx-runtime'],
   },
   source: {
     entry: {
-      index: path.resolve(__dirname, '../__fixtures__/src/index.ts'),
+      index: path.resolve(__dirname, '../../__fixtures__/src/index.ts'),
     },
   },
 });

--- a/tests/integration/minify/config/enabled/package.json
+++ b/tests/integration/minify/config/enabled/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "minify-true-config-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/minify/config/enabled/rslib.config.ts
+++ b/tests/integration/minify/config/enabled/rslib.config.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig()],
+  output: {
+    minify: {
+      js: true,
+      jsOptions: {
+        minimizerOptions: {
+          format: {
+            comments: 'some',
+            preserve_annotations: true,
+          },
+        },
+      },
+    },
+    externals: ['react/jsx-runtime'],
+  },
+  source: {
+    entry: {
+      index: path.resolve(__dirname, '../../__fixtures__/src/index.ts'),
+    },
+  },
+});

--- a/tests/integration/minify/default/rslib.config.ts
+++ b/tests/integration/minify/default/rslib.config.ts
@@ -9,4 +9,7 @@ export default defineConfig({
       index: path.resolve(__dirname, '../__fixtures__/src/index.ts'),
     },
   },
+  output: {
+    externals: ['react/jsx-runtime'],
+  },
 });

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -1,60 +1,93 @@
 import { join } from 'node:path';
 import { buildAndGetResults } from 'test-helper';
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
-test('tree shaking is enabled by default, bar and baz should be shaken', async () => {
-  const fixturePath = join(__dirname, 'default');
-  const { entries } = await buildAndGetResults({ fixturePath });
-  expect(entries.esm).toMatchInlineSnapshot(`
-    "const foo = ()=>{};
-    export { foo };
+describe('minify config', () => {
+  test('tree shaking is enabled by default, bar and baz should be shaken, some comments and annotations are preserved', async () => {
+    const fixturePath = join(__dirname, 'default');
+    const { entries } = await buildAndGetResults({ fixturePath });
+    expect(entries.esm).toMatchInlineSnapshot(`
+    "/*! For license information please see index.js.LICENSE.txt */
+    import * as __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__ from "react/jsx-runtime";
+    /*! Legal Comment */ const foo = ()=>{};
+    const Button = ()=>/*#__PURE__*/ (0, __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__.jsx)('button', {});
+    export { Button, foo };
     "
   `);
-});
+  });
 
-test('tree shaking is disabled by the user, bar and baz should be kept', async () => {
-  const fixturePath = join(__dirname, 'config');
-  const { entries } = await buildAndGetResults({ fixturePath });
-  expect(entries.esm).toMatchInlineSnapshot(`
-    "
-    ;// CONCATENATED MODULE: ../__fixtures__/src/index.ts?__rslib_entry__
+  test('minify is disabled, nothing will be stripped', async () => {
+    const fixturePath = join(__dirname, 'config/disabled');
+    const { entries } = await buildAndGetResults({ fixturePath });
+    expect(entries.esm).toMatchInlineSnapshot(`
+    "import * as __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__ from "react/jsx-runtime";
+
+    ;// CONCATENATED MODULE: external "react/jsx-runtime"
+
+    ;// CONCATENATED MODULE: ../../__fixtures__/src/index.ts?__rslib_entry__
+    /*! Legal Comment */ 
     const foo = ()=>{};
     const bar = ()=>{};
     const baz = ()=>{
         return bar();
     };
+    // normal comment
+    const Button = ()=>/*#__PURE__*/ (0,__WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__.jsx)('button', {});
 
-    export { foo };
+    export { Button, foo };
     "
   `);
+  });
+
+  test('minify is enabled, only preserve some comments and annotations', async () => {
+    const fixturePath = join(__dirname, 'config/enabled');
+    const { entries } = await buildAndGetResults({ fixturePath });
+    expect(entries.esm).toMatchInlineSnapshot(`
+    "/*! For license information please see index.js.LICENSE.txt */
+    import*as t from"react/jsx-runtime";/*! Legal Comment */let o=()=>{},r=()=>/*#__PURE__*/(0,t.jsx)("button",{});export{r as Button,o as foo};"
+  `);
+  });
 });
 
-test('minify is enabled by default in mf format, bar and baz should be minified', async () => {
-  const fixturePath = join(__dirname, 'mf/default');
-  const { mfExposeEntry } = await buildAndGetResults({ fixturePath });
-  // biome-ignore format: snapshot
-  expect(mfExposeEntry).toMatchInlineSnapshot(`""use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["249"],{163:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{foo:function(){return foo}});const foo=()=>{}}}]);"`);
-});
+describe('minify config (mf)', () => {
+  test('minify is enabled by default in mf format, bar and baz should be shaken, some comments and annotations are preserved', async () => {
+    const fixturePath = join(__dirname, 'mf/default');
+    const { mfExposeEntry } = await buildAndGetResults({ fixturePath });
+    // biome-ignore format: snapshot
+    expect(mfExposeEntry).toMatchInlineSnapshot(`
+    "/*! For license information please see __federation_expose_default_export.js.LICENSE.txt */
+    "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["249"],{163:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{Button:function(){return Button},foo:function(){return foo}});var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__=__webpack_require__(37);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("button",{})}}]);"
+  `);
+  });
 
-test('minify is disabled by the user, bar and baz should not be minified', async () => {
-  const fixturePath = join(__dirname, 'mf/config');
-  const { mfExposeEntry } = await buildAndGetResults({ fixturePath });
+  test('minify is disabled by the user, nothing not be stripped', async () => {
+    const fixturePath = join(__dirname, 'mf/config');
+    const { mfExposeEntry } = await buildAndGetResults({ fixturePath });
 
-  expect(mfExposeEntry).toMatchInlineSnapshot(`""use strict";
-(globalThis['disable_minify'] = globalThis['disable_minify'] || []).push([["249"], {
-"163": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-  foo: function() { return foo; }
-});
-const foo = ()=>{};
-const bar = ()=>{};
-const baz = ()=>{
-    return bar();
-};
+    expect(mfExposeEntry).toMatchInlineSnapshot(`
+    ""use strict";
+    (globalThis['disable_minify'] = globalThis['disable_minify'] || []).push([["249"], {
+    "163": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+    __webpack_require__.r(__webpack_exports__);
+    __webpack_require__.d(__webpack_exports__, {
+      Button: function() { return Button; },
+      foo: function() { return foo; }
+    });
+    /* ESM import */var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(37);
+    /* ESM import */var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__);
+    /*! Legal Comment */ 
+    const foo = ()=>{};
+    const bar = ()=>{};
+    const baz = ()=>{
+        return bar();
+    };
+    // normal comment
+    const Button = ()=>/*#__PURE__*/ (0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)('button', {});
 
 
-}),
+    }),
 
-}]);"`);
+    }]);"
+  `);
+  });
 });

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -7,14 +7,13 @@ describe('minify config', () => {
     const fixturePath = join(__dirname, 'default');
     const { entries } = await buildAndGetResults({ fixturePath });
     expect(entries.esm).toMatchInlineSnapshot(`
-      "/*! For license information please see index.js.LICENSE.txt */
-      import * as __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__ from "react/jsx-runtime";
-      /*! Legal Comment */ const foo = ()=>{};
-      // normal comment
-      const Button = ()=>/*#__PURE__*/ (0, __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__.jsx)('button', {});
-      export { Button, foo };
-      "
-    `);
+    "/*! For license information please see index.js.LICENSE.txt */
+    import * as __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__ from "react/jsx-runtime";
+    /*! Legal Comment */ const foo = ()=>{};
+    const Button = ()=>/*#__PURE__*/ (0, __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__.jsx)('button', {});
+    export { Button, foo };
+    "
+  `);
   });
 
   test('minify is disabled, nothing will be stripped', async () => {
@@ -56,10 +55,9 @@ describe('minify config (mf)', () => {
     const { mfExposeEntry } = await buildAndGetResults({ fixturePath });
     // biome-ignore format: snapshot
     expect(mfExposeEntry).toMatchInlineSnapshot(`
-      "/*! For license information please see __federation_expose_default_export.js.LICENSE.txt */
-      "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["249"],{163:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{Button:function(){return Button},foo:function(){return foo}});/* ESM import */var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__=__webpack_require__(37);/*! Legal Comment */const foo=()=>{};// normal comment
-      const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("button",{})}}]);"
-    `);
+    "/*! For license information please see __federation_expose_default_export.js.LICENSE.txt */
+    "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["249"],{163:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{Button:function(){return Button},foo:function(){return foo}});var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__=__webpack_require__(37);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("button",{})}}]);"
+  `);
   });
 
   test('minify is disabled by the user, nothing not be stripped', async () => {

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -7,13 +7,14 @@ describe('minify config', () => {
     const fixturePath = join(__dirname, 'default');
     const { entries } = await buildAndGetResults({ fixturePath });
     expect(entries.esm).toMatchInlineSnapshot(`
-    "/*! For license information please see index.js.LICENSE.txt */
-    import * as __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__ from "react/jsx-runtime";
-    /*! Legal Comment */ const foo = ()=>{};
-    const Button = ()=>/*#__PURE__*/ (0, __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__.jsx)('button', {});
-    export { Button, foo };
-    "
-  `);
+      "/*! For license information please see index.js.LICENSE.txt */
+      import * as __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__ from "react/jsx-runtime";
+      /*! Legal Comment */ const foo = ()=>{};
+      // normal comment
+      const Button = ()=>/*#__PURE__*/ (0, __WEBPACK_EXTERNAL_MODULE_react_jsx_runtime__.jsx)('button', {});
+      export { Button, foo };
+      "
+    `);
   });
 
   test('minify is disabled, nothing will be stripped', async () => {
@@ -55,9 +56,10 @@ describe('minify config (mf)', () => {
     const { mfExposeEntry } = await buildAndGetResults({ fixturePath });
     // biome-ignore format: snapshot
     expect(mfExposeEntry).toMatchInlineSnapshot(`
-    "/*! For license information please see __federation_expose_default_export.js.LICENSE.txt */
-    "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["249"],{163:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{Button:function(){return Button},foo:function(){return foo}});var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__=__webpack_require__(37);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("button",{})}}]);"
-  `);
+      "/*! For license information please see __federation_expose_default_export.js.LICENSE.txt */
+      "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["249"],{163:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{Button:function(){return Button},foo:function(){return foo}});/* ESM import */var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__=__webpack_require__(37);/*! Legal Comment */const foo=()=>{};// normal comment
+      const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("button",{})}}]);"
+    `);
   });
 
   test('minify is disabled by the user, nothing not be stripped', async () => {

--- a/tests/integration/minify/mf/config/rslib.config.ts
+++ b/tests/integration/minify/mf/config/rslib.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
   output: {
     target: 'web',
     minify: false,
+    externals: ['react/jsx-runtime'],
   },
   source: {
     entry: {

--- a/tests/integration/minify/mf/default/rslib.config.ts
+++ b/tests/integration/minify/mf/default/rslib.config.ts
@@ -34,5 +34,6 @@ export default defineConfig({
   },
   output: {
     target: 'web',
+    externals: ['react/jsx-runtime'],
   },
 });

--- a/tests/integration/resolve/index.test.ts
+++ b/tests/integration/resolve/index.test.ts
@@ -8,7 +8,7 @@ test('resolve data url', async () => {
 
   expect(isSuccess).toBeTruthy();
   expect(entries.esm).toMatchInlineSnapshot(`
-    "/* ESM default export */ const javascript_export_default_42 = 42;
+    "const javascript_export_default_42 = 42;
     console.log('x:', javascript_export_default_42);
     "
   `);

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -111,10 +111,8 @@ describe('CJS shims', () => {
       const importMetaUrl = import.meta.url;
       const src_rslib_entry_require = (0, __WEBPACK_EXTERNAL_MODULE_node_module__.createRequire)(import.meta.url);
       const requiredModule = src_rslib_entry_require('./ok.cjs');
-      // https://github.com/web-infra-dev/rslib/issues/425
       const src_rslib_entry_filename = (0, __WEBPACK_EXTERNAL_MODULE_url__.fileURLToPath)(import.meta.url);
       console.log(src_rslib_entry_filename);
-      // https://github.com/web-infra-dev/rslib/pull/399
       const src_rslib_entry_module = null;
       export { src_rslib_entry_filename as __filename, importMetaUrl, src_rslib_entry_module as module, requiredModule };
       "

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,7 @@
     "@codspeed/vitest-plugin": "^3.1.1",
     "@module-federation/rsbuild-plugin": "^0.8.1",
     "@playwright/test": "1.49.0",
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@rsbuild/plugin-less": "^1.1.0",
     "@rsbuild/plugin-react": "^1.1.0",
     "@rsbuild/plugin-sass": "^1.1.2",

--- a/website/docs/en/guide/_meta.json
+++ b/website/docs/en/guide/_meta.json
@@ -23,5 +23,10 @@
     "type": "dir",
     "name": "migration",
     "label": "Migration"
+  },
+  {
+    "type": "dir",
+    "name": "faq",
+    "label": "FAQ"
   }
 ]

--- a/website/docs/en/guide/faq/_meta.json
+++ b/website/docs/en/guide/faq/_meta.json
@@ -1,1 +1,1 @@
-["general", "features", "exceptions"]
+["features"]

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -1,1 +1,30 @@
 # Features FAQ
+
+## How to preserve all comments in the output files?
+
+By default, Rslib uses SWC to remove comments. The corresponding SWC [jsc.minify.format](https://swc.rs/docs/configuration/minification#jscminifyformat) configuration is
+
+```js
+{
+    comments: 'some', //
+    preserveAnnotations: true,
+}
+```
+
+This will only preserve some legal comments and annotations. If you want to preserve all comments, you can refer to the following configuration
+
+```ts title="rslib.config.ts"
+export default {
+  output: {
+    minify: {
+      jsOptions: {
+        minimizerOptions: {
+          format: {
+            comments: 'all', // This will preserve all comments
+          },
+        },
+      },
+    },
+  },
+};
+```

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -1,12 +1,14 @@
 # Features FAQ
 
-## How to preserve all comments in the output files?
+## Code Minification
+
+### How to preserve all comments in the output files?
 
 By default, Rslib uses SWC to remove comments. The corresponding SWC [jsc.minify.format](https://swc.rs/docs/configuration/minification#jscminifyformat) configuration is
 
 ```js
 {
-    comments: 'some', //
+    comments: 'some',
     preserveAnnotations: true,
 }
 ```
@@ -15,6 +17,9 @@ This will only preserve some legal comments and annotations. If you want to pres
 
 ```ts title="rslib.config.ts"
 export default {
+  lib: [
+    // ...
+  ],
   output: {
     minify: {
       jsOptions: {
@@ -22,6 +27,30 @@ export default {
           format: {
             comments: 'all', // This will preserve all comments
           },
+        },
+      },
+    },
+  },
+};
+```
+
+### How to compress the output size while preserving code readability?
+
+Compressing code can reduce the output size and improve loading speed, but the compressed code is less readable and harder to debug. If you want to preserve code readability, you can keep variable names and disable compression to facilitate debugging. Refer to [web-infra-dev/rsbuild#966](https://github.com/web-infra-dev/rsbuild/pull/3966).
+
+```ts title="rslib.config.ts"
+export default {
+  lib: [
+    // ...
+  ],
+  output: {
+    minify: {
+      jsOptions: {
+        minimizerOptions: {
+          // preserve variable name and disable minify for easier debugging
+          mangle: false,
+          minify: false,
+          compress: true,
         },
       },
     },

--- a/website/docs/zh/guide/_meta.json
+++ b/website/docs/zh/guide/_meta.json
@@ -23,5 +23,10 @@
     "type": "dir",
     "name": "migration",
     "label": "迁移"
+  },
+  {
+    "type": "dir",
+    "name": "faq",
+    "label": "常见问题"
   }
 ]

--- a/website/docs/zh/guide/faq/_meta.json
+++ b/website/docs/zh/guide/faq/_meta.json
@@ -1,1 +1,1 @@
-["general", "features", "exceptions"]
+["features"]

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -1,12 +1,14 @@
 # 功能类问题
 
-## 如何保留产物文件代码中的注释？
+## 代码压缩
+
+### 如何保留产物文件代码中的注释？
 
 默认情况下，Rslib 使用 SWC 清除注释，对应的 SWC 的 [jsc.minify.format](https://swc.rs/docs/configuration/minification#jscminifyformat) 配置为
 
 ```js
 {
-    comments: 'some', //
+    comments: 'some',
     preserveAnnotations: true,
 }
 ```
@@ -15,6 +17,9 @@
 
 ```ts title="rslib.config.ts"
 export default {
+  lib: [
+    // ...
+  ],
   output: {
     minify: {
       jsOptions: {
@@ -22,6 +27,30 @@ export default {
           format: {
             comments: 'all', // 将保留所有注释
           },
+        },
+      },
+    },
+  },
+};
+```
+
+### 如何在保留代码可读性的同时，尽可能压缩产物体积？
+
+通过压缩代码可以减小产物体积，并提高加载速度，但是压缩后的代码可读性较差，不利于调试。如果你想保留代码可读性，可以通过如下配置，保留变量名并禁用压缩以方便调试。参考 [web-infra-dev/rsbuild#966](https://github.com/web-infra-dev/rsbuild/pull/3966).
+
+```ts title="rslib.config.ts"
+export default {
+  lib: [
+    // ...
+  ],
+  output: {
+    minify: {
+      jsOptions: {
+        minimizerOptions: {
+          // 保留变量名并禁用压缩以方便调试
+          mangle: false,
+          minify: false,
+          compress: true,
         },
       },
     },

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -1,1 +1,30 @@
 # 功能类问题
+
+## 如何保留产物文件代码中的注释？
+
+默认情况下，Rslib 使用 SWC 清除注释，对应的 SWC 的 [jsc.minify.format](https://swc.rs/docs/configuration/minification#jscminifyformat) 配置为
+
+```js
+{
+    comments: 'some', //
+    preserveAnnotations: true,
+}
+```
+
+这将仅保留部分 legal 注释及 annotations。如果你想保留所有注释，可以参考如下配置
+
+```ts title="rslib.config.ts"
+export default {
+  output: {
+    minify: {
+      jsOptions: {
+        minimizerOptions: {
+          format: {
+            comments: 'all', // 将保留所有注释
+          },
+        },
+      },
+    },
+  },
+};
+```

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "rspress preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.1.9",
+    "@rsbuild/core": "~1.1.10",
     "@rslib/tsconfig": "workspace:*",
     "@rstack-dev/doc-ui": "1.5.4",
     "@types/node": "^22.8.1",


### PR DESCRIPTION
## Summary

- Fix https://github.com/web-infra-dev/rslib/issues/418. By default, strip comment except the ones that preserved by `"some"` (e.g., license comment) and annotations of minification.
- Close https://github.com/web-infra-dev/rslib/pull/424. The configuration in 424 has been added to the FAQ.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
