### PR TITLE
feat: disable autoExternal when format is umd or mf

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -58,6 +58,7 @@ import {
   color,
   getAbsolutePath,
   isEmptyObject,
+  isIntermediateOutputFormat,
   isObject,
   nodeBuiltInModules,
   omit,
@@ -235,13 +236,14 @@ const composeExternalsWarnConfig = (
 };
 
 export const composeAutoExternalConfig = (options: {
-  autoExternal: AutoExternal;
+  format: Format;
+  autoExternal?: AutoExternal;
   pkgJson?: PkgJson;
   userExternals?: NonNullable<RsbuildConfig['output']>['externals'];
 }): RsbuildConfig => {
-  const { autoExternal, pkgJson, userExternals } = options;
+  const { format, autoExternal = true, pkgJson, userExternals } = options;
 
-  if (!autoExternal) {
+  if (autoExternal === false || !isIntermediateOutputFormat(format)) {
     return {};
   }
 
@@ -1005,7 +1007,7 @@ const composeDtsConfig = async (
   libConfig: LibConfig,
   dtsExtension: string,
 ): Promise<RsbuildConfig> => {
-  const { autoExternal, banner, footer } = libConfig;
+  const { format, autoExternal = true, banner, footer } = libConfig;
 
   let { dts } = libConfig;
 
@@ -1028,7 +1030,9 @@ const composeDtsConfig = async (
         build: dts?.build,
         abortOnError: dts?.abortOnError,
         dtsExtension: dts?.autoExtension ? dtsExtension : '.d.ts',
-        autoExternal,
+        autoExternal: !isIntermediateOutputFormat(format!)
+          ? false
+          : autoExternal,
         banner: banner?.dts,
         footer: footer?.dts,
       }),
@@ -1150,7 +1154,7 @@ async function composeLibRsbuildConfig(config: LibConfig) {
     banner = {},
     footer = {},
     autoExtension = true,
-    autoExternal = true,
+    autoExternal,
     externalHelpers = false,
     redirect = {},
     umdName,
@@ -1190,6 +1194,7 @@ async function composeLibRsbuildConfig(config: LibConfig) {
   );
   const syntaxConfig = composeSyntaxConfig(target, config?.syntax);
   const autoExternalConfig = composeAutoExternalConfig({
+    format: format!,
     autoExternal,
     pkgJson,
     userExternals: config.output?.externals,

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -109,6 +109,7 @@ export interface LibConfig extends RsbuildConfig {
   autoExtension?: boolean;
   /**
    * Whether to automatically externalize dependencies of different dependency types and do not bundle them.
+   * Only takes effect when {@link format} is `cjs` or `esm`.
    * @defaultValue `true`
    * @see {@link https://lib.rsbuild.dev/config/lib/auto-external}
    */

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -4,7 +4,7 @@ import path, { isAbsolute, join } from 'node:path';
 import type { RsbuildPlugins } from '@rsbuild/core';
 import color from 'picocolors';
 
-import type { LibConfig, PkgJson } from '../types';
+import type { Format, LibConfig, PkgJson } from '../types';
 import { logger } from './logger';
 
 /**
@@ -230,6 +230,10 @@ export const isTTY = (type: 'stdin' | 'stdout' = 'stdout'): boolean => {
     (type === 'stdin' ? process.stdin.isTTY : process.stdout.isTTY) &&
     !process.env.CI
   );
+};
+
+export const isIntermediateOutputFormat = (format: Format): boolean => {
+  return format === 'cjs' || format === 'esm';
 };
 
 export { color };

--- a/packages/core/tests/external.test.ts
+++ b/packages/core/tests/external.test.ts
@@ -4,10 +4,86 @@ import { composeAutoExternalConfig } from '../src/config';
 vi.mock('rslog');
 
 describe('should composeAutoExternalConfig correctly', () => {
+  it('autoExternal is undefined', () => {
+    const esmResult = composeAutoExternalConfig({
+      format: 'esm',
+      autoExternal: undefined,
+      pkgJson: {
+        name: 'esm',
+        dependencies: {
+          foo: '1.0.0',
+        },
+      },
+    });
+
+    const cjsResult = composeAutoExternalConfig({
+      format: 'cjs',
+      autoExternal: undefined,
+      pkgJson: {
+        name: 'cjs',
+        dependencies: {
+          foo: '1.0.0',
+        },
+      },
+    });
+
+    expect(esmResult).toMatchInlineSnapshot(`
+      {
+        "output": {
+          "externals": [
+            /\\^foo\\(\\$\\|\\\\/\\|\\\\\\\\\\)/,
+            "foo",
+          ],
+        },
+      }
+    `);
+
+    expect(cjsResult).toMatchInlineSnapshot(`
+      {
+        "output": {
+          "externals": [
+            /\\^foo\\(\\$\\|\\\\/\\|\\\\\\\\\\)/,
+            "foo",
+          ],
+        },
+      }
+    `);
+  });
+
+  it('autoExternal should be disabled when format is umd or mf', () => {
+    const umdResult = composeAutoExternalConfig({
+      format: 'umd',
+      autoExternal: undefined,
+      pkgJson: {
+        name: 'umd',
+        dependencies: {
+          foo: '1.0.0',
+        },
+      },
+    });
+
+    expect(umdResult).toMatchInlineSnapshot('{}');
+
+    const mfResult = composeAutoExternalConfig({
+      format: 'mf',
+      autoExternal: undefined,
+      pkgJson: {
+        name: 'mf',
+        dependencies: {
+          foo: '1.0.0',
+        },
+      },
+    });
+
+    expect(mfResult).toMatchInlineSnapshot('{}');
+  });
+
   it('autoExternal is true', () => {
     const result = composeAutoExternalConfig({
+      format: 'esm',
       autoExternal: true,
       pkgJson: {
+        name: 'esm',
         dependencies: {
           foo: '1.0.0',
           foo1: '1.0.0',
@@ -37,8 +113,10 @@ describe('should composeAutoExternalConfig correctly', () => {
 
   it('autoExternal will deduplication ', () => {
     const result = composeAutoExternalConfig({
+      format: 'esm',
       autoExternal: true,
       pkgJson: {
+        name: 'esm',
         dependencies: {
           foo: '1.0.0',
           foo1: '1.0.0',
@@ -70,11 +148,13 @@ describe('should composeAutoExternalConfig correctly', () => {
 
   it('autoExternal is object', () => {
     const result = composeAutoExternalConfig({
+      format: 'esm',
       autoExternal: {
         peerDependencies: false,
         devDependencies: true,
       },
       pkgJson: {
+        name: 'esm',
         dependencies: {
           foo: '1.0.0',
         },
@@ -96,8 +176,10 @@ describe('should composeAutoExternalConfig correctly', () => {
 
   it('autoExternal is false', () => {
     const result = composeAutoExternalConfig({
+      format: 'esm',
       autoExternal: false,
       pkgJson: {
+        name: 'esm',
         dependencies: {
           foo: '1.0.0',
         },
@@ -109,8 +191,10 @@ describe('should composeAutoExternalConfig correctly', () => {
 
   it('autoExternal with user externals object', () => {
     const result = composeAutoExternalConfig({
+      format: 'esm',
       autoExternal: true,
       pkgJson: {
+        name: 'esm',
         dependencies: {
           foo: '1.0.0',
           bar: '1.0.0',
@@ -130,6 +214,7 @@ describe('should composeAutoExternalConfig correctly', () => {
 
   it('read package.json failed', () => {
     const result = composeAutoExternalConfig({
+      format: 'esm',
       autoExternal: true,
     });
 

--- a/tests/integration/umd-library-name/rslib.config.ts
+++ b/tests/integration/umd-library-name/rslib.config.ts
@@ -14,5 +14,8 @@ export default defineConfig({
   },
   output: {
     target: 'web',
+    externals: {
+      react: 'react',
+    },
   },
 });

--- a/website/docs/en/config/lib/auto-external.mdx
+++ b/website/docs/en/config/lib/auto-external.mdx
@@ -21,6 +21,8 @@ type AutoExternal =
 
 Whether to automatically externalize dependencies of different dependency types and do not bundle them.
 
+This option only takes effect when [format](/config/lib/format) is `cjs` or `esm`.
+
 ## Object Type
 
 ### autoExternal.dependencies

--- a/website/docs/en/guide/advanced/third-party-deps.mdx
+++ b/website/docs/en/guide/advanced/third-party-deps.mdx
@@ -15,7 +15,7 @@ In addition to `"dependencies"`, `"peerDependencies"`can also declare dependenci
 
 ## Default handling of third-party dependencies
 
-By default, third-party dependencies under `"dependencies"`, `"optionalDependencies"` and `"peerDependencies"` are not bundled by Rslib.
+By default, when generating CJS or ESM outputs, third-party dependencies under `"dependencies"`, `"optionalDependencies"` and `"peerDependencies"` are not bundled by Rslib.
 
 This is because when the npm package is installed, its `"dependencies"` will also be installed. By not packaging `"dependencies"`, you can reduce the size of the package product.
 

--- a/website/docs/zh/config/lib/auto-external.mdx
+++ b/website/docs/zh/config/lib/auto-external.mdx
@@ -21,6 +21,8 @@ type AutoExternal =
 
 是否自动对不同依赖类型的依赖进行外部化处理，不将其打包。
 
+该选项仅当 [format](/config/lib/format) 为 `cjs` 或 `esm` 时生效。
+
 ## 对象类型
 
 ### autoExternal.dependencies

--- a/website/docs/zh/guide/advanced/third-party-deps.mdx
+++ b/website/docs/zh/guide/advanced/third-party-deps.mdx
@@ -15,7 +15,7 @@
 
 ## 三方依赖的默认处理
 
-默认情况下，`dependencies`、`optionalDependencies` 和 `peerDependencies` 字段下的三方依赖不会被 Rslib 打包。
+默认情况下，当生成 CJS 或 ESM 产物时，`dependencies`、`optionalDependencies` 和 `peerDependencies` 字段下的三方依赖不会被 Rslib 打包。
 
 这是因为在 npm 包安装时，其 `dependencies` 也会被安装。通过不打包 `dependencies`，可以减少包的体积。
 


### PR DESCRIPTION
## Summary

 Disable `autoExternal` when `format` is `umd` or `mf` since their outputs will be directly consumed.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
