### PR TITLE
fix: shared Rsbuild plugins should run only once

### DIFF
--- a/packages/core/src/cli/build.ts
+++ b/packages/core/src/cli/build.ts
@@ -11,6 +11,7 @@ export async function build(
   const environments = await composeRsbuildEnvironments(config);
   const rsbuildInstance = await createRsbuild({
     rsbuildConfig: {
+      plugins: config.plugins,
       environments: pruneEnvironments(environments, options.lib),
     },
   });

--- a/packages/core/src/cli/inspect.ts
+++ b/packages/core/src/cli/inspect.ts
@@ -10,6 +10,7 @@ export async function inspect(
   const environments = await composeRsbuildEnvironments(config);
   const rsbuildInstance = await createRsbuild({
     rsbuildConfig: {
+      plugins: config.plugins,
       environments: pruneEnvironments(environments, options.lib),
     },
   });

--- a/packages/core/src/cli/mf.ts
+++ b/packages/core/src/cli/mf.ts
@@ -25,8 +25,15 @@ async function initMFRsbuild(
   }
 
   mfRsbuildConfig.config = changeEnvToDev(mfRsbuildConfig.config);
+
   const rsbuildInstance = await createRsbuild({
-    rsbuildConfig: mfRsbuildConfig.config,
+    rsbuildConfig: {
+      ...mfRsbuildConfig.config,
+      plugins: [
+        ...(rslibConfig.plugins || []),
+        ...(mfRsbuildConfig.config.plugins || []),
+      ],
+    },
   });
   const devServer = await rsbuildInstance.startDevServer();
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1258,7 +1258,7 @@ export async function composeCreateRsbuildConfig(
   rslibConfig: RslibConfig,
 ): Promise<RsbuildConfigWithLibInfo[]> {
   const constantRsbuildConfig = await createConstantRsbuildConfig();
-  const { lib: libConfigsArray, ...sharedRsbuildConfig } = rslibConfig;
+  const { lib: libConfigsArray, plugins, ...sharedRsbuildConfig } = rslibConfig;
 
   if (!libConfigsArray) {
     throw new Error(

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -4,6 +4,7 @@ import {
   type EnvironmentConfig,
   type RsbuildConfig,
   type RsbuildPlugin,
+  type RsbuildPlugins,
   defineConfig as defineRsbuildConfig,
   loadConfig as loadRsbuildConfig,
   mergeRsbuildConfig,
@@ -1143,8 +1144,11 @@ const composeExternalHelpersConfig = (
   return defaultConfig;
 };
 
-async function composeLibRsbuildConfig(config: LibConfig) {
-  checkMFPlugin(config);
+async function composeLibRsbuildConfig(
+  config: LibConfig,
+  sharedPlugins?: RsbuildPlugins,
+) {
+  checkMFPlugin(config, sharedPlugins);
 
   // Get the absolute path of the root directory to align with Rsbuild's default behavior
   const rootPath = config.root
@@ -1258,7 +1262,11 @@ export async function composeCreateRsbuildConfig(
   rslibConfig: RslibConfig,
 ): Promise<RsbuildConfigWithLibInfo[]> {
   const constantRsbuildConfig = await createConstantRsbuildConfig();
-  const { lib: libConfigsArray, plugins, ...sharedRsbuildConfig } = rslibConfig;
+  const {
+    lib: libConfigsArray,
+    plugins: sharedPlugins,
+    ...sharedRsbuildConfig
+  } = rslibConfig;
 
   if (!libConfigsArray) {
     throw new Error(
@@ -1274,7 +1282,10 @@ export async function composeCreateRsbuildConfig(
 
     // Merge the configuration of each environment based on the shared Rsbuild
     // configuration and Lib configuration in the settings.
-    const libRsbuildConfig = await composeLibRsbuildConfig(userConfig);
+    const libRsbuildConfig = await composeLibRsbuildConfig(
+      userConfig,
+      sharedPlugins,
+    );
 
     // Reset certain fields because they will be completely overridden by the upcoming merge.
     // We don't want to retain them in the final configuration.

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -184,16 +184,20 @@ export function isPluginIncluded(
   );
 }
 
-export function checkMFPlugin(config: LibConfig): boolean {
+export function checkMFPlugin(
+  config: LibConfig,
+  sharedPlugins?: RsbuildPlugins,
+): boolean {
   if (config.format !== 'mf') {
     return true;
   }
 
   // https://github.com/module-federation/core/blob/4e5c4b96ee45899f3ba5904b8927768980d5ad0e/packages/rsbuild-plugin/src/cli/index.ts#L17
-  const added = isPluginIncluded(
-    'rsbuild:module-federation-enhanced',
-    config.plugins,
-  );
+  const added = isPluginIncluded('rsbuild:module-federation-enhanced', [
+    ...(sharedPlugins || []),
+    ...(config.plugins || []),
+  ]);
+
   if (!added) {
     logger.warn(
       `${color.green('format: "mf"')} should be used with ${color.blue(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,6 +687,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0(@rsbuild/core@1.1.9)
 
+  tests/integration/plugins: {}
+
   tests/integration/polyfill:
     dependencies:
       core-js-pure:

--- a/tests/integration/plugins/index.test.ts
+++ b/tests/integration/plugins/index.test.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs';
+import { buildAndGetResults } from 'test-helper';
+import { expect, test } from 'vitest';
+import { distIndex } from './rslib.config';
+
+test('should run shared plugins only once', async () => {
+  const fixturePath = __dirname;
+  await buildAndGetResults({ fixturePath });
+
+  const content = fs.readFileSync(distIndex, 'utf-8');
+  expect(content).toEqual('count: 1');
+});

--- a/tests/integration/plugins/package.json
+++ b/tests/integration/plugins/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "plugins-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/plugins/rslib.config.ts
+++ b/tests/integration/plugins/rslib.config.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RsbuildPlugin } from '@rsbuild/core';
+import { defineConfig } from '@rslib/core';
+
+let count = 0;
+export const distIndex = path.resolve(__dirname, 'dist/count.txt');
+
+const testPlugin: RsbuildPlugin = {
+  name: 'test',
+  setup(api) {
+    api.onAfterBuild(() => {
+      fs.writeFileSync(distIndex, `count: ${++count}`);
+    });
+  },
+};
+
+export default defineConfig({
+  lib: [{ format: 'esm' }, { format: 'cjs' }],
+  plugins: [testPlugin],
+});

--- a/tests/integration/plugins/src/index.ts
+++ b/tests/integration/plugins/src/index.ts
@@ -1,0 +1,1 @@
+export const test = 'hello';


### PR DESCRIPTION
## Summary

I found this issue when testing [rsbuild-plugin-publint](https://github.com/rspack-contrib/rsbuild-plugin-publint).

In Rsbuild, shared plugins will run only once. Take `rsbuild-plugin-publint` as an example, it uses `api.onAfterBuild` to trigger the linting, and this should only be triggered once per build, otherwise it will result in duplicate lint output.

```ts
// rsbuild.config.ts
export default {
  // this is a shared plugin
  plugins: [publintPlugin],
  environments: {
    client: {
      plugins: [clientOnlyPlugin],
    },
    server: {
      plugins: [serverOnlyPlugin],
    },
  },
};
```

Currently Rslib does not align with this behavior, the shared plugins are registered multiple times. After this PR, Rslib will be aligned with Rsbuild.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
