### PR TITLE
fix(create-rslib): correctly resolve `storybook-addon-rslib` in pnpm

### DIFF
--- a/packages/create-rslib/fragments/tools/storybook-react-js/.storybook/main.js
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/.storybook/main.js
@@ -18,7 +18,9 @@ const config = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    'storybook-addon-rslib',
+    {
+      name: getAbsolutePath('storybook-addon-rslib'),
+    },
   ],
   framework: {
     name: getAbsolutePath('storybook-react-rsbuild'),

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/.storybook/main.ts
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/.storybook/main.ts
@@ -19,7 +19,9 @@ const config: StorybookConfig = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    'storybook-addon-rslib',
+    {
+      name: getAbsolutePath('storybook-addon-rslib'),
+    },
   ],
   framework: {
     name: getAbsolutePath('storybook-react-rsbuild'),

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/.storybook/main.js
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/.storybook/main.js
@@ -18,7 +18,9 @@ const config = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    'storybook-addon-rslib',
+    {
+      name: getAbsolutePath('storybook-addon-rslib'),
+    },
   ],
   framework: {
     name: getAbsolutePath('storybook-react-rsbuild'),

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/.storybook/main.ts
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/.storybook/main.ts
@@ -19,7 +19,9 @@ const config: StorybookConfig = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    'storybook-addon-rslib',
+    {
+      name: getAbsolutePath('storybook-addon-rslib'),
+    },
   ],
   framework: {
     name: getAbsolutePath('storybook-react-rsbuild'),

--- a/packages/create-rslib/template-[react]-[storybook]-js/.storybook/main.js
+++ b/packages/create-rslib/template-[react]-[storybook]-js/.storybook/main.js
@@ -18,7 +18,9 @@ const config = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    'storybook-addon-rslib',
+    {
+      name: getAbsolutePath('storybook-addon-rslib'),
+    },
   ],
   framework: {
     name: getAbsolutePath('storybook-react-rsbuild'),

--- a/packages/create-rslib/template-[react]-[storybook]-ts/.storybook/main.ts
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/.storybook/main.ts
@@ -19,7 +19,9 @@ const config: StorybookConfig = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    'storybook-addon-rslib',
+    {
+      name: getAbsolutePath('storybook-addon-rslib'),
+    },
   ],
   framework: {
     name: getAbsolutePath('storybook-react-rsbuild'),


### PR DESCRIPTION
## Summary

Use `getAbsolutePath` in template to correctly resolve `storybook-addon-rslib` in pnpm.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
