### PR TITLE
fix: type missing when set moduleResolution node16+

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,4 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { defineConfig } from 'rslib';
+
+const pluginFixDtsTypes: RsbuildPlugin = {
+  name: 'fix-dts-types',
+  setup(api) {
+    api.onAfterBuild(() => {
+      const typesDir = path.join(process.cwd(), 'dist-types');
+      const pkgPath = path.join(typesDir, 'package.json');
+      if (!fs.existsSync(typesDir)) {
+        fs.mkdirSync(typesDir);
+      }
+      fs.writeFileSync(
+        pkgPath,
+        JSON.stringify({
+          '//': 'This file is for making TypeScript work with moduleResolution node16+.',
+          version: '1.0.0',
+        }),
+        'utf8',
+      );
+    });
+  },
+};
 
 export default defineConfig({
   lib: [
@@ -11,6 +35,7 @@ export default defineConfig({
       },
     },
   ],
+  plugins: [pluginFixDtsTypes],
   source: {
     entry: {
       index: './src/index.ts',


### PR DESCRIPTION
## Summary

closes: #567 

Fix cannot import typing issue when `"moduleResolution": "NodeNext"` in user's `tsconfig.json` by adding an empty `package.json` to the `dist-types` folder.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2353

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
