### PR TITLE
fix: pass server config to Rsbuild

### DIFF
--- a/packages/core/src/cli/build.ts
+++ b/packages/core/src/cli/build.ts
@@ -12,6 +12,7 @@ export async function build(
   const rsbuildInstance = await createRsbuild({
     rsbuildConfig: {
       plugins: config.plugins,
+      server: config.server,
       environments: pruneEnvironments(environments, options.lib),
     },
   });

--- a/packages/core/src/cli/inspect.ts
+++ b/packages/core/src/cli/inspect.ts
@@ -11,6 +11,7 @@ export async function inspect(
   const rsbuildInstance = await createRsbuild({
     rsbuildConfig: {
       plugins: config.plugins,
+      server: config.server,
       environments: pruneEnvironments(environments, options.lib),
     },
   });

--- a/packages/core/src/cli/mf.ts
+++ b/packages/core/src/cli/mf.ts
@@ -1,5 +1,6 @@
 import { createRsbuild, mergeRsbuildConfig } from '@rsbuild/core';
 import type { RsbuildConfig, RsbuildInstance } from '@rsbuild/core';
+import merge from 'node_modules/@rsbuild/core/compiled/webpack-merge';
 import { composeCreateRsbuildConfig } from '../config';
 import type { RslibConfig } from '../types';
 import { onBeforeRestart } from './restart';
@@ -33,8 +34,14 @@ async function initMFRsbuild(
         ...(rslibConfig.plugins || []),
         ...(mfRsbuildConfig.config.plugins || []),
       ],
+      server: mergeRsbuildConfig(
+        rslibConfig.server,
+        mfRsbuildConfig.config.server,
+      ),
     },
   });
+  console.log('rslibConfig.server: ', rslibConfig.server);
+  console.log('mfRsbuildConfig.config.server: ', mfRsbuildConfig.config.server);
   const devServer = await rsbuildInstance.startDevServer();
 
   onBeforeRestart(devServer.server.close);

--- a/packages/core/src/cli/mf.ts
+++ b/packages/core/src/cli/mf.ts
@@ -1,6 +1,5 @@
 import { createRsbuild, mergeRsbuildConfig } from '@rsbuild/core';
 import type { RsbuildConfig, RsbuildInstance } from '@rsbuild/core';
-import merge from 'node_modules/@rsbuild/core/compiled/webpack-merge';
 import { composeCreateRsbuildConfig } from '../config';
 import type { RslibConfig } from '../types';
 import { onBeforeRestart } from './restart';
@@ -40,8 +39,7 @@ async function initMFRsbuild(
       ),
     },
   });
-  console.log('rslibConfig.server: ', rslibConfig.server);
-  console.log('mfRsbuildConfig.config.server: ', mfRsbuildConfig.config.server);
+
   const devServer = await rsbuildInstance.startDevServer();
 
   onBeforeRestart(devServer.server.close);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1335,6 +1335,7 @@ export async function composeCreateRsbuildConfig(
   const {
     lib: libConfigsArray,
     plugins: sharedPlugins,
+    server,
     ...sharedRsbuildConfig
   } = rslibConfig;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,6 +750,10 @@ importers:
 
   tests/integration/resolve/with-main-fields: {}
 
+  tests/integration/server/basic: {}
+
+  tests/integration/server/mf-dev: {}
+
   tests/integration/shims/cjs: {}
 
   tests/integration/shims/esm: {}

--- a/tests/integration/server/basic/package.json
+++ b/tests/integration/server/basic/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "server-basic-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/server/basic/rslib.config.ts
+++ b/tests/integration/server/basic/rslib.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig()],
+  server: {
+    publicDir: {
+      copyOnBuild: false,
+    },
+  },
+});

--- a/tests/integration/server/basic/src/index.ts
+++ b/tests/integration/server/basic/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/tests/integration/server/index.test.ts
+++ b/tests/integration/server/index.test.ts
@@ -34,18 +34,10 @@ describe('server config', async () => {
     childProcess.kill();
 
     // Check if the server config is merged correctly
-    const rsbuildConfig = await import(rsbuildConfigFile);
-    expect(rsbuildConfig.default.server).toMatchInlineSnapshot(`
-      {
-        "base": "/",
-        "compress": true,
-        "host": "0.0.0.0",
-        "htmlFallback": "index",
-        "open": true,
-        "port": 3002,
-        "printUrls": false,
-        "strictPort": false,
-      }
-    `);
+    const rsbuildConfigContent = await fse.readFile(rsbuildConfigFile, 'utf-8');
+    expect(rsbuildConfigContent).toContain(`base: '/'`);
+    expect(rsbuildConfigContent).toContain('open: true');
+    expect(rsbuildConfigContent).toContain('port: 3002');
+    expect(rsbuildConfigContent).toContain('printUrls: false');
   });
 });

--- a/tests/integration/server/index.test.ts
+++ b/tests/integration/server/index.test.ts
@@ -1,0 +1,51 @@
+import { exec } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import fse from 'fs-extra';
+import { awaitFileExists, buildAndGetResults } from 'test-helper';
+import { describe, expect, test } from 'vitest';
+
+describe('server config', async () => {
+  test('basic config', async () => {
+    const fixturePath = join(__dirname, 'basic');
+    await buildAndGetResults({ fixturePath });
+
+    // Check if logo.svg in public is copied to dist/esm
+    const logoPath = join(__dirname, 'dist', 'esm', 'logo.svg');
+    const logoExists = existsSync(logoPath);
+    expect(logoExists).toBe(false);
+  });
+
+  test('mf dev command', async () => {
+    const fixturePath = join(__dirname, 'mf-dev');
+    const distPath = join(fixturePath, 'dist');
+    const rsbuildConfigFile = join(distPath, '.rsbuild/rsbuild.config.mjs');
+    fse.removeSync(distPath);
+
+    const childProcess = exec('npx rslib mf dev', {
+      cwd: fixturePath,
+      env: {
+        ...process.env,
+        DEBUG: 'rsbuild',
+      },
+    });
+
+    await awaitFileExists(rsbuildConfigFile);
+    childProcess.kill();
+
+    // Check if the server config is merged correctly
+    const rsbuildConfig = await import(rsbuildConfigFile);
+    expect(rsbuildConfig.default.server).toMatchInlineSnapshot(`
+      {
+        "base": "/",
+        "compress": true,
+        "host": "0.0.0.0",
+        "htmlFallback": "index",
+        "open": true,
+        "port": 3002,
+        "printUrls": false,
+        "strictPort": false,
+      }
+    `);
+  });
+});

--- a/tests/integration/server/mf-dev/package.json
+++ b/tests/integration/server/mf-dev/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "server-mf-dev-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/server/mf-dev/rslib.config.ts
+++ b/tests/integration/server/mf-dev/rslib.config.ts
@@ -1,0 +1,23 @@
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'mf',
+      server: {
+        port: 3002,
+        printUrls: false,
+      },
+    },
+  ],
+  server: {
+    port: 3001,
+    open: true,
+  },
+  plugins: [
+    pluginModuleFederation({
+      name: 'test',
+    }),
+  ],
+});

--- a/tests/integration/server/mf-dev/src/index.ts
+++ b/tests/integration/server/mf-dev/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';


### PR DESCRIPTION
## Summary

We should pass `server` config to Rsbuild since `mf dev` and some `publicDir` feature need to configure it.

## Related Links

fix: #583 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
