### PR TITLE
fix: do not handle the path that can’t be resolved

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,6 +736,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
 
+  tests/integration/redirect/js-not-resolve: {}
+
   tests/integration/redirect/style-false: {}
 
   tests/integration/require/import-dynamic: {}

--- a/tests/integration/redirect/js-not-resolve/package.json
+++ b/tests/integration/redirect/js-not-resolve/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "redirect-js-no-resolve-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/redirect/js-not-resolve/rslib.config.ts
+++ b/tests/integration/redirect/js-not-resolve/rslib.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    // 0 default
+    generateBundleEsmConfig({
+      bundle: false,
+      output: {
+        distPath: {
+          root: 'dist/default/esm',
+        },
+      },
+    }),
+    // 1 js.path: false
+    generateBundleEsmConfig({
+      bundle: false,
+      output: {
+        distPath: {
+          root: 'dist/js-path-false/esm',
+        },
+      },
+      redirect: {
+        js: {
+          path: false,
+        },
+      },
+    }),
+    // 2 js.extension: false
+    generateBundleEsmConfig({
+      bundle: false,
+      output: {
+        distPath: {
+          root: 'dist/js-extension-false/esm',
+        },
+      },
+      redirect: {
+        js: {
+          extension: false,
+        },
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      '~': './src',
+    },
+  },
+  source: {
+    entry: {
+      index: './src/**',
+    },
+  },
+});

--- a/tests/integration/redirect/js-not-resolve/src/index.js
+++ b/tests/integration/redirect/js-not-resolve/src/index.js
@@ -1,0 +1,5 @@
+import lodash from 'lodash';
+import bar from './bar.js';
+import foo from './foo';
+
+export default lodash.toUpper(foo + bar);

--- a/tests/integration/redirect/js.test.ts
+++ b/tests/integration/redirect/js.test.ts
@@ -44,12 +44,12 @@ test('redirect.js.path false', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
-    import * as __WEBPACK_EXTERNAL_MODULE__bar_js_fb2b582c__ from "@/bar.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__foo_js_ce8863d2__ from "@/foo.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__baz_js_b1797427__ from "~/baz.js";
+    import * as __WEBPACK_EXTERNAL_MODULE__bar_943a8c75__ from "@/bar";
+    import * as __WEBPACK_EXTERNAL_MODULE__foo_a5f33889__ from "@/foo";
+    import * as __WEBPACK_EXTERNAL_MODULE__baz_3ce4598c__ from "~/baz";
     import * as __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__ from "./bar.js";
     import * as __WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__ from "./foo.js";
-    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__.foo + __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__.bar + __WEBPACK_EXTERNAL_MODULE__foo_js_ce8863d2__.foo + __WEBPACK_EXTERNAL_MODULE__bar_js_fb2b582c__.bar + __WEBPACK_EXTERNAL_MODULE__baz_js_b1797427__.baz);
+    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__.foo + __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__.bar + __WEBPACK_EXTERNAL_MODULE__foo_a5f33889__.foo + __WEBPACK_EXTERNAL_MODULE__bar_943a8c75__.bar + __WEBPACK_EXTERNAL_MODULE__baz_3ce4598c__.baz);
     export { src_rslib_entry_ as default };
     "
   `);

--- a/tests/integration/redirect/jsNotResolved.test.ts
+++ b/tests/integration/redirect/jsNotResolved.test.ts
@@ -1,0 +1,103 @@
+import path from 'node:path';
+import stripAnsi from 'strip-ansi';
+import { buildAndGetResults, proxyConsole, queryContent } from 'test-helper';
+import { expect, test } from 'vitest';
+
+test('redirect.js default', async () => {
+  const fixturePath = path.resolve(__dirname, './js-not-resolve');
+  const { logs } = proxyConsole();
+  const contents = (await buildAndGetResults({ fixturePath, lib: ['esm0'] }))
+    .contents;
+
+  const logStrings = logs
+    .map((log) => stripAnsi(log))
+    .filter((log) => log.startsWith('warn'))
+    .sort();
+
+  expect(logStrings).toMatchInlineSnapshot(
+    `
+    [
+      "warn    Failed to resolve module "./bar.js" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+      "warn    Failed to resolve module "./foo" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+      "warn    Failed to resolve module "lodash" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+    ]
+  `,
+  );
+
+  const { content: indexContent } = queryContent(
+    contents.esm0!,
+    /esm\/index\.js/,
+  );
+
+  expect(indexContent).toMatchInlineSnapshot(`
+    "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__ from "./bar.js";
+    import * as __WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__ from "./foo.js";
+    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__["default"] + __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__["default"]);
+    export { src_rslib_entry_ as default };
+    "
+  `);
+});
+
+test('redirect.js.path false', async () => {
+  const fixturePath = path.resolve(__dirname, './js-not-resolve');
+  const { logs } = proxyConsole();
+  const contents = (await buildAndGetResults({ fixturePath, lib: ['esm1'] }))
+    .contents;
+
+  const logStrings = logs
+    .map((log) => stripAnsi(log))
+    .filter((log) => log.startsWith('warn'));
+
+  expect(logStrings.length).toBe(0);
+
+  const { content: indexContent } = queryContent(
+    contents.esm1!,
+    /esm\/index\.js/,
+  );
+
+  expect(indexContent).toMatchInlineSnapshot(`
+    "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__ from "./bar.js";
+    import * as __WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__ from "./foo.js";
+    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__["default"] + __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__["default"]);
+    export { src_rslib_entry_ as default };
+    "
+  `);
+});
+
+test('redirect.js.extension: false', async () => {
+  const fixturePath = path.resolve(__dirname, './js-not-resolve');
+  const { logs } = proxyConsole();
+  const contents = (await buildAndGetResults({ fixturePath, lib: ['esm2'] }))
+    .contents;
+
+  const logStrings = logs
+    .map((log) => stripAnsi(log))
+    .filter((log) => log.startsWith('warn'))
+    .sort();
+
+  expect(logStrings).toMatchInlineSnapshot(
+    `
+    [
+      "warn    Failed to resolve module "./bar.js" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+      "warn    Failed to resolve module "./foo" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+      "warn    Failed to resolve module "lodash" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+    ]
+  `,
+  );
+
+  const { content: indexContent } = queryContent(
+    contents.esm2!,
+    /esm\/index\.js/,
+  );
+
+  expect(indexContent).toMatchInlineSnapshot(`
+    "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__ from "./bar.js";
+    import * as __WEBPACK_EXTERNAL_MODULE__foo_23da6eef__ from "./foo";
+    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_23da6eef__["default"] + __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__["default"]);
+    export { src_rslib_entry_ as default };
+    "
+  `);
+});

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -195,10 +195,12 @@ export async function rslibBuild({
   cwd,
   path,
   modifyConfig,
+  lib,
 }: {
   cwd: string;
   path?: string;
   modifyConfig?: (config: RslibConfig) => void;
+  lib?: string[];
 }) {
   const { content: rslibConfig } = await loadConfig({
     cwd,
@@ -206,7 +208,7 @@ export async function rslibBuild({
   });
   modifyConfig?.(rslibConfig);
   process.chdir(cwd);
-  const rsbuildInstance = await build(rslibConfig);
+  const rsbuildInstance = await build(rslibConfig, { lib });
   return { rsbuildInstance, rslibConfig };
 }
 
@@ -214,6 +216,7 @@ export async function buildAndGetResults(options: {
   fixturePath: string;
   configPath?: string;
   type: 'all';
+  lib?: string[];
 }): Promise<{
   js: BuildResult;
   dts: BuildResult;
@@ -223,19 +226,23 @@ export async function buildAndGetResults(options: {
   fixturePath: string;
   configPath?: string;
   type?: 'js' | 'dts' | 'css';
+  lib?: string[];
 }): Promise<BuildResult>;
 export async function buildAndGetResults({
   fixturePath,
   configPath,
   type = 'js',
+  lib,
 }: {
   fixturePath: string;
   configPath?: string;
   type?: 'js' | 'dts' | 'css' | 'all';
+  lib?: string[];
 }) {
   const { rsbuildInstance, rslibConfig } = await rslibBuild({
     cwd: fixturePath,
     path: configPath,
+    lib,
   });
   const {
     origin: { bundlerConfigs, rsbuildConfig },


### PR DESCRIPTION
## Summary

Given that if a React component library, but `"react"` is not defined in either `devDeps` or `peerDeps`, the requested `"react"` in `import { useEffect } from 'react'` can't be resolved at all, so we should directly skipping process it and emit a warning to users.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
