### PR TITLE
test(path-serializer): WEBPACK_EXTERNAL_MODULE hash

### DIFF
--- a/tests/integration/alias/__snapshots__/index.test.ts.snap
+++ b/tests/integration/alias/__snapshots__/index.test.ts.snap
@@ -20,8 +20,8 @@ if (__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_targe
 `;
 
 exports[`source.alias 3`] = `
-"import * as __WEBPACK_EXTERNAL_MODULE__a_js_256e6de1__ from "./a.js";
-console.info(__WEBPACK_EXTERNAL_MODULE__a_js_256e6de1__.a);
+"import * as <WEBPACK_EXTERNAL_MODULE> from "./a.js";
+console.info(<WEBPACK_EXTERNAL_MODULE>.a);
 "
 `;
 

--- a/tests/integration/external-helpers/__snapshots__/index.test.ts.snap
+++ b/tests/integration/external-helpers/__snapshots__/index.test.ts.snap
@@ -1,14 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`should external @swc/helpers when externalHelpers is true 1`] = `
-"import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check_f500f6c3__ from "@swc/helpers/_/_class_call_check";
-import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class_63e94838__ from "@swc/helpers/_/_create_class";
+"import * as <WEBPACK_EXTERNAL_MODULE> from "@swc/helpers/_/_class_call_check";
+import * as <WEBPACK_EXTERNAL_MODULE> from "@swc/helpers/_/_create_class";
 var src_rslib_entry_FOO = /*#__PURE__*/ function() {
     "use strict";
     function FOO() {
-        (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check_f500f6c3__._)(this, FOO);
+        (0, <WEBPACK_EXTERNAL_MODULE>._)(this, FOO);
     }
-    (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class_63e94838__._)(FOO, [
+    (0, <WEBPACK_EXTERNAL_MODULE>._)(FOO, [
         {
             key: "bar",
             get: function() {}
@@ -21,14 +21,14 @@ export { src_rslib_entry_FOO as default };
 `;
 
 exports[`should external @swc/helpers when externalHelpers is true 2`] = `
-"import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check_f500f6c3__ from "@swc/helpers/_/_class_call_check";
-import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class_63e94838__ from "@swc/helpers/_/_create_class";
+"import * as <WEBPACK_EXTERNAL_MODULE> from "@swc/helpers/_/_class_call_check";
+import * as <WEBPACK_EXTERNAL_MODULE> from "@swc/helpers/_/_create_class";
 var src_rslib_entry_FOO = /*#__PURE__*/ function() {
     "use strict";
     function FOO() {
-        (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check_f500f6c3__._)(this, FOO);
+        (0, <WEBPACK_EXTERNAL_MODULE>._)(this, FOO);
     }
-    (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class_63e94838__._)(FOO, [
+    (0, <WEBPACK_EXTERNAL_MODULE>._)(FOO, [
         {
             key: "bar",
             get: function() {}
@@ -111,14 +111,14 @@ export { src_rslib_entry_FOO as default };
 `;
 
 exports[`should respect user override externalHelpers config 2`] = `
-"import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check_f500f6c3__ from "@swc/helpers/_/_class_call_check";
-import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class_63e94838__ from "@swc/helpers/_/_create_class";
+"import * as <WEBPACK_EXTERNAL_MODULE> from "@swc/helpers/_/_class_call_check";
+import * as <WEBPACK_EXTERNAL_MODULE> from "@swc/helpers/_/_create_class";
 var src_rslib_entry_FOO = /*#__PURE__*/ function() {
     "use strict";
     function FOO() {
-        (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check_f500f6c3__._)(this, FOO);
+        (0, <WEBPACK_EXTERNAL_MODULE>._)(this, FOO);
     }
-    (0, __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class_63e94838__._)(FOO, [
+    (0, <WEBPACK_EXTERNAL_MODULE>._)(FOO, [
         {
             key: "bar",
             get: function() {}

--- a/tests/integration/redirect/js.test.ts
+++ b/tests/integration/redirect/js.test.ts
@@ -21,10 +21,10 @@ test('redirect.js default', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
-    import * as __WEBPACK_EXTERNAL_MODULE__bar_index_js_89500c0c__ from "./bar/index.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__ from "./foo.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__baz_js_a2c1c788__ from "./baz.js";
-    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_js_89500c0c__.bar + __WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_js_89500c0c__.bar + __WEBPACK_EXTERNAL_MODULE__baz_js_a2c1c788__.baz);
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./bar/index.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./foo.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./baz.js";
+    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(<WEBPACK_EXTERNAL_MODULE>.foo + <WEBPACK_EXTERNAL_MODULE>.bar + <WEBPACK_EXTERNAL_MODULE>.foo + <WEBPACK_EXTERNAL_MODULE>.bar + <WEBPACK_EXTERNAL_MODULE>.baz);
     export { src_rslib_entry_ as default };
     "
   `);
@@ -44,12 +44,12 @@ test('redirect.js.path false', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
-    import * as __WEBPACK_EXTERNAL_MODULE__bar_js_fb2b582c__ from "@/bar.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__foo_js_ce8863d2__ from "@/foo.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__baz_js_b1797427__ from "~/baz.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__ from "./bar.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__ from "./foo.js";
-    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__.foo + __WEBPACK_EXTERNAL_MODULE__bar_js_69b41beb__.bar + __WEBPACK_EXTERNAL_MODULE__foo_js_ce8863d2__.foo + __WEBPACK_EXTERNAL_MODULE__bar_js_fb2b582c__.bar + __WEBPACK_EXTERNAL_MODULE__baz_js_b1797427__.baz);
+    import * as <WEBPACK_EXTERNAL_MODULE> from "@/bar.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "@/foo.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "~/baz.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./bar.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./foo.js";
+    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(<WEBPACK_EXTERNAL_MODULE>.foo + <WEBPACK_EXTERNAL_MODULE>.bar + <WEBPACK_EXTERNAL_MODULE>.foo + <WEBPACK_EXTERNAL_MODULE>.bar + <WEBPACK_EXTERNAL_MODULE>.baz);
     export { src_rslib_entry_ as default };
     "
   `);
@@ -67,12 +67,12 @@ test('redirect.js.path with user override externals', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
-    import * as __WEBPACK_EXTERNAL_MODULE__others_bar_index_js_6776b573__ from "./others/bar/index.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__others_foo_js_920f94ba__ from "./others/foo.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__baz_js_a2c1c788__ from "./baz.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__bar_index_js_89500c0c__ from "./bar/index.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__ from "./foo.js";
-    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_js_89500c0c__.bar + __WEBPACK_EXTERNAL_MODULE__others_foo_js_920f94ba__.foo + __WEBPACK_EXTERNAL_MODULE__others_bar_index_js_6776b573__.bar + __WEBPACK_EXTERNAL_MODULE__baz_js_a2c1c788__.baz);
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./others/bar/index.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./others/foo.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./baz.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./bar/index.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./foo.js";
+    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(<WEBPACK_EXTERNAL_MODULE>.foo + <WEBPACK_EXTERNAL_MODULE>.bar + <WEBPACK_EXTERNAL_MODULE>.foo + <WEBPACK_EXTERNAL_MODULE>.bar + <WEBPACK_EXTERNAL_MODULE>.baz);
     export { src_rslib_entry_ as default };
     "
   `);
@@ -98,12 +98,12 @@ test('redirect.js.path with user override alias', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
-    import * as __WEBPACK_EXTERNAL_MODULE__others_bar_index_js_6776b573__ from "./others/bar/index.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__others_foo_js_920f94ba__ from "./others/foo.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__baz_js_a2c1c788__ from "./baz.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__bar_index_js_89500c0c__ from "./bar/index.js";
-    import * as __WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__ from "./foo.js";
-    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_js_89500c0c__.bar + __WEBPACK_EXTERNAL_MODULE__others_foo_js_920f94ba__.foo + __WEBPACK_EXTERNAL_MODULE__others_bar_index_js_6776b573__.bar + __WEBPACK_EXTERNAL_MODULE__baz_js_a2c1c788__.baz);
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./others/bar/index.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./others/foo.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./baz.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./bar/index.js";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./foo.js";
+    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(<WEBPACK_EXTERNAL_MODULE>.foo + <WEBPACK_EXTERNAL_MODULE>.bar + <WEBPACK_EXTERNAL_MODULE>.foo + <WEBPACK_EXTERNAL_MODULE>.bar + <WEBPACK_EXTERNAL_MODULE>.baz);
     export { src_rslib_entry_ as default };
     "
   `);
@@ -124,10 +124,10 @@ test('redirect.js.extension: false', async () => {
   );
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
-    import * as __WEBPACK_EXTERNAL_MODULE__bar_index_ts_bd8d18e6__ from "./bar/index.ts";
-    import * as __WEBPACK_EXTERNAL_MODULE__foo_ts_a526d0a1__ from "./foo.ts";
-    import * as __WEBPACK_EXTERNAL_MODULE__baz_ts_10ee073f__ from "./baz.ts";
-    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_ts_a526d0a1__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_ts_bd8d18e6__.bar + __WEBPACK_EXTERNAL_MODULE__foo_ts_a526d0a1__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_ts_bd8d18e6__.bar + __WEBPACK_EXTERNAL_MODULE__baz_ts_10ee073f__.baz);
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./bar/index.ts";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./foo.ts";
+    import * as <WEBPACK_EXTERNAL_MODULE> from "./baz.ts";
+    const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(<WEBPACK_EXTERNAL_MODULE>.foo + <WEBPACK_EXTERNAL_MODULE>.bar + <WEBPACK_EXTERNAL_MODULE>.foo + <WEBPACK_EXTERNAL_MODULE>.bar + <WEBPACK_EXTERNAL_MODULE>.baz);
     export { src_rslib_entry_ as default };
     "
   `);

--- a/tests/setupVitestTests.ts
+++ b/tests/setupVitestTests.ts
@@ -16,7 +16,7 @@ expect.addSnapshotSerializer(
       {
         match: /__WEBPACK_EXTERNAL_MODULE__(\w+)__/g,
         mark: 'WEBPACK_EXTERNAL_MODULE',
-      }
+      },
     ],
     features: {
       escapeDoubleQuotes: false,

--- a/tests/setupVitestTests.ts
+++ b/tests/setupVitestTests.ts
@@ -12,6 +12,12 @@ beforeEach(() => {
 expect.addSnapshotSerializer(
   createSnapshotSerializer({
     root: path.join(__dirname, '..'),
+    replace: [
+      {
+        match: /__WEBPACK_EXTERNAL_MODULE__(\w+)__/g,
+        mark: 'WEBPACK_EXTERNAL_MODULE',
+      }
+    ],
     features: {
       escapeDoubleQuotes: false,
       transformCLR: false,


### PR DESCRIPTION
## Summary
` import * as __WEBPACK_EXTERNAL_MODULE__foo_ts_a526d0a1__ from "./foo.ts";`

-> 

`import * as <WEBPACK_EXTERNAL_MODULE> from "./foo.ts";`


