### PR TITLE
docs: add how to skip the preprocessing of `less/scss` files

### DIFF
--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -1,5 +1,38 @@
 # Features FAQ
 
+## Style Processing
+
+### How to skip the preprocessing of `less/scss` files in bundleless mode?
+
+Bundleless means that each source file is compiled and built separately, which can be understood as the process of code conversion of source files only. To skip the preprocessing of `less/scss` files, you need to:
+
+1. Set `source.entry` to remove `less/scss` files from the entry.
+2. Set `output.copy` to copy `less/scss` files to the output directory.
+3. Set `redirect.style` to `false` to disable the redirect behavior for the import path of `less/scss` files.
+
+Below is an example of skipping the `scss` file processing. All `scss` files in `src` will be copied to the output directory and retained with consistent relative paths.
+
+```ts title="rslib.config.ts"
+export default defineConfig({
+  lib: [
+    {
+      // ...
+      source: {
+        entry: {
+          index: ['./src/**', '!src/**/*.scss'],
+        },
+      },
+      output: {
+        copy: [{ from: '**/*.scss', context: path.join(__dirname, 'src') }],
+      },
+      redirect: {
+        style: false,
+      },
+    },
+  ],
+});
+```
+
 ## Code Minification
 
 ### How to preserve all comments in the output files?

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -2,15 +2,15 @@
 
 ## Style Processing
 
-### How to skip the preprocessing of `less/scss` files in bundleless mode?
+### How to skip the preprocessing of Less / Sass files in bundleless mode?
 
-Bundleless means that each source file is compiled and built separately, which can be understood as the process of code conversion of source files only. To skip the preprocessing of `less/scss` files, you need to:
+Bundleless means that each source file is compiled and built separately, which can be understood as the process of code conversion of source files only. To skip the preprocessing of `.less/.scss` files, you need to:
 
-1. Set `source.entry` to remove `less/scss` files from the entry.
-2. Set `output.copy` to copy `less/scss` files to the output directory.
-3. Set `redirect.style` to `false` to disable the redirect behavior for the import path of `less/scss` files.
+1. Set `source.entry` to remove `.less/.scss` files from the entry.
+2. Set `output.copy` to copy `.less/.scss` files to the output directory.
+3. Set `redirect.style` to `false` to disable the redirect behavior for the import path of `.less/.scss` files.
 
-Below is an example of skipping the `scss` file processing. All `scss` files in `src` will be copied to the output directory and retained with consistent relative paths.
+Below is an example of skipping the `.scss` file processing. All `.scss` files in `src` will be copied to the output directory and retained with consistent relative paths.
 
 ```ts title="rslib.config.ts"
 export default defineConfig({

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -1,5 +1,38 @@
 # 功能类问题
 
+## 样式处理
+
+### bundleless 模式如何跳过对 `less/scss` 文件的预处理？
+
+bundleless 是指对每个源文件单独进行编译构建，可以理解为仅对源文件进行代码转换的过程。跳过对 `less/scss` 文件的预处理需要：
+
+1. 设置 `source.entry` 将 `less/scss` 文件从入口里移除。
+2. 设置 `output.copy` 将 `less/scss` 文件拷贝到产物目录。
+3. 设置 `redirect.style` 为 `false` 禁用对 `less/scss` 文件导入路径的重定向行为。
+
+下面是一个跳过 `scss` 文件处理的例子，`src` 里面所有的 `scss` 文件都会被拷贝到产物目录下并且保留一致的相对路径。
+
+```ts title="rslib.config.ts"
+export default defineConfig({
+  lib: [
+    {
+      // ...
+      source: {
+        entry: {
+          index: ['./src/**', '!src/**/*.scss'],
+        },
+      },
+      output: {
+        copy: [{ from: '**/*.scss', context: path.join(__dirname, 'src') }],
+      },
+      redirect: {
+        style: false,
+      },
+    },
+  ],
+});
+```
+
 ## 代码压缩
 
 ### 如何保留产物文件代码中的注释？

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -2,15 +2,15 @@
 
 ## 样式处理
 
-### bundleless 模式如何跳过对 `less/scss` 文件的预处理？
+### bundleless 模式如何跳过对 Less / Sass 等文件的预处理？
 
-bundleless 是指对每个源文件单独进行编译构建，可以理解为仅对源文件进行代码转换的过程。跳过对 `less/scss` 文件的预处理需要：
+bundleless 是指对每个源文件单独进行编译构建，可以理解为仅对源文件进行代码转换的过程。跳过对 `.less/.scss` 文件的预处理需要：
 
-1. 设置 `source.entry` 将 `less/scss` 文件从入口里移除。
-2. 设置 `output.copy` 将 `less/scss` 文件拷贝到产物目录。
-3. 设置 `redirect.style` 为 `false` 禁用对 `less/scss` 文件导入路径的重定向行为。
+1. 设置 `source.entry` 将 `.less/.scss` 文件从入口里移除。
+2. 设置 `output.copy` 将 `.less/.scss` 文件拷贝到产物目录。
+3. 设置 `redirect.style` 为 `false` 禁用对 `.less/.scss` 文件导入路径的重定向行为。
 
-下面是一个跳过 `scss` 文件处理的例子，`src` 里面所有的 `scss` 文件都会被拷贝到产物目录下并且保留一致的相对路径。
+下面是一个跳过 `.scss` 文件处理的例子，`src` 里面所有的 `.scss` 文件都会被拷贝到产物目录下并且保留一致的相对路径。
 
 ```ts title="rslib.config.ts"
 export default defineConfig({


### PR DESCRIPTION
## Summary

docs: add how to skip the preprocessing of `less/scss` files

## Related Links

#614 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
