### PR TITLE
feat!: disable `autoExternal` in bundleless mode and only redirect request not in node_modules

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,15 @@ importers:
 
   tests/integration/auto-extension/type-module/false-bundleless: {}
 
+  tests/integration/auto-external/bundle-false:
+    devDependencies:
+      ora:
+        specifier: 8.1.1
+        version: 8.1.1
+      react:
+        specifier: ^19.0.0
+        version: 19.0.0
+
   tests/integration/auto-external/default:
     dependencies:
       ora:

--- a/tests/integration/auto-external/bundle-false/package.json
+++ b/tests/integration/auto-external/bundle-false/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "auto-external-bundle-false-test",
+  "private": true,
+  "devDependencies": {
+    "ora": "8.1.1",
+    "react": "^19.0.0"
+  }
+}

--- a/tests/integration/auto-external/bundle-false/rslib.config.ts
+++ b/tests/integration/auto-external/bundle-false/rslib.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+    }),
+    generateBundleCjsConfig({
+      bundle: false,
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['./src/**'],
+    },
+  },
+});

--- a/tests/integration/auto-external/bundle-false/src/index.ts
+++ b/tests/integration/auto-external/bundle-false/src/index.ts
@@ -1,0 +1,7 @@
+import type { oraPromise } from 'ora';
+import React from 'react';
+
+export type { oraPromise };
+export const foo = () => {
+  return React.version;
+};

--- a/tests/integration/auto-external/bundle-false/tsconfig.json
+++ b/tests/integration/auto-external/bundle-false/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "include": ["src"]
+}

--- a/tests/integration/auto-external/index.test.ts
+++ b/tests/integration/auto-external/index.test.ts
@@ -40,6 +40,19 @@ test('auto external sub path should works', async () => {
   );
 });
 
+test('auto external should be disabled when bundle is false', async () => {
+  const fixturePath = join(__dirname, 'bundle-false');
+  const { js } = await buildAndGetResults({ fixturePath, type: 'all' });
+
+  expect(js.files.esm).not.toContain(
+    'import * as __WEBPACK_EXTERNAL_MODULE_react__ from "react"',
+  );
+
+  expect(js.files.cjs).not.toContain(
+    'var external_react_namespaceObject = require("react");',
+  );
+});
+
 test('auto external false should works', async () => {
   const fixturePath = join(__dirname, 'false');
   const { js, dts } = await buildAndGetResults({ fixturePath, type: 'all' });

--- a/tests/integration/auto-external/index.test.ts
+++ b/tests/integration/auto-external/index.test.ts
@@ -44,12 +44,12 @@ test('auto external should be disabled when bundle is false', async () => {
   const fixturePath = join(__dirname, 'bundle-false');
   const { js } = await buildAndGetResults({ fixturePath, type: 'all' });
 
-  expect(js.files.esm).not.toContain(
+  expect(Object.values(js.contents.esm)[0]).toContain(
     'import * as __WEBPACK_EXTERNAL_MODULE_react__ from "react"',
   );
 
-  expect(js.files.cjs).not.toContain(
-    'var external_react_namespaceObject = require("react");',
+  expect(Object.values(js.contents.cjs)[0]).toContain(
+    'const external_react_namespaceObject = require("react");',
   );
 });
 
@@ -62,7 +62,7 @@ test('auto external false should works', async () => {
   );
 
   expect(js.entries.cjs).not.toContain(
-    'var external_react_namespaceObject = require("react");',
+    'const external_react_namespaceObject = require("react");',
   );
 
   // dts should bundled

--- a/tests/integration/redirect/js-not-resolve/src/index.js
+++ b/tests/integration/redirect/js-not-resolve/src/index.js
@@ -1,5 +1,10 @@
+// can not be resolved
 import lodash from 'lodash';
+// can be resolved but not specified -- phantom dependency
+import prettier from 'prettier';
 import bar from './bar.js';
 import foo from './foo';
+
+console.log('prettier: ', prettier);
 
 export default lodash.toUpper(foo + bar);

--- a/tests/integration/redirect/js.test.ts
+++ b/tests/integration/redirect/js.test.ts
@@ -21,9 +21,11 @@ test('redirect.js default', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE_prettier__ from "prettier";
     import * as __WEBPACK_EXTERNAL_MODULE__bar_index_js__ from "./bar/index.js";
     import * as __WEBPACK_EXTERNAL_MODULE__foo_js__ from "./foo.js";
     import * as __WEBPACK_EXTERNAL_MODULE__baz_js__ from "./baz.js";
+    console.log('prettier: ', __WEBPACK_EXTERNAL_MODULE_prettier__["default"]);
     const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_js__.bar + __WEBPACK_EXTERNAL_MODULE__foo_js__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_js__.bar + __WEBPACK_EXTERNAL_MODULE__baz_js__.baz);
     export { src_rslib_entry_ as default };
     "
@@ -44,11 +46,13 @@ test('redirect.js.path false', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE_prettier__ from "prettier";
     import * as __WEBPACK_EXTERNAL_MODULE__bar__ from "@/bar";
     import * as __WEBPACK_EXTERNAL_MODULE__foo__ from "@/foo";
     import * as __WEBPACK_EXTERNAL_MODULE__baz__ from "~/baz";
     import * as __WEBPACK_EXTERNAL_MODULE__bar_js__ from "./bar.js";
     import * as __WEBPACK_EXTERNAL_MODULE__foo_js__ from "./foo.js";
+    console.log('prettier: ', __WEBPACK_EXTERNAL_MODULE_prettier__["default"]);
     const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js__.foo + __WEBPACK_EXTERNAL_MODULE__bar_js__.bar + __WEBPACK_EXTERNAL_MODULE__foo__.foo + __WEBPACK_EXTERNAL_MODULE__bar__.bar + __WEBPACK_EXTERNAL_MODULE__baz__.baz);
     export { src_rslib_entry_ as default };
     "
@@ -67,11 +71,13 @@ test('redirect.js.path with user override externals', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE_prettier__ from "prettier";
     import * as __WEBPACK_EXTERNAL_MODULE__others_bar_index_js__ from "./others/bar/index.js";
     import * as __WEBPACK_EXTERNAL_MODULE__others_foo_js__ from "./others/foo.js";
     import * as __WEBPACK_EXTERNAL_MODULE__baz_js__ from "./baz.js";
     import * as __WEBPACK_EXTERNAL_MODULE__bar_index_js__ from "./bar/index.js";
     import * as __WEBPACK_EXTERNAL_MODULE__foo_js__ from "./foo.js";
+    console.log('prettier: ', __WEBPACK_EXTERNAL_MODULE_prettier__["default"]);
     const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_js__.bar + __WEBPACK_EXTERNAL_MODULE__others_foo_js__.foo + __WEBPACK_EXTERNAL_MODULE__others_bar_index_js__.bar + __WEBPACK_EXTERNAL_MODULE__baz_js__.baz);
     export { src_rslib_entry_ as default };
     "
@@ -98,11 +104,13 @@ test('redirect.js.path with user override alias', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE_prettier__ from "prettier";
     import * as __WEBPACK_EXTERNAL_MODULE__others_bar_index_js__ from "./others/bar/index.js";
     import * as __WEBPACK_EXTERNAL_MODULE__others_foo_js__ from "./others/foo.js";
     import * as __WEBPACK_EXTERNAL_MODULE__baz_js__ from "./baz.js";
     import * as __WEBPACK_EXTERNAL_MODULE__bar_index_js__ from "./bar/index.js";
     import * as __WEBPACK_EXTERNAL_MODULE__foo_js__ from "./foo.js";
+    console.log('prettier: ', __WEBPACK_EXTERNAL_MODULE_prettier__["default"]);
     const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_js__.bar + __WEBPACK_EXTERNAL_MODULE__others_foo_js__.foo + __WEBPACK_EXTERNAL_MODULE__others_bar_index_js__.bar + __WEBPACK_EXTERNAL_MODULE__baz_js__.baz);
     export { src_rslib_entry_ as default };
     "
@@ -124,9 +132,11 @@ test('redirect.js.extension: false', async () => {
   );
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE_prettier__ from "prettier";
     import * as __WEBPACK_EXTERNAL_MODULE__bar_index_ts__ from "./bar/index.ts";
     import * as __WEBPACK_EXTERNAL_MODULE__foo_ts__ from "./foo.ts";
     import * as __WEBPACK_EXTERNAL_MODULE__baz_ts__ from "./baz.ts";
+    console.log('prettier: ', __WEBPACK_EXTERNAL_MODULE_prettier__["default"]);
     const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_ts__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_ts__.bar + __WEBPACK_EXTERNAL_MODULE__foo_ts__.foo + __WEBPACK_EXTERNAL_MODULE__bar_index_ts__.bar + __WEBPACK_EXTERNAL_MODULE__baz_ts__.baz);
     export { src_rslib_entry_ as default };
     "

--- a/tests/integration/redirect/js/src/index.ts
+++ b/tests/integration/redirect/js/src/index.ts
@@ -1,9 +1,14 @@
+// can not be resolved
 import lodash from 'lodash';
+// can be resolved but not specified -- phantom dependency
+import prettier from 'prettier';
 
 import { bar as bar2 } from '@/bar';
 import { foo as foo2 } from '@/foo';
 import { baz } from '~/baz';
 import { bar } from './bar';
 import { foo } from './foo';
+
+console.log('prettier: ', prettier);
 
 export default lodash.toUpper(foo + bar + foo2 + bar2 + baz);

--- a/tests/integration/redirect/jsNotResolved.test.ts
+++ b/tests/integration/redirect/jsNotResolved.test.ts
@@ -1,28 +1,11 @@
 import path from 'node:path';
-import stripAnsi from 'strip-ansi';
-import { buildAndGetResults, proxyConsole, queryContent } from 'test-helper';
+import { buildAndGetResults, queryContent } from 'test-helper';
 import { expect, test } from 'vitest';
 
 test('redirect.js default', async () => {
   const fixturePath = path.resolve(__dirname, './js-not-resolve');
-  // const { logs } = proxyConsole();
   const contents = (await buildAndGetResults({ fixturePath, lib: ['esm0'] }))
     .contents;
-
-  // const logStrings = logs
-  //   .map((log) => stripAnsi(log))
-  //   .filter((log) => log.startsWith('warn'))
-  //   .sort();
-
-  // expect(logStrings).toMatchInlineSnapshot(
-  //   `
-  //   [
-  //     "warn    Failed to resolve module "./bar.js" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-  //     "warn    Failed to resolve module "./foo" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-  //     "warn    Failed to resolve module "lodash" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-  //   ]
-  // `,
-  // );
 
   const { content: indexContent } = queryContent(
     contents.esm0!,
@@ -43,15 +26,8 @@ test('redirect.js default', async () => {
 
 test('redirect.js.path false', async () => {
   const fixturePath = path.resolve(__dirname, './js-not-resolve');
-  // const { logs } = proxyConsole();
   const contents = (await buildAndGetResults({ fixturePath, lib: ['esm1'] }))
     .contents;
-
-  // const logStrings = logs
-  //   .map((log) => stripAnsi(log))
-  //   .filter((log) => log.startsWith('warn'));
-
-  // expect(logStrings.length).toBe(0);
 
   const { content: indexContent } = queryContent(
     contents.esm1!,
@@ -72,24 +48,8 @@ test('redirect.js.path false', async () => {
 
 test('redirect.js.extension: false', async () => {
   const fixturePath = path.resolve(__dirname, './js-not-resolve');
-  // const { logs } = proxyConsole();
   const contents = (await buildAndGetResults({ fixturePath, lib: ['esm2'] }))
     .contents;
-
-  // const logStrings = logs
-  //   .map((log) => stripAnsi(log))
-  //   .filter((log) => log.startsWith('warn'))
-  //   .sort();
-
-  // expect(logStrings).toMatchInlineSnapshot(
-  //   `
-  //   [
-  //     "warn    Failed to resolve module "./bar.js" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-  //     "warn    Failed to resolve module "./foo" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-  //     "warn    Failed to resolve module "lodash" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-  //   ]
-  // `,
-  // );
 
   const { content: indexContent } = queryContent(
     contents.esm2!,

--- a/tests/integration/redirect/jsNotResolved.test.ts
+++ b/tests/integration/redirect/jsNotResolved.test.ts
@@ -5,24 +5,24 @@ import { expect, test } from 'vitest';
 
 test('redirect.js default', async () => {
   const fixturePath = path.resolve(__dirname, './js-not-resolve');
-  const { logs } = proxyConsole();
+  // const { logs } = proxyConsole();
   const contents = (await buildAndGetResults({ fixturePath, lib: ['esm0'] }))
     .contents;
 
-  const logStrings = logs
-    .map((log) => stripAnsi(log))
-    .filter((log) => log.startsWith('warn'))
-    .sort();
+  // const logStrings = logs
+  //   .map((log) => stripAnsi(log))
+  //   .filter((log) => log.startsWith('warn'))
+  //   .sort();
 
-  expect(logStrings).toMatchInlineSnapshot(
-    `
-    [
-      "warn    Failed to resolve module "./bar.js" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-      "warn    Failed to resolve module "./foo" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-      "warn    Failed to resolve module "lodash" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-    ]
-  `,
-  );
+  // expect(logStrings).toMatchInlineSnapshot(
+  //   `
+  //   [
+  //     "warn    Failed to resolve module "./bar.js" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+  //     "warn    Failed to resolve module "./foo" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+  //     "warn    Failed to resolve module "lodash" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+  //   ]
+  // `,
+  // );
 
   const { content: indexContent } = queryContent(
     contents.esm0!,
@@ -31,8 +31,10 @@ test('redirect.js default', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE_prettier__ from "prettier";
     import * as __WEBPACK_EXTERNAL_MODULE__bar_js__ from "./bar.js";
     import * as __WEBPACK_EXTERNAL_MODULE__foo_js__ from "./foo.js";
+    console.log('prettier: ', __WEBPACK_EXTERNAL_MODULE_prettier__["default"]);
     const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js__["default"] + __WEBPACK_EXTERNAL_MODULE__bar_js__["default"]);
     export { src_rslib_entry_ as default };
     "
@@ -41,15 +43,15 @@ test('redirect.js default', async () => {
 
 test('redirect.js.path false', async () => {
   const fixturePath = path.resolve(__dirname, './js-not-resolve');
-  const { logs } = proxyConsole();
+  // const { logs } = proxyConsole();
   const contents = (await buildAndGetResults({ fixturePath, lib: ['esm1'] }))
     .contents;
 
-  const logStrings = logs
-    .map((log) => stripAnsi(log))
-    .filter((log) => log.startsWith('warn'));
+  // const logStrings = logs
+  //   .map((log) => stripAnsi(log))
+  //   .filter((log) => log.startsWith('warn'));
 
-  expect(logStrings.length).toBe(0);
+  // expect(logStrings.length).toBe(0);
 
   const { content: indexContent } = queryContent(
     contents.esm1!,
@@ -58,8 +60,10 @@ test('redirect.js.path false', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE_prettier__ from "prettier";
     import * as __WEBPACK_EXTERNAL_MODULE__bar_js__ from "./bar.js";
     import * as __WEBPACK_EXTERNAL_MODULE__foo_js__ from "./foo.js";
+    console.log('prettier: ', __WEBPACK_EXTERNAL_MODULE_prettier__["default"]);
     const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo_js__["default"] + __WEBPACK_EXTERNAL_MODULE__bar_js__["default"]);
     export { src_rslib_entry_ as default };
     "
@@ -68,24 +72,24 @@ test('redirect.js.path false', async () => {
 
 test('redirect.js.extension: false', async () => {
   const fixturePath = path.resolve(__dirname, './js-not-resolve');
-  const { logs } = proxyConsole();
+  // const { logs } = proxyConsole();
   const contents = (await buildAndGetResults({ fixturePath, lib: ['esm2'] }))
     .contents;
 
-  const logStrings = logs
-    .map((log) => stripAnsi(log))
-    .filter((log) => log.startsWith('warn'))
-    .sort();
+  // const logStrings = logs
+  //   .map((log) => stripAnsi(log))
+  //   .filter((log) => log.startsWith('warn'))
+  //   .sort();
 
-  expect(logStrings).toMatchInlineSnapshot(
-    `
-    [
-      "warn    Failed to resolve module "./bar.js" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-      "warn    Failed to resolve module "./foo" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-      "warn    Failed to resolve module "lodash" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
-    ]
-  `,
-  );
+  // expect(logStrings).toMatchInlineSnapshot(
+  //   `
+  //   [
+  //     "warn    Failed to resolve module "./bar.js" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+  //     "warn    Failed to resolve module "./foo" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+  //     "warn    Failed to resolve module "lodash" from <ROOT>/tests/integration/redirect/js-not-resolve/src/index.js. If it's an npm package, consider adding it to dependencies or peerDependencies in package.json to make it externalized.",
+  //   ]
+  // `,
+  // );
 
   const { content: indexContent } = queryContent(
     contents.esm2!,
@@ -94,8 +98,10 @@ test('redirect.js.extension: false', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE_prettier__ from "prettier";
     import * as __WEBPACK_EXTERNAL_MODULE__bar_js__ from "./bar.js";
     import * as __WEBPACK_EXTERNAL_MODULE__foo__ from "./foo";
+    console.log('prettier: ', __WEBPACK_EXTERNAL_MODULE_prettier__["default"]);
     const src_rslib_entry_ = __WEBPACK_EXTERNAL_MODULE_lodash__["default"].toUpper(__WEBPACK_EXTERNAL_MODULE__foo__["default"] + __WEBPACK_EXTERNAL_MODULE__bar_js__["default"]);
     export { src_rslib_entry_ as default };
     "

--- a/website/docs/en/config/lib/auto-external.mdx
+++ b/website/docs/en/config/lib/auto-external.mdx
@@ -4,6 +4,12 @@ overviewHeaders: [2, 3]
 
 # lib.autoExternal
 
+:::info
+
+`autoExternal` is a specific configuration for bundle mode. It will not take effect in bundleless mode (set [lib.bundle](/config/lib/bundle) to `false`), because deps will not be bundled in bundleless mode.
+
+:::
+
 - **Type:**
 
 ```ts

--- a/website/docs/en/config/lib/auto-external.mdx
+++ b/website/docs/en/config/lib/auto-external.mdx
@@ -6,7 +6,7 @@ overviewHeaders: [2, 3]
 
 :::info
 
-`autoExternal` is a specific configuration for bundle mode. It will not take effect in bundleless mode (set [lib.bundle](/config/lib/bundle) to `false`), because deps will not be bundled in bundleless mode.
+`autoExternal` is a specific configuration for bundle mode. It will not take effect in bundleless mode (set [lib.bundle](/config/lib/bundle) to `false`) since deps will not be bundled in bundleless mode.
 
 :::
 

--- a/website/docs/en/config/lib/redirect.mdx
+++ b/website/docs/en/config/lib/redirect.mdx
@@ -6,7 +6,7 @@ overviewHeaders: [2, 3]
 
 :::info
 
-Redirect is the unique configuration for bundleless mode (set [lib.bundle](/config/lib/bundle) to `false`). It will not take effect in bundle mode where all output files are packaged into a single file, eliminating the need for import path redirection.
+`redirect` is the unique configuration for bundleless mode (set [lib.bundle](/config/lib/bundle) to `false`). It will not take effect in bundle mode where all output files are packaged into a single file, eliminating the need for import path redirection.
 
 As bundleless mode is still under development, additional redirect configurations will be introduced in the future.
 

--- a/website/docs/en/guide/advanced/third-party-deps.mdx
+++ b/website/docs/en/guide/advanced/third-party-deps.mdx
@@ -1,5 +1,7 @@
 # Handle Third-Party Dependencies
 
+This section introduces how to handle third-party dependencies in bundle mode.
+
 Generally, third-party dependencies required by a project can be installed via the `install` command in the package manager. After the third-party dependencies are successfully installed, they will generally appear under `dependencies` and `devDependencies` in the project `package.json`.
 
 ```json title="package.json"

--- a/website/docs/zh/config/lib/auto-external.mdx
+++ b/website/docs/zh/config/lib/auto-external.mdx
@@ -4,6 +4,12 @@ overviewHeaders: [2, 3]
 
 # lib.autoExternal
 
+:::info
+
+`autoExternal` 是 bundle 模式的特定配置。在 bundleless 模式（将 [lib.bundle](/config/lib/bundle) 设置为 `false`）下不会生效，因为 bundleless 模式下依赖不会被打包。
+
+:::
+
 - **类型：**
 
 ```ts

--- a/website/docs/zh/config/lib/redirect.mdx
+++ b/website/docs/zh/config/lib/redirect.mdx
@@ -6,7 +6,7 @@ overviewHeaders: [2, 3]
 
 :::info
 
-Redirect 是 bundleless 模式（将 [lib.bundle](/config/lib/bundle) 设置为 `false`）的特定配置。在 bundle 模式下不会生效，因为所有输出文件都被打包成一个文件。所以，导入路径不存在因而不需要重定向。
+`redirect` 是 bundleless 模式（将 [lib.bundle](/config/lib/bundle) 设置为 `false`）的特定配置。在 bundle 模式下不会生效，因为所有输出文件都被打包成一个文件。所以，导入路径不存在因而不需要重定向。
 
 由于 bundleless 模式仍在开发中，未来将引入更多的重定向配置。
 

--- a/website/docs/zh/guide/advanced/third-party-deps.mdx
+++ b/website/docs/zh/guide/advanced/third-party-deps.mdx
@@ -1,5 +1,7 @@
 # 处理三方依赖
 
+本节介绍如何在 bundle 模式下处理三方依赖。
+
 通常，项目所需的三方依赖可以通过包管理器的 `install` 命令安装。安装成功后，它们通常会出现在项目的 `package.json` 文件中的 `dependencies` 和 `devDependencies` 字段下。
 
 ```json title="package.json"


### PR DESCRIPTION
## Summary

- **breaking changes**: `autoExternal` only takes effect in bundle mode now
- only redirect request not in node_modules

## Related Links

closes: #616 
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
