### PR TITLE
fix: detect possible glob pattern in bundle more

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -890,8 +890,11 @@ const composeEntryConfig = async (
   if (bundle !== false) {
     let isFileEntry = false;
     traverseEntryQuery(entries, (entry) => {
-      if (fs.existsSync(entry)) {
-        const stats = fs.statSync(entry);
+      const entryAbsPath = path.isAbsolute(entry)
+        ? entry
+        : path.resolve(root, entry);
+      if (fs.existsSync(entryAbsPath)) {
+        const stats = fs.statSync(entryAbsPath);
         isFileEntry = stats.isFile();
       }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,6 +3,7 @@ import path, { dirname, extname, isAbsolute, join } from 'node:path';
 import {
   type EnvironmentConfig,
   type RsbuildConfig,
+  type RsbuildEntry,
   type RsbuildPlugin,
   type RsbuildPlugins,
   type Rspack,
@@ -844,8 +845,9 @@ const composeSyntaxConfig = (
   };
 };
 
-export const appendEntryQuery = (
+const traverseEntryQuery = (
   entry: RsbuildConfigEntry,
+  callback: (entry: string) => string,
 ): RsbuildConfigEntry => {
   const newEntry: Record<string, RsbuildConfigEntryItem> = {};
 
@@ -853,16 +855,16 @@ export const appendEntryQuery = (
     let result: RsbuildConfigEntryItem = value;
 
     if (typeof value === 'string') {
-      result = `${value}?${RSLIB_ENTRY_QUERY}`;
+      result = callback(value);
     } else if (Array.isArray(value)) {
-      result = value.map((item) => `${item}?${RSLIB_ENTRY_QUERY}`);
+      result = value.map(callback);
     } else {
       result = {
         ...value,
         import:
           typeof value.import === 'string'
-            ? `${value.import}?${RSLIB_ENTRY_QUERY}`
-            : value.import.map((item) => `${item}?${RSLIB_ENTRY_QUERY}`),
+            ? callback(value.import)
+            : value.import.map(callback),
       };
     }
 
@@ -871,6 +873,9 @@ export const appendEntryQuery = (
 
   return newEntry;
 };
+
+export const appendEntryQuery = (entries: RsbuildConfigEntry): RsbuildEntry =>
+  traverseEntryQuery(entries, (item) => `${item}?${RSLIB_ENTRY_QUERY}`);
 
 const composeEntryConfig = async (
   entries: RsbuildConfigEntry,
@@ -883,6 +888,22 @@ const composeEntryConfig = async (
   }
 
   if (bundle !== false) {
+    let isFileEntry = false;
+    traverseEntryQuery(entries, (entry) => {
+      if (fs.existsSync(entry)) {
+        const stats = fs.statSync(entry);
+        isFileEntry = stats.isFile();
+      }
+
+      return entry;
+    });
+
+    if (!isFileEntry) {
+      throw new Error(
+        `Glob pattern is not supported when "bundle" is "true", considering ${color.green('set "bundle" to "false"')} to use bundleless mode. See ${color.green('https://lib.rsbuild.dev/guide/basic/output-structure')} for more details.`,
+      );
+    }
+
     return {
       entryConfig: {
         source: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -662,6 +662,8 @@ importers:
 
   tests/integration/entry/glob: {}
 
+  tests/integration/entry/glob-bundle: {}
+
   tests/integration/entry/multiple: {}
 
   tests/integration/entry/single: {}

--- a/tests/integration/entry/glob-bundle/package.json
+++ b/tests/integration/entry/glob-bundle/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "entry-glob-bundle-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/entry/glob-bundle/rslib.config.ts
+++ b/tests/integration/entry/glob-bundle/rslib.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig({})],
+  source: {
+    entry: {
+      index: ['./src', '!./src/ignored'],
+    },
+  },
+});

--- a/tests/integration/entry/glob-bundle/src/bar.ts
+++ b/tests/integration/entry/glob-bundle/src/bar.ts
@@ -1,0 +1,1 @@
+export const bar = 'bar';

--- a/tests/integration/entry/glob-bundle/src/foo.ts
+++ b/tests/integration/entry/glob-bundle/src/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/tests/integration/entry/index.test.ts
+++ b/tests/integration/entry/index.test.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import stripAnsi from 'strip-ansi';
 import { buildAndGetResults, queryContent } from 'test-helper';
 import { expect, test } from 'vitest';
 
@@ -97,4 +98,18 @@ test('glob entry bundleless', async () => {
       ],
     }
   `);
+});
+
+test('glob entry bundle', async () => {
+  const fixturePath = join(__dirname, 'glob-bundle');
+  let errMsg = '';
+  try {
+    await buildAndGetResults({ fixturePath });
+  } catch (e) {
+    errMsg = (e as Error).message;
+  }
+
+  expect(stripAnsi(errMsg)).toMatchInlineSnapshot(
+    `"Glob pattern is not supported when "bundle" is "true", considering set "bundle" to "false" to use bundleless mode. See https://lib.rsbuild.dev/guide/basic/output-structure for more details."`,
+  );
 });


### PR DESCRIPTION
## Summary

Close https://github.com/web-infra-dev/rslib/issues/632.

> > Glob pattern entry like .src/** must be set along with bundle: false.
> 
> I think we could do an active detection here.

<img width="654" alt="image" src="https://github.com/user-attachments/assets/69de75a2-92a7-4bbf-9384-783b628fbf61" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
