### PR TITLE
fix: handle add and unlink file in bundleless mode

### DIFF
--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -216,6 +216,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           {
             "plugins": [
               EntryChunkPlugin {
+                "contextToWatch": null,
+                "contextWatched": false,
                 "enabledImportMetaUrlShim": false,
                 "reactDirectives": {},
                 "shebangChmod": 493,
@@ -449,6 +451,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           {
             "plugins": [
               EntryChunkPlugin {
+                "contextToWatch": null,
+                "contextWatched": false,
                 "enabledImportMetaUrlShim": true,
                 "reactDirectives": {},
                 "shebangChmod": 493,
@@ -668,6 +672,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           {
             "plugins": [
               EntryChunkPlugin {
+                "contextToWatch": null,
+                "contextWatched": false,
                 "enabledImportMetaUrlShim": false,
                 "reactDirectives": {},
                 "shebangChmod": 493,
@@ -822,6 +828,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           {
             "plugins": [
               EntryChunkPlugin {
+                "contextToWatch": null,
+                "contextWatched": false,
                 "enabledImportMetaUrlShim": false,
                 "reactDirectives": {},
                 "shebangChmod": 493,

--- a/tests/integration/cli/build-watch/build.test.ts
+++ b/tests/integration/cli/build-watch/build.test.ts
@@ -1,22 +1,19 @@
 import { exec } from 'node:child_process';
 import path from 'node:path';
 import fse from 'fs-extra';
-import { awaitFileExists } from 'test-helper';
-import { describe, test } from 'vitest';
+import { awaitFileChanges, awaitFileExists } from 'test-helper';
+import { describe, expect, test } from 'vitest';
 
 describe('build --watch command', async () => {
   test('basic', async () => {
     const distPath = path.join(__dirname, 'dist');
     const dist1Path = path.join(__dirname, 'dist-1');
     fse.removeSync(distPath);
-
     fse.removeSync(dist1Path);
-
     const distEsmIndexFile = path.join(__dirname, 'dist/esm/index.js');
     const dist1EsmIndexFile = path.join(__dirname, 'dist-1/esm/index.js');
 
     const tempConfigFile = path.join(__dirname, 'test-temp-rslib.config.mjs');
-
     fse.outputFileSync(
       tempConfigFile,
       `import { defineConfig } from '@rslib/core';
@@ -52,6 +49,71 @@ export default defineConfig({
     );
 
     await awaitFileExists(dist1EsmIndexFile);
+
+    process.kill();
+  });
+});
+
+describe('build --watch should handle add / change / unlink', async () => {
+  test('basic', async () => {
+    const tempSrcPath = path.join(__dirname, 'test-temp-src');
+    await fse.remove(tempSrcPath);
+    await fse.remove(path.join(__dirname, 'dist'));
+    await fse.copy(path.join(__dirname, 'src'), './test-temp-src');
+    const tempConfigFile = path.join(__dirname, 'test-temp-rslib.config.mjs');
+    await fse.remove(tempConfigFile);
+    fse.outputFileSync(
+      tempConfigFile,
+      `import { defineConfig } from '@rslib/core';
+      import { generateBundleEsmConfig } from 'test-helper';
+      
+      export default defineConfig({
+        lib: [
+          generateBundleEsmConfig({
+            source: {
+              entry: {
+                index: 'test-temp-src',
+              },
+            },
+            bundle: false,
+          }),
+        ],
+      });
+      `,
+    );
+
+    const srcIndexFile = path.join(tempSrcPath, 'index.js');
+    const srcFooFile = path.join(tempSrcPath, 'foo.js');
+    const distFooFile = path.join(__dirname, 'dist/esm/foo.js');
+
+    const process = exec(`npx rslib build --watch -c ${tempConfigFile}`, {
+      cwd: __dirname,
+    });
+
+    // add
+    fse.outputFileSync(srcFooFile, `export const foo = 'foo';`);
+    await awaitFileExists(distFooFile);
+    const content1 = await fse.readFile(distFooFile, 'utf-8');
+    expect(content1!).toMatchInlineSnapshot(`
+      "const foo = 'foo';
+      export { foo };
+      "
+    `);
+
+    // unlink
+    // Following "change" cases won't succeed if error is thrown in this step.
+    fse.removeSync(srcIndexFile);
+
+    // change
+    const wait = await awaitFileChanges(distFooFile);
+    fse.outputFileSync(srcFooFile, `export const foo = 'foo1';`);
+    await wait();
+    const content2 = await fse.readFile(distFooFile, 'utf-8');
+    expect(content2!).toMatchInlineSnapshot(`
+      "const foo = 'foo1';
+      export { foo };
+      "
+    `);
 
     process.kill();
   });

--- a/tests/integration/cli/build-watch/rslib.config.ts
+++ b/tests/integration/cli/build-watch/rslib.config.ts
@@ -1,13 +1,15 @@
 import { defineConfig } from '@rslib/core';
-import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+import { generateBundleEsmConfig } from 'test-helper';
 
 export default defineConfig({
   lib: [
     generateBundleEsmConfig({
-      dts: true,
-    }),
-    generateBundleCjsConfig({
-      dts: true,
+      source: {
+        entry: {
+          index: 'src',
+        },
+      },
+      bundle: false,
     }),
   ],
 });

--- a/tests/integration/cli/build-watch/src/index.ts
+++ b/tests/integration/cli/build-watch/src/index.ts
@@ -1,1 +1,1 @@
-export const foo = 'foo';
+export const index = 'index';

--- a/tests/integration/directive/index.test.ts
+++ b/tests/integration/directive/index.test.ts
@@ -93,24 +93,24 @@ describe('react', async () => {
 
   describe('bundle-false', async () => {
     test('React directive at the beginning', async () => {
-      const { content: foo } = queryContent(contents.esm0!, 'foo.js', {
+      const { content: foo } = queryContent(contents.esm!, 'foo.js', {
         basename: true,
       });
       expect(foo!.startsWith(`'use client';`)).toBe(true);
 
-      const { content: bar } = queryContent(contents.esm0!, 'bar.js', {
+      const { content: bar } = queryContent(contents.esm!, 'bar.js', {
         basename: true,
       });
       expect(bar!.startsWith(`'use server';`)).toBe(true);
     });
 
     test('React directive at the beginning even if minified', async () => {
-      const { content: foo } = queryContent(contents.esm1!, 'foo.js', {
+      const { content: foo } = queryContent(contents.cjs!, 'foo.cjs', {
         basename: true,
       });
       expect(foo!.startsWith(`'use client';`)).toBe(true);
 
-      const { content: bar } = queryContent(contents.esm1!, 'bar.js', {
+      const { content: bar } = queryContent(contents.cjs!, 'bar.cjs', {
         basename: true,
       });
       expect(bar!.startsWith(`'use server';`)).toBe(true);

--- a/tests/integration/directive/react/bundleless/rslib.config.ts
+++ b/tests/integration/directive/react/bundleless/rslib.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@rslib/core';
-import { generateBundleEsmConfig } from 'test-helper';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
 
 export default defineConfig({
   lib: [
@@ -7,16 +7,16 @@ export default defineConfig({
       bundle: false,
       output: {
         distPath: {
-          root: './dist/bundle/esm0',
+          root: './dist/esm',
         },
       },
     }),
-    generateBundleEsmConfig({
+    generateBundleCjsConfig({
       bundle: false,
       output: {
         minify: true,
         distPath: {
-          root: './dist/bundle/esm1',
+          root: './dist/cjs',
         },
       },
     }),


### PR DESCRIPTION
## Summary

Previously, the `entry` in bundleless mode is set during the initial build and does not change during the `rslib build --watch` phase. For example, a newly added file will not be monitored, while a file that was included initially will trigger an error (entry module not found) if it is deleted later.

In this PR, we use two combined functionality to resolve the issue:

1. Dynamic entry (https://rspack.dev/config/entry#dynamic-entry): a callback that will revoked when watch build is triggered every time that give us a chance to re-scan the entires.
2. `compilation.contextDependencies`: an extra directory to watch and trigger watch build (e.g. used in https://github.com/soda-x/extra-watch-webpack-plugin)

Limitation:

- `compilation.contextDependencies` will be resolved at the very beginning by LCP path, it won't be changed anymore.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
