### PR TITLE
feat: throw error when no configuration match `--lib` option

### DIFF
--- a/packages/core/src/cli/mf.ts
+++ b/packages/core/src/cli/mf.ts
@@ -31,7 +31,13 @@ async function initMFRsbuild(
     .map((env) => env.id);
 
   if (!selectedEnvironmentIds.length) {
-    throw new Error('No mf format found, please check your config.');
+    throw new Error(
+      `No mf format found in ${
+        options.lib
+          ? `libs ${options.lib.map((lib) => `"${lib}"`).join(', ')}`
+          : 'your config'
+      }, please check your config to ensure that the mf format is enabled correctly.`,
+    );
   }
 
   const selectedEnvironments = pruneEnvironments(

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1561,7 +1561,15 @@ export const pruneEnvironments = (
     return environments;
   }
 
-  return Object.fromEntries(
+  const filteredEnvironments = Object.fromEntries(
     Object.entries(environments).filter(([name]) => libs.includes(name)),
   );
+
+  if (Object.keys(filteredEnvironments).length === 0) {
+    throw new Error(
+      `The following libs are not found: ${libs.map((lib) => `"${lib}"`).join(', ')}.`,
+    );
+  }
+
+  return filteredEnvironments;
 };

--- a/tests/integration/cli/build/build.test.ts
+++ b/tests/integration/cli/build/build.test.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import fse from 'fs-extra';
-import { globContentJSON } from 'test-helper';
+import { buildAndGetResults, globContentJSON } from 'test-helper';
 import { describe, expect, test } from 'vitest';
 
 describe('build command', async () => {
@@ -50,6 +50,21 @@ describe('build command', async () => {
         "<ROOT>/tests/integration/cli/build/dist/esm/index.js",
       ]
     `);
+  });
+
+  test('--lib should throw error if not found', async () => {
+    await fse.remove(path.join(__dirname, 'dist'));
+    try {
+      await buildAndGetResults({
+        fixturePath: __dirname,
+        lib: ['not-exist'],
+      });
+    } catch (error) {
+      expect((error as Error).message).toMatchInlineSnapshot(
+        `"The following libs are not found: "not-exist"."`,
+      );
+    }
+    expect(fse.existsSync(path.join(__dirname, 'dist'))).toBe(false);
   });
 
   test('--config', async () => {

--- a/tests/integration/cli/mf/mf.test.ts
+++ b/tests/integration/cli/mf/mf.test.ts
@@ -1,6 +1,8 @@
 import { exec, execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { describe } from 'node:test';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
+import { startMFDevServer } from '@rslib/core';
 import fse, { existsSync } from 'fs-extra';
 import { awaitFileExists } from 'test-helper';
 import { expect, test } from 'vitest';
@@ -56,6 +58,44 @@ describe('mf-dev', () => {
     expect(existsSync(distPath2)).toBe(true);
 
     childProcess.kill();
+  });
+
+  test('mf-dev --lib should error when lib not found', async () => {
+    try {
+      await startMFDevServer(
+        {
+          lib: [
+            {
+              format: 'mf',
+              plugins: [pluginModuleFederation({ name: 'test-not-exist' })],
+            },
+          ],
+        },
+        {
+          lib: ['not-exist'],
+        },
+      );
+    } catch (error) {
+      expect((error as Error).message).toMatchInlineSnapshot(
+        `"No mf format found in libs "not-exist", please check your config to ensure that the mf format is enabled correctly."`,
+      );
+    }
+  });
+
+  test('mf-dev should error when no mf format', async () => {
+    try {
+      await startMFDevServer({
+        lib: [
+          {
+            format: 'esm',
+          },
+        ],
+      });
+    } catch (error) {
+      expect((error as Error).message).toMatchInlineSnapshot(
+        `"No mf format found in your config, please check your config to ensure that the mf format is enabled correctly."`,
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Throw error when
- No configuration match `--lib` option
- No `format: 'mf'` when `npx rslib mf-dev`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
