### PR TITLE
fix: user externals should have higher priority

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1391,7 +1391,7 @@ async function composeLibRsbuildConfig(
     // #region Externals configs
     // The order of the externals config should come in the following order:
     // 1. `externalsWarnConfig` should come before other externals config to touch the externalized modules first.
-    // 2. `userExternalsConfig` should present later to override the externals config of the ahead ones.
+    // 2. `userExternalsConfig` should present earlier to override the externals config of the ahead ones.
     // 3. The externals config in `bundlelessExternalConfig` should present after other externals config as
     //    it relies on other externals config to bail out the externalized modules first then resolve
     //    the correct path for relative imports.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1391,7 +1391,7 @@ async function composeLibRsbuildConfig(
     // #region Externals configs
     // The order of the externals config should come in the following order:
     // 1. `externalsWarnConfig` should come before other externals config to touch the externalized modules first.
-    // 2. `userExternalsConfig` should present earlier to override the externals config of the ahead ones.
+    // 2. `userExternalsConfig` should present at first to takes effect earlier than others.
     // 3. The externals config in `bundlelessExternalConfig` should present after other externals config as
     //    it relies on other externals config to bail out the externalized modules first then resolve
     //    the correct path for relative imports.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1391,14 +1391,14 @@ async function composeLibRsbuildConfig(
     // #region Externals configs
     // The order of the externals config should come in the following order:
     // 1. `externalsWarnConfig` should come before other externals config to touch the externalized modules first.
-    // 2. The externals config in `bundlelessExternalConfig` should present after other externals config as
+    // 2. `userExternalsConfig` should present later to override the externals config of the ahead ones.
+    // 3. The externals config in `bundlelessExternalConfig` should present after other externals config as
     //    it relies on other externals config to bail out the externalized modules first then resolve
     //    the correct path for relative imports.
-    // 3. `userExternalsConfig` should present later to override the externals config of the ahead ones.
     externalsWarnConfig,
+    userExternalsConfig,
     autoExternalConfig,
     targetExternalsConfig,
-    userExternalsConfig,
     bundlelessExternalConfig,
     // #endregion
     entryConfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,6 +694,16 @@ importers:
 
   tests/integration/externals/node: {}
 
+  tests/integration/externals/user-externals:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+    devDependencies:
+      '@types/lodash':
+        specifier: ^4.17.14
+        version: 4.17.14
+
   tests/integration/format: {}
 
   tests/integration/minify/config/disabled: {}

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -74,3 +74,20 @@ test('require ESM from CJS', async () => {
   const bazValue = await baz();
   expect(bazValue).toBe('baz');
 });
+
+test('user externals', async () => {
+  // Ensure the priority of user externals higher than others.
+  // - memfs: userExternalsConfig > targetExternalsConfig
+  // - lodash-es/zip: userExternalsConfig > autoExternalConfig
+  const fixturePath = join(__dirname, 'user-externals');
+  const { entries } = await buildAndGetResults({ fixturePath });
+  expect(entries.esm).toMatchInlineSnapshot(
+    `
+    "import * as __WEBPACK_EXTERNAL_MODULE_memfs__ from "memfs";
+    import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE_lodash_es_zip_b8981481__ from "lodash-es/zip";
+    console.log(__WEBPACK_EXTERNAL_MODULE_memfs__["default"], __WEBPACK_EXTERNAL_MODULE_lodash__["default"].add, __WEBPACK_EXTERNAL_MODULE_lodash_es_zip_b8981481__["default"]);
+    "
+  `,
+  );
+});

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import stripAnsi from 'strip-ansi';
-import { buildAndGetResults, proxyConsole } from 'test-helper';
+import { buildAndGetResults, proxyConsole, queryContent } from 'test-helper';
 import { expect, test } from 'vitest';
 import { composeModuleImportWarn } from '../../../packages/core/src/config';
 
@@ -77,17 +77,31 @@ test('require ESM from CJS', async () => {
 
 test('user externals', async () => {
   // Ensure the priority of user externals higher than others.
-  // - memfs: userExternalsConfig > targetExternalsConfig
-  // - lodash-es/zip: userExternalsConfig > autoExternalConfig
+  // - "memfs": userExternalsConfig > targetExternalsConfig
+  // - "lodash-es/zip": userExternalsConfig > autoExternalConfig
+  // - "./foo2": userExternalsConfig > bundlelessExternalConfig
+
   const fixturePath = join(__dirname, 'user-externals');
-  const { entries } = await buildAndGetResults({ fixturePath });
-  expect(entries.esm).toMatchInlineSnapshot(
+  const { entries, contents } = await buildAndGetResults({ fixturePath });
+  expect(entries.esm0).toMatchInlineSnapshot(
     `
-    "import * as __WEBPACK_EXTERNAL_MODULE_memfs__ from "memfs";
+    "import * as __WEBPACK_EXTERNAL_MODULE_node_fs_5ea92f0c__ from "node:fs";
     import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
-    import * as __WEBPACK_EXTERNAL_MODULE_lodash_es_zip_b8981481__ from "lodash-es/zip";
-    console.log(__WEBPACK_EXTERNAL_MODULE_memfs__["default"], __WEBPACK_EXTERNAL_MODULE_lodash__["default"].add, __WEBPACK_EXTERNAL_MODULE_lodash_es_zip_b8981481__["default"]);
+    import * as __WEBPACK_EXTERNAL_MODULE_lodash_zip_41bf8b9e__ from "lodash/zip";
+    const foo = 'foo';
+    console.log(__WEBPACK_EXTERNAL_MODULE_node_fs_5ea92f0c__["default"], __WEBPACK_EXTERNAL_MODULE_lodash__["default"].add, __WEBPACK_EXTERNAL_MODULE_lodash_zip_41bf8b9e__["default"], foo);
     "
   `,
   );
+
+  expect(
+    queryContent(contents.esm1!, 'index.js', { basename: true }).content,
+  ).toMatchInlineSnapshot(`
+    "import * as __WEBPACK_EXTERNAL_MODULE_node_fs_5ea92f0c__ from "node:fs";
+    import * as __WEBPACK_EXTERNAL_MODULE_lodash__ from "lodash";
+    import * as __WEBPACK_EXTERNAL_MODULE_lodash_zip_41bf8b9e__ from "lodash/zip";
+    import * as __WEBPACK_EXTERNAL_MODULE__foo2_1d132755__ from "./foo2";
+    console.log(__WEBPACK_EXTERNAL_MODULE_node_fs_5ea92f0c__["default"], __WEBPACK_EXTERNAL_MODULE_lodash__["default"].add, __WEBPACK_EXTERNAL_MODULE_lodash_zip_41bf8b9e__["default"], __WEBPACK_EXTERNAL_MODULE__foo2_1d132755__.foo);
+    "
+  `);
 });

--- a/tests/integration/externals/user-externals/package.json
+++ b/tests/integration/externals/user-externals/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "externals-user-externals-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.17.14"
+  }
+}

--- a/tests/integration/externals/user-externals/rslib.config.ts
+++ b/tests/integration/externals/user-externals/rslib.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig()],
+  output: {
+    externals: { 'lodash/zip': 'lodash-es/zip', 'node:fs': 'memfs' },
+  },
+});

--- a/tests/integration/externals/user-externals/rslib.config.ts
+++ b/tests/integration/externals/user-externals/rslib.config.ts
@@ -1,9 +1,28 @@
 import { defineConfig } from '@rslib/core';
 import { generateBundleEsmConfig } from 'test-helper';
 
+const baseExternals = {
+  externals: { 'lodash/zip': 'lodash-es/zip', 'node:fs': 'memfs' },
+};
+
 export default defineConfig({
-  lib: [generateBundleEsmConfig()],
-  output: {
-    externals: { 'lodash/zip': 'lodash-es/zip', 'node:fs': 'memfs' },
-  },
+  lib: [
+    generateBundleEsmConfig({
+      output: {
+        externals: baseExternals,
+        distPath: {
+          root: 'dist/bundle',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      bundle: false,
+      output: {
+        externals: { ...baseExternals, './foo': './foo2' },
+        distPath: {
+          root: 'dist/bundle-false',
+        },
+      },
+    }),
+  ],
 });

--- a/tests/integration/externals/user-externals/src/foo.js
+++ b/tests/integration/externals/user-externals/src/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/tests/integration/externals/user-externals/src/index.js
+++ b/tests/integration/externals/user-externals/src/index.js
@@ -1,0 +1,5 @@
+import fs from 'node:fs';
+import lodash from 'lodash';
+import zip from 'lodash/zip';
+
+console.log(fs, lodash.add, zip);

--- a/tests/integration/externals/user-externals/src/index.js
+++ b/tests/integration/externals/user-externals/src/index.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import lodash from 'lodash';
 import zip from 'lodash/zip';
+import { foo } from './foo';
 
-console.log(fs, lodash.add, zip);
+console.log(fs, lodash.add, zip, foo);


### PR DESCRIPTION
## Summary

Fix bug introduced in https://github.com/web-infra-dev/rslib/pull/535/files#diff-4114b8f08217be27efd35a3891857cfabc6eb75aee8ab39ba304e4d1b1095323R1317.

User's externals config should take higher priority to matched earlier than `autoExternalConfig` and others.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
