### PR TITLE
chore: remove manually d.ts excluding

### DIFF
--- a/examples/preact-component-bundle-false/rslib.config.ts
+++ b/examples/preact-component-bundle-false/rslib.config.ts
@@ -5,7 +5,7 @@ import { type LibConfig, defineConfig } from '@rslib/core';
 export default defineConfig({
   source: {
     entry: {
-      index: ['./src/**', '!./src/env.d.ts'],
+      index: ['./src/**'],
     },
   },
   lib: [

--- a/examples/react-component-bundle-false/rslib.config.ts
+++ b/examples/react-component-bundle-false/rslib.config.ts
@@ -5,7 +5,7 @@ import { type LibConfig, defineConfig } from '@rslib/core';
 export default defineConfig({
   source: {
     entry: {
-      index: ['./src/**', '!./src/env.d.ts'],
+      index: ['./src/**'],
     },
   },
   lib: [


### PR DESCRIPTION
## Summary

`*.d.ts` is excluded by default in bundleless mode.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
