### PR TITLE
docs: unify title capitalization style

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
-# Contributor Covenant Code of Conduct
+# Contributor covenant code of conduct
 
-## Our Pledge
+## Our pledge
 
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
@@ -12,7 +12,7 @@ and orientation.
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
 
-## Our Standards
+## Our standards
 
 Examples of behavior that contributes to a positive environment for our
 community include:
@@ -36,7 +36,7 @@ Examples of unacceptable behavior include:
 - Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-## Enforcement Responsibilities
+## Enforcement responsibilities
 
 Community leaders are responsible for clarifying and enforcing our standards of
 acceptable behavior and will take appropriate and fair corrective action in
@@ -65,7 +65,7 @@ All complaints will be reviewed and investigated promptly and fairly.
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
 
-## Enforcement Guidelines
+## Enforcement guidelines
 
 Community leaders will follow these Community Impact Guidelines in determining
 the consequences for any action they deem in violation of this Code of Conduct:
@@ -91,7 +91,7 @@ includes avoiding interactions in community spaces as well as external channels
 like social media. Violating these terms may lead to a temporary or
 permanent ban.
 
-### 3. Temporary Ban
+### 3. Temporary ban
 
 **Community Impact**: A serious violation of community standards, including
 sustained inappropriate behavior.
@@ -102,7 +102,7 @@ private interaction with the people involved, including unsolicited interaction
 with those enforcing the Code of Conduct, is allowed during this period.
 Violating these terms may lead to a permanent ban.
 
-### 4. Permanent Ban
+### 4. Permanent ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
 standards, including sustained inappropriate behavior, harassment of an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Rslib Contributing Guide
+# Rslib contributing guide
 
 Thanks for that you are interested in contributing to Rslib. Before starting your contribution, please take a moment to read the following guidelines.
 
@@ -14,7 +14,7 @@ fnm use
 nvm use
 ```
 
-## Install Dependencies
+## Install dependencies
 
 Enable [pnpm](https://pnpm.io/) with corepack:
 
@@ -34,11 +34,11 @@ What this will do:
 - Create symlinks between packages in the monorepo
 - Run the prepare script to build all packages, powered by [nx](https://nx.dev/).
 
-## Making Changes and Building
+## Making changes and building
 
 Once you have set up the local development environment in your forked repo, we can start development.
 
-### Checkout A New Branch
+### Checkout a new branch
 
 It is recommended to develop on a new branch, as it will make things easier later when you submit a pull request:
 
@@ -46,7 +46,7 @@ It is recommended to develop on a new branch, as it will make things easier late
 git checkout -b MY_BRANCH_NAME
 ```
 
-### Build the Package
+### Build the package
 
 Use [nx build](https://nx.dev/nx-api/nx/documents/run) to build the package you want to change:
 
@@ -68,13 +68,13 @@ npx nx build @rslib/core --watch
 
 ## Testing
 
-### Add New Tests
+### Add new tests
 
 If you've fixed a bug or added code that should be tested, then add some tests.
 
 You can add unit test cases in the `<PACKAGE_DIR>/tests` folder. The test runner is based on [Vitest](https://vitest.dev/).
 
-### Run Unit Tests
+### Run unit tests
 
 Before submitting a pull request, it's important to make sure that the changes haven't introduced any regressions or bugs. You can run the unit tests for the project by executing the following command:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Rslib has the following features:
 - **Declaration file generation**: Including isolated declarations.
 - **Advanced features**: Module Federation, asset compression, PostCSS, Lightning CSS, and more.
 
-## 📚 Getting Started
+## 📚 Getting started
 
 To get started with Rslib, see the [Quick Start](https://lib.rsbuild.dev/guide/start/quick-start).
 
@@ -109,7 +109,7 @@ Please read the [Contributing Guide](https://github.com/web-infra-dev/rslib/blob
   </table>
 </a>
 
-### Code of Conduct
+### Code of conduct
 
 This repo has adopted the ByteDance Open Source Code of Conduct. Please check [Code of Conduct](./CODE_OF_CONDUCT.md) for more details.
 

--- a/examples/module-federation/mf-remote/README.md
+++ b/examples/module-federation/mf-remote/README.md
@@ -7,7 +7,7 @@ A Module Federation remote module built with Rsbuild. It is consumed by [mf-reac
 
 Extra remote module is **optional**, it is used to demonstrate a complex Module Federation set up here.
 
-## Get Started
+## Get started
 
 Start the dev server:
 

--- a/packages/create-rslib/template-common/README.md
+++ b/packages/create-rslib/template-common/README.md
@@ -1,4 +1,4 @@
-# Rslib Project
+# Rslib project
 
 ## Setup
 
@@ -8,7 +8,7 @@ Install the dependencies:
 pnpm install
 ```
 
-## Get Started
+## Get started
 
 Build the library:
 

--- a/website/README.md
+++ b/website/README.md
@@ -6,6 +6,10 @@ This website is built with [Rspress](https://github.com/web-infra-dev/rspress), 
 
 Currently Rslib provides documentation in English and Chinese. If you can use Chinese, please update both documents at the same time. Otherwise, just update the English documentation.
 
+## Writing style guide
+
+The same as Rspack: [Writing style guide](https://github.com/web-infra-dev/rspack/tree/main/website#writing-style-guide).
+
 ### Image assets
 
 For images you use in the document, it's better to upload them to the [rspack-contrib/rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) repository, so the size of the current repository doesn't get too big.

--- a/website/README.md
+++ b/website/README.md
@@ -1,4 +1,4 @@
-# Rslib Website
+# Rslib website
 
 This website is built with [Rspress](https://github.com/web-infra-dev/rspress), the document content can be written using markdown or mdx syntax. You can refer to the [Rspress Website](https://rspress.dev/) for detailed usage.
 
@@ -6,7 +6,7 @@ This website is built with [Rspress](https://github.com/web-infra-dev/rspress), 
 
 Currently Rslib provides documentation in English and Chinese. If you can use Chinese, please update both documents at the same time. Otherwise, just update the English documentation.
 
-### Image Assets
+### Image assets
 
 For images you use in the document, it's better to upload them to the [rspack-contrib/rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) repository, so the size of the current repository doesn't get too big.
 

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -1,1 +1,1 @@
-# Rslib Core
+# Rslib core

--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -1,1 +1,1 @@
-# Rslib Types
+# Rslib types

--- a/website/docs/en/config/lib/auto-extension.mdx
+++ b/website/docs/en/config/lib/auto-extension.mdx
@@ -5,7 +5,7 @@
 
 Whether to automatically set the file extension based on the [`format`](/config/lib/format) option in the JavaScript output files.
 
-## Default Extension
+## Default extension
 
 By default that when `autoExtension` is set to `true`, the file extension will be:
 
@@ -15,7 +15,7 @@ By default that when `autoExtension` is set to `true`, the file extension will b
 
 When `autoExtension` is set to `false`, the file extension will be default to `.js`.
 
-## Customize Extension
+## Customize extension
 
 You can set `autoExtension` to `false` and use [output.filename](https://rsbuild.dev/config/output/filename) to customize the JavaScript output files.
 

--- a/website/docs/en/config/lib/auto-external.mdx
+++ b/website/docs/en/config/lib/auto-external.mdx
@@ -29,7 +29,7 @@ type AutoExternal =
 
 Whether to automatically externalize dependencies of different dependency types and do not bundle them.
 
-## Object Type
+## Object type
 
 ### autoExternal.dependencies
 
@@ -59,7 +59,7 @@ Whether to automatically externalize dependencies of type `peerDependencies`.
 
 Whether to automatically externalize dependencies of type `devDependencies`.
 
-## Default Value
+## Default value
 
 The default value of `autoExternal` is `true`, which means the following dependency types will **not be bundled**:
 
@@ -91,7 +91,7 @@ export default {
 
 ## Example
 
-### Customize Externalized Dependency Types
+### Customize externalized dependency types
 
 To disable the processing of a specific type of dependency, you can configure `autoExternal` as an object like this:
 
@@ -109,7 +109,7 @@ export default {
 };
 ```
 
-### Disable Default Behavior
+### Disable default behavior
 
 If you want to disable the default behavior, you can set `autoExternal` to `false`:
 

--- a/website/docs/en/config/lib/banner.mdx
+++ b/website/docs/en/config/lib/banner.mdx
@@ -18,7 +18,7 @@ type Banner = {
 
 Inject content into the top of each JavaScript, CSS or DTS output file.
 
-## Object Type
+## Object type
 
 ### banner.js
 
@@ -48,7 +48,7 @@ The banner content in JavaScript and CSS file is based on the [BannerPlugin](htt
 - `raw: true` is enabled by default, so the banner content will be injected as a raw string instead of wrapping in a comment. So if you want to inject a comment, you should add `/*` and `*/` or other comment syntax by yourself.
 - The `stage` option is set to the stage after the JavaScript and CSS files are optimized, thus preventing the banner content from being optimized away.
 
-## Customize Banner Content
+## Customize banner content
 
 If the above default settings cannot meet your requirements, you can customize the banner content through `tools.rspack.plugins` to add a [BannerPlugin](https://rspack.dev/plugins/webpack/banner-plugin) instance with the corresponding options.
 

--- a/website/docs/en/config/lib/bundle.mdx
+++ b/website/docs/en/config/lib/bundle.mdx
@@ -13,7 +13,7 @@ The bundleless mode is not fully supported yet, and some features like [assets](
 
 :::
 
-## Set Entry
+## Set entry
 
 We should specify the entry file for the build.
 

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -22,7 +22,7 @@ type Dts =
 
 Configure the generation of the TypeScript declaration files.
 
-## Boolean Type
+## Boolean type
 
 DTS generation is an optional feature, you can set `dts: true` to enable [bundleless DTS](/guide/advanced/dts#bundleless-dts) generation.
 
@@ -50,7 +50,7 @@ export default {
 };
 ```
 
-## Object Type
+## Object type
 
 If you want to customize the DTS generation, you can set the `dts` option to an object.
 
@@ -92,7 +92,7 @@ export default {
 
 :::
 
-#### Handle Third-Party Packages
+#### Handle third-party packages
 
 When we bundle DTS files, we should specify which third-party package types need to be bundled, refer to the [Handle Third-Party Dependencies](/guide/advanced/third-party-deps) documentation for more details about externals related configurations.
 
@@ -102,7 +102,7 @@ When we bundle DTS files, we should specify which third-party package types need
 
 The output directory of DTS files.
 
-#### Default Value
+#### Default value
 
 The default value follows the priority below:
 
@@ -175,7 +175,7 @@ When this configuration is disabled, there is no guarantee that the type files w
 
 Whether to automatically set the DTS file extension based on the [format](/config/lib/format) option.
 
-#### Default Extension
+#### Default extension
 
 By default that when `dts.autoExtension` is `false`, the DTS file extension will be `.d.ts`.
 

--- a/website/docs/en/config/lib/footer.mdx
+++ b/website/docs/en/config/lib/footer.mdx
@@ -18,7 +18,7 @@ type Footer = {
 
 Inject content into the bottom of each JavaScript, CSS or DTS file.
 
-## Object Type
+## Object type
 
 ### footer.js
 
@@ -48,7 +48,7 @@ The footer content in JavaScript and CSS file is based on the [BannerPlugin](htt
 - `raw: true` is enabled by default, so the footer content will be injected as a raw string instead of wrapping in a comment. So if you want to inject a comment, you should add `/*` and `*/` or other comment syntax by yourself.
 - The `stage` option is set to the stage after the JavaScript and CSS files are optimized, thus preventing the footer content from being optimized away.
 
-## Customize Footer Content
+## Customize footer content
 
 If the above default settings cannot meet your requirements, you can customize the footer content through `tools.rspack.plugins` to add a [BannerPlugin](https://rspack.dev/plugins/webpack/banner-plugin) instance with the corresponding options.
 

--- a/website/docs/en/config/lib/id.mdx
+++ b/website/docs/en/config/lib/id.mdx
@@ -11,7 +11,7 @@ Rslib uses Rsbuild's [environments](https://rsbuild.dev/guide/advanced/environme
 
 :::
 
-## Default Value
+## Default value
 
 By default, Rslib automatically generates an ID for each library in the format `${format}${index}`. Here, `format` refers to the value specified in the current lib's [format](/config/lib/format), and `index` indicates the order of the library within all libraries of the same format. If there is only one library with the current format, the `index` will be empty. Otherwise, it will start from `0` and increment.
 

--- a/website/docs/en/config/lib/index.mdx
+++ b/website/docs/en/config/lib/index.mdx
@@ -1,4 +1,4 @@
-# Lib Configurations
+# Lib configurations
 
 - **Type:**
 

--- a/website/docs/en/config/lib/syntax.mdx
+++ b/website/docs/en/config/lib/syntax.mdx
@@ -27,7 +27,7 @@ Configure the syntax to which JavaScript and CSS will be downgraded.
 
 See [Output Compatibility - Syntax Downgrade](/guide/advanced/output-compatibility) for more details.
 
-## Set ECMAScript Version
+## Set ECMAScript version
 
 You can set the ECMAScript version directly, such as `es2015`, `es2022`, etc.
 
@@ -41,7 +41,7 @@ export default {
 };
 ```
 
-## Set Browserslist Query
+## Set browserslist query
 
 You can also set the [Browserslist query](https://browsersl.ist/), such as `last 2 versions`, `> 1%`, `node >= 16`, `chrome >= 80`, etc.
 
@@ -55,7 +55,7 @@ export default {
 };
 ```
 
-## Mix ECMAScript Version and Browserslist Query
+## Mix ECMAScript version and browserslist query
 
 You can also mix ECMAScript version and Browserslist query, such as `es2015` and `node 20`. Rslib will turn ECMAScript Version into Browserslist query, and then merge them together.
 

--- a/website/docs/en/config/rsbuild/index.mdx
+++ b/website/docs/en/config/rsbuild/index.mdx
@@ -1,7 +1,7 @@
 import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
 import { Overview } from 'rspress/theme';
 
-# Rsbuild Configurations
+# Rsbuild configurations
 
 Rslib inherits its configuration from Rsbuild, so you can also configure the <RsbuildDocBadge path="/config" text="config" /> options from Rsbuild. This chapter introduces some common configuration items and explains how to use them in Rslib.
 

--- a/website/docs/en/config/rsbuild/plugins.mdx
+++ b/website/docs/en/config/rsbuild/plugins.mdx
@@ -10,7 +10,7 @@ Rslib and Rsbuild share the same plugin system, so you can use Rsbuild plugins i
 Currently, some plugins have not been adapted to the [bundleless](/guide/basic/output-structure#bundle--bundleless) mode of Rslib, such as the Vue plugin and Svelte plugin. Therefore, these plugins can only be used in the bundle mode.
 :::
 
-## Using Plugins
+## Using plugins
 
 You can register Rsbuild plugins in `rslib.config.*` using the `plugins` option, see [Rsbuild - plugins](https://rsbuild.dev/config/plugins).
 
@@ -23,7 +23,7 @@ export default defineConfig({
 });
 ```
 
-## Official Plugins
+## Official plugins
 
 The following are official plugins that can be used in Rsbuild, and applicable to Rslib.
 
@@ -90,7 +90,7 @@ The following are common framework-agnostic plugins:
 You can find the source code of all official plugins in [web-infra-dev/rsbuild](https://github.com/web-infra-dev/rsbuild) and [rspack-contrib](https://github.com/rspack-contrib).
 :::
 
-## Community Plugins
+## Community plugins
 
 You can check out the Rsbuild plugins provided by the community at [awesome-rspack - Rsbuild Plugins](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rsbuild-plugins).
 

--- a/website/docs/en/guide/advanced/dts.mdx
+++ b/website/docs/en/guide/advanced/dts.mdx
@@ -12,7 +12,7 @@ TypeScript Declaration Files (DTS) provide type information for JavaScript code.
 4. **IDE Support**: Improve the developer experience in IDEs like Visual Studio Code, WebStorm, and others.
 5. **Library Consumption**: Make it easier for users to use and understand your library.
 
-## What are Bundle DTS and Bundleless DTS
+## What are bundle DTS and bundleless DTS
 
 ### Bundle DTS
 
@@ -40,7 +40,7 @@ Bundleless DTS involves generating a separate declaration file for each module i
   - **Multiple Files**: Users may need to handle multiple declaration files when using the library.
   - **Complex Management**: May require additional configuration to correctly reference all files.
 
-## How to Generate DTS in Rslib
+## How to generate DTS in Rslib
 
 Rslib defaults to generating bundleless DTS, which using [TypeScript Compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API) and bundle DTS is also supported by [API Extractor](https://api-extractor.com/).
 

--- a/website/docs/en/guide/advanced/module-doc.mdx
+++ b/website/docs/en/guide/advanced/module-doc.mdx
@@ -1,1 +1,1 @@
-# Module Doc
+# Module doc

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -20,7 +20,7 @@ Module Federation can help you:
 - Reduce the overall size of the application
 - Improve application performance
 
-## Quick Start
+## Quick start
 
 First install the [Module Federation Rsbuild Plugin](https://www.npmjs.com/package/@module-federation/rsbuild-plugin).
 
@@ -90,7 +90,7 @@ However, if you want this Rslib Module to consume other producers at the same ti
 
 ## Develop MF remote module
 
-### Use Host App
+### Use host app
 
 Rslib support developing Module Federation Rslib project with a host application.
 
@@ -112,7 +112,7 @@ with Hot Module Replacement (HMR).
 
 <PackageManagerTabs command="run dev" />
 
-#### 2. Start Host App
+#### 2. Start host app
 
 Set up the host app to consume the Rslib Module Federation library. Check out the [@module-federation/rsbuild-plugin
 ](https://www.npmjs.com/package/@module-federation/rsbuild-plugin) for more information.

--- a/website/docs/en/guide/advanced/output-compatibility.mdx
+++ b/website/docs/en/guide/advanced/output-compatibility.mdx
@@ -1,11 +1,11 @@
 import { Steps, SourceCode } from '@theme';
 import { PackageManagerTabs } from '@theme';
 
-# Output Compatibility
+# Output compatibility
 
 This chapter introduces how to specify which target environment should be supported.
 
-## Syntax Downgrade
+## Syntax downgrade
 
 By setting [lib.syntax](/config/lib/syntax), you can choose the syntax to which JavaScript and CSS will be downgraded. You can use the query syntax from [Browserslist](https://browsersl.ist/). Rslib also supports common ECMAScript version numbers, such as `ES2015`.
 

--- a/website/docs/en/guide/advanced/storybook.mdx
+++ b/website/docs/en/guide/advanced/storybook.mdx
@@ -11,7 +11,7 @@ import { Tab, Tabs } from 'rspress/theme';
 You can create a new project with Storybook by using [create-rslib](/guide/start/quick-start#creating-an-rslib-project).
 :::
 
-## Getting Started
+## Getting started
 
 ### Setup a Rslib project
 

--- a/website/docs/en/guide/advanced/third-party-deps.mdx
+++ b/website/docs/en/guide/advanced/third-party-deps.mdx
@@ -1,4 +1,4 @@
-# Handle Third-Party Dependencies
+# Handle third-party dependencies
 
 This section introduces how to handle third-party dependencies in bundle mode.
 

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -45,7 +45,7 @@ Options:
   -h, --help            display help for command
 ```
 
-### Watch Mode
+### Watch mode
 
 You can use `rslib build --watch` or `rslib build -w` to enable watch mode for watching for changes and rebuild.
 
@@ -53,7 +53,7 @@ You can use `rslib build --watch` or `rslib build -w` to enable watch mode for w
 npx rslib build -w
 ```
 
-### Environment Variables
+### Environment variables
 
 Rslib supports injecting env variables or expressions into the code during build, which is helpful for distinguishing the running environment or replacing constants.
 
@@ -66,7 +66,7 @@ You can see more details in [Rsbuild - Environment Variables](https://rsbuild.de
 
 :::
 
-#### Env Mode
+#### Env mode
 
 Rslib supports reading `.env.[mode]` and `.env.[mode].local` files. You can specify the env mode using the `--env-mode <mode>` flag.
 
@@ -91,7 +91,7 @@ It is recommended to use `--env-mode` to set the env mode, and not to modify `pr
 
 :::
 
-#### Env Directory
+#### Env directory
 
 By default, the `.env` file is located in the root directory of the project. You can specify the env directory by using the `--env-dir <dir>` option in the CLI.
 
@@ -169,7 +169,7 @@ Inspect config succeed, open following files to view the content:
   - Rspack Config (esm): /project/dist/.rsbuild/rspack.config.esm.mjs
 ```
 
-### Verbose Content
+### Verbose content
 
 By default, the inspect command omits the content of functions in the configuration object. You can add the `--verbose` option to output the complete content of functions:
 
@@ -177,7 +177,7 @@ By default, the inspect command omits the content of functions in the configurat
 rslib inspect --verbose
 ```
 
-### Multiple Output Formats
+### Multiple output formats
 
 If the current project has multiple output formats, such as ESM artifact and CJS artifact simultaneously, multiple Rspack configuration files will be generated in the `dist/.rsbuild` directory.
 
@@ -212,9 +212,9 @@ Options:
   -h, --help            display help for command
 ```
 
-## Common Options
+## Common options
 
-### Filter Libraries
+### Filter libraries
 
 Rslib provides the `--lib` option to run command for specified libraries.
 

--- a/website/docs/en/guide/basic/configure-rslib.mdx
+++ b/website/docs/en/guide/basic/configure-rslib.mdx
@@ -2,7 +2,7 @@
 
 Rslib's configuration is based on Rsbuild, which means that you can use all of Rsbuild configurations, as well as the `lib` configuration specific to Rslib.
 
-## Configuration Structure
+## Configuration structure
 
 Rslib provides the `lib` option to configure the library outputs. It is an array, and each object is used to describe a format of the output.
 
@@ -17,7 +17,7 @@ export default {
 };
 ```
 
-### Common Rsbuild Configurations
+### Common Rsbuild configurations
 
 You can set common Rsbuild configurations outside the `lib` field, which will be inherited by each configuration object inside the `lib` field.
 
@@ -35,7 +35,7 @@ export default {
 };
 ```
 
-### Separate Rsbuild Configurations
+### Separate Rsbuild configurations
 
 In the `lib` field, you can set separate Rsbuild configurations for each output format, which will override the common Rsbuild configurations outside the `lib` field.
 
@@ -66,7 +66,7 @@ Rslib will generate the [environments](https://rsbuild.dev/config/environments) 
 
 You can also refer to the [Configuration Overview](/config/) page to view the detailed introduction of all configurations.
 
-## Configuration File
+## Configuration file
 
 When you use the CLI of Rslib, Rslib will automatically read the configuration file in the root directory of the current project and resolve it in the following order:
 
@@ -105,7 +105,7 @@ When you use the `.ts`, `.mts`, and `.cts` extensions, Rslib will use [jiti](htt
 
 :::
 
-## Specify Config File
+## Specify config file
 
 Rslib CLI uses the `--config` option to specify the config file, which can be set to a relative path or an absolute path.
 
@@ -125,7 +125,7 @@ You can also abbreviate the `--config` option to `-c`:
 rslib build -c rslib.prod.config.mjs
 ```
 
-## Using Environment Variables
+## Using environment variables
 
 In the configuration file, you can use Node.js environment variables such as `process.env.NODE_ENV` to dynamically set different configurations:
 
@@ -162,7 +162,7 @@ Rslib is built on top of Rsbuild and Rsbuild supports directly modifying the Rsp
 
 For more details, refer to [Configure Rspack](https://rsbuild.dev/guide/basic/configure-rspack).
 
-## Configuration Debug
+## Configuration debug
 
 You can enable Rslib's debug mode by adding the `DEBUG=rsbuild` environment variable when executing a build. It will display the final Rsbuild/Rspack configuration after processing by Rslib.
 

--- a/website/docs/en/guide/basic/output-format.mdx
+++ b/website/docs/en/guide/basic/output-format.mdx
@@ -3,7 +3,7 @@ import CJS from '../start/components/CJS.mdx';
 import UMD from '../start/components/UMD.mdx';
 import MF from '../start/components/MF.mdx';
 
-# Output Format
+# Output format
 
 There are four supported output formats for the generated JavaScript files in Rslib: `esm`, `cjs`, `umd`, and `mf`. In this chapter, we will introduce the differences between these formats and how to choose the right one for your library.
 

--- a/website/docs/en/guide/basic/output-structure.mdx
+++ b/website/docs/en/guide/basic/output-structure.mdx
@@ -1,4 +1,4 @@
-# Output Structure
+# Output structure
 
 ## bundle / bundleless
 

--- a/website/docs/en/guide/basic/typescript.mdx
+++ b/website/docs/en/guide/basic/typescript.mdx
@@ -1,8 +1,8 @@
-# Use Typescript
+# Use TypeScript
 
 Rslib supports TypeScript by default, allowing you to directly use `.ts` and `.tsx` files in your projects.
 
-## TypeScript Transpilation
+## TypeScript transpilation
 
 Rslib uses SWC by default for transpiling TypeScript code, and it also supports switching to Babel for transpilation.
 
@@ -30,7 +30,7 @@ export type { SomeType } from './types';
 
 > See [SWC - Migrating from tsc](https://swc.rs/docs/migrating-from-tsc) for more details about the differences between SWC and tsc.
 
-## tsconfig.json Path
+## tsconfig.json path
 
 Rslib by default reads the `tsconfig.json` file from the root directory. You can use [source.tsconfigPath](/config/rsbuild/source#sourcetsconfigpath) to configure a custom `tsconfig.json` file path.
 

--- a/website/docs/en/guide/basic/upgrade-rslib.mdx
+++ b/website/docs/en/guide/basic/upgrade-rslib.mdx
@@ -11,7 +11,7 @@ Rslib is still in 0.x version stage, and the API may change frequently. We recom
 
 :::
 
-## Using Taze
+## Using taze
 
 We recommend using [Taze](https://github.com/antfu-collective/taze) to upgrade the Rslib version. Taze is a CLI tool for updating npm dependencies.
 

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -1,6 +1,6 @@
 # Features FAQ
 
-## Style Processing
+## Style processing
 
 ### How to skip the preprocessing of Less / Sass files in bundleless mode?
 
@@ -35,7 +35,7 @@ export default defineConfig({
 });
 ```
 
-## Code Minification
+## Code minification
 
 ### How to preserve all comments in the output files?
 

--- a/website/docs/en/guide/migration/modernjs-module.mdx
+++ b/website/docs/en/guide/migration/modernjs-module.mdx
@@ -87,7 +87,7 @@ export default defineConfig({
 });
 ```
 
-## TypeScript Declaration
+## TypeScript declaration
 
 If you use Typescript in your `Modern.js Module` and need to generate declaration files, add the following changes:
 
@@ -179,7 +179,7 @@ export default defineConfig({
 });
 ```
 
-## Contents Supplement
+## Contents supplement
 
 This migration doc is contributed by community user [YanPes](https://github.com/YanPes). Much appreciation for his contribution!
 

--- a/website/docs/en/guide/migration/tsup.mdx
+++ b/website/docs/en/guide/migration/tsup.mdx
@@ -2,7 +2,7 @@
 
 This section introduces how to migrate a project using tsup to Rslib.
 
-## Installing Dependencies
+## Installing dependencies
 
 First, you need to replace the npm dependencies of tsup with Rslib's dependencies.
 
@@ -16,7 +16,7 @@ import { PackageManagerTabs } from '@theme';
 
 <PackageManagerTabs command="add @rslib/core -D" />
 
-## Updating npm Scripts
+## Updating npm scripts
 
 Next, you need to update the npm scripts in your package.json to use Rslib's CLI commands.
 
@@ -31,7 +31,7 @@ Next, you need to update the npm scripts in your package.json to use Rslib's CLI
 }
 ```
 
-## Create Configuration File
+## Create configuration file
 
 Create a Rslib configuration file `rslib.config.ts` in the same directory as `package.json`, and add the following content:
 
@@ -41,7 +41,7 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({});
 ```
 
-## Configuration Migration
+## Configuration migration
 
 Here is the corresponding Rslib configuration for tsup configuration:
 
@@ -64,7 +64,7 @@ Here is the corresponding Rslib configuration for tsup configuration:
 | terserOptions | [output.minify](/config/rsbuild/output#outputminify)                                                       |
 | tsconfig      | [source.tsconfigPath](/config/rsbuild/source#sourcetsconfigpath)                                           |
 
-## Contents Supplement
+## Contents supplement
 
 The current document only covers part of the migration process. If you find suitable content to add, feel free to contribute to the documentation via pull request 🤝.
 

--- a/website/docs/en/guide/solution/index.mdx
+++ b/website/docs/en/guide/solution/index.mdx
@@ -2,7 +2,7 @@
 
 In this chapter, we will introduce how to use Rslib to development libraries for browser and Node.js. We will also cover how to create libraries for different UI frameworks.
 
-## Browser Target
+## Browser target
 
 When developing a library that runs in the browser, you can package it in both [ESM](/guide/basic/output-format#esm--cjs) and [CJS](/guide/basic/output-format#esm--cjs) formats for integration with application bundlers. Configuring the package [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) to ESM output allows for better tree shaking. Additionally, you can create [UMD](/guide/basic/output-format#umd) format output for direct browser use and even generate [Module Federation ](/guide/advanced/module-federation) formats for dynamic loading by other applications. Configure [Browserslist](https://rsbuild.dev/guide/advanced/browserslist) according to the target browser support to determine the downgrade syntax of the output, or adding [polyfill](/guide/advanced/output-compatibility) for API compatibility.
 
@@ -15,7 +15,7 @@ Refer to the solutions in this chapter to learn how to use Rslib to develop brow
 {/* TODO: Clarify default behavior */}
 {/* ### Default Behavior */}
 
-## Node.js Target
+## Node.js target
 
 Rslib set [target](/config/rsbuild/output#outputtarget) to `"node"` by default to development libraries for Node.js.
 

--- a/website/docs/en/guide/solution/nodejs.mdx
+++ b/website/docs/en/guide/solution/nodejs.mdx
@@ -2,7 +2,7 @@
 
 In this document, you will learn how to build a Node.js library using Rslib.
 
-## Create Node.js Project
+## Create Node.js project
 
 You can use `create-rslib` to create a project with Rslib + Node.js. Just execute the following command:
 

--- a/website/docs/en/guide/solution/react.mdx
+++ b/website/docs/en/guide/solution/react.mdx
@@ -2,7 +2,7 @@
 
 In this document, you will learn how to build a React component library with Rslib.
 
-## Create React Project
+## Create React project
 
 You can use `create-rslib` to create a project with Rslib + React. Just execute the following command:
 
@@ -19,7 +19,7 @@ import { PackageManagerTabs } from '@theme';
 
 Then select `React` when prompted to "Select template".
 
-## Use Rslib in an Existing Project
+## Use Rslib in an existing project
 
 To develop a React library, you need to set the [target](/config/rsbuild/output#outputtarget) to `"web"` in `rslib.config.ts`. This is crucial because Rslib sets the `target` to `"node"` by default, which differs from the default target of Rsbuild.
 
@@ -42,7 +42,7 @@ export default defineConfig({
 });
 ```
 
-## JSX Transform
+## JSX transform
 
 - **Type**: `'automatic' | 'classic'`
 - **Default**: `'automatic'`
@@ -74,7 +74,7 @@ export default defineConfig({
 });
 ```
 
-## JSX Import Source
+## JSX import source
 
 - **Type**: `string`
 - **Default**: `'react'`
@@ -107,7 +107,7 @@ export default defineConfig({
 {/* TODO */}
 {/* ## SVGR */}
 
-## Further Reading
+## Further reading
 
 - [Rsbuild React Plugin](https://rsbuild.dev/plugins/list/plugin-react#swcreactoptionsruntime)
 - [SWC Compilation - jsc.transform.react](https://swc.rs/docs/configuration/compilation#jsctransformreact)

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -1,6 +1,6 @@
-# Quick Start
+# Quick start
 
-## Setup Environment
+## Setup environment
 
 Before getting started, you will need to install [Node.js](https://nodejs.org/) >= version 16, it is recommended to use the Node.js LTS version.
 
@@ -21,7 +21,7 @@ nvm install --lts
 nvm use --lts
 ```
 
-## Creating an Rslib Project
+## Creating an Rslib project
 
 You can use the [`create-rslib`](https://www.npmjs.com/package/create-rslib) to create a new Rslib project. Run the following command:
 
@@ -54,7 +54,7 @@ Each template supports both JavaScript and TypeScript, along with optional devel
 We're working to provide templates for more frameworks (such as Vue).
 :::
 
-### Development Tools
+### Development tools
 
 `create-rslib` can help you set up some commonly used development tools, including [Vitest](https://vitest.dev/), [Storybook](https://storybook.js.org/). You can use the arrow keys and the space bar to make your selections. If you don't need these tools, you can simply press Enter to skip.
 
@@ -68,7 +68,7 @@ We're working to provide templates for more frameworks (such as Vue).
 └
 ```
 
-### Optional Tools
+### Optional tools
 
 `create-rslib` can help you set up some commonly used linter and formatter tools, including [Biome](https://biomejs.dev/), [ESLint](https://eslint.org/), and [prettier](https://prettier.io/). You can use the arrow keys and the space bar to make your selections. If you don't need these tools, you can simply press Enter to skip.
 
@@ -84,7 +84,7 @@ We're working to provide templates for more frameworks (such as Vue).
 Biome provides similar linting and formatting features to ESLint and Prettier. If you select Biome, you typically won't need to choose ESLint or Prettier as well.
 :::
 
-### Current Directory
+### Current directory
 
 If you need to create a project in the current directory, you can set the target folder to `.`:
 
@@ -98,7 +98,7 @@ If you need to create a project in the current directory, you can set the target
 │  Continue and override files
 ```
 
-### Quick Creation
+### Quick creation
 
 [create-rslib](https://www.npmjs.com/package/create-rslib) provides some CLI flags. By setting these CLI flags, you can skip the interactive selection steps and create the project with one command.
 
@@ -125,14 +125,14 @@ Options:
   --override       override files in target directory
 ```
 
-## Migrate from Existing Projects
+## Migrate from existing projects
 
 If you need to migrate from an existing project to Rslib, you can refer to the following guides:
 
 - [Migrating from tsup](/guide/migration/tsup)
 - [Migrating from Modern.js Module](/guide/migration/modernjs-module)
 
-### Other Projects
+### Other projects
 
 For other types of projects, you can manually install the [@rslib/core](https://www.npmjs.com/package/@rslib/core) package:
 

--- a/website/docs/zh/config/lib/syntax.mdx
+++ b/website/docs/zh/config/lib/syntax.mdx
@@ -55,7 +55,7 @@ export default {
 };
 ```
 
-## 混合使用 ECMAScript 版本和 Browserslist 查询
+## 混合使用 ECMAScript 版本和 browserslist 查询
 
 你也可以混合使用 ECMAScript 版本和 Browserslist 查询语句，例如 `es2015` 和 `node 20`。Rslib 会将 ECMAScript 版本转换为 Browserslist 查询语句，然后将它们合并在一起。
 

--- a/website/docs/zh/guide/advanced/dts.mdx
+++ b/website/docs/zh/guide/advanced/dts.mdx
@@ -12,7 +12,7 @@ TypeScript 声明文件 (DTS) 提供 JavaScript 代码的类型信息。 DTS 文
 4. **IDE 支持**: 改善 Visual Studio Code、WebStorm 等 IDE 中的开发者体验。
 5. **库消费**: 让其他使用者更容易使用和理解该库。
 
-## 什么是 Bundle DTS 和 Bundleless DTS
+## 什么是 bundle DTS 和 bundleless DTS
 
 ### Bundle DTS
 

--- a/website/docs/zh/guide/solution/index.mdx
+++ b/website/docs/zh/guide/solution/index.mdx
@@ -2,7 +2,7 @@
 
 在本章中，将介绍如何使用 Rslib 开发浏览器和 Node.js 的库。我们还将介绍如何为不同的 UI 框架创建库。
 
-## Browser Target
+## Browser target
 
 开发在浏览器中运行的库时，可以将其打包为 [ESM](/guide/basic/output-format#esm--cjs) 和 [CJS](/guide/basic/output-format#esm--cjs) 格式，用于与 app 的 bundler 集成。将包 [conditional-exports](https://nodejs.org/api/packages.html#conditional-exports) 配置为 ESM 输出可以更好地进行 treeshaking。此外，你可以创建 [UMD](/guide/basic/output-format#umd) 格式输出以供浏览器直接使用，甚至可以生成 [模块联邦](/guide/advanced/module-federation) 格式以供其他应用程序动态加载。根据目标浏览器支持配置 [Browserslist](https://rsbuild.dev/zh/guide/advanced/browserslist)以确定输出的降级语法，或添加 [polyfill](/guide/advanced/output-compatibility) 用于兼容 API。
 
@@ -15,7 +15,7 @@
 {/* TODO: Clarify default behavior */}
 {/* ### Default Behavior */}
 
-## Node.js Target
+## Node.js target
 
 Rslib 默认将 [target](/config/rsbuild/output#outputtarget) 设置为 `"node"`，以方便开发 Node.js 中使用的库。
 

--- a/website/docs/zh/guide/solution/react.mdx
+++ b/website/docs/zh/guide/solution/react.mdx
@@ -42,7 +42,7 @@ export default defineConfig({
 });
 ```
 
-## JSX Transform
+## JSX transform
 
 - **类型**: `'automatic' | 'classic'`
 - **默认值**: `'automatic'`
@@ -74,7 +74,7 @@ export default defineConfig({
 });
 ```
 
-## JSX Import Source
+## JSX import source
 
 - **类型**: `string`
 - **默认值**: `'react'`


### PR DESCRIPTION
## Summary

See https://github.com/web-infra-dev/rspack/pull/8973 for background.

The documents are formatted with the [heading-case](https://github.com/rspack-contrib/heading-case) tool . This tool can be integrated to our CI when it becomes more stable.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
