### PR TITLE
chore: remove unused `@rslib/core` to avoid nx cache error

### DIFF
--- a/examples/preact-component-bundle-false/rslib.config.ts
+++ b/examples/preact-component-bundle-false/rslib.config.ts
@@ -1,6 +1,6 @@
 import { pluginPreact } from '@rsbuild/plugin-preact';
 import { pluginSass } from '@rsbuild/plugin-sass';
-import { type LibConfig, defineConfig } from '@rslib/core';
+import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   source: {

--- a/examples/react-component-bundle-false/rslib.config.ts
+++ b/examples/react-component-bundle-false/rslib.config.ts
@@ -1,6 +1,6 @@
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSass } from '@rsbuild/plugin-sass';
-import { type LibConfig, defineConfig } from '@rslib/core';
+import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   source: {

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -32,7 +32,6 @@
     "create-rstack": "1.1.0"
   },
   "devDependencies": {
-    "@rslib/core": "workspace:*",
     "@rslib/tsconfig": "workspace:*",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,9 +320,6 @@ importers:
         specifier: 1.1.0
         version: 1.1.0
     devDependencies:
-      '@rslib/core':
-        specifier: workspace:*
-        version: link:../core
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig


### PR DESCRIPTION
## Summary

ts error in fragments of template is acceptable

![image](https://github.com/user-attachments/assets/1d965a3d-7346-49d2-91c8-d02446fc12c6)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
