### PR TITLE
feat: clear console before ready log

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -10,6 +10,7 @@ import {
   defineConfig as defineRsbuildConfig,
   loadConfig as loadRsbuildConfig,
   mergeRsbuildConfig,
+  logger as rsbuildLogger,
   rspack,
 } from '@rsbuild/core';
 import { glob } from 'tinyglobby';
@@ -80,6 +81,15 @@ import {
   transformSyntaxToRspackTarget,
 } from './utils/syntax';
 import { loadTsconfig } from './utils/tsconfig';
+
+rsbuildLogger.override({
+  start: (message) => {
+    // Soft clear, copied from https://github.com/lukeed/console-clear/blob/master/index.js.
+    // "start" callback will only be called on watch mode (first compile not included).
+    process.stdout.write('\x1B[H\x1B[2J');
+    logger.start(message);
+  },
+});
 
 /**
  * This function helps you to autocomplete configuration types.


### PR DESCRIPTION
## Summary

Previously, Rslib's logs have continuously accumulated results from previous builds, which can make it challenging to observe the outcomes of the most recent builds, particularly when there were errors in earlier builds.

In this PR, soft clear on watch mode.

Before:

https://github.com/user-attachments/assets/2c4dbddf-315f-419f-b7b5-b3f9a69da2b6

After:

https://github.com/user-attachments/assets/48d26830-d71c-4510-85f1-1610dafa5309

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
