### PR TITLE
fix: warn duplicate entries in bundleless mode

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1021,13 +1021,13 @@ const composeEntryConfig = async (
         const entryName = getEntryName(file);
 
         if (resolvedEntries[entryName]) {
-          const originalFile = resolvedEntries[entryName];
-
           calcLcp &&
             logger.warn(
               `Duplicate entry ${color.cyan(entryName)} from ${color.cyan(
                 path.relative(root, file),
-              )} and ${color.cyan(path.relative(root, originalFile))}, which may lead to the incorrect output, please rename the file.`,
+              )} and ${color.cyan(
+                path.relative(root, resolvedEntries[entryName]),
+              )}, which may lead to the incorrect output, please rename the file.`,
             );
         }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1019,11 +1019,18 @@ const composeEntryConfig = async (
 
       for (const file of resolvedEntryFiles) {
         const entryName = getEntryName(file);
+
         if (resolvedEntries[entryName]) {
-          logger.warn(
-            `duplicate entry: ${entryName}, this may lead to the incorrect output, please rename the file`,
-          );
+          const originalFile = resolvedEntries[entryName];
+
+          calcLcp &&
+            logger.warn(
+              `Duplicate entry ${color.cyan(entryName)} from ${color.cyan(
+                path.relative(root, file),
+              )} and ${color.cyan(path.relative(root, originalFile))}, which may lead to the incorrect output, please rename the file.`,
+            );
         }
+
         resolvedEntries[entryName] = file;
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,6 +676,8 @@ importers:
 
   tests/integration/entry/default: {}
 
+  tests/integration/entry/duplicate: {}
+
   tests/integration/entry/glob: {}
 
   tests/integration/entry/multiple: {}

--- a/tests/integration/entry/duplicate/package.json
+++ b/tests/integration/entry/duplicate/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "entry-duplicate-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/entry/duplicate/rslib.config.ts
+++ b/tests/integration/entry/duplicate/rslib.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+    }),
+  ],
+});

--- a/tests/integration/entry/duplicate/src/index.css
+++ b/tests/integration/entry/duplicate/src/index.css
@@ -1,0 +1,3 @@
+.red {
+  color: red;
+}

--- a/tests/integration/entry/duplicate/src/index.module.css
+++ b/tests/integration/entry/duplicate/src/index.module.css
@@ -1,0 +1,3 @@
+.counter-text {
+  font-size: 50px;
+}

--- a/tests/integration/entry/duplicate/src/index.ts
+++ b/tests/integration/entry/duplicate/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/tests/integration/entry/index.test.ts
+++ b/tests/integration/entry/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import stripAnsi from 'strip-ansi';
-import { buildAndGetResults, queryContent } from 'test-helper';
+import { buildAndGetResults, proxyConsole, queryContent } from 'test-helper';
 import { expect, test } from 'vitest';
 
 test('default entry', async () => {
@@ -167,4 +167,22 @@ test('validate entry and throw errors', async () => {
   expect(stripAnsi(errMsg)).toMatchInlineSnapshot(
     `"The source.entry configuration should be an object, but received string: ./src/**. Checkout https://lib.rsbuild.dev/config/rsbuild/source#sourceentry for more details."`,
   );
+});
+
+test('duplicate entry in bundleless mode', async () => {
+  const { logs, restore } = proxyConsole();
+  const fixturePath = join(__dirname, 'duplicate');
+  await buildAndGetResults({ fixturePath });
+
+  const logStrings = logs.map((log) => stripAnsi(log));
+
+  expect(
+    logStrings.some((log) =>
+      log.includes(
+        'Duplicate entry index from src/index.ts and src/index.svg, which may lead to the incorrect output, please rename the file.',
+      ),
+    ),
+  ).toBe(true);
+
+  restore();
 });

--- a/tests/integration/entry/index.test.ts
+++ b/tests/integration/entry/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path';
+import path, { join } from 'node:path';
 import stripAnsi from 'strip-ansi';
 import { buildAndGetResults, proxyConsole, queryContent } from 'test-helper';
 import { expect, test } from 'vitest';
@@ -179,7 +179,9 @@ test('duplicate entry in bundleless mode', async () => {
   expect(
     logStrings.some((log) =>
       log.includes(
-        'Duplicate entry index from src/index.ts and src/index.svg, which may lead to the incorrect output, please rename the file.',
+        `Duplicate entry index from ${path.normalize(
+          'src/index.ts',
+        )} and ${path.normalize('src/index.svg')}, which may lead to the incorrect output, please rename the file.`,
       ),
     ),
   ).toBe(true);


### PR DESCRIPTION
## Summary

For duplicate entries in bundleless mode, we already deal with css files which is common to have same name in library development. But for some static assets, which usually not appear at the same level of Javascript files, this PR log a warning if they are in the same level as what Javascript files locates.

## Related Links

close: #199 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
