### PR TITLE
ci(corepack): fix corepack key id mismatch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest --force
           corepack enable
 
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,9 @@ jobs:
           ref: ${{ inputs.ref || 'main' }}
 
       - name: Install pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest --force
           corepack enable
 
       - name: Setup Node.js

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,9 @@ jobs:
           fetch-depth: 1
 
       - name: Install pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest --force
           corepack enable
 
       - name: Setup Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Install pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,9 @@ jobs:
           fetch-depth: 10
 
       - name: Install pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - uses: dorny/paths-filter@v3.0.2
         id: changes
@@ -65,7 +67,9 @@ jobs:
           git config --system core.longpaths true
 
       - name: Install pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -108,7 +112,9 @@ jobs:
           fetch-depth: 10
 
       - name: Install pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest --force
           corepack enable
 
       - uses: dorny/paths-filter@v3.0.2
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest --force
           corepack enable
 
       - name: Setup Node.js ${{ matrix.node-version }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest --force
           corepack enable
 
       - name: Setup Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary



Add `npm install -g corepack@latest --force` before `corepack enable` to fix corepack key id mismatch issue.

> `--force` to prevent windows install error

![image](https://github.com/user-attachments/assets/47a73c6c-240e-4c15-bf7b-1e23f8b1c54d)


## Related Links

https://github.com/nodejs/corepack/issues/612

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
