### PR TITLE
feat(core): reexport "@rslib/core/types" from "@rsbuild/core/types"

### DIFF
--- a/examples/preact-component-bundle-false/src/env.d.ts
+++ b/examples/preact-component-bundle-false/src/env.d.ts
@@ -1,9 +1,1 @@
-declare module '*.module.scss' {
-  const classes: { [key: string]: string };
-  export default classes;
-}
-
-declare module '*.svg' {
-  const url: string;
-  export default url;
-}
+/// <reference types="@rslib/core/types" />

--- a/examples/react-component-bundle-false/src/env.d.ts
+++ b/examples/react-component-bundle-false/src/env.d.ts
@@ -1,9 +1,1 @@
-declare module '*.module.scss' {
-  const classes: { [key: string]: string };
-  export default classes;
-}
-
-declare module '*.svg' {
-  const url: string;
-  export default url;
-}
+/// <reference types="@rslib/core/types" />

--- a/examples/react-component-bundle/src/env.d.ts
+++ b/examples/react-component-bundle/src/env.d.ts
@@ -1,9 +1,1 @@
-declare module '*.module.scss' {
-  const classes: { [key: string]: string };
-  export default classes;
-}
-
-declare module '*.svg' {
-  const url: string;
-  export default url;
-}
+/// <reference types="@rslib/core/types" />

--- a/examples/react-component-umd/src/env.d.ts
+++ b/examples/react-component-umd/src/env.d.ts
@@ -1,4 +1,1 @@
-declare module '*.module.scss' {
-  const classes: { [key: string]: string };
-  export default classes;
-}
+/// <reference types="@rslib/core/types" />

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,9 @@
       "types": "./dist-types/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./types": {
+      "types": "./types.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
@@ -29,7 +32,8 @@
     "bin",
     "dist",
     "dist-types",
-    "compiled"
+    "compiled",
+    "types.d.ts"
   ],
   "scripts": {
     "build": "rslib build",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,7 +17,7 @@
       "rslog": ["./compiled/rslog"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "types.d.ts"],
   "exclude": ["**/node_modules"],
   "references": [
     {

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@rsbuild/core/types" />

--- a/website/docs/en/guide/migration/modernjs-module.mdx
+++ b/website/docs/en/guide/migration/modernjs-module.mdx
@@ -146,13 +146,19 @@ In addition, you have to install the `@rsbuild/plugin-sass` package as `devDepen
 
 <PackageManagerTabs command="add @rsbuild/plugin-sass -D" />
 
-If you run Typescript together with Sass, you might run into DTS generation errors. This can be resolved by adding a `global.d.ts` file in your `/src` directory.
+If you run Typescript together with Sass, you might run into DTS generation errors. This can be resolved by adding a `env.d.ts` file in your `/src` directory.
 
-```ts title="global.d.ts"
+```ts title="src/env.d.ts"
 declare module '*.scss' {
   const content: { [className: string]: string };
   export default content;
 }
+```
+
+or
+
+```ts title="src/env.d.ts"
+/// <reference types="@rslib/core/types" />
 ```
 
 ## CSS Modules

--- a/website/docs/zh/guide/migration/modernjs-module.mdx
+++ b/website/docs/zh/guide/migration/modernjs-module.mdx
@@ -146,13 +146,19 @@ export default defineConfig({
 
 <PackageManagerTabs command="add @rsbuild/plugin-sass -D" />
 
-如果你在运行 Typescript 和 Sass，你可能会遇到 DTS 生成错误。这可以通过在 `/src` 目录中添加一个 `global.d.ts` 文件来解决。
+如果你在运行 Typescript 和 Sass，你可能会遇到 DTS 生成错误。这可以通过在 `/src` 目录中添加一个 `env.d.ts` 文件来解决。
 
-```ts title="global.d.ts"
+```ts title="src/env.d.ts"
 declare module '*.scss' {
   const content: { [className: string]: string };
   export default content;
 }
+```
+
+或者
+
+```ts title="src/env.d.ts"
+/// <reference types="@rslib/core/types" />
 ```
 
 ## CSS Modules


### PR DESCRIPTION
## Summary

for `src/env.d.ts`

1.

```ts
// src/env.d.ts
declare module '*.module.scss' {
  const classes: { [key: string]: string };
  export default classes;
}

declare module '*.svg' {
  const url: string;
  export default url;
}
```

2.

```ts
/// <reference types="@rslib/core/types" />
```


https://rsbuild.dev/zh/guide/basic/static-assets#%E7%B1%BB%E5%9E%8B%E5%A3%B0%E6%98%8E