### PR TITLE
fix(dts): correct tsconfig path not found error message

### DIFF
--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, fork } from 'node:child_process';
 import { dirname, extname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { type RsbuildConfig, type RsbuildPlugin, logger } from '@rsbuild/core';
+import color from 'picocolors';
 import ts from 'typescript';
 import { loadTsconfig, processSourceEntry } from './utils';
 
@@ -88,7 +89,9 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
         );
 
         if (!tsconfigPath) {
-          logger.error(`tsconfig.json not found in ${cwd}`);
+          logger.error(
+            `Failed to resolve tsconfig file ${color.cyan(`"${config.source.tsconfigPath}"`)} from ${color.cyan(cwd)}. Please ensure that the file exists.`,
+          );
           throw new Error();
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,6 +640,8 @@ importers:
 
   tests/integration/dts/bundle-false/true: {}
 
+  tests/integration/dts/bundle-false/tsconfig-path: {}
+
   tests/integration/dts/bundle/abort-on-error: {}
 
   tests/integration/dts/bundle/absolute-entry: {}

--- a/tests/integration/dts/bundle-false/tsconfig-path/package.json
+++ b/tests/integration/dts/bundle-false/tsconfig-path/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-true-bundle-false-tsconfig-path-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/bundle-false/tsconfig-path/rslib.config.ts
+++ b/tests/integration/dts/bundle-false/tsconfig-path/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src/index.ts',
+    },
+    tsconfigPath: '../path_not_exist/tsconfig.json',
+  },
+});


### PR DESCRIPTION
## Summary

The tsconfig path might not be `tsconfig.json` when it's customized.

<img width="479" alt="image" src="https://github.com/user-attachments/assets/84b80547-e520-4123-95f3-00aac65de790" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
