### PR TITLE
fix: clean dts distPath earlier

### DIFF
--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -12,13 +12,7 @@ import { logger } from '@rsbuild/core';
 import color from 'picocolors';
 import type { DtsGenOptions } from './index';
 import { emitDts } from './tsc';
-import {
-  calcLongestCommonPath,
-  cleanDtsFiles,
-  cleanTsBuildInfoFile,
-  clearTempDeclarationDir,
-  ensureTempDeclarationDir,
-} from './utils';
+import { calcLongestCommonPath, ensureTempDeclarationDir } from './utils';
 
 const isObject = (obj: unknown): obj is Record<string, any> =>
   Object.prototype.toString.call(obj) === '[object Object]';
@@ -115,11 +109,9 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
   const {
     bundle,
     dtsEntry,
+    dtsEmitPath,
     tsconfigPath,
     tsConfigResult,
-    distPath,
-    rootDistPath,
-    cleanDistPath,
     name,
     cwd,
     build,
@@ -137,24 +129,6 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
   logger.start(`Generating DTS... ${color.gray(`(${name})`)}`);
 
   const { options: rawCompilerOptions, fileNames } = tsConfigResult;
-
-  const dtsEmitPath =
-    distPath ?? rawCompilerOptions.declarationDir ?? rootDistPath;
-
-  // clean dts files
-  if (cleanDistPath !== false) {
-    await cleanDtsFiles(dtsEmitPath);
-  }
-
-  // clean .rslib temp folder
-  if (bundle) {
-    await clearTempDeclarationDir(cwd);
-  }
-
-  // clean tsbuildinfo file
-  if (rawCompilerOptions.composite || rawCompilerOptions.incremental || build) {
-    await cleanTsBuildInfoFile(tsconfigPath, rawCompilerOptions);
-  }
 
   // The longest common path of all non-declaration input files.
   // If composite is set, the default is instead the directory containing the tsconfig.json file.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,6 +682,8 @@ importers:
 
   tests/integration/dts/composite/process-files: {}
 
+  tests/integration/dts/copy: {}
+
   tests/integration/entry/default: {}
 
   tests/integration/entry/duplicate: {}

--- a/tests/integration/dts/copy/copy.d.ts
+++ b/tests/integration/dts/copy/copy.d.ts
@@ -1,0 +1,5 @@
+export type Copy = {
+  from: string;
+  to: string;
+  context: string;
+};

--- a/tests/integration/dts/copy/package.json
+++ b/tests/integration/dts/copy/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-copy-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/copy/rslib.config.ts
+++ b/tests/integration/dts/copy/rslib.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      dts: true,
+    }),
+  ],
+  output: {
+    copy: {
+      patterns: [
+        {
+          from: './copy.d.ts',
+          to: './copy.d.ts',
+          context: __dirname,
+        },
+      ],
+    },
+  },
+});

--- a/tests/integration/dts/copy/src/index.ts
+++ b/tests/integration/dts/copy/src/index.ts
@@ -1,0 +1,2 @@
+export const a = 'hello world';
+export type A = string;

--- a/tests/integration/dts/copy/tsconfig.json
+++ b/tests/integration/dts/copy/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@rslib/tsconfig/base",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"]
+}

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -590,3 +590,20 @@ describe('dts when composite: true', () => {
     expect(existsSync(buildInfoPath)).toBeTruthy();
   });
 });
+
+describe('use with other features', async () => {
+  test('use output.copy to copy dts files', async () => {
+    const fixturePath = join(__dirname, 'copy');
+    const { files } = await buildAndGetResults({
+      fixturePath,
+      type: 'dts',
+    });
+
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/copy/dist/esm/copy.d.ts",
+        "<ROOT>/tests/integration/dts/copy/dist/esm/index.d.ts",
+      ]
+    `);
+  });
+});


### PR DESCRIPTION
## Summary

This pull request includes several changes to the `packages/plugin-dts` module and some additions to the integration tests. The main focus is on refactoring the `generateDts` function and adding new test configurations.

We should do these clean operations earlier in main process to avoid issue like below when users use `output.copy` to copy some DTS files into assets.

![image](https://github.com/user-attachments/assets/32b2d860-1014-41db-833d-0bbc7107ffa6)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
