### PR TITLE
fix(CI): should filter workspaces in pkg-pr-new

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,8 +2,8 @@
 name: Preview Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   preview:
-    if: github.repository == 'web-infra-dev/rslib' && github.event.pull_request.merged == true
+    if: github.repository == 'web-infra-dev/rslib'
     runs-on: ubuntu-latest
 
     steps:
@@ -46,4 +46,4 @@ jobs:
 
       - name: Publish Preview
         if: steps.changes.outputs.changed == 'true'
-        run: pnpx pkg-pr-new publish --compact --pnpm
+        run: pnpx pkg-pr-new publish --compact --pnpm ./packages/*


### PR DESCRIPTION
## Summary

- Run pkg.pr when push to main
- Filter workspaces in pkg-pr-new

## Related Links

#764 
#766

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
