### PR TITLE
feat: warn if `declarationDir` or `outDir` is resolved outside project root

### DIFF
--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, fork } from 'node:child_process';
-import { dirname, extname, join, relative } from 'node:path';
+import { dirname, extname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { type RsbuildConfig, type RsbuildPlugin, logger } from '@rsbuild/core';
 import color from 'picocolors';

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -506,21 +506,18 @@ export async function cleanTsBuildInfoFile(
   }
 }
 
-const windowsSlashRegex = /\\/g;
-export function normalizeSlash(p: string): string {
-  return p.replace(windowsSlashRegex, '/');
-}
-
 export function warnIfOutside(
   cwd: string,
   dir: string | undefined,
   label: string,
 ): void {
   if (dir) {
-    const relDir = relative(cwd, dir);
-    if (relDir.startsWith('..') || relDir.startsWith('/')) {
+    const normalizedCwd = normalize(cwd);
+    const normalizedDir = normalize(dir);
+    const relDir = relative(normalizedCwd, normalizedDir);
+    if (relDir.startsWith('..') || relDir.startsWith(path.sep)) {
       logger.warn(
-        `The resolved ${label} ${color.cyan(normalizeSlash(dir))} is outside the project root ${color.cyan(normalizeSlash(cwd))}, please check your tsconfig file.`,
+        `The resolved ${label} ${color.cyan(normalizedDir)} is outside the project root ${color.cyan(normalizedCwd)}, please check your tsconfig file.`,
       );
     }
   }

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -506,6 +506,11 @@ export async function cleanTsBuildInfoFile(
   }
 }
 
+const windowsSlashRegex = /\\/g;
+export function normalizeSlash(p: string): string {
+  return p.replace(windowsSlashRegex, '/');
+}
+
 export function warnIfOutside(
   cwd: string,
   dir: string | undefined,
@@ -515,7 +520,7 @@ export function warnIfOutside(
     const relDir = relative(cwd, dir);
     if (relDir.startsWith('..') || relDir.startsWith('/')) {
       logger.warn(
-        `The resolved ${label} ${color.cyan(dir)} is outside the project root ${color.cyan(cwd)}, please check your tsconfig file.`,
+        `The resolved ${label} ${color.cyan(normalizeSlash(dir))} is outside the project root ${color.cyan(normalizeSlash(cwd))}, please check your tsconfig file.`,
       );
     }
   }

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -515,7 +515,8 @@ export function warnIfOutside(
     const normalizedCwd = normalize(cwd);
     const normalizedDir = normalize(dir);
     const relDir = relative(normalizedCwd, normalizedDir);
-    if (relDir.startsWith('..') || relDir.startsWith(path.sep)) {
+
+    if (relDir.startsWith('..')) {
       logger.warn(
         `The resolved ${label} ${color.cyan(normalizedDir)} is outside the project root ${color.cyan(normalizedCwd)}, please check your tsconfig file.`,
       );

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -505,3 +505,18 @@ export async function cleanTsBuildInfoFile(
     await fsP.rm(tsbuildInfoFilePath, { force: true });
   }
 }
+
+export function warnIfOutside(
+  cwd: string,
+  dir: string | undefined,
+  label: string,
+): void {
+  if (dir) {
+    const relDir = relative(cwd, dir);
+    if (relDir.startsWith('..') || relDir.startsWith('/')) {
+      logger.warn(
+        `The resolved ${label} ${color.cyan(dir)} is outside the project root ${color.cyan(cwd)}, please check your tsconfig file.`,
+      );
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,6 +675,8 @@ importers:
 
   tests/integration/dts/bundle/true: {}
 
+  tests/integration/dts/check/outside-root: {}
+
   tests/integration/dts/composite/abort-on-error: {}
 
   tests/integration/dts/composite/basic: {}

--- a/tests/integration/dts/check/outside-root/package.json
+++ b/tests/integration/dts/check/outside-root/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-check-outdise-root-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/check/outside-root/rslib.config.ts
+++ b/tests/integration/dts/check/outside-root/rslib.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      dts: true,
+    }),
+  ],
+});

--- a/tests/integration/dts/check/outside-root/src/index.ts
+++ b/tests/integration/dts/check/outside-root/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/tests/integration/dts/check/outside-root/tsconfig.json
+++ b/tests/integration/dts/check/outside-root/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig/declarationDir.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"]
+}

--- a/tests/integration/dts/check/tsconfig/declarationDir.json
+++ b/tests/integration/dts/check/tsconfig/declarationDir.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist"
+  }
+}

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import path, { join } from 'node:path';
+import { join, normalize } from 'node:path';
 import stripAnsi from 'strip-ansi';
 import {
   buildAndGetResults,
@@ -617,13 +617,12 @@ describe('check tsconfig.json field', async () => {
       type: 'dts',
     });
     const logStrings = logs.map((log) => stripAnsi(log));
+    restore();
 
-    const expectDeclarationDir = join(__dirname, 'check/tsconfig/dist')
-      .split(path.sep)
-      .join('/');
-    const expectRoot = join(__dirname, 'check/outside-root')
-      .split(path.sep)
-      .join('/');
+    const expectDeclarationDir = normalize(
+      join(__dirname, 'check/tsconfig/dist'),
+    );
+    const expectRoot = normalize(join(__dirname, 'check/outside-root'));
 
     expect(
       logStrings.some((log) =>
@@ -634,7 +633,5 @@ describe('check tsconfig.json field', async () => {
     ).toEqual(true);
 
     expect(files.esm).toMatchInlineSnapshot('undefined');
-
-    restore();
   });
 });

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { join, normalize, resolve } from 'node:path';
+import { join, normalize } from 'node:path';
 import stripAnsi from 'strip-ansi';
 import {
   buildAndGetResults,

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { join, normalize } from 'node:path';
+import path, { join } from 'node:path';
 import stripAnsi from 'strip-ansi';
 import {
   buildAndGetResults,
@@ -618,14 +618,22 @@ describe('check tsconfig.json field', async () => {
     });
     const logStrings = logs.map((log) => stripAnsi(log));
 
-    expect(files.esm).toMatchInlineSnapshot('undefined');
+    const expectDeclarationDir = join(__dirname, 'check/tsconfig/dist')
+      .split(path.sep)
+      .join('/');
+    const expectRoot = join(__dirname, 'check/outside-root')
+      .split(path.sep)
+      .join('/');
+
     expect(
       logStrings.some((log) =>
         log.includes(
-          `The resolved declarationDir ${normalize(join(__dirname, 'check/tsconfig/dist'))} is outside the project root ${normalize(join(__dirname, 'check/outside-root'))}, please check your tsconfig file.`,
+          `The resolved declarationDir ${expectDeclarationDir} is outside the project root ${expectRoot}, please check your tsconfig file.`,
         ),
       ),
     ).toEqual(true);
+
+    expect(files.esm).toMatchInlineSnapshot('undefined');
 
     restore();
   });


### PR DESCRIPTION
## Summary

warn if `declarationDir` or `outDir` is resolved outside project root

## Related Links

#779 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
