### PR TITLE
fix: revert dtsEmitPath generate logic to respect `output.distPath.root`

### DIFF
--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -8,6 +8,7 @@ import {
   cleanDtsFiles,
   cleanTsBuildInfoFile,
   clearTempDeclarationDir,
+  getDtsEmitPath,
   loadTsconfig,
   processSourceEntry,
   warnIfOutside,
@@ -115,8 +116,11 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
           rawCompilerOptions;
         // the priority of dtsEmitPath is dts.distPath > declarationDir > output.distPath.root
         // outDir is not considered since in multiple formats, the dts files may not in the same directory as the js files
-        const dtsEmitPath =
-          options.distPath ?? declarationDir ?? config.output?.distPath?.root;
+        const dtsEmitPath = getDtsEmitPath(
+          options.distPath,
+          declarationDir,
+          config.output?.distPath?.root,
+        );
 
         // check whether declarationDir or outDir is outside from current project
         warnIfOutside(cwd, declarationDir, 'declarationDir');

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -114,8 +114,6 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
         const { options: rawCompilerOptions } = tsConfigResult;
         const { declarationDir, outDir, composite, incremental } =
           rawCompilerOptions;
-        // the priority of dtsEmitPath is dts.distPath > declarationDir > output.distPath.root
-        // outDir is not considered since in multiple formats, the dts files may not in the same directory as the js files
         const dtsEmitPath = getDtsEmitPath(
           options.distPath,
           declarationDir,

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -113,11 +113,10 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
         const { options: rawCompilerOptions } = tsConfigResult;
         const { declarationDir, outDir, composite, incremental } =
           rawCompilerOptions;
+        // the priority of dtsEmitPath is dts.distPath > declarationDir > output.distPath.root
+        // outDir is not considered since in multiple formats, the dts files may not in the same directory as the js files
         const dtsEmitPath =
-          options.distPath ??
-          declarationDir ??
-          outDir ??
-          config.output?.distPath?.root;
+          options.distPath ?? declarationDir ?? config.output?.distPath?.root;
 
         // check whether declarationDir or outDir is outside from current project
         warnIfOutside(cwd, declarationDir, 'declarationDir');

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -506,6 +506,8 @@ export async function cleanTsBuildInfoFile(
   }
 }
 
+// the priority of dtsEmitPath is dts.distPath > declarationDir > output.distPath.root
+// outDir is not considered since in multiple formats, the dts files may not in the same directory as the js files
 export function getDtsEmitPath(
   pathFromPlugin: string | undefined,
   declarationDir: string | undefined,

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -506,6 +506,14 @@ export async function cleanTsBuildInfoFile(
   }
 }
 
+export function getDtsEmitPath(
+  pathFromPlugin: string | undefined,
+  declarationDir: string | undefined,
+  distPath: string,
+): string {
+  return pathFromPlugin ?? declarationDir ?? distPath;
+}
+
 export function warnIfOutside(
   cwd: string,
   dir: string | undefined,

--- a/packages/plugin-dts/tests/dts.test.ts
+++ b/packages/plugin-dts/tests/dts.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { PluginDtsOptions } from '../src/index';
+import { getDtsEmitPath } from '../src/utils';
+
+describe('getDtsEmitPath', () => {
+  const baseConfig = {
+    output: {
+      distPath: {
+        root: '/dist-config',
+      },
+    },
+  };
+  const declarationDir = '/dist-declarationDir';
+
+  it('should return options.distPath with the highest priority', () => {
+    const options: PluginDtsOptions = {
+      distPath: '/dist-options',
+    };
+    const result = getDtsEmitPath(
+      options.distPath,
+      declarationDir,
+      baseConfig.output.distPath.root,
+    );
+    expect(result).toBe('/dist-options');
+  });
+  it('should return declarationDir when options.distPath is undefined', () => {
+    const options: PluginDtsOptions = {};
+    const result = getDtsEmitPath(
+      options.distPath,
+      declarationDir,
+      baseConfig.output.distPath.root,
+    );
+    expect(result).toBe('/dist-declarationDir');
+  });
+
+  it('should return config.output.distPath.root when both options.distPath and declarationDir are undefined', () => {
+    const options: PluginDtsOptions = {};
+    const result = getDtsEmitPath(
+      options.distPath,
+      undefined,
+      baseConfig.output.distPath.root,
+    );
+    expect(result).toBe('/dist-config');
+  });
+});

--- a/packages/plugin-dts/tests/dts.test.ts
+++ b/packages/plugin-dts/tests/dts.test.ts
@@ -23,6 +23,7 @@ describe('getDtsEmitPath', () => {
     );
     expect(result).toBe('/dist-options');
   });
+
   it('should return declarationDir when options.distPath is undefined', () => {
     const options: PluginDtsOptions = {};
     const result = getDtsEmitPath(


### PR DESCRIPTION
## Summary

In https://github.com/web-infra-dev/rslib/pull/780, `outDir` is used to generate dtsEmitPath with a higher priority than `output.distPath.root`. This is an unexpected change, this PR revert it.

## Related Links

close: #785 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
