### PR TITLE
feat: support bundle DTS of multiple entries

### DIFF
--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -10,7 +10,7 @@ import {
 } from 'node:path';
 import { logger } from '@rsbuild/core';
 import color from 'picocolors';
-import type { DtsGenOptions } from './index';
+import type { DtsEntry, DtsGenOptions } from './index';
 import { emitDts } from './tsc';
 import { calcLongestCommonPath, ensureTempDeclarationDir } from './utils';
 
@@ -198,7 +198,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
           );
         return { name: entryName, path: newPath };
       })
-      .filter(Boolean) as { name: string; path: string }[];
+      .filter(Boolean) as Required<DtsEntry>[];
   }
 
   const bundleDtsIfNeeded = async () => {

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -49,7 +49,7 @@ export type DtsGenOptions = PluginDtsOptions & {
   name: string;
   cwd: string;
   isWatch: boolean;
-  dtsEntry: DtsEntry;
+  dtsEntry: DtsEntry[];
   dtsEmitPath: string;
   build?: boolean;
   tsconfigPath: string;
@@ -89,8 +89,9 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
 
         const { config } = environment;
 
-        // TODO: @microsoft/api-extractor only support single entry to bundle DTS
-        // use first element of Record<string, string> type entry config
+        // @microsoft/api-extractor only support single entry to bundle DTS
+        // see https://github.com/microsoft/rushstack/issues/1596#issuecomment-546790721
+        // we support multiple entries by calling api-extractor multiple times
         const dtsEntry = processSourceEntry(
           options.bundle!,
           config.source?.entry,

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -406,26 +406,25 @@ export async function processDtsFiles(
 export function processSourceEntry(
   bundle: boolean,
   entryConfig: NonNullable<RsbuildConfig['source']>['entry'],
-): DtsEntry {
+): DtsEntry[] {
   if (!bundle) {
-    return {
-      name: undefined,
-      path: undefined,
-    };
+    return [];
   }
 
   if (
     entryConfig &&
     Object.values(entryConfig).every((val) => typeof val === 'string')
   ) {
-    return {
-      name: Object.keys(entryConfig)[0] as string,
-      path: Object.values(entryConfig)[0] as string,
-    };
+    return Object.entries(entryConfig as Record<string, string>).map(
+      ([name, path]) => ({
+        name,
+        path,
+      }),
+    );
   }
 
   throw new Error(
-    '@microsoft/api-extractor only support single entry of Record<string, string> type to bundle DTS, please check your entry config.',
+    '@microsoft/api-extractor only support entry of Record<string, string> type to bundle DTS, please check your entry config.',
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -667,6 +667,8 @@ importers:
 
   tests/integration/dts/bundle/false: {}
 
+  tests/integration/dts/bundle/multiple-entries: {}
+
   tests/integration/dts/bundle/rootdir:
     devDependencies:
       '@types/chromecast-caf-sender':

--- a/tests/integration/dts/__snapshots__/index.test.ts.snap
+++ b/tests/integration/dts/__snapshots__/index.test.ts.snap
@@ -61,6 +61,59 @@ export { }
 }
 `;
 
+exports[`dts when bundle: true > multiple entries 3`] = `
+[
+  "export declare const num1 = 1;
+
+export declare const num2 = 2;
+
+export declare const num3 = 3;
+
+export declare const numSum: number;
+
+export declare const str1 = "str1";
+
+export declare const str2 = "str2";
+
+export declare const str3 = "str3";
+
+export declare const strSum: string;
+
+export { }
+",
+  "export declare const num1 = 1;
+
+export declare const num2 = 2;
+
+export declare const num3 = 3;
+
+export declare const numSum: number;
+
+export declare const str1 = "str1";
+
+export declare const str2 = "str2";
+
+export declare const str3 = "str3";
+
+export declare const strSum: string;
+
+export { }
+",
+  "export declare const numSum: number;
+
+export declare const strSum: string;
+
+export { }
+",
+  "export declare const numSum: number;
+
+export declare const strSum: string;
+
+export { }
+",
+]
+`;
+
 exports[`dts when bundle: true > rootdir calculation should ignore declaration files 3`] = `
 {
   "cjs": "export declare const num1 = 1;

--- a/tests/integration/dts/bundle/multiple-entries/package.json
+++ b/tests/integration/dts/bundle/multiple-entries/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-bundle-multiple-entries-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/bundle/multiple-entries/rslib.config.ts
+++ b/tests/integration/dts/bundle/multiple-entries/rslib.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      dts: {
+        bundle: true,
+      },
+    }),
+    generateBundleCjsConfig({
+      dts: {
+        bundle: true,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src/index.ts',
+      sum: '../__fixtures__/src/sum.ts',
+    },
+    tsconfigPath: '../__fixtures__/tsconfig.json',
+  },
+});

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -6,6 +6,7 @@ import {
   createTempFiles,
   globContentJSON,
   proxyConsole,
+  queryContent,
 } from 'test-helper';
 import { describe, expect, test } from 'vitest';
 
@@ -338,6 +339,43 @@ describe('dts when bundle: true', () => {
         "<ROOT>/tests/integration/dts/bundle/clean/dist-types/cjs/index.d.ts",
       ]
     `);
+  });
+
+  test('multiple entries', async () => {
+    const fixturePath = join(__dirname, 'bundle', 'multiple-entries');
+    const { files, contents } = await buildAndGetResults({
+      fixturePath,
+      type: 'dts',
+    });
+
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle/multiple-entries/dist/esm/index.d.ts",
+        "<ROOT>/tests/integration/dts/bundle/multiple-entries/dist/esm/sum.d.ts",
+      ]
+    `);
+
+    expect(files.cjs).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts/bundle/multiple-entries/dist/cjs/index.d.ts",
+        "<ROOT>/tests/integration/dts/bundle/multiple-entries/dist/cjs/sum.d.ts",
+      ]
+    `);
+
+    const { content: indexEsm } = queryContent(contents.esm, 'index.d.ts', {
+      basename: true,
+    });
+    const { content: indexCjs } = queryContent(contents.cjs, 'index.d.ts', {
+      basename: true,
+    });
+    const { content: sumEsm } = queryContent(contents.esm, 'sum.d.ts', {
+      basename: true,
+    });
+    const { content: sumCjs } = queryContent(contents.cjs, 'sum.d.ts', {
+      basename: true,
+    });
+
+    expect([indexEsm, indexCjs, sumEsm, sumCjs]).toMatchSnapshot();
   });
 });
 

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -86,12 +86,6 @@ export default {
 };
 ```
 
-::: note
-
-[@microsoft/api-extractor](https://www.npmjs.com/package/@microsoft/api-extractor) only supports bundle DTS for single entry. If you want to generate bundle DTS for multiple entries, you can add extra lib configuration in [lib](/config/lib/) field to split multiple entries into multiple lib configurations.
-
-:::
-
 #### Handle third-party packages
 
 When we bundle DTS files, we should specify which third-party package types need to be bundled, refer to the [Handle Third-Party Dependencies](/guide/advanced/third-party-deps) documentation for more details about externals related configurations.

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -86,12 +86,6 @@ export default {
 };
 ```
 
-::: note
-
-[@microsoft/api-extractor](https://www.npmjs.com/package/@microsoft/api-extractor) 只支持为单个入口打包 DTS。如果你想要为多个入口生成打包后的 DTS，你可以在 [lib](/config/lib/) 字段中添加额外的 lib 配置，将多个入口拆分为多个 lib 配置。
-
-:::
-
 #### 处理第三方依赖
 
 当我们打包 DTS 文件时，我们需要指定哪些第三方包的类型需要被打包，可以参考 [处理第三方依赖](/guide/advanced/third-party-deps) 文档了解更多关于 externals 相关的配置。


### PR DESCRIPTION
## Summary

`@microsoft/api-extractor` only support single entry to bundle DTS, in this PR, we support multiple entries by calling api-extractor multiple times.

## Related Links

close: #738 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
