### PR TITLE
docs: correct `externalHelpers` highlights

### DIFF
--- a/website/docs/en/config/lib/external-helpers.mdx
+++ b/website/docs/en/config/lib/external-helpers.mdx
@@ -7,7 +7,7 @@ Whether to import SWC helper functions from [@swc/helpers](https://www.npmjs.com
 
 By default, the output JavaScript file may depend on helper functions to support the target environment or output format, and these helper functions will be inlined in the file that requires it.
 
-When `externalHelpers` set to `true`, the output JavaScript will import helper functions from the external module `@swc/helpers`.
+When `externalHelpers` set to `true`, the output JavaScript will import helper functions from the external module `@swc/helpers`. This helps reduce duplicate helper code in the final bundles, and reduces the bundle size.
 
 ::: note
 
@@ -29,7 +29,7 @@ export default class FOO {
 
 When `externalHelpers` is disabled, the output JavaScript will inline helper functions.
 
-```ts title="rslib.config.ts" {6}
+```ts title="rslib.config.ts" {5}
 export default {
   lib: [
     {
@@ -79,7 +79,7 @@ export { src_FOO as default };
 
 When `externalHelpers` is enabled, the output JavaScript will import helper functions from the external module `@swc/helpers`.
 
-```ts title="rslib.config.ts" {6}
+```ts title="rslib.config.ts" {5}
 export default {
   lib: [
     {

--- a/website/docs/zh/config/lib/external-helpers.mdx
+++ b/website/docs/zh/config/lib/external-helpers.mdx
@@ -7,7 +7,7 @@
 
 默认情况下，输出的 JavaScript 文件可能需要辅助函数来支持目标环境或输出格式，这些辅助函数会被内联到需要它们的文件中。
 
-当 `externalHelpers` 设置为 `true` 时，输出的 JavaScript 将从外部模块 `@swc/helpers` 导入辅助函数。
+当 `externalHelpers` 设置为 `true` 时，输出的 JavaScript 将从外部模块 `@swc/helpers` 导入辅助函数，这有助于减少最终包中的重复辅助代码，减小包体积。
 
 ::: note
 
@@ -29,7 +29,7 @@ export default class FOO {
 
 当 `externalHelpers` 禁用时，输出的 JavaScript 将内联辅助函数。
 
-```ts title="rslib.config.ts" {6}
+```ts title="rslib.config.ts" {5}
 export default {
   lib: [
     {
@@ -79,7 +79,7 @@ export { src_FOO as default };
 
 当启用 `externalHelpers` 时，输出的 JavaScript 将从外部模块 `@swc/helpers` 导入辅助函数。
 
-```ts title="rslib.config.ts" {6}
+```ts title="rslib.config.ts" {5}
 export default {
   lib: [
     {


### PR DESCRIPTION
## Summary

Correct `externalHelpers` highlights and update description.

![image](https://github.com/user-attachments/assets/a57fc53e-ee61-4497-871f-232c458b6da2)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
