### PR TITLE
docs: modify description of `resolve.alias`

### DIFF
--- a/website/docs/en/config/rsbuild/resolve.mdx
+++ b/website/docs/en/config/rsbuild/resolve.mdx
@@ -10,7 +10,7 @@ Control the priority between the `paths` option in `tsconfig.json` and the `reso
 
 ## resolve.alias <RsbuildDocBadge path="/config/resolve/alias" text="resolve.alias" />
 
-Create aliases to import or require certain modules, same as the [resolve.alias](https://rspack.dev/config/resolve#resolvealias) config of Rspack.
+Set the alias for the module path, which is used to simplify the import path or redirect the module reference, similar to the [resolve.alias](https://rspack.dev/config/resolve#resolvealias) config of Rspack.
 
 For TypeScript projects, you only need to configure [compilerOptions.paths](https://www.typescriptlang.org/tsconfig/#paths) in the `tsconfig.json` file. Rslib will automatically recognize it, so there is no need to configure the `resolve.alias` option separately.
 

--- a/website/docs/zh/config/rsbuild/resolve.mdx
+++ b/website/docs/zh/config/rsbuild/resolve.mdx
@@ -10,7 +10,7 @@ import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
 
 ## resolve.alias <RsbuildDocBadge path="/config/resolve/alias" text="resolve.alias" />
 
-设置文件引用的别名，对应 Rspack 的 [resolve.alias](https://rspack.dev/zh/config/resolve#resolvealias) 配置。
+设置模块路径的别名，用于简化导入路径或重定向模块引用，类似于 Rspack 的 [resolve.alias](https://rspack.dev/zh/config/resolve#resolvealias) 配置。
 
 对于 TypeScript 项目，你只需要在 `tsconfig.json` 中配置 [compilerOptions.paths](https://www.typescriptlang.org/tsconfig/#paths) 即可，Rslib 会自动识别它，不需要额外配置 `resolve.alias` 字段。
 


### PR DESCRIPTION
## Summary

Modify description of `resolve.alias`, and users can click to jump to the Rsbuild documentation for more detailed information.

![image](https://github.com/user-attachments/assets/7066a8a3-e748-442f-b01c-372ec96665b7)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
