### PR TITLE
refactor: optimize dts logs/docs with `declaration files` keyword

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -45,31 +45,31 @@ export type Syntax =
 export type Dts =
   | {
       /**
-       * Whether to bundle the DTS files.
+       * Whether to bundle the declaration files.
        * @defaultValue `false`
        * @see {@link https://lib.rsbuild.dev/config/lib/dts#dtsbundle}
        */
       bundle?: boolean;
       /**
-       * The output directory of DTS files.
+       * The output directory of declaration files.
        * @defaultValue {@link https://lib.rsbuild.dev/config/lib/dts#default-value}
        * @see {@link https://lib.rsbuild.dev/config/lib/dts#dtsdistpath}
        */
       distPath?: string;
       /**
-       * Whether to generate DTS files with building the project references.
+       * Whether to generate declaration files with building the project references.
        * @defaultValue `false`
        * @see {@link https://lib.rsbuild.dev/config/lib/dts#dtsbuild}
        */
       build?: boolean;
       /**
-       * Whether to abort the build process when an error occurs during DTS generation.
+       * Whether to abort the build process when an error occurs during declaration files generation.
        * @defaultValue `true`
        * @see {@link https://lib.rsbuild.dev/config/lib/dts#dtsabortonerror}
        */
       abortOnError?: boolean;
       /**
-       * Whether to automatically set the DTS file extension based on the {@link format} option.
+       * Whether to automatically set the declaration file extension based on the {@link format} option.
        * @defaultValue `false`
        * @see {@link https://lib.rsbuild.dev/config/lib/dts#dtsautoextension}
        */
@@ -251,13 +251,13 @@ export interface LibConfig extends EnvironmentConfig {
    */
   externalHelpers?: boolean;
   /**
-   * Inject content into the top of each JavaScript, CSS or DTS file.
+   * Inject content into the top of each JavaScript, CSS or declaration file.
    * @defaultValue `{}`
    * @see {@link https://lib.rsbuild.dev/config/lib/banner}
    */
   banner?: BannerAndFooter;
   /**
-   * Inject content into the bottom of each JavaScript, CSS or DTS file.
+   * Inject content into the bottom of each JavaScript, CSS or declaration file.
    * @defaultValue `{}`
    * @see {@link https://lib.rsbuild.dev/config/lib/footer}
    */

--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -8,7 +8,7 @@ An [Rsbuild plugin](https://www.npmjs.com/package/rsbuild-plugin-dts) to emit de
 
 ## Using in Rslib
 
-Read [DTS](https://lib.rsbuild.dev/guide/advanced/dts) and [lib.dts](https://lib.rsbuild.dev/config/lib/dts) for more details.
+Read [Declaration files](https://lib.rsbuild.dev/guide/advanced/dts) and [lib.dts](https://lib.rsbuild.dev/config/lib/dts) for more details.
 
 ## Using in Rsbuild
 
@@ -36,11 +36,11 @@ export default {
 - **Type:** `boolean`
 - **Default:** `false`
 
-Whether to bundle the DTS files.
+Whether to bundle the declaration files.
 
-If you want to [bundle DTS](https://lib.rsbuild.dev/guide/advanced/dts#bundle-dts) files, you should:
+If you want to [bundle declaration files](https://lib.rsbuild.dev/guide/advanced/dts#bundle-declaration-files) files, you should:
 
-1. Install `@microsoft/api-extractor` as a development dependency, which is the underlying tool used for bundling DTS files.
+1. Install `@microsoft/api-extractor` as a development dependency, which is the underlying tool used for bundling declaration files.
 
 ```bash
 npm add @microsoft/api-extractor -D
@@ -58,7 +58,7 @@ pluginDts({
 
 - **Type:** `string`
 
-The output directory of DTS files. The default value follows the priority below:
+The output directory of declaration files. The default value follows the priority below:
 
 1. The `distPath` value of the plugin options.
 2. The `declarationDir` value in the `tsconfig.json` file.
@@ -75,7 +75,7 @@ pluginDts({
 - **Type:** `boolean`
 - **Default:** `false`
 
-Whether to generate DTS files with building the project references. This is equivalent to using the `--build` flag with the `tsc` command. See [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) for more details.
+Whether to generate declaration files with building the project references. This is equivalent to using the `--build` flag with the `tsc` command. See [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) for more details.
 
 When this option is enabled, you must explicitly set `declarationDir` or `outDir` in `tsconfig.json` in order to meet the build requirements.
 
@@ -84,7 +84,7 @@ When this option is enabled, you must explicitly set `declarationDir` or `outDir
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to abort the build process when an error occurs during DTS generation.
+Whether to abort the build process when an error occurs during declaration files generation.
 
 By default, type errors will cause the build to fail.
 
@@ -101,7 +101,7 @@ pluginDts({
 - **Type:** `string`
 - **Default:** `'.d.ts'`
 
-The extension of the DTS file.
+The extension of the declaration file.
 
 ```js
 pluginDts({
@@ -114,7 +114,7 @@ pluginDts({
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to automatically externalize dependencies of different dependency types and do not bundle them into the DTS file.
+Whether to automatically externalize dependencies of different dependency types and do not bundle them into the declaration file.
 
 The default value of `autoExternal` is `true`, which means the following dependency types will not be bundled:
 
@@ -142,7 +142,7 @@ pluginDts({
 - **Type:** `string`
 - **Default:** `undefined`
 
-Inject content into the top of each DTS file.
+Inject content into the top of each declaration file.
 
 ```js
 pluginDts({
@@ -155,7 +155,7 @@ pluginDts({
 - **Type:** `string`
 - **Default:** `undefined`
 
-Inject content into the bottom of each DTS file.
+Inject content into the bottom of each declaration file.
 
 ```js
 pluginDts({
@@ -201,7 +201,7 @@ pluginDts({
 
 Whether to automatically redirect the import paths of TypeScript declaration output files.
 
-- When set to `true`, Rslib will redirect the import path in the DTS output file to the corresponding relative path based on the [compilerOptions.paths](https://typescriptlang.org/tsconfig#paths) configured in `tsconfig.json`.
+- When set to `true`, Rslib will redirect the import path in the declaration output file to the corresponding relative path based on the [compilerOptions.paths](https://typescriptlang.org/tsconfig#paths) configured in `tsconfig.json`.
 
 ```ts
 // `compilerOptions.paths` is set to `{ "@/*": ["src/*"] }`
@@ -221,7 +221,7 @@ import { foo } from '../foo'; // expected output './dist/utils/index.d.ts'
 
 Whether to automatically redirect the file extension to import paths based on the TypeScript declaration output files.
 
-- When set to `true`, the import paths in DTS files will be redirected to the corresponding JavaScript extension which can be resolved to corresponding DTS file. The extension of the DTS output file is related to the `dtsExtension` configuration.
+- When set to `true`, the import paths in declaration files will be redirected to the corresponding JavaScript extension which can be resolved to corresponding declaration file. The extension of the declaration output file is related to the `dtsExtension` configuration.
 
 ```ts
 // `dtsExtension` is set to `.d.mts`

--- a/packages/plugin-dts/src/apiExtractor.ts
+++ b/packages/plugin-dts/src/apiExtractor.ts
@@ -76,12 +76,11 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
         await addBannerAndFooter(untrimmedFilePath, banner, footer);
 
         logger.info(
-          `API Extractor bundle DTS succeeded: ${color.cyan(untrimmedFilePath)} in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+          `API Extractor bundle declaration files succeeded: ${color.cyan(untrimmedFilePath)} in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
         );
       }),
     );
   } catch (e) {
-    logger.error('API Extractor Error');
-    throw new Error(`${e}`);
+    throw new Error(`API Extractor Error:\n ${e}`);
   }
 }

--- a/packages/plugin-dts/src/apiExtractor.ts
+++ b/packages/plugin-dts/src/apiExtractor.ts
@@ -76,7 +76,7 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
         await addBannerAndFooter(untrimmedFilePath, banner, footer);
 
         logger.info(
-          `API Extractor bundle declaration files succeeded: ${color.cyan(untrimmedFilePath)} in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+          `bundle declaration files succeeded: ${color.cyan(untrimmedFilePath)} in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
         );
       }),
     );

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -126,7 +126,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
       extension: false,
     },
   } = data;
-  logger.start(`Generating DTS... ${color.gray(`(${name})`)}`);
+  logger.start(`Generating declaration files... ${color.gray(`(${name})`)}`);
 
   const { options: rawCompilerOptions, fileNames } = tsConfigResult;
 
@@ -147,7 +147,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
   );
 
   if (build) {
-    // do not allow to use bundle DTS when 'build: true' since temp declarationDir should be set by user in tsconfig
+    // do not allow to use bundle declaration files when 'build: true' since temp declarationDir should be set by user in tsconfig
     if (bundle) {
       throw Error(`Can not set "dts.bundle: true" when "dts.build: true"`);
     }

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -126,7 +126,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
       extension: false,
     },
   } = data;
-  logger.start(`Generating declaration files... ${color.gray(`(${name})`)}`);
+  logger.start(`generating declaration files... ${color.gray(`(${name})`)}`);
 
   const { options: rawCompilerOptions, fileNames } = tsConfigResult;
 

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -89,7 +89,7 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
 
         const { config } = environment;
 
-        // @microsoft/api-extractor only support single entry to bundle DTS
+        // @microsoft/api-extractor only support single entry to bundle declaration files
         // see https://github.com/microsoft/rushstack/issues/1596#issuecomment-546790721
         // we support multiple entries by calling api-extractor multiple times
         const dtsEntry = processSourceEntry(
@@ -171,7 +171,7 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
               } else if (message === 'error') {
                 resolve({
                   status: 'error',
-                  errorMessage: `Error occurred in ${environment.name} DTS generation`,
+                  errorMessage: `Error occurred in ${environment.name} declaration files generation.`,
                 });
               }
             });
@@ -188,7 +188,7 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
 
         promisesResult = await Promise.all(dtsPromises);
       },
-      // Set the order to 'pre' to ensure that when DTS files of multiple formats are generated simultaneously,
+      // Set the order to 'pre' to ensure that when declaration files of multiple formats are generated simultaneously,
       // all errors are thrown together before exiting the process.
       order: 'pre',
     });
@@ -205,7 +205,7 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
           }
           result.errorMessage && logger.error(result.errorMessage);
           logger.warn(
-            'With the `abortOnError` configuration currently turned off, type errors do not cause build failures, but they do not guarantee proper type file output.',
+            'With `abortOnError` configuration currently disabled, type errors will not fail the build, but proper type declaration output cannot be guaranteed.',
           );
         }
       }

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -285,7 +285,7 @@ export async function emitDts(
     }
 
     logger.ready(
-      `Declaration files generated in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+      `declaration files generated in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
     );
   } else {
     // watch mode, can also deal with incremental build

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -4,6 +4,8 @@ import ts from 'typescript';
 import type { DtsRedirect } from './index';
 import { getFileLoc, getTimeCost, processDtsFiles } from './utils';
 
+const logPrefix = color.dim('[tsc]');
+
 export type EmitDtsOptions = {
   name: string;
   cwd: string;
@@ -53,15 +55,13 @@ async function handleDiagnosticsAndProcessFiles(
   );
 
   if (diagnosticMessages.length) {
-    logger.error(
-      `Failed to emit declaration files. ${color.gray(`(${name})`)}`,
-    );
-
     for (const message of diagnosticMessages) {
-      logger.error(message);
+      logger.error(logPrefix, message);
     }
 
-    throw new Error('DTS generation failed');
+    throw new Error(
+      `Failed to generate declaration files. ${color.gray(`(${name})`)}`,
+    );
   }
 }
 
@@ -110,6 +110,7 @@ export async function emitDts(
     const fileLoc = getFileLoc(diagnostic, configPath);
 
     logger.error(
+      logPrefix,
       `${fileLoc} - ${color.red('error')} ${color.gray(`TS${diagnostic.code}:`)}`,
       ts.flattenDiagnosticMessageText(
         diagnostic.messageText,
@@ -132,16 +133,16 @@ export async function emitDts(
     // 6031: File change detected. Starting incremental compilation...
     // 6032: Starting compilation in watch mode...
     if (diagnostic.code === 6031 || diagnostic.code === 6032) {
-      logger.info(message);
+      logger.info(logPrefix, message);
     }
 
     // 6194: 0 errors or 2+ errors!
     if (diagnostic.code === 6194) {
       if (errorCount === 0 || !errorCount) {
-        logger.info(message);
+        logger.info(logPrefix, message);
         onComplete(true);
       } else {
-        logger.error(message);
+        logger.error(logPrefix, message);
       }
       await processDtsFiles(
         bundle,
@@ -157,7 +158,7 @@ export async function emitDts(
 
     // 6193: 1 error
     if (diagnostic.code === 6193) {
-      logger.error(message);
+      logger.error(logPrefix, message);
       await processDtsFiles(
         bundle,
         declarationDir,
@@ -277,16 +278,14 @@ export async function emitDts(
       );
 
       if (errorNumber > 0) {
-        logger.error(
-          `Failed to emit declaration files. ${color.gray(`(${name})`)}`,
+        throw new Error(
+          `Failed to generate declaration files. ${color.gray(`(${name})`)}`,
         );
-
-        throw new Error('DTS generation failed');
       }
     }
 
     logger.ready(
-      `DTS generated in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+      `Declaration files generated in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
     );
   } else {
     // watch mode, can also deal with incremental build

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -398,7 +398,7 @@ export async function processDtsFiles(
       const newFile = file.replace('.d.ts', dtsExtension);
       fs.renameSync(file, newFile);
     } catch (error) {
-      logger.error(`Error renaming DTS file ${file}: ${error}`);
+      logger.error(`Failed to rename declaration file ${file}: ${error}`);
     }
   }
 }
@@ -424,7 +424,7 @@ export function processSourceEntry(
   }
 
   throw new Error(
-    '@microsoft/api-extractor only support entry of Record<string, string> type to bundle DTS, please check your entry config.',
+    '@microsoft/api-extractor only support entry of Record<string, string> type to bundle declaration files, please check your entry config.',
   );
 }
 

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -464,7 +464,9 @@ describe('dts when build: true', () => {
       });
     } catch (err: any) {
       // not easy to proxy child process stdout
-      expect(err.message).toBe('Error occurred in esm DTS generation');
+      expect(err.message).toBe(
+        'Error occurred in esm declaration files generation.',
+      );
     }
   });
 

--- a/website/docs/en/config/lib/banner.mdx
+++ b/website/docs/en/config/lib/banner.mdx
@@ -16,7 +16,7 @@ type Banner = {
 
 - **Default:** `{}`
 
-Inject content into the top of each JavaScript, CSS or DTS output file.
+Inject content into the top of each JavaScript, CSS or declaration output file.
 
 ## Object type
 
@@ -39,7 +39,7 @@ Inject content into the top of each CSS output file.
 - **Type:** `string`
 - **Default:** `undefined`
 
-Inject content into the top of each DTS output file.
+Inject content into the top of each declaration output file.
 
 ## Notice
 
@@ -73,6 +73,6 @@ export default {
 
 :::warning
 
-The banner content in DTS files is handled differently from JavaScript and CSS output files. It is written directly using the file system API, so setting `BannerPlugin` will not affect it.
+The banner content in declaration files is handled differently from JavaScript and CSS output files. It is written directly using the file system API, so setting `BannerPlugin` will not affect it.
 
 :::

--- a/website/docs/en/config/lib/bundle.mdx
+++ b/website/docs/en/config/lib/bundle.mdx
@@ -75,7 +75,7 @@ export default {
 
 ::: note
 
-If [DTS generation](/config/lib/dts) is enabled, remember to set [exclude](https://www.typescriptlang.org/tsconfig/#exclude) field in `tsconfig.json` to avoid generating TypeScript declaration files for the corresponding files.
+If [declaration files generation](/config/lib/dts) is enabled, remember to set [exclude](https://www.typescriptlang.org/tsconfig/#exclude) field in `tsconfig.json` to avoid generating TypeScript declaration files for the corresponding files.
 
 For example, exclude test files within the `src` folder:
 

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -24,7 +24,7 @@ Configure the generation of the TypeScript declaration files.
 
 ## Boolean type
 
-DTS generation is an optional feature, you can set `dts: true` to enable [bundleless DTS](/guide/advanced/dts#bundleless-dts) generation.
+Declaration files generation is an optional feature, you can set `dts: true` to enable [bundleless declaration files](/guide/advanced/dts#bundleless-declaration-files) generation.
 
 ```ts title="rslib.config.ts" {5}
 export default {
@@ -37,7 +37,7 @@ export default {
 };
 ```
 
-If you want to disable DTS generation, you can set `dts: false` or do not specify the `dts` option.
+If you want to disable declaration files generation, you can set `dts: false` or do not specify the `dts` option.
 
 ```ts title="rslib.config.ts" {5}
 export default {
@@ -52,20 +52,20 @@ export default {
 
 ## Object type
 
-If you want to customize the DTS generation, you can set the `dts` option to an object.
+If you want to customize the declaration files generation, you can set the `dts` option to an object.
 
 ### dts.bundle
 
 - **Type:** `boolean`
 - **Default:** `false`
 
-Whether to bundle the DTS files.
+Whether to bundle the declaration files.
 
 #### Example
 
-If you want to [bundle DTS](/guide/advanced/dts#bundle-dts) files, you should:
+If you want to [bundle declaration files](/guide/advanced/dts#bundle-declaration-files) files, you should:
 
-1. Install [@microsoft/api-extractor](https://www.npmjs.com/package/@microsoft/api-extractor) as a development dependency, which is the underlying tool used for bundling DTS files.
+1. Install [@microsoft/api-extractor](https://www.npmjs.com/package/@microsoft/api-extractor) as a development dependency, which is the underlying tool used for bundling declaration files.
 
 import { PackageManagerTabs } from '@theme';
 
@@ -88,13 +88,13 @@ export default {
 
 #### Handle third-party packages
 
-When we bundle DTS files, we should specify which third-party package types need to be bundled, refer to the [Handle Third-Party Dependencies](/guide/advanced/third-party-deps) documentation for more details about externals related configurations.
+When we bundle declaration files, we should specify which third-party package types need to be bundled, refer to the [Handle Third-Party Dependencies](/guide/advanced/third-party-deps) documentation for more details about externals related configurations.
 
 ### dts.distPath
 
 - **Type:** `string`
 
-The output directory of DTS files.
+The output directory of declaration files.
 
 #### Default value
 
@@ -124,7 +124,7 @@ export default {
 - **Type:** `boolean`
 - **Default:** `false`
 
-Whether to generate DTS files with building the project references. This is equivalent to using the `--build` flag with the `tsc` command. See [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) for more details.
+Whether to generate declaration files with building the project references. This is equivalent to using the `--build` flag with the `tsc` command. See [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) for more details.
 
 ::: note
 
@@ -137,7 +137,7 @@ When this option is enabled, you must explicitly set `declarationDir` or `outDir
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to abort the build process when an error occurs during DTS generation.
+Whether to abort the build process when an error occurs during declaration files generation.
 
 By default, type errors will cause the build to fail.
 
@@ -167,13 +167,13 @@ When this configuration is disabled, there is no guarantee that the type files w
 - **Type:** `boolean`
 - **Default:** `false`
 
-Whether to automatically set the DTS file extension based on the [format](/config/lib/format) option.
+Whether to automatically set the declaration file extension based on the [format](/config/lib/format) option.
 
 #### Default extension
 
-By default that when `dts.autoExtension` is `false`, the DTS file extension will be `.d.ts`.
+By default that when `dts.autoExtension` is `false`, the declaration file extension will be `.d.ts`.
 
-When `dts.autoExtension` is set to `true`, the DTS file extension will be:
+When `dts.autoExtension` is set to `true`, the declaration file extension will be:
 
 - `.d.ts` with `esm` format and `.d.cts` with `cjs` format when `type: module` in `package.json`.
 
@@ -181,6 +181,6 @@ When `dts.autoExtension` is set to `true`, the DTS file extension will be:
 
 ::: note
 
-It follows the same logic as [lib.autoExtension](/config/lib/auto-extension), but the default value is different since the DTS file extension may cause some issues with different module resolution strategies.
+It follows the same logic as [lib.autoExtension](/config/lib/auto-extension), but the default value is different since the declaration file extension may cause some issues with different module resolution strategies.
 
 :::

--- a/website/docs/en/config/lib/footer.mdx
+++ b/website/docs/en/config/lib/footer.mdx
@@ -16,7 +16,7 @@ type Footer = {
 
 - **Default:** `{}`
 
-Inject content into the bottom of each JavaScript, CSS or DTS file.
+Inject content into the bottom of each JavaScript, CSS or declaration file.
 
 ## Object type
 
@@ -39,7 +39,7 @@ Inject content into the bottom of each CSS output file.
 - **Type:** `string`
 - **Default:** `undefined`
 
-Inject content into the bottom of each DTS output file.
+Inject content into the bottom of each declaration output file.
 
 ## Notice
 
@@ -74,6 +74,6 @@ export default {
 
 :::warning
 
-The footer content in DTS files is handled differently from JavaScript and CSS files. It is written directly using the file system API, so setting `BannerPlugin` will not affect it.
+The footer content in declaration files is handled differently from JavaScript and CSS files. It is written directly using the file system API, so setting `BannerPlugin` will not affect it.
 
 :::

--- a/website/docs/en/config/lib/out-base.mdx
+++ b/website/docs/en/config/lib/out-base.mdx
@@ -53,6 +53,6 @@ dist
 
 ::: tip
 
-When the project needs to generate DTS type declaration files, to ensure that the generated DTS files and JS files maintain a consistent output directory structure, if you modify the `outBase` configuration, you need to make sure that the [rootDir](https://www.typescriptlang.org/tsconfig/rootDir.html) in `tsconfig.json` to the same path.
+When the project needs to generate declaration files, to ensure that the generated declaration files and JS files maintain a consistent output directory structure, if you modify the `outBase` configuration, you need to make sure that the [rootDir](https://www.typescriptlang.org/tsconfig/rootDir.html) in `tsconfig.json` to the same path.
 
 :::

--- a/website/docs/en/config/lib/redirect.mdx
+++ b/website/docs/en/config/lib/redirect.mdx
@@ -212,13 +212,13 @@ Whether to automatically redirect the import paths of TypeScript declaration out
 - **Type:** `boolean`
 - **Default:** `true`
 
-When set to `true`, Rslib will redirect the import path in the DTS output file to the corresponding relative path based on the [compilerOptions.paths](https://typescriptlang.org/tsconfig#paths) configured in `tsconfig.json`.
+When set to `true`, Rslib will redirect the import path in the declaration output file to the corresponding relative path based on the [compilerOptions.paths](https://typescriptlang.org/tsconfig#paths) configured in `tsconfig.json`.
 
 When set to `false`, the original import path will remain unchanged.
 
 - **Example:**
 
-When `compilerOptions.paths` is set to `{ "@/*": ["src/*"] }` in `tsconfig.json`, the DTS output file will be redirected to the correct relative path:
+When `compilerOptions.paths` is set to `{ "@/*": ["src/*"] }` in `tsconfig.json`, the declaration output file will be redirected to the correct relative path:
 
 ```ts
 import { foo } from '@/foo'; // source code of './src/bar.ts' ↓
@@ -235,7 +235,7 @@ Whether to automatically redirect the file extension to import paths based on th
 - **Type:** `boolean`
 - **Default:** `false`
 
-When set to `true`, the import paths in DTS files will be redirected to the corresponding JavaScript extension which can be resolved to corresponding DTS file.
+When set to `true`, the import paths in declaration files will be redirected to the corresponding JavaScript extension which can be resolved to corresponding declaration file.
 
 When set to `false`, the file extension will remain unchanged from the original import path in the rewritten import path of the output file (regardless of whether it is specified or specified as any value).
 

--- a/website/docs/en/guide/advanced/dts.mdx
+++ b/website/docs/en/guide/advanced/dts.mdx
@@ -1,10 +1,10 @@
-# DTS
+# Declaration files
 
-This chapter introduces what TypeScript Declaration Files (DTS) are and how to generate DTS files in Rslib.
+This chapter introduces what [TypeScript Declaration Files](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) are and how to generate declaration files in Rslib.
 
-## What is DTS
+## What is declaration files
 
-TypeScript Declaration Files (DTS) provide type information for JavaScript code. DTS files typically have a `.d.ts` extension. They allow the TypeScript compiler to understand the type structure of JavaScript code, enabling features like:
+TypeScript Declaration Files provide type information for JavaScript code. Declaration files typically have a `.d.ts` extension. They allow the TypeScript compiler to understand the type structure of JavaScript code, enabling features like:
 
 1. **Type Checking**: Provide type information for JavaScript code, helping developers catch potential type errors at compile time.
 2. **Code Completion**: Enhance code editor features like autocomplete and code navigation.
@@ -12,11 +12,11 @@ TypeScript Declaration Files (DTS) provide type information for JavaScript code.
 4. **IDE Support**: Improve the developer experience in IDEs like Visual Studio Code, WebStorm, and others.
 5. **Library Consumption**: Make it easier for users to use and understand your library.
 
-## What are bundle DTS and bundleless DTS
+## What are bundle declaration files and bundleless declaration files
 
-### Bundle DTS
+### Bundle declaration files
 
-Bundle DTS involves bundling multiple TypeScript declaration files into a single declaration file.
+Bundle declaration files involves bundling multiple TypeScript declaration files into a single declaration file.
 
 - **Pros:**
 
@@ -27,9 +27,9 @@ Bundle DTS involves bundling multiple TypeScript declaration files into a single
   - **Complex Generation**: Generating and maintaining a single bundle file can become complex in large projects.
   - **Debugging Challenges**: Debugging type issues may not be as intuitive as with separate files.
 
-### Bundleless DTS
+### Bundleless declaration files
 
-Bundleless DTS involves generating a separate declaration file for each module in the library, just like `tsc` does.
+Bundleless declaration files involves generating a separate declaration file for each module in the library, just like `tsc` does.
 
 - **Pros:**
 
@@ -40,17 +40,17 @@ Bundleless DTS involves generating a separate declaration file for each module i
   - **Multiple Files**: Users may need to handle multiple declaration files when using the library.
   - **Complex Management**: May require additional configuration to correctly reference all files.
 
-## How to generate DTS in Rslib
+## How to generate declaration files in Rslib
 
-Rslib defaults to generating bundleless DTS, which using [TypeScript Compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API) and bundle DTS is also supported by [API Extractor](https://api-extractor.com/).
+Rslib defaults to generating bundleless declaration files, which using [TypeScript Compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API) and bundle declaration files is also supported by [API Extractor](https://api-extractor.com/).
 
-If you want to generate bundleless DTS, you can:
+If you want to generate bundleless declaration files, you can:
 
 - Set `dts: true` or `dts: { bundle: false }` in the Rslib configuration file.
 
-If you want to generate bundle DTS, you can:
+If you want to generate bundle declaration files, you can:
 
-1. Install `@microsoft/api-extractor` as `devDependencies`, which is the underlying tool used for bundling DTS files.
+1. Install `@microsoft/api-extractor` as `devDependencies`, which is the underlying tool used for bundling declaration files.
 
 import { PackageManagerTabs } from '@theme';
 
@@ -60,6 +60,6 @@ import { PackageManagerTabs } from '@theme';
 
 ::: tip
 
-You can refer to [lib.dts](/config/lib/dts) for more details about DTS configuration.
+You can refer to [lib.dts](/config/lib/dts) for more details about declaration files configuration.
 
 :::

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -93,15 +93,15 @@ export default {
 };
 ```
 
-## d.ts generation
+## Declaration files generation
 
 ### How to additionally exclude specified dependencies when `dts.bundle` is `true`?
 
-Rslib uses [rsbuild-plugin-dts](https://github.com/web-infra-dev/rslib/blob/main/packages/plugin-dts/README.md) to generate d.ts files, which supports configuration via [output.externals](/config/rsbuild/output#outputtarget) for excluding certain dependencies from bundled d.ts files.
+Rslib uses [rsbuild-plugin-dts](https://github.com/web-infra-dev/rslib/blob/main/packages/plugin-dts/README.md) to generate declaration files, which supports configuration via [output.externals](/config/rsbuild/output#outputtarget) for excluding certain dependencies from bundled declaration files.
 
-For example, a typical React component library often does not declare @types/react in peerDependencies but only in devDependencies. Following the [autoExternal](/config/lib/auto-external) logic for dependency handling, Rslib will attempt to bundle @types/react into the d.ts artifact during the build. However, in practice, a component library should not bundle @types/react.
+For example, a typical React component library often does not declare `@types/react` in `peerDependencies` but only in `devDependencies`. Following the [autoExternal](/config/lib/auto-external) logic for dependency handling, Rslib will attempt to bundle `@types/react` into the declaration output files during the build. However, in practice, a component library should not bundle `@types/react`.
 
-In this scenario, you can configure [output.externals](/config/rsbuild/output#outputtarget) to exclude @types/react.
+In this scenario, you can configure [output.externals](/config/rsbuild/output#outputtarget) to exclude `@types/react`.
 
 ```ts title="rslib.config.ts"
 export default {

--- a/website/docs/en/guide/migration/modernjs-module.mdx
+++ b/website/docs/en/guide/migration/modernjs-module.mdx
@@ -146,7 +146,7 @@ In addition, you have to install the `@rsbuild/plugin-sass` package as `devDepen
 
 <PackageManagerTabs command="add @rsbuild/plugin-sass -D" />
 
-If you run TypeScript together with Sass, you might run into DTS generation errors. This can be resolved by adding a `env.d.ts` file in your `/src` directory.
+If you run TypeScript together with Sass, you might run into declaration files generation errors. This can be resolved by adding a `env.d.ts` file in your `/src` directory.
 
 ```ts title="src/env.d.ts"
 declare module '*.scss' {

--- a/website/docs/en/guide/start/glossary.mdx
+++ b/website/docs/en/guide/start/glossary.mdx
@@ -21,10 +21,6 @@ CJS stands for [CommonJS](https://nodejs.org/api/modules.html#modules-commonjs-m
 
 Bundleless refers to a development mode that departs from the traditional practice of bundling multiple JavaScript / TypeScript files into a single or few output files that are then served to the app. Instead, it transforms each file.
 
-## DTS
-
-DTS stands for [TypeScript Declaration Files](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html), providing type information for JavaScript code.
-
 ## Module Federation
 
 <MF />

--- a/website/docs/zh/config/lib/banner.mdx
+++ b/website/docs/zh/config/lib/banner.mdx
@@ -16,7 +16,7 @@ type Banner = {
 
 - **默认值：** `{}`
 
-在每个 JavaScript、CSS 或 DTS 输出文件顶部注入内容。
+在每个 JavaScript、CSS 或 类型声明输出文件顶部注入内容。
 
 ## 对象类型
 
@@ -39,7 +39,7 @@ type Banner = {
 - **类型：** `string`
 - **默认值：** `undefined`
 
-在每个 DTS 输出文件顶部注入内容。
+在每个类型声明输出文件顶部注入内容。
 
 ## 注意事项
 
@@ -73,6 +73,6 @@ export default {
 
 :::warning
 
-DTS 文件中的 banner 内容处理方式与 JavaScript 和 CSS 输出文件不同。它是直接使用文件系统 API 写入的，所以设置 `BannerPlugin` 不会对其产生影响。
+类型声明文件中的 banner 内容处理方式与 JavaScript 和 CSS 输出文件不同。它是直接使用文件系统 API 写入的，所以设置 `BannerPlugin` 不会对其产生影响。
 
 :::

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -24,7 +24,7 @@ type Dts =
 
 ## 布尔类型
 
-DTS 生成是一个可选功能，你可以设置 `dts: true` 来启用 [bundleless 的 DTS](/guide/advanced/dts#bundleless-dts) 生成。
+类型声明文件生成是一个可选功能，你可以设置 `dts: true` 来启用 [bundleless 类型](/guide/advanced/dts#bundleless-类型) 生成。
 
 ```ts title="rslib.config.ts" {5}
 export default {
@@ -37,7 +37,7 @@ export default {
 };
 ```
 
-如果你想要禁用 DTS 生成，可以设置 `dts: false` 或者不指定 `dts` 选项。
+如果你想要禁用类型声明文件生成，可以设置 `dts: false` 或者不指定 `dts` 选项。
 
 ```ts title="rslib.config.ts" {5}
 export default {
@@ -52,20 +52,20 @@ export default {
 
 ## 对象类型
 
-如果你想要自定义 DTS 的生成，可以将 `dts` 选项设置为一个对象。
+如果你想要自定义类型声明文件的生成，可以将 `dts` 选项设置为一个对象。
 
 ### dts.bundle
 
 - **类型：** `boolean`
 - **默认值：** `false`
 
-是否打包 DTS 文件。
+是否打包类型声明文件。
 
 #### 示例
 
-如果你想要 [打包 DTS](/guide/advanced/dts#bundle-dts) 文件，你需要：
+如果你想要 [bundle 类型](/guide/advanced/dts#bundle-类型)，你需要：
 
-1. 安装 [@microsoft/api-extractor](https://www.npmjs.com/package/@microsoft/api-extractor) 作为开发依赖，它是用于打包 DTS 文件的底层工具。
+1. 安装 [@microsoft/api-extractor](https://www.npmjs.com/package/@microsoft/api-extractor) 作为开发依赖，它是用于打包类型声明文件的底层工具。
 
 import { PackageManagerTabs } from '@theme';
 
@@ -88,13 +88,13 @@ export default {
 
 #### 处理第三方依赖
 
-当我们打包 DTS 文件时，我们需要指定哪些第三方包的类型需要被打包，可以参考 [处理第三方依赖](/guide/advanced/third-party-deps) 文档了解更多关于 externals 相关的配置。
+当我们打包类型声明文件时，我们需要指定哪些第三方包的类型需要被打包，可以参考 [处理第三方依赖](/guide/advanced/third-party-deps) 文档了解更多关于 externals 相关的配置。
 
 ### dts.distPath
 
 - **类型：** `string`
 
-DTS 文件的输出目录。
+类型声明文件的输出目录。
 
 #### 默认值
 
@@ -124,7 +124,7 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `false`
 
-是否在生成 DTS 文件时构建项目的 references。这相当于在 `tsc` 命令中使用 `--build` 标志。更多详细信息请参考 [项目引用](https://www.typescriptlang.org/docs/handbook/project-references.html)。
+是否在生成类型声明文件时构建项目的 references。这相当于在 `tsc` 命令中使用 `--build` 标志。更多详细信息请参考 [项目引用](https://www.typescriptlang.org/docs/handbook/project-references.html)。
 
 ::: note
 
@@ -137,7 +137,7 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `true`
 
-当 DTS 生成过程中出现错误时，是否中止构建过程。
+当类型声明文件生成过程中出现错误时，是否中止构建过程。
 
 默认情况下，类型错误会导致构建失败。
 
@@ -167,13 +167,13 @@ export default {
 - **类型：** `boolean`
 - **默认值：** `false`
 
-是否根据 [format](/config/lib/format) 选项自动设置 DTS 文件扩展名。
+是否根据 [format](/config/lib/format) 选项自动设置类型声明文件扩展名。
 
 #### 默认扩展名
 
-当 `dts.autoExtension` 为 `false` 时，DTS 文件扩展名默认为 `.d.ts`。
+当 `dts.autoExtension` 为 `false` 时，类型声明文件扩展名默认为 `.d.ts`。
 
-当 `dts.autoExtension` 设置为 `true` 时，DTS 文件扩展名将会是：
+当 `dts.autoExtension` 设置为 `true` 时，类型声明文件扩展名将会是：
 
 - 当 `package.json` 中设置 `type: module` 时，`esm` 格式使用 `.d.ts`，`cjs` 格式使用 `.d.cts`。
 
@@ -181,6 +181,6 @@ export default {
 
 ::: note
 
-这遵循与 [lib.autoExtension](/config/lib/auto-extension) 相同的逻辑，但默认值不同，因为 DTS 文件扩展名可能会在不同的模块解析策略中造成一些问题。
+这遵循与 [lib.autoExtension](/config/lib/auto-extension) 相同的逻辑，但默认值不同，因为类型声明文件扩展名可能会在不同的模块解析策略中造成一些问题。
 
 :::

--- a/website/docs/zh/config/lib/footer.mdx
+++ b/website/docs/zh/config/lib/footer.mdx
@@ -16,7 +16,7 @@ type Footer = {
 
 - **默认值：** `{}`
 
-在每个 JavaScript、CSS 或 DTS 文件底部注入内容。
+在每个 JavaScript、CSS 或类型声明文件底部注入内容。
 
 ## 对象类型
 
@@ -39,7 +39,7 @@ type Footer = {
 - **类型：** `string`
 - **默认值：** `undefined`
 
-在每个 DTS 输出文件底部注入内容。
+在每个类型声明输出文件底部注入内容。
 
 ## 注意事项
 
@@ -74,6 +74,6 @@ export default {
 
 :::warning
 
-DTS 文件中的 footer 内容与 JavaScript 和 CSS 文件的处理方式不同。它是直接通过文件系统 API 写入的，所以设置 `BannerPlugin` 不会对其产生影响。
+类型声明文件中的 footer 内容与 JavaScript 和 CSS 文件的处理方式不同。它是直接通过文件系统 API 写入的，所以设置 `BannerPlugin` 不会对其产生影响。
 
 :::

--- a/website/docs/zh/config/lib/out-base.mdx
+++ b/website/docs/zh/config/lib/out-base.mdx
@@ -53,6 +53,6 @@ dist
 
 ::: tip
 
-当项目需要生成 DTS 类型声明文件时，为了保证生成的 DTS 文件与 JS 文件保持一致的输出目录结构，如果修改了 `outBase` 配置，需要确保 `tsconfig.json` 中的 [rootDir](https://www.typescriptlang.org/tsconfig/rootDir.html) 为相同的路径。
+当项目需要生成类型声明文件时，为了保证生成的类型声明文件与 JS 文件保持一致的输出目录结构，如果修改了 `outBase` 配置，需要确保 `tsconfig.json` 中的 [rootDir](https://www.typescriptlang.org/tsconfig/rootDir.html) 为相同的路径。
 
 :::

--- a/website/docs/zh/config/lib/redirect.mdx
+++ b/website/docs/zh/config/lib/redirect.mdx
@@ -212,13 +212,13 @@ import url from './assets/logo.mjs'; // 预期生成的代码
 - **类型:** `boolean`
 - **默认值:** `true`
 
-当设置为 `true` 时，Rslib 会根据 `tsconfig.json` 文件中配置的 [compilerOptions.paths](https://typescriptlang.org/tsconfig#paths)，将 DTS 产物文件中的导入路径重定向为对应的相对路径。
+当设置为 `true` 时，Rslib 会根据 `tsconfig.json` 文件中配置的 [compilerOptions.paths](https://typescriptlang.org/tsconfig#paths)，将类型声明产物文件中的导入路径重定向为对应的相对路径。
 
 当设置为 `false` 时，将保持原始导入路径不变。
 
 - **示例：**
 
-在 `tsconfig.json` 中将 `compilerOptions.paths` 设置为 `{ "@/*": ["src/*"] }` 时，DTS 产物文件将被重定向到正确的相对路径：
+在 `tsconfig.json` 中将 `compilerOptions.paths` 设置为 `{ "@/*": ["src/*"] }` 时，类型声明产物文件将被重定向到正确的相对路径：
 
 ```ts
 import { foo } from '@/foo'; // './src/bar.ts' 的源码 ↓
@@ -235,7 +235,7 @@ import { foo } from '../foo'; // './dist/utils/index.d.ts' 预期生成的代码
 - **类型:** `boolean`
 - **默认值:** `false`
 
-当设置为 `true` 时，DTS 文件中的引入路径会被重定向到对应的可以解析到相应 DTS 文件的 JavaScript 文件扩展名。
+当设置为 `true` 时，类型声明文件中的引入路径会被重定向到对应的可以解析到相应类型声明文件的 JavaScript 文件扩展名。
 
 当设置为 `false` 时，文件扩展名将保持原始导入路径不变（无论是否指定或指定为任意值）。
 

--- a/website/docs/zh/guide/advanced/dts.mdx
+++ b/website/docs/zh/guide/advanced/dts.mdx
@@ -1,10 +1,10 @@
 # 类型生成
 
-本章介绍什么是 TypeScript 声明文件（DTS）以及如何在 Rslib 中生成 DTS 文件。
+本章介绍什么是 [TypeScript 类型声明文件](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)，以及如何在 Rslib 中生成类型声明文件。
 
-## 什么是 DTS
+## 什么是类型声明文件
 
-TypeScript 声明文件 (DTS) 提供 JavaScript 代码的类型信息。 DTS 文件通常具有 `.d.ts` 扩展名。它们允许 TypeScript 编译器理解 JavaScript 代码的类型结构，从而实现以下功能：
+TypeScript 类型声明文件提供 JavaScript 代码的类型信息。类型声明文件通常具有 `.d.ts` 扩展名。它们允许 TypeScript 编译器理解 JavaScript 代码的类型结构，从而实现以下功能：
 
 1. **类型检查**: 为 JavaScript 代码提供类型信息，帮助开发人员在编译时捕获潜在的类型错误。
 2. **代码补全**: 增强代码编辑器功能，例如自动完成和代码导航。
@@ -12,11 +12,11 @@ TypeScript 声明文件 (DTS) 提供 JavaScript 代码的类型信息。 DTS 文
 4. **IDE 支持**: 改善 Visual Studio Code、WebStorm 等 IDE 中的开发者体验。
 5. **库消费**: 让其他使用者更容易使用和理解该库。
 
-## 什么是 bundle DTS 和 bundleless DTS
+## 什么是 bundle 类型和 bundleless 类型
 
-### Bundle DTS
+### Bundle 类型
 
-Bundle DTS 将多个 TypeScript 声明文件 bundle 到一个声明文件中。
+Bundle 类型将多个 TypeScript 声明文件打包到一个声明文件中。
 
 - **优势:**
 
@@ -27,9 +27,9 @@ Bundle DTS 将多个 TypeScript 声明文件 bundle 到一个声明文件中。
   - **生成复杂**: 在大型项目中，生成和维护单个 bundle 文件可能会变得复杂。
   - **调试困难**: 调试类型问题可能不像各个文件单独输出那样直观。
 
-### Bundleless DTS
+### Bundleless 类型
 
-Bundleless DTS 为库中的每个模块生成单独的声明文件，就像 `tsc` 一样。
+Bundleless 类型为库中的每个模块生成单独的声明文件，就像 `tsc` 一样。
 
 - **优势:**
 
@@ -40,17 +40,17 @@ Bundleless DTS 为库中的每个模块生成单独的声明文件，就像 `tsc
   - **多文件**: 用户在使用该库时可能需要处理多个声明文件。
   - **管理复杂**: 可能需要额外的配置才能正确引用所有文件。
 
-## 如何在 Rslib 中生成 DTS
+## 如何在 Rslib 中生成类型声明文件
 
-Rslib 默认使用 [TypeScript Compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API) 生成 Bundleless DTS， 用 [API Extractor](https://api-extractor.com/) 生成 Bundle DTS。
+Rslib 默认使用 [TypeScript Compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API) 生成 bundleless 类型，用 [API Extractor](https://api-extractor.com/) 生成 bundle 类型。
 
-如果你想生成 Bundleless DTS，可以：
+如果你想生成 bundleless 类型，可以：
 
 - 设置 `dts: true` 或者 `dts: { bundle: false }` 在 Rslib 配置文件。
 
-如果你想生成 Bundle DTS，可以：
+如果你想生成 bundle 类型，可以：
 
-1. 安装 `@microsoft/api-extractor` 作为 `devDependencies`, 这是用于 bundle DTS 文件的底层工具。
+1. 安装 `@microsoft/api-extractor` 作为 `devDependencies`, 这是用于打包类型声明文件的底层工具。
 
 import { PackageManagerTabs } from '@theme';
 
@@ -60,6 +60,6 @@ import { PackageManagerTabs } from '@theme';
 
 ::: tip
 
-你可以参考 [lib.dts](/config/lib/dts) 获取更多有关 DTS 配置的详细信息。
+你可以参考 [lib.dts](/config/lib/dts) 获取更多有关类型声明文件配置的详细信息。
 
 :::

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -93,15 +93,15 @@ export default {
 };
 ```
 
-## d.ts 生成
+## 类型声明文件生成
 
 ### 如何在 `dts.bundle` 为 `true` 时额外排除指定的依赖？
 
-Rslib 通过 [rsbuild-plugin-dts](https://github.com/web-infra-dev/rslib/blob/main/packages/plugin-dts/README.md) 完成对 d.ts 文件的生成，该插件支持通过 [output.externals](/config/rsbuild/output#outputtarget) 进行配置，用于从打包后的 d.ts 文件中排除指定的依赖。
+Rslib 通过 [rsbuild-plugin-dts](https://github.com/web-infra-dev/rslib/blob/main/packages/plugin-dts/README.md) 完成对类型声明文件的生成，该插件支持通过 [output.externals](/config/rsbuild/output#outputtarget) 进行配置，用于从打包后的类型声明文件中排除指定的依赖。
 
-举个例子：常见的 React 组件库通常不会将 @types/react 声明在 peerDependencies 中，而是仅声明在 devDependencies，按照 [autoExternal](/config/lib/auto-external) 处理依赖的逻辑，在打包时 Rslib 会尝试将 @types/react 一同打包进 d.ts 产物中，但在实践中组件库并不应该打包 @types/react。
+举个例子：常见的 React 组件库通常不会将 `@types/react` 声明在 `peerDependencies` 中，而是仅声明在 `devDependencies`，按照 [autoExternal](/config/lib/auto-external) 处理依赖的逻辑，在打包时 Rslib 会尝试将 `@types/react` 一同打包进类型声明文件产物中，但在实践中组件库并不应该打包 `@types/react`。
 
-此时可以通过配置 [output.externals](/config/rsbuild/output#outputtarget) 来排除 @types/react。
+此时可以通过配置 [output.externals](/config/rsbuild/output#outputtarget) 来排除 `@types/react`。
 
 ```ts title="rslib.config.ts"
 export default {

--- a/website/docs/zh/guide/migration/modernjs-module.mdx
+++ b/website/docs/zh/guide/migration/modernjs-module.mdx
@@ -146,7 +146,7 @@ export default defineConfig({
 
 <PackageManagerTabs command="add @rsbuild/plugin-sass -D" />
 
-如果你在运行 TypeScript 和 Sass，你可能会遇到 DTS 生成错误。这可以通过在 `/src` 目录中添加一个 `env.d.ts` 文件来解决。
+如果你在运行 TypeScript 和 Sass，你可能会遇到类型声明文件生成错误。这可以通过在 `/src` 目录中添加一个 `env.d.ts` 文件来解决。
 
 ```ts title="src/env.d.ts"
 declare module '*.scss' {

--- a/website/docs/zh/guide/start/glossary.mdx
+++ b/website/docs/zh/guide/start/glossary.mdx
@@ -21,10 +21,6 @@ CJS 代表 [CommonJS](https://nodejs.org/api/modules.html#modules-commonjs-modul
 
 Bundleless 是指一种开发模式，它与将多个 JavaScript/TypeScript 文件 bundle 到单个或很少的输出文件中，然后再将其提供给应用的传统做法不同。相反，它为每个文件都进行 transform 转译。
 
-## DTS
-
-DTS 表示 [TypeScript 声明文件](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)，为 JavaScript 代码提供类型信息。
-
 ## 模块联邦
 
 <MF />


### PR DESCRIPTION
## Summary

- Replace keyword `DTS` in docs and plugin logs to `declaration files` to make users easier to understand.
- Add `[tsc]` prefix to dts logs to make log sources clearer

![image](https://github.com/user-attachments/assets/98194e32-7a09-4cdb-8f3b-46cfc8b37120)

![image](https://github.com/user-attachments/assets/0f9b83f3-82c0-4ae2-a8fc-5fe281b977a2)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
