### PR TITLE
fix: should check lib array non-empty

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1571,9 +1571,11 @@ export async function composeCreateRsbuildConfig(
     ...sharedRsbuildConfig
   } = rslibConfig;
 
-  if (!libConfigsArray) {
+  if (!Array.isArray(libConfigsArray) || libConfigsArray.length === 0) {
     throw new Error(
-      `Expect lib field to be an array, but got ${libConfigsArray}.`,
+      `Expect "lib" field to be a non-empty array, but got: ${color.cyan(
+        JSON.stringify(libConfigsArray),
+      )}.`,
     );
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -607,6 +607,8 @@ importers:
 
   tests/integration/cli/mf/dev: {}
 
+  tests/integration/config-check/lib-array: {}
+
   tests/integration/copy: {}
 
   tests/integration/decorators/default: {}

--- a/tests/integration/config-check/index.test.ts
+++ b/tests/integration/config-check/index.test.ts
@@ -1,0 +1,14 @@
+import { join } from 'node:path';
+import { buildAndGetResults } from 'test-helper';
+import { expect, test } from 'vitest';
+
+test('should throw error when lib array not exists or empty', async () => {
+  const fixturePath = join(__dirname, 'lib-array');
+  try {
+    await buildAndGetResults({ fixturePath });
+  } catch (error) {
+    expect((error as Error).message).toMatchInlineSnapshot(
+      `"Expect "lib" field to be a non-empty array, but got: []."`,
+    );
+  }
+});

--- a/tests/integration/config-check/index.test.ts
+++ b/tests/integration/config-check/index.test.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import stripAnsi from 'strip-ansi';
 import { buildAndGetResults } from 'test-helper';
 import { expect, test } from 'vitest';
 
@@ -7,7 +8,7 @@ test('should throw error when lib array not exists or empty', async () => {
   try {
     await buildAndGetResults({ fixturePath });
   } catch (error) {
-    expect((error as Error).message).toMatchInlineSnapshot(
+    expect(stripAnsi((error as Error).message)).toMatchInlineSnapshot(
       `"Expect "lib" field to be a non-empty array, but got: []."`,
     );
   }

--- a/tests/integration/config-check/lib-array/package.json
+++ b/tests/integration/config-check/lib-array/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "config-check-lib-array-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/config-check/lib-array/rslib.config.ts
+++ b/tests/integration/config-check/lib-array/rslib.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [],
+});


### PR DESCRIPTION
## Summary

`lib` field is **required** in Rslib, we should check it is a valid array with at least one element.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
