### PR TITLE
fix: standardize logging messages

### DIFF
--- a/packages/core/__mocks__/rslog.cjs
+++ b/packages/core/__mocks__/rslog.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   logger: {
     warn: () => {},
+    override: () => {},
   },
 };

--- a/packages/core/src/cli/restart.ts
+++ b/packages/core/src/cli/restart.ts
@@ -64,9 +64,9 @@ const beforeRestart = async ({
 
   if (filePath) {
     const filename = path.basename(filePath);
-    logger.info(`Restart because ${color.yellow(filename)} is changed.\n`);
+    logger.info(`restart because ${color.yellow(filename)} is changed.\n`);
   } else {
-    logger.info('Restarting...\n');
+    logger.info('restarting...\n');
   }
 
   for (const cleaner of cleaners) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -282,7 +282,7 @@ const composeExternalsWarnConfig = (
           if (contextInfo.issuer && dependencyType === 'commonjs') {
             matchUserExternals(externals, request, _callback);
             if (shouldWarn) {
-              logger.warn(composeModuleImportWarn(request));
+              logger.warn(composeModuleImportWarn(request, contextInfo.issuer));
             }
           }
           callback();
@@ -324,7 +324,7 @@ export const composeAutoExternalConfig = (options: {
 
   if (!pkgJson) {
     logger.warn(
-      'autoExternal configuration will not be applied due to read package.json failed',
+      'The `autoExternal` configuration will not be applied due to read package.json failed',
     );
     return {};
   }
@@ -782,8 +782,11 @@ const composeShimsConfig = (
   return { rsbuildConfig, enabledShims };
 };
 
-export const composeModuleImportWarn = (request: string): string => {
-  return `The externalized commonjs request ${color.green(`"${request}"`)} will use ${color.blue('"module"')} external type in ESM format. If you want to specify other external type, consider setting the request and type with ${color.blue('"output.externals"')}.`;
+export const composeModuleImportWarn = (
+  request: string,
+  issuer: string,
+): string => {
+  return `The externalized commonjs request ${color.green(`"${request}"`)} from ${color.green(issuer)} will use ${color.blue('"module"')} external type in ESM format. If you want to specify other external type, consider setting the request and type with ${color.blue('"output.externals"')}.`;
 };
 
 const composeExternalsConfig = (

--- a/packages/core/src/utils/extension.ts
+++ b/packages/core/src/utils/extension.ts
@@ -24,7 +24,7 @@ export const getDefaultExtension = (options: {
 
   if (!pkgJson) {
     logger.warn(
-      'autoExtension configuration will not be applied due to read package.json failed',
+      'The `autoExtension` configuration will not be applied due to read package.json failed',
     );
     return {
       jsExtension,

--- a/packages/core/src/utils/helper.ts
+++ b/packages/core/src/utils/helper.ts
@@ -117,7 +117,9 @@ export const readPackageJson = (rootPath: string): undefined | PkgJson => {
   const pkgJsonPath = path.join(rootPath, './package.json');
 
   if (!fs.existsSync(pkgJsonPath)) {
-    logger.warn(`package.json does not exist in the ${rootPath} directory`);
+    logger.warn(
+      `The \`package.json\` file does not exist in the ${rootPath} directory`,
+    );
     return;
   }
 

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -96,8 +96,8 @@ export async function emptyDir(dir: string): Promise<void> {
       });
     }
   } catch (err) {
-    logger.debug(`Failed to empty dir: ${dir}`);
-    logger.debug(err);
+    logger.warn(`Failed to empty dir: ${dir}`);
+    logger.warn(err);
   }
 }
 
@@ -332,7 +332,7 @@ export async function redirectDtsImports(
 
       code.overwrite(start, end, normalizedRedirectImportPath);
     } catch (err) {
-      logger.debug(err);
+      logger.warn(err);
     }
   }
 

--- a/tests/integration/auto-external/index.test.ts
+++ b/tests/integration/auto-external/index.test.ts
@@ -91,6 +91,7 @@ test('should get warn when use require in ESM', async () => {
 
   const shouldWarn = ['react', 'e2', 'e3', 'e5', 'e6', 'e7'];
   const shouldNotWarn = ['e1', 'e4', 'e8', 'lodash/add', 'lodash/drop'];
+  const issuer = join(fixturePath, 'src/index.ts');
 
   for (const item of shouldWarn) {
     expect(entries.esm).toContain(
@@ -98,18 +99,18 @@ test('should get warn when use require in ESM', async () => {
     );
   }
 
-  for (const item of shouldWarn) {
+  for (const request of shouldWarn) {
     expect(
       logStrings.some((l) =>
-        l.includes(stripAnsi(composeModuleImportWarn(item))),
+        l.includes(stripAnsi(composeModuleImportWarn(request, issuer))),
       ),
     ).toBe(true);
   }
 
-  for (const item of shouldNotWarn) {
+  for (const request of shouldNotWarn) {
     expect(
       logStrings.some((l) =>
-        l.includes(stripAnsi(composeModuleImportWarn(item))),
+        l.includes(stripAnsi(composeModuleImportWarn(request, issuer))),
       ),
     ).toBe(false);
   }

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -40,6 +40,7 @@ test('should get warn when use require in ESM', async () => {
   const fixturePath = join(__dirname, 'module-import-warn');
   const { entries } = await buildAndGetResults({ fixturePath });
   const logStrings = logs.map((log) => stripAnsi(log));
+  const issuer = join(fixturePath, 'src/index.ts');
 
   for (const external of [
     'import * as __WEBPACK_EXTERNAL_MODULE_bar__ from "bar";',
@@ -51,7 +52,7 @@ test('should get warn when use require in ESM', async () => {
   for (const external of ['foo', 'bar', 'qux']) {
     expect(
       logStrings.some((l) =>
-        l.includes(stripAnsi(composeModuleImportWarn(external))),
+        l.includes(stripAnsi(composeModuleImportWarn(external, issuer))),
       ),
     ).toBe(true);
   }
@@ -59,7 +60,7 @@ test('should get warn when use require in ESM', async () => {
   for (const external of ['./baz', 'quxx']) {
     expect(
       logStrings.some((l) =>
-        l.includes(stripAnsi(composeModuleImportWarn(external))),
+        l.includes(stripAnsi(composeModuleImportWarn(external, issuer))),
       ),
     ).toBe(false);
   }


### PR DESCRIPTION
## Summary

- Include several changes to enforce a consistent logging message case convention across the codebase

```js
/**
 * Logging message case convention:
 *
 * Info, ready, success and debug messages:
 * - Start with lowercase
 * - Example: "info  build started..."
 *
 * Errors and warnings:
 * - Start with uppercase
 * - Example: "error  Failed to build"
 *
 * This convention helps distinguish between normal operations
 * and important alerts that require attention.
 */
```

- Use `rslib` as our DEBUG key
- Add issuer path in logs of `module-import-warn` cases

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
