### PR TITLE
chore(deps): update Rsbuild to v1.2.19

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.10.0",
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@rsbuild/plugin-react": "^1.1.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.10.0",
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@rsbuild/plugin-react": "^1.1.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "rsbuild-plugin-dts": "workspace:*",
     "tinyglobby": "^0.2.12"
   },

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@storybook/addon-essentials": "^8.6.4",
     "@storybook/addon-interactions": "^8.6.4",
     "@storybook/addon-links": "^8.6.4",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@storybook/addon-essentials": "^8.6.4",
     "@storybook/addon-interactions": "^8.6.4",
     "@storybook/addon-links": "^8.6.4",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -19,7 +19,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.4",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.4",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -18,7 +18,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.4",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.4",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.51.1",
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@rslib/tsconfig": "workspace:*",
     "rsbuild-plugin-publint": "^0.3.0",
     "rslib": "npm:@rslib/core@0.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,13 +91,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.10.0
-        version: 0.10.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.10.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@rsbuild/core':
-        specifier: ~1.2.18
-        version: 1.2.18
+        specifier: ~1.2.19
+        version: 1.2.19
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
       '@types/react':
         specifier: ^19.0.10
         version: 19.0.10
@@ -115,13 +115,13 @@ importers:
         version: 0.10.0(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/rsbuild-plugin':
         specifier: ^0.10.0
-        version: 0.10.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.10.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/storybook-addon':
         specifier: ^4.0.7
-        version: 4.0.7(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@storybook/core@8.6.4(prettier@3.5.3)(storybook@8.6.4(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)
+        version: 4.0.7(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@storybook/core@8.6.4(prettier@3.5.3)(storybook@8.6.4(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -142,10 +142,10 @@ importers:
         version: 8.6.4(prettier@3.5.3)
       storybook-addon-rslib:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@1.2.18)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2)
+        version: 1.0.0(@rsbuild/core@1.2.19)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2)
       storybook-react-rsbuild:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0)
+        version: 1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -158,13 +158,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.10.0
-        version: 0.10.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.10.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@rsbuild/core':
-        specifier: ~1.2.18
-        version: 1.2.18
+        specifier: ~1.2.19
+        version: 1.2.19
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
       '@types/react':
         specifier: ^19.0.10
         version: 19.0.10
@@ -179,10 +179,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@1.2.18)(preact@10.26.4)
+        version: 1.3.1(@rsbuild/core@1.2.19)(preact@10.26.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.18)
+        version: 1.2.2(@rsbuild/core@1.2.19)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -194,10 +194,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.18)
+        version: 1.2.2(@rsbuild/core@1.2.19)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -212,10 +212,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.18)
+        version: 1.2.2(@rsbuild/core@1.2.19)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -230,10 +230,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.18)
+        version: 1.2.2(@rsbuild/core@1.2.19)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -248,7 +248,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.2.18)(vue@3.5.13(typescript@5.8.2))
+        version: 1.0.7(@rsbuild/core@1.2.19)(vue@3.5.13(typescript@5.8.2))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -265,8 +265,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~1.2.18
-        version: 1.2.18
+        specifier: ~1.2.19
+        version: 1.2.19
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
@@ -276,7 +276,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.10.0
-        version: 0.10.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.10.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -303,7 +303,7 @@ importers:
         version: 1.2.7(typescript@5.8.2)
       rsbuild-plugin-publint:
         specifier: ^0.3.0
-        version: 0.3.0(@rsbuild/core@1.2.18)
+        version: 0.3.0(@rsbuild/core@1.2.19)
       rslib:
         specifier: npm:@rslib/core@0.5.4
         version: '@rslib/core@0.5.4(@microsoft/api-extractor@7.51.1(@types/node@22.8.1))(typescript@5.8.2)'
@@ -337,7 +337,7 @@ importers:
         version: 11.3.0
       rsbuild-plugin-publint:
         specifier: ^0.3.0
-        version: 0.3.0(@rsbuild/core@1.2.18)
+        version: 0.3.0(@rsbuild/core@1.2.19)
       rslib:
         specifier: npm:@rslib/core@0.5.4
         version: '@rslib/core@0.5.4(@microsoft/api-extractor@7.51.1(@types/node@22.8.1))(typescript@5.8.2)'
@@ -370,14 +370,14 @@ importers:
         specifier: ^7.51.1
         version: 7.51.1(@types/node@22.8.1)
       '@rsbuild/core':
-        specifier: ~1.2.18
-        version: 1.2.18
+        specifier: ~1.2.19
+        version: 1.2.19
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
       rsbuild-plugin-publint:
         specifier: ^0.3.0
-        version: 0.3.0(@rsbuild/core@1.2.18)
+        version: 0.3.0(@rsbuild/core@1.2.19)
       rslib:
         specifier: npm:@rslib/core@0.5.4
         version: '@rslib/core@0.5.4(@microsoft/api-extractor@7.51.1(@types/node@22.8.1))(typescript@5.8.2)'
@@ -401,22 +401,22 @@ importers:
         version: 4.0.0(vite@6.0.11(@types/node@22.8.1)(jiti@2.4.2)(sass-embedded@1.85.0)(stylus@0.64.0)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))(vitest@3.0.8(@types/debug@4.1.12)(@types/node@22.8.1)(jiti@2.4.2)(sass-embedded@1.85.0)(stylus@0.64.0)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.10.0
-        version: 0.10.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.10.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@playwright/test':
         specifier: 1.51.0
         version: 1.51.0
       '@rsbuild/core':
-        specifier: ~1.2.18
-        version: 1.2.18
+        specifier: ~1.2.19
+        version: 1.2.19
       '@rsbuild/plugin-less':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.18)
+        version: 1.2.2(@rsbuild/core@1.2.19)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -475,7 +475,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
 
   tests/integration/asset/json: {}
 
@@ -491,10 +491,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.2.18)(typescript@5.8.2)
+        version: 1.0.7(@rsbuild/core@1.2.19)(typescript@5.8.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -588,10 +588,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.18)
+        version: 1.1.1(@rsbuild/core@1.2.19)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.2.18)(typescript@5.8.2)
+        version: 1.0.7(@rsbuild/core@1.2.19)(typescript@5.8.2)
 
   tests/integration/cli/build: {}
 
@@ -755,7 +755,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.2.18)
+        version: 1.3.0(@rsbuild/core@1.2.19)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -765,7 +765,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.2.18)
+        version: 1.3.0(@rsbuild/core@1.2.19)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -783,7 +783,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.4
-        version: 1.0.4(@rsbuild/core@1.2.18)
+        version: 1.0.4(@rsbuild/core@1.2.19)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.11.1
         version: 0.11.1(@babel/core@7.26.9)
@@ -906,13 +906,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.0.8
-        version: 1.0.8(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
+        version: 1.0.8(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.0.8
-        version: 1.0.8(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
+        version: 1.0.8(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -970,11 +970,11 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~1.2.18
-        version: 1.2.18
+        specifier: ~1.2.19
+        version: 1.2.19
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.18)
+        version: 1.2.2(@rsbuild/core@1.2.19)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -998,7 +998,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.3
-        version: 1.0.3(@rsbuild/core@1.2.18)
+        version: 1.0.3(@rsbuild/core@1.2.19)
       rspress:
         specifier: ^2.0.0-alpha.2
         version: 2.0.0-alpha.2(webpack@5.98.0)
@@ -2099,8 +2099,8 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
 
-  '@rsbuild/core@1.2.18':
-    resolution: {integrity: sha512-hnqYu75ewn4X4f+/FqLZ5DUv1CaqLuzJl1HGgkOMWg1gj8b5kmidGHcGFCgRMQqJacdMGJGAy0yJHGLVuDPYNg==}
+  '@rsbuild/core@1.2.19':
+    resolution: {integrity: sha512-k76is4HygmbYYMLG2V1d1yQeurHHC+ZEtGs/nwE11y6HmwSndoFhmjOeQbQ2Ul0b2B8HErksqSMtlCxd37YPPQ==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
@@ -7693,12 +7693,12 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.10.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)':
+  '@module-federation/rsbuild-plugin@0.10.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)':
     dependencies:
       '@module-federation/enhanced': 0.10.0(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/sdk': 0.10.0
     optionalDependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -7762,12 +7762,12 @@ snapshots:
     dependencies:
       isomorphic-rslog: 0.0.6
 
-  '@module-federation/storybook-addon@4.0.7(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@storybook/core@8.6.4(prettier@3.5.3)(storybook@8.6.4(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)':
+  '@module-federation/storybook-addon@4.0.7(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@storybook/core@8.6.4(prettier@3.5.3)(storybook@8.6.4(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)':
     dependencies:
       '@module-federation/enhanced': 0.10.0(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/sdk': 0.10.0
     optionalDependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       '@storybook/core': 8.6.4(prettier@3.5.3)(storybook@8.6.4(prettier@3.5.3))
       webpack: 5.98.0
       webpack-virtual-modules: 0.6.2
@@ -7942,7 +7942,7 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rsbuild/core@1.2.18':
+  '@rsbuild/core@1.2.19':
     dependencies:
       '@rspack/core': 1.2.8(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
@@ -7952,13 +7952,13 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.2.18)':
+  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.2.19)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.9)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.9)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.9)
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -7966,13 +7966,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.1.1(@rsbuild/core@1.2.18)':
+  '@rsbuild/plugin-less@1.1.1(@rsbuild/core@1.2.19)':
     dependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
-  '@rsbuild/plugin-node-polyfill@1.3.0(@rsbuild/core@1.2.18)':
+  '@rsbuild/plugin-node-polyfill@1.3.0(@rsbuild/core@1.2.19)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -7998,13 +7998,13 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
 
-  '@rsbuild/plugin-preact@1.3.1(@rsbuild/core@1.2.18)(preact@10.26.4)':
+  '@rsbuild/plugin-preact@1.3.1(@rsbuild/core@1.2.19)(preact@10.26.4)':
     dependencies:
       '@prefresh/core': 1.5.3(preact@10.26.4)
       '@prefresh/utils': 1.2.0
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       '@rspack/plugin-preact-refresh': 1.1.2(@prefresh/core@1.5.3(preact@10.26.4))(@prefresh/utils@1.2.0)
       '@swc/plugin-prefresh': 6.2.0
     transitivePeerDependencies:
@@ -8016,24 +8016,24 @@ snapshots:
       '@rspack/plugin-react-refresh': 1.0.1(react-refresh@0.16.0)
       react-refresh: 0.16.0
 
-  '@rsbuild/plugin-react@1.1.1(@rsbuild/core@1.2.18)':
+  '@rsbuild/plugin-react@1.1.1(@rsbuild/core@1.2.19)':
     dependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       '@rspack/plugin-react-refresh': 1.0.1(react-refresh@0.16.0)
       react-refresh: 0.16.0
 
-  '@rsbuild/plugin-sass@1.2.2(@rsbuild/core@1.2.18)':
+  '@rsbuild/plugin-sass@1.2.2(@rsbuild/core@1.2.19)':
     dependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.2
       reduce-configs: 1.1.0
       sass-embedded: 1.85.0
 
-  '@rsbuild/plugin-stylus@1.0.8(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)':
+  '@rsbuild/plugin-stylus@1.0.8(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)':
     dependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
       stylus: 0.64.0
@@ -8043,10 +8043,10 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.0.7(@rsbuild/core@1.2.18)(typescript@5.8.2)':
+  '@rsbuild/plugin-svgr@1.0.7(@rsbuild/core@1.2.19)(typescript@5.8.2)':
     dependencies:
-      '@rsbuild/core': 1.2.18
-      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.2.18)
+      '@rsbuild/core': 1.2.19
+      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.2.19)
       '@svgr/core': 8.1.0(typescript@5.8.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.2))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.2))(typescript@5.8.2)
@@ -8056,21 +8056,21 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-type-check@1.2.1(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)':
+  '@rsbuild/plugin-type-check@1.2.1(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.0
       ts-checker-rspack-plugin: 1.1.1(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)
     optionalDependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-vue@1.0.7(@rsbuild/core@1.2.18)(vue@3.5.13(typescript@5.8.2))':
+  '@rsbuild/plugin-vue@1.0.7(@rsbuild/core@1.2.19)(vue@3.5.13(typescript@5.8.2))':
     dependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       vue-loader: 17.4.2(vue@3.5.13(typescript@5.8.2))(webpack@5.98.0)
       webpack: 5.98.0
     transitivePeerDependencies:
@@ -8083,8 +8083,8 @@ snapshots:
 
   '@rslib/core@0.5.4(@microsoft/api-extractor@7.51.1(@types/node@22.8.1))(typescript@5.8.2)':
     dependencies:
-      '@rsbuild/core': 1.2.18
-      rsbuild-plugin-dts: 0.5.4(@microsoft/api-extractor@7.51.1(@types/node@22.8.1))(@rsbuild/core@1.2.18)(typescript@5.8.2)
+      '@rsbuild/core': 1.2.19
+      rsbuild-plugin-dts: 0.5.4(@microsoft/api-extractor@7.51.1(@types/node@22.8.1))(@rsbuild/core@1.2.19)(typescript@5.8.2)
       tinyglobby: 0.2.12
     optionalDependencies:
       '@microsoft/api-extractor': 7.51.1(@types/node@22.8.1)
@@ -12235,10 +12235,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.34.2
       fsevents: 2.3.3
 
-  rsbuild-plugin-dts@0.5.4(@microsoft/api-extractor@7.51.1(@types/node@22.8.1))(@rsbuild/core@1.2.18)(typescript@5.8.2):
+  rsbuild-plugin-dts@0.5.4(@microsoft/api-extractor@7.51.1(@types/node@22.8.1))(@rsbuild/core@1.2.19)(typescript@5.8.2):
     dependencies:
       '@ast-grep/napi': 0.36.1
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       magic-string: 0.30.17
       picocolors: 1.1.1
       tinyglobby: 0.2.12
@@ -12247,23 +12247,23 @@ snapshots:
       '@microsoft/api-extractor': 7.51.1(@types/node@22.8.1)
       typescript: 5.8.2
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.2.18):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.2.19):
     optionalDependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
 
-  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.2.18):
+  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.2.19):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
 
-  rsbuild-plugin-publint@0.3.0(@rsbuild/core@1.2.18):
+  rsbuild-plugin-publint@0.3.0(@rsbuild/core@1.2.19):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.2
     optionalDependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
 
   rslog@1.2.3: {}
 
@@ -12585,18 +12585,18 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@1.0.0(@rsbuild/core@1.2.18)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2):
+  storybook-addon-rslib@1.0.0(@rsbuild/core@1.2.19)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2):
     dependencies:
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 1.0.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
     optionalDependencies:
       typescript: 5.8.2
 
-  storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3):
+  storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3):
     dependencies:
-      '@rsbuild/core': 1.2.18
-      '@rsbuild/plugin-type-check': 1.2.1(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)
+      '@rsbuild/core': 1.2.19
+      '@rsbuild/plugin-type-check': 1.2.1(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)
       '@storybook/addon-docs': 8.4.2(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(webpack-sources@3.2.3)
       '@storybook/core-webpack': 8.4.2(storybook@8.6.4(prettier@3.5.3))
       browser-assert: 1.2.1
@@ -12609,7 +12609,7 @@ snapshots:
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.2.18)
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.2.19)
       sirv: 2.0.4
       storybook: 8.6.4(prettier@3.5.3)
       ts-dedent: 2.2.0
@@ -12623,10 +12623,10 @@ snapshots:
       - '@types/react'
       - webpack-sources
 
-  storybook-react-rsbuild@1.0.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0):
+  storybook-react-rsbuild@1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.34.2)
-      '@rsbuild/core': 1.2.18
+      '@rsbuild/core': 1.2.19
       '@storybook/react': 8.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.2)(webpack@5.98.0)
       '@types/node': 18.19.64
@@ -12638,7 +12638,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       resolve: 1.22.10
       storybook: 8.6.4(prettier@3.5.3)
-      storybook-builder-rsbuild: 1.0.0(@rsbuild/core@1.2.18)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.10)(storybook@8.6.4(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.8.2

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -7,7 +7,7 @@ import { composeModuleImportWarn } from '../../../packages/core/src/config';
 test('should fail to build when `output.target` is not "node"', async () => {
   const fixturePath = join(__dirname, 'browser');
   const build = buildAndGetResults({ fixturePath });
-  await expect(build).rejects.toThrowError('Rspack build failed!');
+  await expect(build).rejects.toThrowError('Rspack build failed.');
 });
 
 test('auto externalize Node.js built-in modules when `output.target` is "node"', async () => {

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.0",
     "@module-federation/rsbuild-plugin": "^0.10.0",
     "@playwright/test": "1.51.0",
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@rsbuild/plugin-less": "^1.1.1",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rsbuild/plugin-sass": "^1.2.2",

--- a/tests/scripts/rsbuild.ts
+++ b/tests/scripts/rsbuild.ts
@@ -89,7 +89,9 @@ const updateConfigForTest = async (
 };
 
 const createRsbuild = async (
-  rsbuildOptions: CreateRsbuildOptions,
+  rsbuildOptions: CreateRsbuildOptions & {
+    rsbuildConfig?: RsbuildConfig;
+  },
   plugins: RsbuildPlugins = [],
 ) => {
   const { createRsbuild: createRsbuildInner } = await import('@rsbuild/core');
@@ -110,6 +112,7 @@ export async function dev({
   ...options
 }: CreateRsbuildOptions & {
   plugins?: RsbuildPlugins;
+  rsbuildConfig?: RsbuildConfig;
   /**
    * Playwright Page instance.
    * This method will automatically goto the page.

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "rspress preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.18",
+    "@rsbuild/core": "~1.2.19",
     "@rsbuild/plugin-sass": "^1.2.2",
     "@rslib/tsconfig": "workspace:*",
     "@rstack-dev/doc-ui": "1.7.2",


### PR DESCRIPTION
## Summary

Update Rsbuild to v1.2.19 and adapt to the error message change, related https://github.com/web-infra-dev/rsbuild/pull/4772

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v1.2.19

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
