### PR TITLE
fix: correct use contextDependencies

### DIFF
--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -225,7 +225,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "plugins": [
               EntryChunkPlugin {
                 "contextToWatch": null,
-                "contextWatched": false,
                 "enabledImportMetaUrlShim": false,
                 "reactDirectives": {},
                 "shebangChmod": 493,
@@ -469,7 +468,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "plugins": [
               EntryChunkPlugin {
                 "contextToWatch": null,
-                "contextWatched": false,
                 "enabledImportMetaUrlShim": true,
                 "reactDirectives": {},
                 "shebangChmod": 493,
@@ -691,7 +689,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "plugins": [
               EntryChunkPlugin {
                 "contextToWatch": null,
-                "contextWatched": false,
                 "enabledImportMetaUrlShim": false,
                 "reactDirectives": {},
                 "shebangChmod": 493,
@@ -848,7 +845,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "plugins": [
               EntryChunkPlugin {
                 "contextToWatch": null,
-                "contextWatched": false,
                 "enabledImportMetaUrlShim": false,
                 "reactDirectives": {},
                 "shebangChmod": 493,

--- a/tests/integration/cli/build-watch/build.test.ts
+++ b/tests/integration/cli/build-watch/build.test.ts
@@ -1,5 +1,6 @@
-import { exec } from 'node:child_process';
+import { exec, spawn } from 'node:child_process';
 import path from 'node:path';
+import { after } from 'node:test';
 import fse from 'fs-extra';
 import { awaitFileChanges, awaitFileExists } from 'test-helper';
 import { describe, expect, test } from 'vitest';
@@ -59,44 +60,64 @@ describe('build --watch should handle add / change / unlink', async () => {
     const tempSrcPath = path.join(__dirname, 'test-temp-src');
     await fse.remove(tempSrcPath);
     await fse.remove(path.join(__dirname, 'dist'));
-    await fse.copy(path.join(__dirname, 'src'), tempSrcPath);
+    await fse.copy(path.join(__dirname, 'src'), path.resolve(tempSrcPath));
     const tempConfigFile = path.join(__dirname, 'test-temp-rslib.config.mjs');
     await fse.remove(tempConfigFile);
     fse.outputFileSync(
       tempConfigFile,
       `import { defineConfig } from '@rslib/core';
-      import { generateBundleEsmConfig } from 'test-helper';
-      
-      export default defineConfig({
-        lib: [
-          generateBundleEsmConfig({
-            source: {
-              entry: {
-                index: 'test-temp-src',
-              },
-            },
-            bundle: false,
-          }),
-        ],
-      });
-      `,
+import { generateBundleEsmConfig, generateBundleCjsConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+    }),
+    generateBundleCjsConfig({
+      bundle: false,
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['./test-temp-src/**'],
+    },
+  },
+});
+`,
     );
 
     const srcIndexFile = path.join(tempSrcPath, 'index.ts');
-    const srcFooFile = path.join(tempSrcPath, 'foo.js');
+    const srcFooFile = path.join(tempSrcPath, 'foo.ts');
+    const srcFoo2File = path.join(tempSrcPath, 'foo2.ts');
+    const distIndexFile = path.join(__dirname, 'dist/esm/index.js');
     const distFooFile = path.join(__dirname, 'dist/esm/foo.js');
+    const distFoo2File = path.join(__dirname, 'dist/esm/foo2.js');
 
-    const process = exec(`npx rslib build --watch -c ${tempConfigFile}`, {
-      cwd: __dirname,
-    });
+    const child = spawn(
+      'npx',
+      ['rslib', 'build', '--watch', '-c', tempConfigFile],
+      {
+        cwd: __dirname,
+        stdio: 'inherit',
+        shell: true,
+      },
+    );
 
-    // add
+    await awaitFileExists(distIndexFile);
+
     fse.outputFileSync(srcFooFile, `export const foo = 'foo';`);
-    await awaitFileExists(distFooFile);
+    fse.outputFileSync(srcFoo2File, `export const foo2 = 'foo2';`);
+    await awaitFileExists(distFoo2File);
     const content1 = await fse.readFile(distFooFile, 'utf-8');
     expect(content1!).toMatchInlineSnapshot(`
       "const foo = 'foo';
       export { foo };
+      "
+    `);
+    const content2 = await fse.readFile(distFoo2File, 'utf-8');
+    expect(content2!).toMatchInlineSnapshot(`
+      "const foo2 = 'foo2';
+      export { foo2 };
       "
     `);
 
@@ -108,13 +129,15 @@ describe('build --watch should handle add / change / unlink', async () => {
     const wait = await awaitFileChanges(distFooFile);
     fse.outputFileSync(srcFooFile, `export const foo = 'foo1';`);
     await wait();
-    const content2 = await fse.readFile(distFooFile, 'utf-8');
-    expect(content2!).toMatchInlineSnapshot(`
+    const content3 = await fse.readFile(distFooFile, 'utf-8');
+    expect(content3!).toMatchInlineSnapshot(`
       "const foo = 'foo1';
       export { foo };
       "
     `);
 
-    process.kill();
+    after(() => {
+      child.kill();
+    });
   });
 });

--- a/tests/integration/cli/build-watch/rslib.config.ts
+++ b/tests/integration/cli/build-watch/rslib.config.ts
@@ -1,15 +1,18 @@
 import { defineConfig } from '@rslib/core';
-import { generateBundleEsmConfig } from 'test-helper';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
 
 export default defineConfig({
   lib: [
+    generateBundleCjsConfig({
+      bundle: false,
+    }),
     generateBundleEsmConfig({
-      source: {
-        entry: {
-          index: 'src',
-        },
-      },
       bundle: false,
     }),
   ],
+  source: {
+    entry: {
+      index: ['./src/**'],
+    },
+  },
 });


### PR DESCRIPTION
## Summary

- The `contextDependencies.add()` only works with `.tapPromise` in Rspack now due to a bug, so the hooks name is changed in this PR.
- Changed the test case, to make it failed in previous implementation.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
