### PR TITLE
refactor: optimize dts logs and show codeblocks of tsc diagnostics

### DIFF
--- a/packages/plugin-dts/src/apiExtractor.ts
+++ b/packages/plugin-dts/src/apiExtractor.ts
@@ -93,7 +93,7 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
         await addBannerAndFooter(untrimmedFilePath, banner, footer);
 
         logger.ready(
-          `bundle declaration files succeeded: ${color.cyan(relative(cwd, untrimmedFilePath))} in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+          `declaration files bundled successfully: ${color.cyan(relative(cwd, untrimmedFilePath))} in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
         );
       }),
     );

--- a/packages/plugin-dts/src/apiExtractor.ts
+++ b/packages/plugin-dts/src/apiExtractor.ts
@@ -2,12 +2,15 @@ import { join, relative } from 'node:path';
 import {
   Extractor,
   ExtractorConfig,
+  ExtractorLogLevel,
   type ExtractorResult,
 } from '@microsoft/api-extractor';
 import { logger } from '@rsbuild/core';
 import color from 'picocolors';
 import type { DtsEntry } from './index';
 import { addBannerAndFooter, getTimeCost } from './utils';
+
+const logPrefixApiExtractor = color.dim('[api-extractor]');
 
 export type BundleOptions = {
   name: string;
@@ -66,6 +69,20 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
           extractorConfig,
           {
             localBuild: true,
+            messageCallback(message) {
+              /**
+               * message.text is readonly, we can not add prefix
+               * do not log below two cases
+               * 1. Analysis will use the bundled TypeScript version 5.7.3
+               * 2. The target project appears to use TypeScript 5.8.2 which is newer than the bundled compiler engine; consider upgrading API Extractor.
+               */
+              if (
+                message.messageId === 'console-compiler-version-notice' ||
+                message.messageId === 'console-preamble'
+              ) {
+                message.logLevel = ExtractorLogLevel.None;
+              }
+            },
           },
         );
 
@@ -75,12 +92,12 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
 
         await addBannerAndFooter(untrimmedFilePath, banner, footer);
 
-        logger.info(
-          `bundle declaration files succeeded: ${color.cyan(untrimmedFilePath)} in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+        logger.ready(
+          `bundle declaration files succeeded: ${color.cyan(relative(cwd, untrimmedFilePath))} in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
         );
       }),
     );
   } catch (e) {
-    throw new Error(`API Extractor Error:\n ${e}`);
+    throw new Error(`${logPrefixApiExtractor} ${e}`);
   }
 }

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -126,7 +126,9 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
       extension: false,
     },
   } = data;
-  logger.start(`generating declaration files... ${color.gray(`(${name})`)}`);
+  if (!isWatch) {
+    logger.start(`generating declaration files... ${color.gray(`(${name})`)}`);
+  }
 
   const { options: rawCompilerOptions, fileNames } = tsConfigResult;
 

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -28,7 +28,6 @@ export type EmitDtsOptions = {
 async function handleDiagnosticsAndProcessFiles(
   diagnostics: readonly ts.Diagnostic[],
   configPath: string,
-  host: ts.CompilerHost,
   bundle: boolean,
   declarationDir: string,
   dtsExtension: string,
@@ -192,7 +191,6 @@ export async function emitDts(
       await handleDiagnosticsAndProcessFiles(
         allDiagnostics,
         configPath,
-        host,
         bundle,
         declarationDir,
         dtsExtension,
@@ -226,7 +224,6 @@ export async function emitDts(
       await handleDiagnosticsAndProcessFiles(
         allDiagnostics,
         configPath,
-        host,
         bundle,
         declarationDir,
         dtsExtension,

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -277,7 +277,7 @@ export async function emitDts(
 
     if (bundle) {
       logger.info(
-        `preparing declaration files in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+        `declaration files prepared in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
       );
     } else {
       logger.ready(


### PR DESCRIPTION
## Summary

- Do not verbose some meaningless logs of api-extractor.
- Add `[api-extractor]` prefix for error when bunding dts files.
- Output relative paths for dts files/source file to reduce length of logs.
- Use `formatDiagnosticsWithColorAndContext` to show codeblocks of tsc diagnostics.

### bundleless dts + build
![image](https://github.com/user-attachments/assets/31b8e928-924c-40de-b154-2adc432dee49)

### bundleless dts + watch
![image](https://github.com/user-attachments/assets/53b47a55-b3b9-48d6-b932-2e56fdbba6e7)

### bundle dts + build
![image](https://github.com/user-attachments/assets/e63a46af-c5ee-49bf-8486-459fed4de63a)

### bundle dts + watch
![image](https://github.com/user-attachments/assets/4df941cf-c544-4d1e-85a6-13a568afaf08)


## Related Links

close: https://github.com/web-infra-dev/rslib/issues/631

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
