### PR TITLE
fix: override default values of some type descriptions

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -502,6 +502,8 @@ export function composeDecoratorsConfig(
 }
 
 export async function createConstantRsbuildConfig(): Promise<EnvironmentConfig> {
+  // When the default configuration is inconsistent with rsbuild, remember to modify the type hints
+  // see https://github.com/web-infra-dev/rslib/discussions/856
   return defineRsbuildConfig({
     dev: {
       progressBar: false,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -304,6 +304,10 @@ export interface LibConfig extends EnvironmentConfig {
    * @see {@link https://lib.rsbuild.dev/config/lib/out-base}
    */
   outBase?: string;
+  /**
+   * @inheritdoc
+   */
+  output?: RslibOutputConfig;
 }
 
 export type LibOnlyConfig = Omit<LibConfig, keyof EnvironmentConfig>;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -324,7 +324,7 @@ interface RslibOutputConfig extends OutputConfig {
    * When minify is not specified, Rslib will use a sane default for minify options.
    * The default options will only perform dead code elimination and unused code elimination.
    *
-   * detail: {@link https://lib.rsbuild.dev/config/rsbuild/output#outputminify rsbuild-outputminify}
+   * @see {@link https://lib.rsbuild.dev/config/rsbuild/output#outputminify}
    */
   minify?: OutputConfig['minify'];
 }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,4 +1,9 @@
-import type { EnvironmentConfig, RsbuildConfig, Rspack } from '@rsbuild/core';
+import type {
+  EnvironmentConfig,
+  OutputConfig,
+  RsbuildConfig,
+  Rspack,
+} from '@rsbuild/core';
 import type { GetAsyncFunctionFromUnion } from './utils';
 
 export type Format = 'esm' | 'cjs' | 'umd' | 'mf';
@@ -303,8 +308,33 @@ export interface LibConfig extends EnvironmentConfig {
 
 export type LibOnlyConfig = Omit<LibConfig, keyof EnvironmentConfig>;
 
+interface RslibOutputConfig extends OutputConfig {
+  /**
+   * @override
+   * @default 'node'
+   */
+  target?: OutputConfig['target'];
+  /**
+   * @override
+   * @default false
+   */
+  filenameHash?: OutputConfig['filenameHash'];
+  /**
+   * @override
+   * When minify is not specified, Rslib will use a sane default for minify options.
+   * The default options will only perform dead code elimination and unused code elimination.
+   *
+   * detail: {@link https://lib.rsbuild.dev/config/rsbuild/output#outputminify rsbuild-outputminify}
+   */
+  minify?: OutputConfig['minify'];
+}
+
 export interface RslibConfig extends RsbuildConfig {
   lib: LibConfig[];
+  /**
+   * @inheritdoc
+   */
+  output?: RslibOutputConfig;
 }
 
 export type ConfigParams = {


### PR DESCRIPTION
## Summary

Fix inaccurate type descriptions in `RslibConfig` using `@override` annotation

## Related Links

GH-856

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
