### PR TITLE
chore(deps): bump Rslib/Rspress/Rsbuild

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.11.1",
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@rsbuild/plugin-react": "^1.1.1",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.11.1",
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@rsbuild/plugin-react": "^1.1.1",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "rsbuild-plugin-dts": "workspace:*",
     "tinyglobby": "^0.2.12"
   },
@@ -57,7 +57,7 @@
     "picocolors": "1.1.1",
     "prebundle": "1.2.7",
     "rsbuild-plugin-publint": "^0.3.0",
-    "rslib": "npm:@rslib/core@0.5.4",
+    "rslib": "npm:@rslib/core@0.5.5",
     "rslog": "^1.2.3",
     "tsconfck": "3.1.5",
     "typescript": "^5.8.2"

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@storybook/addon-essentials": "^8.6.7",
     "@storybook/addon-interactions": "^8.6.7",
     "@storybook/addon-links": "^8.6.7",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@storybook/addon-essentials": "^8.6.7",
     "@storybook/addon-interactions": "^8.6.7",
     "@storybook/addon-links": "^8.6.7",

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^22.8.1",
     "fs-extra": "^11.3.0",
     "rsbuild-plugin-publint": "^0.3.0",
-    "rslib": "npm:@rslib/core@0.5.4",
+    "rslib": "npm:@rslib/core@0.5.5",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2"
   },

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -19,7 +19,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.7",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.7",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -18,7 +18,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.7",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.7",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -37,10 +37,10 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.52.1",
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@rslib/tsconfig": "workspace:*",
     "rsbuild-plugin-publint": "^0.3.0",
-    "rslib": "npm:@rslib/core@0.5.4",
+    "rslib": "npm:@rslib/core@0.5.5",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,13 +91,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.11.1
-        version: 0.11.1(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@rsbuild/core':
-        specifier: ~1.2.19
-        version: 1.2.19
+        specifier: 1.3.0-beta.0
+        version: 1.3.0-beta.0
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@types/react':
         specifier: ^19.0.12
         version: 19.0.12
@@ -112,16 +112,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.11.1
-        version: 0.11.1(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/rsbuild-plugin':
         specifier: ^0.11.1
-        version: 0.11.1(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/storybook-addon':
         specifier: ^4.0.9
-        version: 4.0.9(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@storybook/core@8.6.7(prettier@3.5.3)(storybook@8.6.7(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)
+        version: 4.0.9(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@storybook/core@8.6.7(prettier@3.5.3)(storybook@8.6.7(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -142,10 +142,10 @@ importers:
         version: 8.6.7(prettier@3.5.3)
       storybook-addon-rslib:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@1.2.19)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2)
+        version: 1.0.0(@rsbuild/core@1.3.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2)
       storybook-react-rsbuild:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0)
+        version: 1.0.0(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -158,13 +158,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.11.1
-        version: 0.11.1(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@rsbuild/core':
-        specifier: ~1.2.19
-        version: 1.2.19
+        specifier: 1.3.0-beta.0
+        version: 1.3.0-beta.0
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@types/react':
         specifier: ^19.0.12
         version: 19.0.12
@@ -179,10 +179,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@1.2.19)(preact@10.26.4)
+        version: 1.3.1(@rsbuild/core@1.3.0-beta.0)(preact@10.26.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.19)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -194,10 +194,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.19)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -212,10 +212,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.19)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -230,10 +230,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.19)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -248,7 +248,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.2.19)(vue@3.5.13(typescript@5.8.2))
+        version: 1.0.7(@rsbuild/core@1.3.0-beta.0)(vue@3.5.13(typescript@5.8.2))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -265,8 +265,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~1.2.19
-        version: 1.2.19
+        specifier: 1.3.0-beta.0
+        version: 1.3.0-beta.0
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
@@ -276,7 +276,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.11.1
-        version: 0.11.1(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -303,10 +303,10 @@ importers:
         version: 1.2.7(typescript@5.8.2)
       rsbuild-plugin-publint:
         specifier: ^0.3.0
-        version: 0.3.0(@rsbuild/core@1.2.19)
+        version: 0.3.0(@rsbuild/core@1.3.0-beta.0)
       rslib:
-        specifier: npm:@rslib/core@0.5.4
-        version: '@rslib/core@0.5.4(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(typescript@5.8.2)'
+        specifier: npm:@rslib/core@0.5.5
+        version: '@rslib/core@0.5.5(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(typescript@5.8.2)'
       rslog:
         specifier: ^1.2.3
         version: 1.2.3
@@ -339,8 +339,8 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0(@rsbuild/core@1.2.19)
       rslib:
-        specifier: npm:@rslib/core@0.5.4
-        version: '@rslib/core@0.5.4(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(typescript@5.8.2)'
+        specifier: npm:@rslib/core@0.5.5
+        version: '@rslib/core@0.5.5(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(typescript@5.8.2)'
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
@@ -370,17 +370,17 @@ importers:
         specifier: ^7.52.1
         version: 7.52.1(@types/node@22.8.1)
       '@rsbuild/core':
-        specifier: ~1.2.19
-        version: 1.2.19
+        specifier: 1.3.0-beta.0
+        version: 1.3.0-beta.0
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
       rsbuild-plugin-publint:
         specifier: ^0.3.0
-        version: 0.3.0(@rsbuild/core@1.2.19)
+        version: 0.3.0(@rsbuild/core@1.3.0-beta.0)
       rslib:
-        specifier: npm:@rslib/core@0.5.4
-        version: '@rslib/core@0.5.4(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(typescript@5.8.2)'
+        specifier: npm:@rslib/core@0.5.5
+        version: '@rslib/core@0.5.5(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(typescript@5.8.2)'
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -401,25 +401,25 @@ importers:
         version: 4.0.0(vite@6.0.11(@types/node@22.8.1)(jiti@2.4.2)(sass-embedded@1.85.0)(stylus@0.64.0)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))(vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.8.1)(jiti@2.4.2)(sass-embedded@1.85.0)(stylus@0.64.0)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.11.1
-        version: 0.11.1(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
       '@rsbuild/core':
-        specifier: ~1.2.19
-        version: 1.2.19
+        specifier: 1.3.0-beta.0
+        version: 1.3.0-beta.0
       '@rsbuild/plugin-less':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.19)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.0)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.2.19)
+        version: 1.0.2(@rsbuild/core@1.3.0-beta.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -478,7 +478,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
 
   tests/integration/asset/json: {}
 
@@ -494,10 +494,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.2.19)(typescript@5.8.2)
+        version: 1.0.7(@rsbuild/core@1.3.0-beta.0)(typescript@5.8.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -591,10 +591,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.2.19)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.2.19)(typescript@5.8.2)
+        version: 1.0.7(@rsbuild/core@1.3.0-beta.0)(typescript@5.8.2)
 
   tests/integration/cli/build: {}
 
@@ -786,7 +786,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.4
-        version: 1.0.4(@rsbuild/core@1.2.19)
+        version: 1.0.4(@rsbuild/core@1.3.0-beta.0)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.12.0
         version: 0.12.0(@babel/core@7.26.9)
@@ -913,13 +913,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.0.8
-        version: 1.0.8(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
+        version: 1.0.8(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.0.8
-        version: 1.0.8(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
+        version: 1.0.8(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -977,11 +977,11 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~1.2.19
-        version: 1.2.19
+        specifier: 1.3.0-beta.0
+        version: 1.3.0-beta.0
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.2.19)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -1005,10 +1005,10 @@ importers:
         version: 19.0.0(react@19.0.0)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.3
-        version: 1.0.3(@rsbuild/core@1.2.19)
+        version: 1.0.3(@rsbuild/core@1.3.0-beta.0)
       rspress:
-        specifier: ^2.0.0-alpha.3
-        version: 2.0.0-alpha.3(webpack@5.98.0)
+        specifier: ^2.0.0-alpha.4
+        version: 2.0.0-alpha.4(webpack@5.98.0)
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
@@ -1795,6 +1795,9 @@ packages:
       webpack:
         optional: true
 
+  '@module-federation/error-codes@0.11.0':
+    resolution: {integrity: sha512-IyN5fi3KvB9WFeXeCVMdaGl/VI/Dejrx6Gqxrq5V74Tj7Us2VfcGyOUU7+AEue52gmq7qpIe0ctbr79RF16mWg==}
+
   '@module-federation/error-codes@0.11.1':
     resolution: {integrity: sha512-N1cs1qwrO8cU/OzfnBbr+3FaVbrJk6QEAsQ8H+YxGRrh/kHsR2BKpZCX79jTG27oDbz45FLjQ98YucMMXC24EA==}
 
@@ -1833,8 +1836,14 @@ packages:
       vue-tsc:
         optional: true
 
+  '@module-federation/runtime-core@0.11.0':
+    resolution: {integrity: sha512-s1cZfrBZ47SfbMNPsc35yx66N4IjVl475ZtYRmsNq3/DHRJxk7AC5Be/O0Z5SHKYHVJydXhmqDT+kX7zMM+4dw==}
+
   '@module-federation/runtime-core@0.11.1':
     resolution: {integrity: sha512-6KxLfkCl05Ey69Xg/dsjf7fPit9qGXZ0lpwaG2agiCqC3JCDxYjT7tgGvnWhTXCcztb/ThpT+bHrRD4Kw8SMhA==}
+
+  '@module-federation/runtime-tools@0.11.0':
+    resolution: {integrity: sha512-zSB4Ypg/zXCaljdSCMWPpCXQ1D4OSBeT9fHkj/Wb/5a+ZX02MicVhT/6y3g6rGG/3PqbP4jlQMhSC2jMv2Kcxg==}
 
   '@module-federation/runtime-tools@0.11.1':
     resolution: {integrity: sha512-8UqMbHJSdkEvKlnlXpR/OjMA77bUbhtmv0I4UO+PA1zBga4y3/St6NOjD66NTINKeWEgsCt1aepXHspduXp33w==}
@@ -1842,11 +1851,17 @@ packages:
   '@module-federation/runtime-tools@0.8.4':
     resolution: {integrity: sha512-fjVOsItJ1u5YY6E9FnS56UDwZgqEQUrWFnouRiPtK123LUuqUI9FH4redZoKWlE1PB0ir1Z3tnqy8eFYzPO38Q==}
 
+  '@module-federation/runtime@0.11.0':
+    resolution: {integrity: sha512-jUOMwMiyNs/Q7xhHhimCn4DOddEmj0IhSC7vqZojPzFyowRcmaKptGHD8pr5oA3RcCu1l1BOQMhSKbZbplTTXA==}
+
   '@module-federation/runtime@0.11.1':
     resolution: {integrity: sha512-yxxa/TRXaNggb34N+oL82J7r9+GZ3gYTCDyGibYqtsC5j7+9oB4tmc0UyhjrGMhg+fF8TAWFZjNKo7ZnyN9LcQ==}
 
   '@module-federation/runtime@0.8.4':
     resolution: {integrity: sha512-yZeZ7z2Rx4gv/0E97oLTF3V6N25vglmwXGgoeju/W2YjsFvWzVtCDI7zRRb0mJhU6+jmSM8jP1DeQGbea/AiZQ==}
+
+  '@module-federation/sdk@0.11.0':
+    resolution: {integrity: sha512-px2BVTs/rJ9aYzQNkEhi5/qTMN7FSUO3wuaTc52Cc/bG4gq5dX8hYXUQNfi6dVhl6Zg2/2GtTX0ym7d7jjpYDg==}
 
   '@module-federation/sdk@0.11.1':
     resolution: {integrity: sha512-QS6zevdQYLCGF6NFf0LysMGARh+dZxMeoRKKDUW5PYi3XOk+tjJ7QsDKybfcBZBNgBJfIuwxh4Oei6WOFJEfRg==}
@@ -1883,6 +1898,9 @@ packages:
 
   '@module-federation/third-party-dts-extractor@0.11.1':
     resolution: {integrity: sha512-oyyelSLGFObM699p192Cuk/LxEDdzSOywDUXrzPa/qSKNFii5WartjQRc4QPMLnsQaGD7fQVTTiBkvVBcWUdyQ==}
+
+  '@module-federation/webpack-bundler-runtime@0.11.0':
+    resolution: {integrity: sha512-rq8dldquwNDtaLImucld0WMUAkfFfng1HQARMLc0jb9VO7KLqC6FH58Iph/4yaEJFW0V8RXDGnTDVXFnYSAa1Q==}
 
   '@module-federation/webpack-bundler-runtime@0.11.1':
     resolution: {integrity: sha512-XlVegGyCBBLId8Jr6USjPOFYViQ0CCtoYjHpC8y1FOGtuXLGrvnEdFcl4XHlFlp3MY3Rxhr8QigrdZhYe5bRWg==}
@@ -2106,6 +2124,11 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
 
+  '@rsbuild/core@1.3.0-beta.0':
+    resolution: {integrity: sha512-2/ZW4okF5IQBmbeulte6Pw/+Z5H/IZYqwIJ+sj3WP2yxyqp4BwUbtghXnIQ8i6u9O7f5p64d0yMtJOYT2+7H0A==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
+
   '@rsbuild/plugin-babel@1.0.4':
     resolution: {integrity: sha512-ZYbyC3zNYluTWTJDVrAW3eRJfvSTIQlp/bs20iY/MATm8/rRq2xtlAP5keCYxpx5CJZX7IT7i6f4z24/YrJJwA==}
     peerDependencies:
@@ -2170,8 +2193,8 @@ packages:
     peerDependencies:
       '@rsbuild/core': 1.x
 
-  '@rslib/core@0.5.4':
-    resolution: {integrity: sha512-rJ+wG++/Y8SbyuJB1RhlgnOUPzsxubD0lBivZWXVhOGawAea7mUoI4kZQ6YmF0iybW1QA61wHOf3FY+R1BxvgQ==}
+  '@rslib/core@0.5.5':
+    resolution: {integrity: sha512-RpjixdO8a4G99+jZ5P4W35fZyhHasBa13lvErUPXT0fz1QBfLiR/HS+QikjIFiyS538oAaZ8/8BLf88vHERQ0w==}
     engines: {node: '>=16.7.0'}
     hasBin: true
     peerDependencies:
@@ -2188,8 +2211,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@1.3.0-beta.0':
+    resolution: {integrity: sha512-K7IDzEt5bTF3uvQtQQz4MyAA+aoKfr3W6EfU0OnDRPkJh3BnMAlCGHfVrmoe920EPcMKXRebyYIIqaRIW2+2Bw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.2.8':
     resolution: {integrity: sha512-0/qOVbMuzZ+WbtDa4TbH46R4vph/W6MHcXbrXDO+vpdTMFDVJ64DnZXT7aqvGcY+7vTCIGm0GT+6ooR4KaIX8A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.3.0-beta.0':
+    resolution: {integrity: sha512-GdLqcl++p5YxwL4ONPctwop1O1yQ5wuwrmuXnvpPlt+H+yLCNW+RhN4RtFj+fQwLk4r2QDUxlLkGvOCJLUYFAA==}
     cpu: [x64]
     os: [darwin]
 
@@ -2198,8 +2231,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@1.3.0-beta.0':
+    resolution: {integrity: sha512-/CIKLq9FZnYfOowpJEP2+T9sIownOZdMH+SvJ+BQfDCuwKh0+kU3vAHTnTvO3Ngs0jTmhiFAZovQUdgVQhbzlA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-musl@1.2.8':
     resolution: {integrity: sha512-N1oZsXfJ9VLLcK7p1PS65cxLYQCZ7iqHW2OP6Ew2+hlz/d1hzngxgzrtZMCXFOHXDvTzVu5ff6jGS2v7+zv2tA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.3.0-beta.0':
+    resolution: {integrity: sha512-7WzFokwdnxWK3BjzSjsIYhY8Yd7k26bUV0D/fWBFP81Tw9VuuuR5TSuQEkv0RtzPxhr3+Jcmfh+5KZw3qUGI4Q==}
     cpu: [arm64]
     os: [linux]
 
@@ -2208,8 +2251,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@1.3.0-beta.0':
+    resolution: {integrity: sha512-yrDuI/iE4ZYp44Q5nRDRdRBTtRH2QoQaPG9Z3w3LbUqArAU8rpSMJAkTruVfjcrHrMV1J+4/lMKm5Q9hXXgX+A==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@1.2.8':
     resolution: {integrity: sha512-GFv0Bod268OcXIcjeLoPlK0oz8rClEIxIRFkz+ejhbvfCwRJ+Fd+EKaaKQTBfZQujPqc0h2GctIF25nN5pFTmA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@1.3.0-beta.0':
+    resolution: {integrity: sha512-61gbjSUxXmIYspzzi61ubh87AEKqDz2dKPoxdeZfs+o1UU139N1cv/CAVYkn4VNg91txiCBSUuvANEZl0mUjgg==}
     cpu: [x64]
     os: [linux]
 
@@ -2218,8 +2271,18 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rspack/binding-win32-arm64-msvc@1.3.0-beta.0':
+    resolution: {integrity: sha512-io0SNiyT6vB9Vd3kYsgsL85UNZSIFx1YyHUcDq/1aH4d1HldvafMtPggLwcZhWU6IG8Svg2npvsNAsZJem3YIA==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rspack/binding-win32-ia32-msvc@1.2.8':
     resolution: {integrity: sha512-GHYzNOSoiLyG9elLTmMqADJMQzjll+co4irp5AgZ+KHG9EVq0qEHxDqDIJxZnUA15U8JDvCgo6YAo3T0BFEL0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@1.3.0-beta.0':
+    resolution: {integrity: sha512-+0YjQGZk1GaiGoqt0nvZHlfRlYmlyNVQJzdc4Kztd469RWIkDeJkIWo+1t6ik6/vSzVaCWYum5iyYAm9f8Yeaw==}
     cpu: [ia32]
     os: [win32]
 
@@ -2228,11 +2291,31 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@1.3.0-beta.0':
+    resolution: {integrity: sha512-FBaUAA7vCt+SJ1+kbFDdvmMNsa+30GULnUrN7Lnat9f4h3PfVPG+z7ClG/uhTgHCdp7EmyJx+yRt2/NGvA+R+A==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@1.2.8':
     resolution: {integrity: sha512-T3FMB3N9P1AbSAryfkSRJkPtmeSYs/Gj9zUZoPz1ckPEIcWZmpUOQbJylldjbw5waxtCL1haHNbi0pcSvxiaJw==}
 
+  '@rspack/binding@1.3.0-beta.0':
+    resolution: {integrity: sha512-dYnT+gdDz2o9o0e2TW1EW67jrdkZHq0iZs49jYytANjsJY4zlu7UTT7Bcuw6mMLXMZLyRRJjCS2gS8GBjqo7RQ==}
+
   '@rspack/core@1.2.8':
     resolution: {integrity: sha512-ppj3uQQtkhgrYDLrUqb33YbpNEZCpAudpfVuOHGsvUrAnu1PijbfJJymoA5ZvUhM+HNMvPI5D1ie97TXyb0UVg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@rspack/tracing': ^1.x
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@rspack/tracing':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@1.3.0-beta.0':
+    resolution: {integrity: sha512-mZ0v/AfSQOCe74Zlb+YIeVRJKHbemYRBzthSra56Gus+StNCe2Fggp88LUNgkVljTMhFpRA1ShTqsOOvAGxOuQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rspack/tracing': ^1.x
@@ -2261,8 +2344,8 @@ packages:
       react-refresh:
         optional: true
 
-  '@rspress/core@2.0.0-alpha.3':
-    resolution: {integrity: sha512-q5/MoIevPRX8KRsnvCZ1ZpYbs1SmPXY0uJcDPm6ChK+0EvnrCOQNRdAeR1Si8sMxCszRDd7jbFwM5aKxlf8AHA==}
+  '@rspress/core@2.0.0-alpha.4':
+    resolution: {integrity: sha512-+18JDoEis5EVk9isfKCzdj/pxvIEzzZpLFuodCxLVPpffa9lPIQbvb6jW4ZUf4QCNvTHg66LgjxLiTCA57rGwA==}
     engines: {node: '>=14.17.6'}
 
   '@rspress/mdx-rs-darwin-arm64@0.6.6':
@@ -2317,33 +2400,33 @@ packages:
     resolution: {integrity: sha512-NpNhTKBIlV3O6ADhoZkgHvBFvXMW2TYlIWmIT1ysJESUBqDpaN9H3Teve5fugjU2pQ2ORBZO6SQGKliMw/8m/Q==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@2.0.0-alpha.3':
-    resolution: {integrity: sha512-U1detSiGlAd+2U6oK1/PEPBulOKUnODsygWvfiY4fydF9FAhcvjeDWanmiAoNWnKBj+bmUMay/e9nR1vtSSpmw==}
+  '@rspress/plugin-auto-nav-sidebar@2.0.0-alpha.4':
+    resolution: {integrity: sha512-5+iy1ULz+2diGI5M7bPyaJpS7qOZnhljch/HsDja3whAIAdJkUi9QYNihMKFBqLEyZPYaRD5lfWehJcbB5WHWg==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-container-syntax@2.0.0-alpha.3':
-    resolution: {integrity: sha512-//IDlD/BKUkx/TRtxSIlTNomf7cU7Hc9Aeqtl02jk+b/wNbirmpFKQKCU5kvyZTzCLuHMEQSTe+Asf3PWqzlnQ==}
+  '@rspress/plugin-container-syntax@2.0.0-alpha.4':
+    resolution: {integrity: sha512-Nv0mhcSLDYmiDxeU6UtQ0D1+2BrrinA9xvOSr8FpoVQ+pWckG9yzTftunRu2gN8VV+BMSfDMJIhujIRDySr0Ug==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-last-updated@2.0.0-alpha.3':
-    resolution: {integrity: sha512-6xvPvSnx2wPPnKFjVyHSUspaDWRMrTMXg1HO+YOnruSMjXQGELoagGRObH0FUtXQkmUH8Og8w0Ezf6a7oZZISQ==}
+  '@rspress/plugin-last-updated@2.0.0-alpha.4':
+    resolution: {integrity: sha512-HQ2RwM6u/yrU5Cy+CNgOEqJ8CXlhT4OL3vvB/7+sluKiVwY9udCMyPrb+R0V8PS+D+VqL3Wkp/xa3SsdJ+mUcg==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-medium-zoom@2.0.0-alpha.3':
-    resolution: {integrity: sha512-3mInIGNIdMD5g+AdLAEHuN+xPHH/Wn58xWcyH4MKlvvZRhfhBd3xwWQbWB1tNlCelwNfREuqcaq65HITRJBQxg==}
+  '@rspress/plugin-medium-zoom@2.0.0-alpha.4':
+    resolution: {integrity: sha512-wFjGm6GKoxY13p3tCP955XqfRIWL1E7eCELhcVfU6Do5a9NWBfHdBfzpGCoIE+E2gFTF3+TH+zI/bmB00dmQLQ==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/runtime': ^2.0.0-alpha.3
+      '@rspress/runtime': ^2.0.0-alpha.4
 
-  '@rspress/runtime@2.0.0-alpha.3':
-    resolution: {integrity: sha512-NFzPc+LsHyFN8DUpXDQJGbJQ8o/YNnDkc4pcntqWMuG5pyAqp8Qe+w9n80w4iM47P0TRDnMkUXv1vS2ZezmksQ==}
+  '@rspress/runtime@2.0.0-alpha.4':
+    resolution: {integrity: sha512-gCjMRquKSTvaKKaP6yC8nf0bH5qbpK+ZQ7zFlwMclF41JAqavES0zZrisQaBWFAx7P63etr/xQxLfSJ49lRctA==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/shared@2.0.0-alpha.3':
-    resolution: {integrity: sha512-h6vOhwwe57pDZWJjbKO4IUCNpYM/8XAIjHWT8NCQKCgNE7lCykXgifvZQtPHTEfQA0EX1BowlruHhsZkIo6Ntw==}
+  '@rspress/shared@2.0.0-alpha.4':
+    resolution: {integrity: sha512-cGUJcMXDbeLty6tkwuYvjJ3z1ugCdSl9V9sN46XVcXgejerJALJ0wduDTcRYEV+g7apFl1l8Ky29cprp7FCvZQ==}
 
-  '@rspress/theme-default@2.0.0-alpha.3':
-    resolution: {integrity: sha512-7N+Fwv99t6tPITVsR6D+7DS2kfWA5kdfX7s2GyCnJE1oAuK+idq392xkvsUG2j+bauNvbg2VEQqbOOjurdBeUg==}
+  '@rspress/theme-default@2.0.0-alpha.4':
+    resolution: {integrity: sha512-4ed/4wSOxqqrH0Hf3s+vpkTXwGO/4BvkdB6E6OPW4dkOqbxZxOyuTqgGuiF7+mAcPsrdyXQ3qWw3V5bcHvm/3A==}
     engines: {node: '>=14.17.6'}
 
   '@rstack-dev/doc-ui@1.7.3':
@@ -5633,8 +5716,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rsbuild-plugin-dts@0.5.4:
-    resolution: {integrity: sha512-8z4gC7/vj2acLb5zdkgQ4N6l4EnFqC16x3tcqkkpsv/C+2W2Jyr6SKHRWbfWrki/hiv9K5WansHlsmL7TKC+BQ==}
+  rsbuild-plugin-dts@0.5.5:
+    resolution: {integrity: sha512-e3sH3Rmzjb5vlifyvBYmtk/IzCK6x9K3HoxbkZUgH194MYrWNDe9IU8tBVj4DpZmYjAZf8/Znk5ntsYXDBCnZw==}
     engines: {node: '>=16.7.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -5680,8 +5763,8 @@ packages:
   rspress-plugin-font-open-sans@1.0.0:
     resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
 
-  rspress@2.0.0-alpha.3:
-    resolution: {integrity: sha512-tJZxBQ21Cp8eUYGm7U9E7N4twYkWVJwR4yEmDSoqiotf5lrS24ft2METvLBwdp90U5OfPD+tRHKXEPpSLay+hQ==}
+  rspress@2.0.0-alpha.4:
+    resolution: {integrity: sha512-lclXE8HoShCiY6TnV0Uuo5dEucgNFq3RCt3JK+E3NQbJZsTZFG1GhlHgcp8hItlxMTEFOaU+la83qL6MnWHfVQ==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -7581,7 +7664,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.11.1(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)':
+  '@module-federation/enhanced@0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.11.1
       '@module-federation/data-prefetch': 0.11.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -7590,7 +7673,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.11.1(@module-federation/runtime-tools@0.11.1)
       '@module-federation/managers': 0.11.1
       '@module-federation/manifest': 0.11.1(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))
-      '@module-federation/rspack': 0.11.1(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))
+      '@module-federation/rspack': 0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))
       '@module-federation/runtime-tools': 0.11.1
       '@module-federation/sdk': 0.11.1
       btoa: 1.2.1
@@ -7607,6 +7690,8 @@ snapshots:
       - react-dom
       - supports-color
       - utf-8-validate
+
+  '@module-federation/error-codes@0.11.0': {}
 
   '@module-federation/error-codes@0.11.1': {}
 
@@ -7637,12 +7722,12 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.11.1(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)':
+  '@module-federation/rsbuild-plugin@0.11.1(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)':
     dependencies:
-      '@module-federation/enhanced': 0.11.1(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+      '@module-federation/enhanced': 0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/sdk': 0.11.1
     optionalDependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -7655,7 +7740,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.11.1(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))':
+  '@module-federation/rspack@0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.11.1
       '@module-federation/dts-plugin': 0.11.1(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))
@@ -7664,7 +7749,7 @@ snapshots:
       '@module-federation/manifest': 0.11.1(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))
       '@module-federation/runtime-tools': 0.11.1
       '@module-federation/sdk': 0.11.1
-      '@rspack/core': 1.2.8(@swc/helpers@0.5.15)
+      '@rspack/core': 1.3.0-beta.0(@swc/helpers@0.5.15)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.8.2
@@ -7675,10 +7760,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@module-federation/runtime-core@0.11.0':
+    dependencies:
+      '@module-federation/error-codes': 0.11.0
+      '@module-federation/sdk': 0.11.0
+
   '@module-federation/runtime-core@0.11.1':
     dependencies:
       '@module-federation/error-codes': 0.11.1
       '@module-federation/sdk': 0.11.1
+
+  '@module-federation/runtime-tools@0.11.0':
+    dependencies:
+      '@module-federation/runtime': 0.11.0
+      '@module-federation/webpack-bundler-runtime': 0.11.0
 
   '@module-federation/runtime-tools@0.11.1':
     dependencies:
@@ -7689,6 +7784,12 @@ snapshots:
     dependencies:
       '@module-federation/runtime': 0.8.4
       '@module-federation/webpack-bundler-runtime': 0.8.4
+
+  '@module-federation/runtime@0.11.0':
+    dependencies:
+      '@module-federation/error-codes': 0.11.0
+      '@module-federation/runtime-core': 0.11.0
+      '@module-federation/sdk': 0.11.0
 
   '@module-federation/runtime@0.11.1':
     dependencies:
@@ -7701,18 +7802,20 @@ snapshots:
       '@module-federation/error-codes': 0.8.4
       '@module-federation/sdk': 0.8.4
 
+  '@module-federation/sdk@0.11.0': {}
+
   '@module-federation/sdk@0.11.1': {}
 
   '@module-federation/sdk@0.8.4':
     dependencies:
       isomorphic-rslog: 0.0.6
 
-  '@module-federation/storybook-addon@4.0.9(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@storybook/core@8.6.7(prettier@3.5.3)(storybook@8.6.7(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)':
+  '@module-federation/storybook-addon@4.0.9(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@storybook/core@8.6.7(prettier@3.5.3)(storybook@8.6.7(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)':
     dependencies:
-      '@module-federation/enhanced': 0.11.1(@rspack/core@1.2.8(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+      '@module-federation/enhanced': 0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/sdk': 0.11.1
     optionalDependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
       '@storybook/core': 8.6.7(prettier@3.5.3)(storybook@8.6.7(prettier@3.5.3))
       webpack: 5.98.0
       webpack-virtual-modules: 0.6.2
@@ -7732,6 +7835,11 @@ snapshots:
       find-pkg: 2.0.0
       fs-extra: 9.1.0
       resolve: 1.22.8
+
+  '@module-federation/webpack-bundler-runtime@0.11.0':
+    dependencies:
+      '@module-federation/runtime': 0.11.0
+      '@module-federation/sdk': 0.11.0
 
   '@module-federation/webpack-bundler-runtime@0.11.1':
     dependencies:
@@ -7887,13 +7995,23 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.2.19)':
+  '@rsbuild/core@1.3.0-beta.0':
+    dependencies:
+      '@rspack/core': 1.3.0-beta.0(@swc/helpers@0.5.15)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.15
+      core-js: 3.41.0
+      jiti: 2.4.2
+    transitivePeerDependencies:
+      - '@rspack/tracing'
+
+  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.3.0-beta.0)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.9)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.9)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.9)
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -7901,9 +8019,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.1.1(@rsbuild/core@1.2.19)':
+  '@rsbuild/plugin-less@1.1.1(@rsbuild/core@1.3.0-beta.0)':
     dependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
@@ -7935,11 +8053,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.2.19
 
-  '@rsbuild/plugin-preact@1.3.1(@rsbuild/core@1.2.19)(preact@10.26.4)':
+  '@rsbuild/plugin-preact@1.3.1(@rsbuild/core@1.3.0-beta.0)(preact@10.26.4)':
     dependencies:
       '@prefresh/core': 1.5.3(preact@10.26.4)
       '@prefresh/utils': 1.2.0
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
       '@rspack/plugin-preact-refresh': 1.1.2(@prefresh/core@1.5.3(preact@10.26.4))(@prefresh/utils@1.2.0)
       '@swc/plugin-prefresh': 6.2.0
     transitivePeerDependencies:
@@ -7951,18 +8069,24 @@ snapshots:
       '@rspack/plugin-react-refresh': 1.0.1(react-refresh@0.16.0)
       react-refresh: 0.16.0
 
-  '@rsbuild/plugin-sass@1.2.2(@rsbuild/core@1.2.19)':
+  '@rsbuild/plugin-react@1.1.1(@rsbuild/core@1.3.0-beta.0)':
     dependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
+      '@rspack/plugin-react-refresh': 1.0.1(react-refresh@0.16.0)
+      react-refresh: 0.16.0
+
+  '@rsbuild/plugin-sass@1.2.2(@rsbuild/core@1.3.0-beta.0)':
+    dependencies:
+      '@rsbuild/core': 1.3.0-beta.0
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.2
       reduce-configs: 1.1.0
       sass-embedded: 1.85.0
 
-  '@rsbuild/plugin-stylus@1.0.8(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)':
+  '@rsbuild/plugin-stylus@1.0.8(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)':
     dependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
       stylus: 0.64.0
@@ -7972,10 +8096,10 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.0.7(@rsbuild/core@1.2.19)(typescript@5.8.2)':
+  '@rsbuild/plugin-svgr@1.0.7(@rsbuild/core@1.3.0-beta.0)(typescript@5.8.2)':
     dependencies:
-      '@rsbuild/core': 1.2.19
-      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.2.19)
+      '@rsbuild/core': 1.3.0-beta.0
+      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.3.0-beta.0)
       '@svgr/core': 8.1.0(typescript@5.8.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.2))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.2))(typescript@5.8.2)
@@ -7985,25 +8109,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-type-check@1.2.1(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)':
+  '@rsbuild/plugin-type-check@1.2.1(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.0
-      ts-checker-rspack-plugin: 1.1.1(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)
+      ts-checker-rspack-plugin: 1.1.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2)
     optionalDependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.2.19)':
+  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.3.0-beta.0)':
     optionalDependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
 
-  '@rsbuild/plugin-vue@1.0.7(@rsbuild/core@1.2.19)(vue@3.5.13(typescript@5.8.2))':
+  '@rsbuild/plugin-vue@1.0.7(@rsbuild/core@1.3.0-beta.0)(vue@3.5.13(typescript@5.8.2))':
     dependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
       vue-loader: 17.4.2(vue@3.5.13(typescript@5.8.2))(webpack@5.98.0)
       webpack: 5.98.0
     transitivePeerDependencies:
@@ -8014,10 +8138,10 @@ snapshots:
       - vue
       - webpack-cli
 
-  '@rslib/core@0.5.4(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(typescript@5.8.2)':
+  '@rslib/core@0.5.5(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(typescript@5.8.2)':
     dependencies:
       '@rsbuild/core': 1.2.19
-      rsbuild-plugin-dts: 0.5.4(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(@rsbuild/core@1.2.19)(typescript@5.8.2)
+      rsbuild-plugin-dts: 0.5.5(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(@rsbuild/core@1.2.19)(typescript@5.8.2)
       tinyglobby: 0.2.12
     optionalDependencies:
       '@microsoft/api-extractor': 7.52.1(@types/node@22.8.1)
@@ -8028,28 +8152,55 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.2.8':
     optional: true
 
+  '@rspack/binding-darwin-arm64@1.3.0-beta.0':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.2.8':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.3.0-beta.0':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.2.8':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@1.3.0-beta.0':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.2.8':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.3.0-beta.0':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.2.8':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@1.3.0-beta.0':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.2.8':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.3.0-beta.0':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.2.8':
     optional: true
 
+  '@rspack/binding-win32-arm64-msvc@1.3.0-beta.0':
+    optional: true
+
   '@rspack/binding-win32-ia32-msvc@1.2.8':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@1.3.0-beta.0':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.2.8':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.3.0-beta.0':
     optional: true
 
   '@rspack/binding@1.2.8':
@@ -8064,10 +8215,31 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.2.8
       '@rspack/binding-win32-x64-msvc': 1.2.8
 
+  '@rspack/binding@1.3.0-beta.0':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.3.0-beta.0
+      '@rspack/binding-darwin-x64': 1.3.0-beta.0
+      '@rspack/binding-linux-arm64-gnu': 1.3.0-beta.0
+      '@rspack/binding-linux-arm64-musl': 1.3.0-beta.0
+      '@rspack/binding-linux-x64-gnu': 1.3.0-beta.0
+      '@rspack/binding-linux-x64-musl': 1.3.0-beta.0
+      '@rspack/binding-win32-arm64-msvc': 1.3.0-beta.0
+      '@rspack/binding-win32-ia32-msvc': 1.3.0-beta.0
+      '@rspack/binding-win32-x64-msvc': 1.3.0-beta.0
+
   '@rspack/core@1.2.8(@swc/helpers@0.5.15)':
     dependencies:
       '@module-federation/runtime-tools': 0.8.4
       '@rspack/binding': 1.2.8
+      '@rspack/lite-tapable': 1.0.1
+      caniuse-lite: 1.0.30001703
+    optionalDependencies:
+      '@swc/helpers': 0.5.15
+
+  '@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.11.0
+      '@rspack/binding': 1.3.0-beta.0
       '@rspack/lite-tapable': 1.0.1
       caniuse-lite: 1.0.30001703
     optionalDependencies:
@@ -8087,7 +8259,7 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.16.0
 
-  '@rspress/core@2.0.0-alpha.3(webpack@5.98.0)':
+  '@rspress/core@2.0.0-alpha.4(webpack@5.98.0)':
     dependencies:
       '@mdx-js/loader': 2.3.0(webpack@5.98.0)
       '@mdx-js/mdx': 2.3.0
@@ -8095,13 +8267,13 @@ snapshots:
       '@rsbuild/core': 1.2.19
       '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.2.19)
       '@rspress/mdx-rs': 0.6.6
-      '@rspress/plugin-auto-nav-sidebar': 2.0.0-alpha.3
-      '@rspress/plugin-container-syntax': 2.0.0-alpha.3
-      '@rspress/plugin-last-updated': 2.0.0-alpha.3
-      '@rspress/plugin-medium-zoom': 2.0.0-alpha.3(@rspress/runtime@2.0.0-alpha.3)
-      '@rspress/runtime': 2.0.0-alpha.3
-      '@rspress/shared': 2.0.0-alpha.3
-      '@rspress/theme-default': 2.0.0-alpha.3
+      '@rspress/plugin-auto-nav-sidebar': 2.0.0-alpha.4
+      '@rspress/plugin-container-syntax': 2.0.0-alpha.4
+      '@rspress/plugin-last-updated': 2.0.0-alpha.4
+      '@rspress/plugin-medium-zoom': 2.0.0-alpha.4(@rspress/runtime@2.0.0-alpha.4)
+      '@rspress/runtime': 2.0.0-alpha.4
+      '@rspress/shared': 2.0.0-alpha.4
+      '@rspress/theme-default': 2.0.0-alpha.4
       enhanced-resolve: 5.18.1
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -8164,32 +8336,32 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.6
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.6
 
-  '@rspress/plugin-auto-nav-sidebar@2.0.0-alpha.3':
+  '@rspress/plugin-auto-nav-sidebar@2.0.0-alpha.4':
     dependencies:
-      '@rspress/shared': 2.0.0-alpha.3
+      '@rspress/shared': 2.0.0-alpha.4
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-container-syntax@2.0.0-alpha.3':
+  '@rspress/plugin-container-syntax@2.0.0-alpha.4':
     dependencies:
-      '@rspress/shared': 2.0.0-alpha.3
+      '@rspress/shared': 2.0.0-alpha.4
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-last-updated@2.0.0-alpha.3':
+  '@rspress/plugin-last-updated@2.0.0-alpha.4':
     dependencies:
-      '@rspress/shared': 2.0.0-alpha.3
+      '@rspress/shared': 2.0.0-alpha.4
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-medium-zoom@2.0.0-alpha.3(@rspress/runtime@2.0.0-alpha.3)':
+  '@rspress/plugin-medium-zoom@2.0.0-alpha.4(@rspress/runtime@2.0.0-alpha.4)':
     dependencies:
-      '@rspress/runtime': 2.0.0-alpha.3
+      '@rspress/runtime': 2.0.0-alpha.4
       medium-zoom: 1.1.0
 
-  '@rspress/runtime@2.0.0-alpha.3':
+  '@rspress/runtime@2.0.0-alpha.4':
     dependencies:
-      '@rspress/shared': 2.0.0-alpha.3
+      '@rspress/shared': 2.0.0-alpha.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 2.0.5(react@18.3.1)
@@ -8197,7 +8369,7 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/shared@2.0.0-alpha.3':
+  '@rspress/shared@2.0.0-alpha.4':
     dependencies:
       '@rsbuild/core': 1.2.19
       gray-matter: 4.0.3
@@ -8206,11 +8378,11 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/theme-default@2.0.0-alpha.3':
+  '@rspress/theme-default@2.0.0-alpha.4':
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rspress/runtime': 2.0.0-alpha.3
-      '@rspress/shared': 2.0.0-alpha.3
+      '@rspress/runtime': 2.0.0-alpha.4
+      '@rspress/shared': 2.0.0-alpha.4
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.7.43
@@ -12116,7 +12288,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.34.2
       fsevents: 2.3.3
 
-  rsbuild-plugin-dts@0.5.4(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(@rsbuild/core@1.2.19)(typescript@5.8.2):
+  rsbuild-plugin-dts@0.5.5(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(@rsbuild/core@1.2.19)(typescript@5.8.2):
     dependencies:
       '@ast-grep/napi': 0.36.2
       '@rsbuild/core': 1.2.19
@@ -12128,16 +12300,16 @@ snapshots:
       '@microsoft/api-extractor': 7.52.1(@types/node@22.8.1)
       typescript: 5.8.2
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.2.19):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.3.0-beta.0):
     optionalDependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
 
-  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.2.19):
+  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.3.0-beta.0):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
 
   rsbuild-plugin-publint@0.3.0(@rsbuild/core@1.2.19):
     dependencies:
@@ -12145,6 +12317,13 @@ snapshots:
       publint: 0.3.2
     optionalDependencies:
       '@rsbuild/core': 1.2.19
+
+  rsbuild-plugin-publint@0.3.0(@rsbuild/core@1.3.0-beta.0):
+    dependencies:
+      picocolors: 1.1.1
+      publint: 0.3.2
+    optionalDependencies:
+      '@rsbuild/core': 1.3.0-beta.0
 
   rslog@1.2.3: {}
 
@@ -12154,11 +12333,11 @@ snapshots:
 
   rspress-plugin-font-open-sans@1.0.0: {}
 
-  rspress@2.0.0-alpha.3(webpack@5.98.0):
+  rspress@2.0.0-alpha.4(webpack@5.98.0):
     dependencies:
       '@rsbuild/core': 1.2.19
-      '@rspress/core': 2.0.0-alpha.3(webpack@5.98.0)
-      '@rspress/shared': 2.0.0-alpha.3
+      '@rspress/core': 2.0.0-alpha.4(webpack@5.98.0)
+      '@rspress/shared': 2.0.0-alpha.4
       cac: 6.7.14
       chokidar: 3.6.0
       picocolors: 1.1.1
@@ -12466,18 +12645,18 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@1.0.0(@rsbuild/core@1.2.19)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2):
+  storybook-addon-rslib@1.0.0(@rsbuild/core@1.3.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2):
     dependencies:
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 1.0.0(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
     optionalDependencies:
       typescript: 5.8.2
 
-  storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3):
+  storybook-builder-rsbuild@1.0.0(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3):
     dependencies:
-      '@rsbuild/core': 1.2.19
-      '@rsbuild/plugin-type-check': 1.2.1(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)
+      '@rsbuild/core': 1.3.0-beta.0
+      '@rsbuild/plugin-type-check': 1.2.1(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2)
       '@storybook/addon-docs': 8.4.2(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(webpack-sources@3.2.3)
       '@storybook/core-webpack': 8.4.2(storybook@8.6.7(prettier@3.5.3))
       browser-assert: 1.2.1
@@ -12490,7 +12669,7 @@ snapshots:
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.2.19)
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.3.0-beta.0)
       sirv: 2.0.4
       storybook: 8.6.7(prettier@3.5.3)
       ts-dedent: 2.2.0
@@ -12504,10 +12683,10 @@ snapshots:
       - '@types/react'
       - webpack-sources
 
-  storybook-react-rsbuild@1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0):
+  storybook-react-rsbuild@1.0.0(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.34.2)
-      '@rsbuild/core': 1.2.19
+      '@rsbuild/core': 1.3.0-beta.0
       '@storybook/react': 8.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.2)(webpack@5.98.0)
       '@types/node': 18.19.64
@@ -12519,7 +12698,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       resolve: 1.22.10
       storybook: 8.6.7(prettier@3.5.3)
-      storybook-builder-rsbuild: 1.0.0(@rsbuild/core@1.2.19)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 1.0.0(@rsbuild/core@1.3.0-beta.0)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.7(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.8.2
@@ -12803,7 +12982,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.1.1(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2):
+  ts-checker-rspack-plugin@1.1.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@rspack/lite-tapable': 1.0.1
@@ -12813,7 +12992,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.8.2
     optionalDependencies:
-      '@rspack/core': 1.2.8(@swc/helpers@0.5.15)
+      '@rspack/core': 1.3.0-beta.0(@swc/helpers@0.5.15)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.0",
     "@module-federation/rsbuild-plugin": "^0.11.1",
     "@playwright/test": "1.51.1",
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@rsbuild/plugin-less": "^1.1.1",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rsbuild/plugin-sass": "^1.2.2",

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "rspress preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.2.19",
+    "@rsbuild/core": "1.3.0-beta.0",
     "@rsbuild/plugin-sass": "^1.2.2",
     "@rslib/tsconfig": "workspace:*",
     "@rstack-dev/doc-ui": "1.7.3",
@@ -19,7 +19,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rsbuild-plugin-google-analytics": "1.0.3",
-    "rspress": "^2.0.0-alpha.3",
+    "rspress": "^2.0.0-alpha.4",
     "rspress-plugin-font-open-sans": "1.0.0"
   }
 }


### PR DESCRIPTION
## Summary

bump Rstack packages:

- Rslib: `0.5.4` -> `0.5.5`
- Rspress: `2.0.0-alpha.3` -> `2.0.0-alpha.4`
- Rsbuild: `1.2.19` -> `1.3.0-beta.0`
## Related Links
- https://github.com/web-infra-dev/rslib/releases/tag/v0.5.5
- https://github.com/web-infra-dev/rspress/releases/tag/v2.0.0-alpha.4
- https://github.com/web-infra-dev/rsbuild/releases/tag/v1.3.0-beta.0

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
