### PR TITLE
docs: fix Discord URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This repo has adopted the ByteDance Open Source Code of Conduct. Please check [C
 
 ## 🧑‍💻 Community
 
-Come and chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! The Rstack team and users are active there, and we're always looking for contributions.
+Come and chat with us on [Discord](https://discord.gg/7uHaPXcVyV)! The Rstack team and users are active there, and we're always looking for contributions.
 
 ## 🌟 Quality
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This repo has adopted the ByteDance Open Source Code of Conduct. Please check [C
 
 ## 🧑‍💻 Community
 
-Come and chat with us on [Discord](https://discord.gg/FQfm7VqU)! The Rstack team and users are active there, and we're always looking for contributions.
+Come and chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! The Rstack team and users are active there, and we're always looking for contributions.
 
 ## 🌟 Quality
 


### PR DESCRIPTION
## Summary

Invalid Discord invite URL, replaced with the one mentioned in rspack as they all should lead to the same server

## Related Links

- https://github.com/web-infra-dev/rspack/blob/main/README.md?plain=1#L46

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
