### PR TITLE
chore(deps): update Rsbuild to v1.3.0-beta.2

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.11.1",
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@rsbuild/plugin-react": "^1.1.1",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.11.1",
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@rsbuild/plugin-react": "^1.1.1",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "rsbuild-plugin-dts": "workspace:*",
     "tinyglobby": "^0.2.12"
   },

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@storybook/addon-essentials": "^8.6.8",
     "@storybook/addon-interactions": "^8.6.8",
     "@storybook/addon-links": "^8.6.8",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@storybook/addon-essentials": "^8.6.8",
     "@storybook/addon-interactions": "^8.6.8",
     "@storybook/addon-links": "^8.6.8",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -19,7 +19,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.8",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.8",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -18,7 +18,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.8",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.8",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.52.1",
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@rslib/tsconfig": "workspace:*",
     "rsbuild-plugin-publint": "^0.3.0",
     "rslib": "npm:@rslib/core@0.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,13 +91,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.11.1
-        version: 0.11.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@rsbuild/core':
-        specifier: 1.3.0-beta.1
-        version: 1.3.0-beta.1
+        specifier: 1.3.0-beta.2
+        version: 1.3.0-beta.2
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@types/react':
         specifier: ^19.0.12
         version: 19.0.12
@@ -112,16 +112,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.11.1
-        version: 0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/rsbuild-plugin':
         specifier: ^0.11.1
-        version: 0.11.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/storybook-addon':
         specifier: ^4.0.9
-        version: 4.0.9(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@storybook/core@8.6.8(prettier@3.5.3)(storybook@8.6.8(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)
+        version: 4.0.9(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(@storybook/core@8.6.8(prettier@3.5.3)(storybook@8.6.8(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -142,10 +142,10 @@ importers:
         version: 8.6.8(prettier@3.5.3)
       storybook-addon-rslib:
         specifier: ^1.0.1
-        version: 1.0.1(@rsbuild/core@1.3.0-beta.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2)
+        version: 1.0.1(@rsbuild/core@1.3.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2)
       storybook-react-rsbuild:
         specifier: ^1.0.1
-        version: 1.0.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0)
+        version: 1.0.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -158,13 +158,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.11.1
-        version: 0.11.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@rsbuild/core':
-        specifier: 1.3.0-beta.1
-        version: 1.3.0-beta.1
+        specifier: 1.3.0-beta.2
+        version: 1.3.0-beta.2
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@types/react':
         specifier: ^19.0.12
         version: 19.0.12
@@ -179,10 +179,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@1.3.0-beta.1)(preact@10.26.4)
+        version: 1.3.1(@rsbuild/core@1.3.0-beta.2)(preact@10.26.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.3.0-beta.1)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -194,10 +194,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.3.0-beta.1)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -212,10 +212,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.3.0-beta.1)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -230,10 +230,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.3.0-beta.1)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -248,7 +248,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.3.0-beta.1)(vue@3.5.13(typescript@5.8.2))
+        version: 1.0.7(@rsbuild/core@1.3.0-beta.2)(vue@3.5.13(typescript@5.8.2))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -265,8 +265,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: 1.3.0-beta.1
-        version: 1.3.0-beta.1
+        specifier: 1.3.0-beta.2
+        version: 1.3.0-beta.2
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
@@ -276,7 +276,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.11.1
-        version: 0.11.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -303,7 +303,7 @@ importers:
         version: 1.2.7(typescript@5.8.2)
       rsbuild-plugin-publint:
         specifier: ^0.3.0
-        version: 0.3.0(@rsbuild/core@1.3.0-beta.1)
+        version: 0.3.0(@rsbuild/core@1.3.0-beta.2)
       rslib:
         specifier: npm:@rslib/core@0.5.5
         version: '@rslib/core@0.5.5(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(typescript@5.8.2)'
@@ -370,14 +370,14 @@ importers:
         specifier: ^7.52.1
         version: 7.52.1(@types/node@22.8.1)
       '@rsbuild/core':
-        specifier: 1.3.0-beta.1
-        version: 1.3.0-beta.1
+        specifier: 1.3.0-beta.2
+        version: 1.3.0-beta.2
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
       rsbuild-plugin-publint:
         specifier: ^0.3.0
-        version: 0.3.0(@rsbuild/core@1.3.0-beta.1)
+        version: 0.3.0(@rsbuild/core@1.3.0-beta.2)
       rslib:
         specifier: npm:@rslib/core@0.5.5
         version: '@rslib/core@0.5.5(@microsoft/api-extractor@7.52.1(@types/node@22.8.1))(typescript@5.8.2)'
@@ -401,25 +401,25 @@ importers:
         version: 4.0.0(vite@6.0.11(@types/node@22.8.1)(jiti@2.4.2)(sass-embedded@1.85.0)(stylus@0.64.0)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))(vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.8.1)(jiti@2.4.2)(sass-embedded@1.85.0)(stylus@0.64.0)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.11.1
-        version: 0.11.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+        version: 0.11.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
       '@rsbuild/core':
-        specifier: 1.3.0-beta.1
-        version: 1.3.0-beta.1
+        specifier: 1.3.0-beta.2
+        version: 1.3.0-beta.2
       '@rsbuild/plugin-less':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.3.0-beta.1)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.2)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.3.0-beta.1)
+        version: 1.0.2(@rsbuild/core@1.3.0-beta.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -478,7 +478,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
 
   tests/integration/asset/json: {}
 
@@ -494,10 +494,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.3.0-beta.1)(typescript@5.8.2)
+        version: 1.0.7(@rsbuild/core@1.3.0-beta.2)(typescript@5.8.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -591,10 +591,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+        version: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.3.0-beta.1)(typescript@5.8.2)
+        version: 1.0.7(@rsbuild/core@1.3.0-beta.2)(typescript@5.8.2)
 
   tests/integration/cli/build: {}
 
@@ -786,7 +786,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.4
-        version: 1.0.4(@rsbuild/core@1.3.0-beta.1)
+        version: 1.0.4(@rsbuild/core@1.3.0-beta.2)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.12.0
         version: 0.12.0(@babel/core@7.26.9)
@@ -913,13 +913,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.0.8
-        version: 1.0.8(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
+        version: 1.0.8(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.0.8
-        version: 1.0.8(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
+        version: 1.0.8(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -977,11 +977,11 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: 1.3.0-beta.1
-        version: 1.3.0-beta.1
+        specifier: 1.3.0-beta.2
+        version: 1.3.0-beta.2
       '@rsbuild/plugin-sass':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.3.0-beta.1)
+        version: 1.2.2(@rsbuild/core@1.3.0-beta.2)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -1005,7 +1005,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.3
-        version: 1.0.3(@rsbuild/core@1.3.0-beta.1)
+        version: 1.0.3(@rsbuild/core@1.3.0-beta.2)
       rspress:
         specifier: ^2.0.0-alpha.5
         version: 2.0.0-alpha.5(webpack@5.98.0)
@@ -1795,9 +1795,6 @@ packages:
       webpack:
         optional: true
 
-  '@module-federation/error-codes@0.11.0':
-    resolution: {integrity: sha512-IyN5fi3KvB9WFeXeCVMdaGl/VI/Dejrx6Gqxrq5V74Tj7Us2VfcGyOUU7+AEue52gmq7qpIe0ctbr79RF16mWg==}
-
   '@module-federation/error-codes@0.11.1':
     resolution: {integrity: sha512-N1cs1qwrO8cU/OzfnBbr+3FaVbrJk6QEAsQ8H+YxGRrh/kHsR2BKpZCX79jTG27oDbz45FLjQ98YucMMXC24EA==}
 
@@ -1836,14 +1833,8 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/runtime-core@0.11.0':
-    resolution: {integrity: sha512-s1cZfrBZ47SfbMNPsc35yx66N4IjVl475ZtYRmsNq3/DHRJxk7AC5Be/O0Z5SHKYHVJydXhmqDT+kX7zMM+4dw==}
-
   '@module-federation/runtime-core@0.11.1':
     resolution: {integrity: sha512-6KxLfkCl05Ey69Xg/dsjf7fPit9qGXZ0lpwaG2agiCqC3JCDxYjT7tgGvnWhTXCcztb/ThpT+bHrRD4Kw8SMhA==}
-
-  '@module-federation/runtime-tools@0.11.0':
-    resolution: {integrity: sha512-zSB4Ypg/zXCaljdSCMWPpCXQ1D4OSBeT9fHkj/Wb/5a+ZX02MicVhT/6y3g6rGG/3PqbP4jlQMhSC2jMv2Kcxg==}
 
   '@module-federation/runtime-tools@0.11.1':
     resolution: {integrity: sha512-8UqMbHJSdkEvKlnlXpR/OjMA77bUbhtmv0I4UO+PA1zBga4y3/St6NOjD66NTINKeWEgsCt1aepXHspduXp33w==}
@@ -1851,17 +1842,11 @@ packages:
   '@module-federation/runtime-tools@0.8.4':
     resolution: {integrity: sha512-fjVOsItJ1u5YY6E9FnS56UDwZgqEQUrWFnouRiPtK123LUuqUI9FH4redZoKWlE1PB0ir1Z3tnqy8eFYzPO38Q==}
 
-  '@module-federation/runtime@0.11.0':
-    resolution: {integrity: sha512-jUOMwMiyNs/Q7xhHhimCn4DOddEmj0IhSC7vqZojPzFyowRcmaKptGHD8pr5oA3RcCu1l1BOQMhSKbZbplTTXA==}
-
   '@module-federation/runtime@0.11.1':
     resolution: {integrity: sha512-yxxa/TRXaNggb34N+oL82J7r9+GZ3gYTCDyGibYqtsC5j7+9oB4tmc0UyhjrGMhg+fF8TAWFZjNKo7ZnyN9LcQ==}
 
   '@module-federation/runtime@0.8.4':
     resolution: {integrity: sha512-yZeZ7z2Rx4gv/0E97oLTF3V6N25vglmwXGgoeju/W2YjsFvWzVtCDI7zRRb0mJhU6+jmSM8jP1DeQGbea/AiZQ==}
-
-  '@module-federation/sdk@0.11.0':
-    resolution: {integrity: sha512-px2BVTs/rJ9aYzQNkEhi5/qTMN7FSUO3wuaTc52Cc/bG4gq5dX8hYXUQNfi6dVhl6Zg2/2GtTX0ym7d7jjpYDg==}
 
   '@module-federation/sdk@0.11.1':
     resolution: {integrity: sha512-QS6zevdQYLCGF6NFf0LysMGARh+dZxMeoRKKDUW5PYi3XOk+tjJ7QsDKybfcBZBNgBJfIuwxh4Oei6WOFJEfRg==}
@@ -1898,9 +1883,6 @@ packages:
 
   '@module-federation/third-party-dts-extractor@0.11.1':
     resolution: {integrity: sha512-oyyelSLGFObM699p192Cuk/LxEDdzSOywDUXrzPa/qSKNFii5WartjQRc4QPMLnsQaGD7fQVTTiBkvVBcWUdyQ==}
-
-  '@module-federation/webpack-bundler-runtime@0.11.0':
-    resolution: {integrity: sha512-rq8dldquwNDtaLImucld0WMUAkfFfng1HQARMLc0jb9VO7KLqC6FH58Iph/4yaEJFW0V8RXDGnTDVXFnYSAa1Q==}
 
   '@module-federation/webpack-bundler-runtime@0.11.1':
     resolution: {integrity: sha512-XlVegGyCBBLId8Jr6USjPOFYViQ0CCtoYjHpC8y1FOGtuXLGrvnEdFcl4XHlFlp3MY3Rxhr8QigrdZhYe5bRWg==}
@@ -2124,8 +2106,8 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
 
-  '@rsbuild/core@1.3.0-beta.1':
-    resolution: {integrity: sha512-k5cpA5EYZQ4V+Vbf4o9EJBYh2uQw5KEuzgbg8tAwo5bN7IhaagrroXq8vxP+zF2UOj3q/7RMFjh7bARouX4x2w==}
+  '@rsbuild/core@1.3.0-beta.2':
+    resolution: {integrity: sha512-/gcHzROIZp12s/WkTvWNU3cyCZzvRop9/6o4WdXRR1sbxa6TZXQ/rMzmdM/upVnx2mwstvO+3vByrQbgZ7B7SA==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
@@ -2211,8 +2193,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.3.0-beta.0':
-    resolution: {integrity: sha512-K7IDzEt5bTF3uvQtQQz4MyAA+aoKfr3W6EfU0OnDRPkJh3BnMAlCGHfVrmoe920EPcMKXRebyYIIqaRIW2+2Bw==}
+  '@rspack/binding-darwin-arm64@1.3.0-beta.1':
+    resolution: {integrity: sha512-bOKW/m9Ggmes1lXFsM0nxgYqKVlc1rg+bw8/wXS2Iyq0nQaW1FVO3LYCAaj3yYaOjmB7oSwd1Rd7mcInof010w==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2221,8 +2203,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.3.0-beta.0':
-    resolution: {integrity: sha512-GdLqcl++p5YxwL4ONPctwop1O1yQ5wuwrmuXnvpPlt+H+yLCNW+RhN4RtFj+fQwLk4r2QDUxlLkGvOCJLUYFAA==}
+  '@rspack/binding-darwin-x64@1.3.0-beta.1':
+    resolution: {integrity: sha512-XRnhgzYrjWgGHqyoAJ1s/fDxygEGej0JCJMVPHTDCHDbtt+TnAoqmcP/2MxVsf9HYdKZzTRT2VcBnPy7R2m9yQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -2231,8 +2213,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@1.3.0-beta.0':
-    resolution: {integrity: sha512-/CIKLq9FZnYfOowpJEP2+T9sIownOZdMH+SvJ+BQfDCuwKh0+kU3vAHTnTvO3Ngs0jTmhiFAZovQUdgVQhbzlA==}
+  '@rspack/binding-linux-arm64-gnu@1.3.0-beta.1':
+    resolution: {integrity: sha512-GzkbSVRpeAoiLIoYnAc21dAvS0Nc07x4JPczkSx/SVQRzPUfflJOMC/k6i541405E7/1Am/IVlg/WtNhA4aVTA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2241,8 +2223,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.3.0-beta.0':
-    resolution: {integrity: sha512-7WzFokwdnxWK3BjzSjsIYhY8Yd7k26bUV0D/fWBFP81Tw9VuuuR5TSuQEkv0RtzPxhr3+Jcmfh+5KZw3qUGI4Q==}
+  '@rspack/binding-linux-arm64-musl@1.3.0-beta.1':
+    resolution: {integrity: sha512-eo1EVtr9JGwy5HKTo+KaiIGJpD8boo5325XO/it8H+1abcXV8mPq4h0P/tUs4N2yxV2iI537p2JqmXoPL1Wnmw==}
     cpu: [arm64]
     os: [linux]
 
@@ -2251,8 +2233,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.3.0-beta.0':
-    resolution: {integrity: sha512-yrDuI/iE4ZYp44Q5nRDRdRBTtRH2QoQaPG9Z3w3LbUqArAU8rpSMJAkTruVfjcrHrMV1J+4/lMKm5Q9hXXgX+A==}
+  '@rspack/binding-linux-x64-gnu@1.3.0-beta.1':
+    resolution: {integrity: sha512-z880gep+twGC+znanuyW7PRKP2Y5dDdERWTLBUEYF9EEpup6nXEXw7GunfcrAeDdRpCi13Mr/iMUlqH2qfwkmQ==}
     cpu: [x64]
     os: [linux]
 
@@ -2261,8 +2243,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.3.0-beta.0':
-    resolution: {integrity: sha512-61gbjSUxXmIYspzzi61ubh87AEKqDz2dKPoxdeZfs+o1UU139N1cv/CAVYkn4VNg91txiCBSUuvANEZl0mUjgg==}
+  '@rspack/binding-linux-x64-musl@1.3.0-beta.1':
+    resolution: {integrity: sha512-BQXI7OlAyuBd7Ir8v81h6BBIJOqT7HGLtkJY88in8QO60uWjpuxYZuh2A4Ox8oAg2+XNXXfmVhzlx9UxC5PoJQ==}
     cpu: [x64]
     os: [linux]
 
@@ -2271,8 +2253,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@1.3.0-beta.0':
-    resolution: {integrity: sha512-io0SNiyT6vB9Vd3kYsgsL85UNZSIFx1YyHUcDq/1aH4d1HldvafMtPggLwcZhWU6IG8Svg2npvsNAsZJem3YIA==}
+  '@rspack/binding-win32-arm64-msvc@1.3.0-beta.1':
+    resolution: {integrity: sha512-R5v3P/NC5HHRjG/fA+kg+S0DNpmR+W6cB/7UU6tjsoQ30gukSN62MuMbcXUTXOsbIBnraWfjDOJ78pnQH9Q1AQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -2281,8 +2263,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.3.0-beta.0':
-    resolution: {integrity: sha512-+0YjQGZk1GaiGoqt0nvZHlfRlYmlyNVQJzdc4Kztd469RWIkDeJkIWo+1t6ik6/vSzVaCWYum5iyYAm9f8Yeaw==}
+  '@rspack/binding-win32-ia32-msvc@1.3.0-beta.1':
+    resolution: {integrity: sha512-mWx70lbAXbN76Oue8vDvmi6T7gM1IsdWJvUuO8sxw5sNLXJtilvexhzq7RzzpOHZKa/2hJOV5PjQcYsHr5zYew==}
     cpu: [ia32]
     os: [win32]
 
@@ -2291,16 +2273,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.3.0-beta.0':
-    resolution: {integrity: sha512-FBaUAA7vCt+SJ1+kbFDdvmMNsa+30GULnUrN7Lnat9f4h3PfVPG+z7ClG/uhTgHCdp7EmyJx+yRt2/NGvA+R+A==}
+  '@rspack/binding-win32-x64-msvc@1.3.0-beta.1':
+    resolution: {integrity: sha512-es2DZL4Mg2vJn3atfleQoCZbWgXXB424ENWCg54DVtA3tUbvx+du2j2ygCpnXF6/ITLgA3dSZnQR6Kh4SEQXvQ==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@1.2.8':
     resolution: {integrity: sha512-T3FMB3N9P1AbSAryfkSRJkPtmeSYs/Gj9zUZoPz1ckPEIcWZmpUOQbJylldjbw5waxtCL1haHNbi0pcSvxiaJw==}
 
-  '@rspack/binding@1.3.0-beta.0':
-    resolution: {integrity: sha512-dYnT+gdDz2o9o0e2TW1EW67jrdkZHq0iZs49jYytANjsJY4zlu7UTT7Bcuw6mMLXMZLyRRJjCS2gS8GBjqo7RQ==}
+  '@rspack/binding@1.3.0-beta.1':
+    resolution: {integrity: sha512-2jJTKGb1XprTNa/COYRuvd0TOJSiOf6eOtoKj1of5YZA5doIsht8RhI63RahCxoIJZlNv99jwhbtIGVcfi3YAg==}
 
   '@rspack/core@1.2.8':
     resolution: {integrity: sha512-ppj3uQQtkhgrYDLrUqb33YbpNEZCpAudpfVuOHGsvUrAnu1PijbfJJymoA5ZvUhM+HNMvPI5D1ie97TXyb0UVg==}
@@ -2314,8 +2296,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@1.3.0-beta.0':
-    resolution: {integrity: sha512-mZ0v/AfSQOCe74Zlb+YIeVRJKHbemYRBzthSra56Gus+StNCe2Fggp88LUNgkVljTMhFpRA1ShTqsOOvAGxOuQ==}
+  '@rspack/core@1.3.0-beta.1':
+    resolution: {integrity: sha512-oWT+zkZ7cgZ6M6yyAjM4cETz5qOZ6f8UEmhlOndM9pxiMtRfWWbgW1U9qxN4sOlZTU3D0K9C1aBj7u5IFD2i0w==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rspack/tracing': ^1.x
@@ -3241,8 +3223,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001703:
-    resolution: {integrity: sha512-kRlAGTRWgPsOj7oARC9m1okJEXdL/8fekFVcxA8Hl7GH4r/sN4OJn/i6Flde373T50KS7Y37oFbMwlE8+F42kQ==}
+  caniuse-lite@1.0.30001707:
+    resolution: {integrity: sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==}
 
   case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
@@ -7664,7 +7646,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)':
+  '@module-federation/enhanced@0.11.1(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.11.1
       '@module-federation/data-prefetch': 0.11.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -7673,7 +7655,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.11.1(@module-federation/runtime-tools@0.11.1)
       '@module-federation/managers': 0.11.1
       '@module-federation/manifest': 0.11.1(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))
-      '@module-federation/rspack': 0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))
+      '@module-federation/rspack': 0.11.1(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))
       '@module-federation/runtime-tools': 0.11.1
       '@module-federation/sdk': 0.11.1
       btoa: 1.2.1
@@ -7690,8 +7672,6 @@ snapshots:
       - react-dom
       - supports-color
       - utf-8-validate
-
-  '@module-federation/error-codes@0.11.0': {}
 
   '@module-federation/error-codes@0.11.1': {}
 
@@ -7722,12 +7702,12 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.11.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)':
+  '@module-federation/rsbuild-plugin@0.11.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)':
     dependencies:
-      '@module-federation/enhanced': 0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+      '@module-federation/enhanced': 0.11.1(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/sdk': 0.11.1
     optionalDependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -7740,7 +7720,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))':
+  '@module-federation/rspack@0.11.1(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.11.1
       '@module-federation/dts-plugin': 0.11.1(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))
@@ -7749,7 +7729,7 @@ snapshots:
       '@module-federation/manifest': 0.11.1(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))
       '@module-federation/runtime-tools': 0.11.1
       '@module-federation/sdk': 0.11.1
-      '@rspack/core': 1.3.0-beta.0(@swc/helpers@0.5.15)
+      '@rspack/core': 1.3.0-beta.1(@swc/helpers@0.5.15)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.8.2
@@ -7760,20 +7740,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/runtime-core@0.11.0':
-    dependencies:
-      '@module-federation/error-codes': 0.11.0
-      '@module-federation/sdk': 0.11.0
-
   '@module-federation/runtime-core@0.11.1':
     dependencies:
       '@module-federation/error-codes': 0.11.1
       '@module-federation/sdk': 0.11.1
-
-  '@module-federation/runtime-tools@0.11.0':
-    dependencies:
-      '@module-federation/runtime': 0.11.0
-      '@module-federation/webpack-bundler-runtime': 0.11.0
 
   '@module-federation/runtime-tools@0.11.1':
     dependencies:
@@ -7784,12 +7754,6 @@ snapshots:
     dependencies:
       '@module-federation/runtime': 0.8.4
       '@module-federation/webpack-bundler-runtime': 0.8.4
-
-  '@module-federation/runtime@0.11.0':
-    dependencies:
-      '@module-federation/error-codes': 0.11.0
-      '@module-federation/runtime-core': 0.11.0
-      '@module-federation/sdk': 0.11.0
 
   '@module-federation/runtime@0.11.1':
     dependencies:
@@ -7802,20 +7766,18 @@ snapshots:
       '@module-federation/error-codes': 0.8.4
       '@module-federation/sdk': 0.8.4
 
-  '@module-federation/sdk@0.11.0': {}
-
   '@module-federation/sdk@0.11.1': {}
 
   '@module-federation/sdk@0.8.4':
     dependencies:
       isomorphic-rslog: 0.0.6
 
-  '@module-federation/storybook-addon@4.0.9(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@storybook/core@8.6.8(prettier@3.5.3)(storybook@8.6.8(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)':
+  '@module-federation/storybook-addon@4.0.9(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(@storybook/core@8.6.8(prettier@3.5.3)(storybook@8.6.8(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)':
     dependencies:
-      '@module-federation/enhanced': 0.11.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
+      '@module-federation/enhanced': 0.11.1(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(vue-tsc@2.2.8(typescript@5.8.2))(webpack@5.98.0)
       '@module-federation/sdk': 0.11.1
     optionalDependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
       '@storybook/core': 8.6.8(prettier@3.5.3)(storybook@8.6.8(prettier@3.5.3))
       webpack: 5.98.0
       webpack-virtual-modules: 0.6.2
@@ -7835,11 +7797,6 @@ snapshots:
       find-pkg: 2.0.0
       fs-extra: 9.1.0
       resolve: 1.22.8
-
-  '@module-federation/webpack-bundler-runtime@0.11.0':
-    dependencies:
-      '@module-federation/runtime': 0.11.0
-      '@module-federation/sdk': 0.11.0
 
   '@module-federation/webpack-bundler-runtime@0.11.1':
     dependencies:
@@ -7995,9 +7952,9 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rsbuild/core@1.3.0-beta.1':
+  '@rsbuild/core@1.3.0-beta.2':
     dependencies:
-      '@rspack/core': 1.3.0-beta.0(@swc/helpers@0.5.15)
+      '@rspack/core': 1.3.0-beta.1(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.15
       core-js: 3.41.0
@@ -8005,13 +7962,13 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.3.0-beta.1)':
+  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.3.0-beta.2)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.9)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.9)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.9)
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -8019,9 +7976,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.1.1(@rsbuild/core@1.3.0-beta.1)':
+  '@rsbuild/plugin-less@1.1.1(@rsbuild/core@1.3.0-beta.2)':
     dependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
@@ -8053,11 +8010,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.2.19
 
-  '@rsbuild/plugin-preact@1.3.1(@rsbuild/core@1.3.0-beta.1)(preact@10.26.4)':
+  '@rsbuild/plugin-preact@1.3.1(@rsbuild/core@1.3.0-beta.2)(preact@10.26.4)':
     dependencies:
       '@prefresh/core': 1.5.3(preact@10.26.4)
       '@prefresh/utils': 1.2.0
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
       '@rspack/plugin-preact-refresh': 1.1.2(@prefresh/core@1.5.3(preact@10.26.4))(@prefresh/utils@1.2.0)
       '@swc/plugin-prefresh': 6.2.0
     transitivePeerDependencies:
@@ -8069,24 +8026,24 @@ snapshots:
       '@rspack/plugin-react-refresh': 1.0.1(react-refresh@0.16.0)
       react-refresh: 0.16.0
 
-  '@rsbuild/plugin-react@1.1.1(@rsbuild/core@1.3.0-beta.1)':
+  '@rsbuild/plugin-react@1.1.1(@rsbuild/core@1.3.0-beta.2)':
     dependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
       '@rspack/plugin-react-refresh': 1.0.1(react-refresh@0.16.0)
       react-refresh: 0.16.0
 
-  '@rsbuild/plugin-sass@1.2.2(@rsbuild/core@1.3.0-beta.1)':
+  '@rsbuild/plugin-sass@1.2.2(@rsbuild/core@1.3.0-beta.2)':
     dependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.2
       reduce-configs: 1.1.0
       sass-embedded: 1.85.0
 
-  '@rsbuild/plugin-stylus@1.0.8(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)':
+  '@rsbuild/plugin-stylus@1.0.8(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.98.0)':
     dependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
       stylus: 0.64.0
@@ -8096,10 +8053,10 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.0.7(@rsbuild/core@1.3.0-beta.1)(typescript@5.8.2)':
+  '@rsbuild/plugin-svgr@1.0.7(@rsbuild/core@1.3.0-beta.2)(typescript@5.8.2)':
     dependencies:
-      '@rsbuild/core': 1.3.0-beta.1
-      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.3.0-beta.1)
+      '@rsbuild/core': 1.3.0-beta.2
+      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.3.0-beta.2)
       '@svgr/core': 8.1.0(typescript@5.8.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.2))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.2))(typescript@5.8.2)
@@ -8109,25 +8066,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-type-check@1.2.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2)':
+  '@rsbuild/plugin-type-check@1.2.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(typescript@5.8.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.0
-      ts-checker-rspack-plugin: 1.1.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2)
+      ts-checker-rspack-plugin: 1.1.1(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(typescript@5.8.2)
     optionalDependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.3.0-beta.1)':
+  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.3.0-beta.2)':
     optionalDependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
 
-  '@rsbuild/plugin-vue@1.0.7(@rsbuild/core@1.3.0-beta.1)(vue@3.5.13(typescript@5.8.2))':
+  '@rsbuild/plugin-vue@1.0.7(@rsbuild/core@1.3.0-beta.2)(vue@3.5.13(typescript@5.8.2))':
     dependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
       vue-loader: 17.4.2(vue@3.5.13(typescript@5.8.2))(webpack@5.98.0)
       webpack: 5.98.0
     transitivePeerDependencies:
@@ -8152,55 +8109,55 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.2.8':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.3.0-beta.0':
+  '@rspack/binding-darwin-arm64@1.3.0-beta.1':
     optional: true
 
   '@rspack/binding-darwin-x64@1.2.8':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.3.0-beta.0':
+  '@rspack/binding-darwin-x64@1.3.0-beta.1':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.2.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.3.0-beta.0':
+  '@rspack/binding-linux-arm64-gnu@1.3.0-beta.1':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.2.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.3.0-beta.0':
+  '@rspack/binding-linux-arm64-musl@1.3.0-beta.1':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.2.8':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.3.0-beta.0':
+  '@rspack/binding-linux-x64-gnu@1.3.0-beta.1':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.2.8':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.3.0-beta.0':
+  '@rspack/binding-linux-x64-musl@1.3.0-beta.1':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.2.8':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.3.0-beta.0':
+  '@rspack/binding-win32-arm64-msvc@1.3.0-beta.1':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.2.8':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.3.0-beta.0':
+  '@rspack/binding-win32-ia32-msvc@1.3.0-beta.1':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.2.8':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.3.0-beta.0':
+  '@rspack/binding-win32-x64-msvc@1.3.0-beta.1':
     optional: true
 
   '@rspack/binding@1.2.8':
@@ -8215,33 +8172,33 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.2.8
       '@rspack/binding-win32-x64-msvc': 1.2.8
 
-  '@rspack/binding@1.3.0-beta.0':
+  '@rspack/binding@1.3.0-beta.1':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.3.0-beta.0
-      '@rspack/binding-darwin-x64': 1.3.0-beta.0
-      '@rspack/binding-linux-arm64-gnu': 1.3.0-beta.0
-      '@rspack/binding-linux-arm64-musl': 1.3.0-beta.0
-      '@rspack/binding-linux-x64-gnu': 1.3.0-beta.0
-      '@rspack/binding-linux-x64-musl': 1.3.0-beta.0
-      '@rspack/binding-win32-arm64-msvc': 1.3.0-beta.0
-      '@rspack/binding-win32-ia32-msvc': 1.3.0-beta.0
-      '@rspack/binding-win32-x64-msvc': 1.3.0-beta.0
+      '@rspack/binding-darwin-arm64': 1.3.0-beta.1
+      '@rspack/binding-darwin-x64': 1.3.0-beta.1
+      '@rspack/binding-linux-arm64-gnu': 1.3.0-beta.1
+      '@rspack/binding-linux-arm64-musl': 1.3.0-beta.1
+      '@rspack/binding-linux-x64-gnu': 1.3.0-beta.1
+      '@rspack/binding-linux-x64-musl': 1.3.0-beta.1
+      '@rspack/binding-win32-arm64-msvc': 1.3.0-beta.1
+      '@rspack/binding-win32-ia32-msvc': 1.3.0-beta.1
+      '@rspack/binding-win32-x64-msvc': 1.3.0-beta.1
 
   '@rspack/core@1.2.8(@swc/helpers@0.5.15)':
     dependencies:
       '@module-federation/runtime-tools': 0.8.4
       '@rspack/binding': 1.2.8
       '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001703
+      caniuse-lite: 1.0.30001707
     optionalDependencies:
       '@swc/helpers': 0.5.15
 
-  '@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15)':
+  '@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15)':
     dependencies:
-      '@module-federation/runtime-tools': 0.11.0
-      '@rspack/binding': 1.3.0-beta.0
+      '@module-federation/runtime-tools': 0.11.1
+      '@rspack/binding': 1.3.0-beta.1
       '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001703
+      caniuse-lite: 1.0.30001707
     optionalDependencies:
       '@swc/helpers': 0.5.15
 
@@ -9324,7 +9281,7 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001703
+      caniuse-lite: 1.0.30001707
       electron-to-chromium: 1.5.88
       node-releases: 2.0.19
       update-browserslist-db: 1.1.1(browserslist@4.24.4)
@@ -9377,7 +9334,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001703: {}
+  caniuse-lite@1.0.30001707: {}
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
 
@@ -12300,16 +12257,16 @@ snapshots:
       '@microsoft/api-extractor': 7.52.1(@types/node@22.8.1)
       typescript: 5.8.2
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.3.0-beta.1):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.3.0-beta.2):
     optionalDependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
 
-  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.3.0-beta.1):
+  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.3.0-beta.2):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
 
   rsbuild-plugin-publint@0.3.0(@rsbuild/core@1.2.19):
     dependencies:
@@ -12318,12 +12275,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.2.19
 
-  rsbuild-plugin-publint@0.3.0(@rsbuild/core@1.3.0-beta.1):
+  rsbuild-plugin-publint@0.3.0(@rsbuild/core@1.3.0-beta.2):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.2
     optionalDependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
 
   rslog@1.2.3: {}
 
@@ -12645,18 +12602,18 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@1.0.1(@rsbuild/core@1.3.0-beta.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2):
+  storybook-addon-rslib@1.0.1(@rsbuild/core@1.3.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3))(typescript@5.8.2):
     dependencies:
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 1.0.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 1.0.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
     optionalDependencies:
       typescript: 5.8.2
 
-  storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3):
+  storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3):
     dependencies:
-      '@rsbuild/core': 1.3.0-beta.1
-      '@rsbuild/plugin-type-check': 1.2.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2)
+      '@rsbuild/core': 1.3.0-beta.2
+      '@rsbuild/plugin-type-check': 1.2.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(typescript@5.8.2)
       '@storybook/addon-docs': 8.4.2(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(webpack-sources@3.2.3)
       '@storybook/core-webpack': 8.4.2(storybook@8.6.8(prettier@3.5.3))
       browser-assert: 1.2.1
@@ -12669,7 +12626,7 @@ snapshots:
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.3.0-beta.1)
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.3.0-beta.2)
       sirv: 2.0.4
       storybook: 8.6.8(prettier@3.5.3)
       ts-dedent: 2.2.0
@@ -12683,10 +12640,10 @@ snapshots:
       - '@types/react'
       - webpack-sources
 
-  storybook-react-rsbuild@1.0.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0):
+  storybook-react-rsbuild@1.0.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.34.2)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)(webpack@5.98.0):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.34.2)
-      '@rsbuild/core': 1.3.0-beta.1
+      '@rsbuild/core': 1.3.0-beta.2
       '@storybook/react': 8.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.2)(webpack@5.98.0)
       '@types/node': 18.19.64
@@ -12698,7 +12655,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       resolve: 1.22.10
       storybook: 8.6.8(prettier@3.5.3)
-      storybook-builder-rsbuild: 1.0.1(@rsbuild/core@1.3.0-beta.1)(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 1.0.1(@rsbuild/core@1.3.0-beta.2)(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(@types/react@19.0.12)(storybook@8.6.8(prettier@3.5.3))(typescript@5.8.2)(webpack-sources@3.2.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.8.2
@@ -12982,7 +12939,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.1.1(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))(typescript@5.8.2):
+  ts-checker-rspack-plugin@1.1.1(@rspack/core@1.3.0-beta.1(@swc/helpers@0.5.15))(typescript@5.8.2):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@rspack/lite-tapable': 1.0.1
@@ -12992,7 +12949,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.8.2
     optionalDependencies:
-      '@rspack/core': 1.3.0-beta.0(@swc/helpers@0.5.15)
+      '@rspack/core': 1.3.0-beta.1(@swc/helpers@0.5.15)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/integration/decorators/__snapshots__/index.test.ts.snap
+++ b/tests/integration/decorators/__snapshots__/index.test.ts.snap
@@ -39,19 +39,18 @@ exports[`decorators default to 2022-03 1`] = `
         };
         ctx.addInitializer = createAddInitializerMethod(initializers, decoratorFinishedRef);
         var get, set;
-        if (0 === kind) {
-            if (isPrivate) {
-                get = desc.get;
-                set = desc.set;
-            } else {
-                get = function() {
-                    return this[name];
-                };
-                set = function(v) {
-                    this[name] = v;
-                };
-            }
-        } else if (2 === kind) get = function() {
+        if (0 === kind) if (isPrivate) {
+            get = desc.get;
+            set = desc.set;
+        } else {
+            get = function() {
+                return this[name];
+            };
+            set = function(v) {
+                this[name] = v;
+            };
+        }
+        else if (2 === kind) get = function() {
             return desc.value;
         };
         else {
@@ -148,14 +147,12 @@ exports[`decorators default to 2022-03 1`] = `
                         set: set
                     };
                 } else value = newValue;
-                if (void 0 !== newInit) {
-                    if (void 0 === init) init = newInit;
-                    else if ("function" == typeof init) init = [
-                        init,
-                        newInit
-                    ];
-                    else init.push(newInit);
-                }
+                if (void 0 !== newInit) if (void 0 === init) init = newInit;
+                else if ("function" == typeof init) init = [
+                    init,
+                    newInit
+                ];
+                else init.push(newInit);
             }
         }
         if (0 === kind || 1 === kind) {
@@ -184,19 +181,18 @@ exports[`decorators default to 2022-03 1`] = `
             } else if (2 === kind) desc.value = value;
             else if (3 === kind) desc.get = value;
             else if (4 === kind) desc.set = value;
-            if (isPrivate) {
-                if (1 === kind) {
-                    ret.push(function(instance, args) {
-                        return value.get.call(instance, args);
-                    });
-                    ret.push(function(instance, args) {
-                        return value.set.call(instance, args);
-                    });
-                } else if (2 === kind) ret.push(value);
-                else ret.push(function(instance, args) {
-                    return value.call(instance, args);
+            if (isPrivate) if (1 === kind) {
+                ret.push(function(instance, args) {
+                    return value.get.call(instance, args);
                 });
-            } else Object.defineProperty(base, name, desc);
+                ret.push(function(instance, args) {
+                    return value.set.call(instance, args);
+                });
+            } else if (2 === kind) ret.push(value);
+            else ret.push(function(instance, args) {
+                return value.call(instance, args);
+            });
+            else Object.defineProperty(base, name, desc);
         }
     }
     function applyMemberDecs(Class, decInfos, metadata) {
@@ -207,7 +203,7 @@ exports[`decorators default to 2022-03 1`] = `
         var existingStaticNonFields = new Map();
         for(var i = 0; i < decInfos.length; i++){
             var decInfo = decInfos[i];
-            if (!!Array.isArray(decInfo)) {
+            if (Array.isArray(decInfo)) {
                 var kind = decInfo[1];
                 var name = decInfo[2];
                 var isPrivate = decInfo.length > 3;
@@ -393,19 +389,18 @@ exports[`decorators with experimentalDecorators in tsconfig 2`] = `
         };
         ctx.addInitializer = createAddInitializerMethod(initializers, decoratorFinishedRef);
         var get, set;
-        if (0 === kind) {
-            if (isPrivate) {
-                get = desc.get;
-                set = desc.set;
-            } else {
-                get = function() {
-                    return this[name];
-                };
-                set = function(v) {
-                    this[name] = v;
-                };
-            }
-        } else if (2 === kind) get = function() {
+        if (0 === kind) if (isPrivate) {
+            get = desc.get;
+            set = desc.set;
+        } else {
+            get = function() {
+                return this[name];
+            };
+            set = function(v) {
+                this[name] = v;
+            };
+        }
+        else if (2 === kind) get = function() {
             return desc.value;
         };
         else {
@@ -502,14 +497,12 @@ exports[`decorators with experimentalDecorators in tsconfig 2`] = `
                         set: set
                     };
                 } else value = newValue;
-                if (void 0 !== newInit) {
-                    if (void 0 === init) init = newInit;
-                    else if ("function" == typeof init) init = [
-                        init,
-                        newInit
-                    ];
-                    else init.push(newInit);
-                }
+                if (void 0 !== newInit) if (void 0 === init) init = newInit;
+                else if ("function" == typeof init) init = [
+                    init,
+                    newInit
+                ];
+                else init.push(newInit);
             }
         }
         if (0 === kind || 1 === kind) {
@@ -538,19 +531,18 @@ exports[`decorators with experimentalDecorators in tsconfig 2`] = `
             } else if (2 === kind) desc.value = value;
             else if (3 === kind) desc.get = value;
             else if (4 === kind) desc.set = value;
-            if (isPrivate) {
-                if (1 === kind) {
-                    ret.push(function(instance, args) {
-                        return value.get.call(instance, args);
-                    });
-                    ret.push(function(instance, args) {
-                        return value.set.call(instance, args);
-                    });
-                } else if (2 === kind) ret.push(value);
-                else ret.push(function(instance, args) {
-                    return value.call(instance, args);
+            if (isPrivate) if (1 === kind) {
+                ret.push(function(instance, args) {
+                    return value.get.call(instance, args);
                 });
-            } else Object.defineProperty(base, name, desc);
+                ret.push(function(instance, args) {
+                    return value.set.call(instance, args);
+                });
+            } else if (2 === kind) ret.push(value);
+            else ret.push(function(instance, args) {
+                return value.call(instance, args);
+            });
+            else Object.defineProperty(base, name, desc);
         }
     }
     function applyMemberDecs(Class, decInfos, metadata) {
@@ -561,7 +553,7 @@ exports[`decorators with experimentalDecorators in tsconfig 2`] = `
         var existingStaticNonFields = new Map();
         for(var i = 0; i < decInfos.length; i++){
             var decInfo = decInfos[i];
-            if (!!Array.isArray(decInfo)) {
+            if (Array.isArray(decInfo)) {
                 var kind = decInfo[1];
                 var name = decInfo[2];
                 var isPrivate = decInfo.length > 3;

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -56,7 +56,7 @@ describe('minify config (mf)', () => {
     // biome-ignore format: snapshot
     expect(mfExposeEntry).toMatchInlineSnapshot(`
       "/*! For license information please see __federation_expose_default_export.js.LICENSE.txt */
-      "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["249"],{128:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{Button:()=>Button,foo:()=>foo});var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__=__webpack_require__(37);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("button",{})}}]);"
+      "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["249"],{759:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{Button:()=>Button,foo:()=>foo});var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__=__webpack_require__(37);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("button",{})}}]);"
     `);
   });
 
@@ -67,7 +67,7 @@ describe('minify config (mf)', () => {
     expect(mfExposeEntry).toMatchInlineSnapshot(`
       ""use strict";
       (globalThis["disable_minify"] = globalThis["disable_minify"] || []).push([["249"], {
-      128: (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+      759: (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
       __webpack_require__.r(__webpack_exports__);
       __webpack_require__.d(__webpack_exports__, {
         Button: () => (Button),

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.0",
     "@module-federation/rsbuild-plugin": "^0.11.1",
     "@playwright/test": "1.51.1",
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@rsbuild/plugin-less": "^1.1.1",
     "@rsbuild/plugin-react": "^1.1.1",
     "@rsbuild/plugin-sass": "^1.2.2",

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "rspress preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.3.0-beta.1",
+    "@rsbuild/core": "1.3.0-beta.2",
     "@rsbuild/plugin-sass": "^1.2.2",
     "@rslib/tsconfig": "workspace:*",
     "@rstack-dev/doc-ui": "1.7.3",


### PR DESCRIPTION
## Summary

Update Rsbuild to v1.3.0-beta.2 and fix test snapshots.

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v1.3.0-beta.2

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
