### PR TITLE
feat: export Rspack and Rsbuild

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,3 +15,4 @@ export const version: string = RSLIB_VERSION;
 
 export { rspack, type Rspack } from '@rsbuild/core';
 export * as rsbuild from '@rsbuild/core';
+export type * as Rsbuild from '@rsbuild/core';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,3 +12,6 @@ export { logger } from './utils/logger';
 export type * from './types';
 
 export const version: string = RSLIB_VERSION;
+
+export { rspack, type Rspack } from '@rsbuild/core';
+export * as rsbuild from '@rsbuild/core';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,4 +15,3 @@ export const version: string = RSLIB_VERSION;
 
 export { rspack, type Rspack } from '@rsbuild/core';
 export * as rsbuild from '@rsbuild/core';
-export type * as Rsbuild from '@rsbuild/core';


### PR DESCRIPTION
## Summary

Make developers convenient to import `rspack` instance and related Rsbuild public APIs and types in Rslib configuration files.

```ts
import { defineConfig, rsbuild, rspack } from '@rslib/core';

type EnvironmentContext = rsbuild.EnvironmentContext;
const PLUGIN_SWC_NAME = rsbuild.PLUGIN_SWC_NAME;

export default defineConfig({
  lib: [
    {
      format: 'esm',
      tools: {
        rspack: {
          plugins: [new rspack.CircularDependencyRspackPlugin({})],
        },
      },
    },
  ],
});


```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
