### PR TITLE
test: use local vendor instead of unpkg for react umd outputs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,7 +68,8 @@
     '@types/node',
     'node',
     // umd tests need to lock this version
-    'react-aliased',
+    'react-18',
+    'react-dom-18',
   ],
   postUpdateOptions: ['pnpmDedupe'],
 }

--- a/biome.json
+++ b/biome.json
@@ -21,10 +21,7 @@
     "ignoreUnknown": true
   },
   "formatter": {
-    "ignore": [
-      "**/.rslib/*",
-      "./tests/e2e/react-component/public/umd/index.js"
-    ],
+    "ignore": ["**/.rslib/*", "./tests/e2e/react-component/public/umd/*"],
     "indentStyle": "space"
   },
   "javascript": {
@@ -47,7 +44,7 @@
     "enabled": true,
     "ignore": [
       "./tests/integration/**/*/src/*",
-      "./tests/e2e/react-component/public/umd/index.js"
+      "./tests/e2e/react-component/public/umd/*"
     ],
     "rules": {
       "recommended": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -975,8 +975,8 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0
       react-18:
-        specifier: npm:react@18.3.0
-        version: react@18.3.0
+        specifier: npm:react@18.3.1
+        version: react@18.3.1
 
   tests/integration/umd-library-name:
     devDependencies:
@@ -5746,10 +5746,6 @@ packages:
     peerDependencies:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
-
-  react@18.3.0:
-    resolution: {integrity: sha512-RPutkJftSAldDibyrjuku7q11d3oy6wKOyPe5K1HA/HwwrXcEqBdHsLypkC2FFYjP7bPUa6gbzSBhw4sY2JcDg==}
-    engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -12401,10 +12397,6 @@ snapshots:
       prop-types: 15.8.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-
-  react@18.3.0:
-    dependencies:
-      loose-envify: 1.4.0
 
   react@18.3.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,12 @@ importers:
       '@examples/react-component-umd':
         specifier: workspace:*
         version: link:../../../examples/react-component-umd
+      react-18:
+        specifier: npm:react@18.3.1
+        version: react@18.3.1
+      react-dom-18:
+        specifier: npm:react-dom@18.3.1
+        version: react-dom@18.3.1(react@19.1.0)
 
   tests/integration/alias: {}
 
@@ -968,7 +974,7 @@ importers:
       react:
         specifier: ^19.1.0
         version: 19.1.0
-      react-aliased:
+      react-18:
         specifier: npm:react@18.3.0
         version: react@18.3.0
 
@@ -12325,6 +12331,12 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
+      scheduler: 0.23.2
+
+  react-dom@18.3.1(react@19.1.0):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 19.1.0
       scheduler: 0.23.2
 
   react-dom@19.1.0(react@19.1.0):

--- a/tests/e2e/react-component/package.json
+++ b/tests/e2e/react-component/package.json
@@ -3,11 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "build:umd": "cd ../../../examples/react-component-umd && pnpm run build",
     "dev:bundle": "../../node_modules/.bin/rsbuild dev --environment=bundle",
     "dev:bundle-false": "../../node_modules/.bin/rsbuild dev --environment=bundleFalse",
-    "dev:umd": "pnpm umd:build && pnpm umd:copy && ../../node_modules/.bin/rsbuild dev --environment=umd",
-    "umd:build": "cd ../../../examples/react-component-umd && pnpm run build",
-    "umd:copy": "rm -rf ./public && mkdir -p ./public/umd && cp ../../../examples/react-component-umd/dist/umd/index.js ./public/umd/index.js && cp node_modules/react-18/umd/react.development.js ./public/umd/react.development.js && cp node_modules/react-dom-18/umd/react-dom.development.js ./public/umd/react-dom.development.js"
+    "dev:umd": "pnpm build:umd && ../../node_modules/.bin/rsbuild dev --environment=umd"
   },
   "dependencies": {
     "@examples/react-component-bundle": "workspace:*",

--- a/tests/e2e/react-component/package.json
+++ b/tests/e2e/react-component/package.json
@@ -7,11 +7,13 @@
     "dev:bundle-false": "../../node_modules/.bin/rsbuild dev --environment=bundleFalse",
     "dev:umd": "pnpm umd:build && pnpm umd:copy && ../../node_modules/.bin/rsbuild dev --environment=umd",
     "umd:build": "cd ../../../examples/react-component-umd && pnpm run build",
-    "umd:copy": "rm -rf ./public && mkdir -p ./public/umd && cp ../../../examples/react-component-umd/dist/umd/index.js ./public/umd/index.js"
+    "umd:copy": "rm -rf ./public && mkdir -p ./public/umd && cp ../../../examples/react-component-umd/dist/umd/index.js ./public/umd/index.js && cp node_modules/react-18/umd/react.development.js ./public/umd/react.development.js && cp node_modules/react-dom-18/umd/react-dom.development.js ./public/umd/react-dom.development.js"
   },
   "dependencies": {
     "@examples/react-component-bundle": "workspace:*",
     "@examples/react-component-bundle-false": "workspace:*",
-    "@examples/react-component-umd": "workspace:*"
+    "@examples/react-component-umd": "workspace:*",
+    "react-18": "npm:react@18.3.1",
+    "react-dom-18": "npm:react-dom@18.3.1"
   }
 }

--- a/tests/e2e/react-component/rsbuild.config.ts
+++ b/tests/e2e/react-component/rsbuild.config.ts
@@ -57,6 +57,20 @@ export default defineConfig({
           'react-dom': 'window ReactDom',
           'react-dom/client': 'window ReactDom',
         },
+        copy: [
+          {
+            from: '../../../examples/react-component-umd/dist/umd/index.js',
+            to: 'umd/index.js',
+          },
+          {
+            from: 'node_modules/react-18/umd/react.development.js',
+            to: 'umd/react.development.js',
+          },
+          {
+            from: 'node_modules/react-dom-18/umd/react-dom.development.js',
+            to: 'umd/react-dom.development.js',
+          },
+        ],
       },
     },
   },

--- a/tests/e2e/react-component/rsbuild.config.ts
+++ b/tests/e2e/react-component/rsbuild.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
           {
             tag: 'script',
             attrs: {
-              src: 'https://unpkg.com/react@18/umd/react.development.js',
+              src: '/umd/react.development.js',
             },
             head: true,
             append: true,
@@ -31,7 +31,7 @@ export default defineConfig({
           {
             tag: 'script',
             attrs: {
-              src: 'https://unpkg.com/react-dom@18/umd/react-dom.development.js',
+              src: '/umd/react-dom.development.js',
             },
             head: true,
             append: true,

--- a/tests/integration/umd-globals/index.test.ts
+++ b/tests/integration/umd-globals/index.test.ts
@@ -8,5 +8,5 @@ test('correct read globals from CommonJS', async () => {
   });
 
   const { fn } = require(entryFiles.umd);
-  expect(await fn('ok')).toBe('DEBUG:18.3.0/ok');
+  expect(await fn('ok')).toBe('DEBUG:18.3.1/ok');
 });

--- a/tests/integration/umd-globals/package.json
+++ b/tests/integration/umd-globals/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "react": "^19.1.0",
-    "react-18": "npm:react@18.3.0"
+    "react-18": "npm:react@18.3.1"
   },
   "peerDependencies": {
     "react": "^18.3.1"

--- a/tests/integration/umd-globals/package.json
+++ b/tests/integration/umd-globals/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "react": "^19.1.0",
-    "react-aliased": "npm:react@18.3.0"
+    "react-18": "npm:react@18.3.0"
   },
   "peerDependencies": {
     "react": "^18.3.1"

--- a/tests/integration/umd-globals/rslib.config.ts
+++ b/tests/integration/umd-globals/rslib.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   lib: [generateBundleUmdConfig()],
   output: {
     externals: {
-      react: 'react-aliased',
+      react: 'react-18',
     },
   },
   source: {


### PR DESCRIPTION
## Summary

Add umd output of `react` and `react-dom` to local to avoid using `unpkg` thus avoiding issues with the CDN service that cause unstable test results.

![image](https://github.com/user-attachments/assets/ee48fb8f-cf96-4009-ae4e-636c5a7b6082)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
