### PR TITLE
fix(examples): correct use require in ESM

### DIFF
--- a/examples/module-federation/mf-react-component/.storybook/main.ts
+++ b/examples/module-federation/mf-react-component/.storybook/main.ts
@@ -1,5 +1,7 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import type { StorybookConfig } from 'storybook-react-rsbuild';
+const require = createRequire(import.meta.url);
 
 /**
  * This function is used to resolve the absolute path of a package.


### PR DESCRIPTION
## Summary

Previous write-up will break in node23 (https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require). Use the correct write-up.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
