### PR TITLE
chore(renovate): update non-major dependencies together

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,10 +48,10 @@
       groupSlug: 'types',
     },
     {
-      groupName: 'all patch dependencies',
-      groupSlug: 'all-patch',
+      groupName: 'non-major dependencies',
+      groupSlug: 'non-major',
       matchPackageNames: ['**'],
-      matchUpdateTypes: ['patch'],
+      matchUpdateTypes: ['patch', 'minor'],
     },
     // manually update peer dependencies
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,8 +48,8 @@
       groupSlug: 'types',
     },
     {
-      groupName: 'non-major dependencies',
-      groupSlug: 'non-major',
+      groupName: 'all non-major dependencies',
+      groupSlug: 'all-non-major',
       matchPackageNames: ['**'],
       matchUpdateTypes: ['patch', 'minor'],
     },


### PR DESCRIPTION
## Summary

This pull request updates the Renovate configuration to refine dependency grouping and update behavior. The most important change is the renaming and expansion of the "all patch dependencies" group to include minor updates as well.

### Renovate configuration changes:

* [`.github/renovate.json5`](diffhunk://#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790L51-R54): Renamed the `groupName` from "all patch dependencies" to "non-major dependencies" and updated the `groupSlug` to `non-major`. Additionally, expanded the `matchUpdateTypes` to include both `patch` and `minor` updates instead of just `patch`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
