### PR TITLE
fix: rename error when apply bundleless dts filename

### DIFF
--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -378,7 +378,7 @@ export async function processDtsFiles(
     );
   }
 
-  const dtsFiles = await glob(convertPath(join(dir, '/**/*.d.ts')), {
+  const dtsFiles = await glob(convertPath(join(dir, '/**/*.d.{ts,cts,mts}')), {
     absolute: true,
   });
 
@@ -399,9 +399,6 @@ export async function processDtsFiles(
             rootDir,
           );
         }
-
-        const newFile = file.replace('.d.ts', dtsExtension);
-        await fsP.rename(file, newFile);
       } catch (error) {
         logger.error(`Failed to rename declaration file ${file}: ${error}`);
       }

--- a/tests/integration/dts/bundle-false/auto-extension/rslib.config.ts
+++ b/tests/integration/dts/bundle-false/auto-extension/rslib.config.ts
@@ -5,11 +5,17 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       bundle: false,
+      dts: {
+        autoExtension: true,
+        distPath: './dist/types',
+        bundle: false,
+      },
     }),
     generateBundleCjsConfig({
       bundle: false,
       dts: {
         autoExtension: true,
+        distPath: './dist/types',
         bundle: false,
       },
     }),

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -90,10 +90,14 @@ describe('dts when bundle: false', () => {
 
     expect(files.cjs).toMatchInlineSnapshot(`
       [
-        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/cjs/index.d.cts",
-        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/cjs/sum.d.cts",
-        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/cjs/utils/numbers.d.cts",
-        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/cjs/utils/strings.d.cts",
+        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/types/index.d.cts",
+        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/types/index.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/types/sum.d.cts",
+        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/types/sum.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/types/utils/numbers.d.cts",
+        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/types/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/types/utils/strings.d.cts",
+        "<ROOT>/tests/integration/dts/bundle-false/auto-extension/dist/types/utils/strings.d.ts",
       ]
     `);
   });


### PR DESCRIPTION
## Summary

If we enable `dts.autoExtension`, when renaming `.d.ts` to `.d.cts`, there may throw error `error   Failed to rename declaration file foo.d.ts: Error: ENOENT: no such file or directory, rename foo.d.ts -> foo.d.ts` or there may only have `foo.d.cts` due to file conflict.

The best solution is to use the `writeFile` function of the ts compiler api to directly emit correct filename.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
