### PR TITLE
fix: should throw error when no entry find with bundle dts

### DIFF
--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -421,12 +421,20 @@ export function processSourceEntry(
     entryConfig &&
     Object.values(entryConfig).every((val) => typeof val === 'string')
   ) {
-    return Object.entries(entryConfig as Record<string, string>).map(
+    const entries = Object.entries(entryConfig as Record<string, string>).map(
       ([name, path]) => ({
         name,
         path,
       }),
     );
+
+    if (entries.length === 0) {
+      throw new Error(
+        `Can not find a valid entry for ${color.cyan('dts.bundle')} option, please check your entry config.`,
+      );
+    }
+
+    return entries;
   }
 
   throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,8 @@ importers:
 
   tests/integration/dts/bundle/multiple-entries: {}
 
+  tests/integration/dts/bundle/no-entry: {}
+
   tests/integration/dts/bundle/rootdir:
     devDependencies:
       '@types/chromecast-caf-sender':

--- a/tests/integration/dts/bundle/no-entry/package.json
+++ b/tests/integration/dts/bundle/no-entry/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dts-bundle-no-entry-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/dts/bundle/no-entry/rslib.config.ts
+++ b/tests/integration/dts/bundle/no-entry/rslib.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: true,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: '../__fixtures__/src',
+    },
+    tsconfigPath: '../__fixtures__/tsconfig.json',
+  },
+});

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -377,6 +377,21 @@ describe('dts when bundle: true', () => {
 
     expect([indexEsm, indexCjs, sumEsm, sumCjs]).toMatchSnapshot();
   });
+
+  test('can not find a valid entry', async () => {
+    const fixturePath = join(__dirname, 'bundle', 'no-entry');
+    const { restore } = proxyConsole();
+
+    try {
+      await buildAndGetResults({ fixturePath, type: 'dts' });
+    } catch (err: any) {
+      expect(err.message).toMatchInlineSnapshot(
+        `"Can not find a valid entry for dts.bundle option, please check your entry config."`,
+      );
+    }
+
+    restore();
+  });
 });
 
 describe('dts when build: true', () => {

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -385,7 +385,7 @@ describe('dts when bundle: true', () => {
     try {
       await buildAndGetResults({ fixturePath, type: 'dts' });
     } catch (err: any) {
-      expect(err.message).toMatchInlineSnapshot(
+      expect(stripAnsi(err.message)).toMatchInlineSnapshot(
         `"Can not find a valid entry for dts.bundle option, please check your entry config."`,
       );
     }


### PR DESCRIPTION
## Summary

should throw error when no entry find with bundle dts

When users apply bundleless js but need a bundle dts in an object, we can not deal with this.

`dts.only` should be a solution for this case.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
