### PR TITLE
fix: should process correct format of dts files

### DIFF
--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -378,7 +378,7 @@ export async function processDtsFiles(
     );
   }
 
-  const dtsFiles = await globDtsFiles(dir);
+  const dtsFiles = await globDtsFiles(dir, [`/**/*${dtsExtension}`]);
 
   await Promise.all(
     dtsFiles.map(async (file) => {
@@ -474,8 +474,10 @@ export async function calcLongestCommonPath(
   return lca;
 }
 
-export const globDtsFiles = async (dir: string): Promise<string[]> => {
-  const patterns = ['/**/*.d.ts', '/**/*.d.cts', '/**/*.d.mts'];
+export const globDtsFiles = async (
+  dir: string,
+  patterns: string[],
+): Promise<string[]> => {
   const dtsFiles = await Promise.all(
     patterns.map((pattern) =>
       glob(convertPath(join(dir, pattern)), { absolute: true }),
@@ -486,7 +488,8 @@ export const globDtsFiles = async (dir: string): Promise<string[]> => {
 };
 
 export async function cleanDtsFiles(dir: string): Promise<void> {
-  const allFiles = await globDtsFiles(dir);
+  const patterns = ['/**/*.d.ts', '/**/*.d.cts', '/**/*.d.mts'];
+  const allFiles = await globDtsFiles(dir, patterns);
 
   await Promise.all(allFiles.map((file) => fsP.rm(file, { force: true })));
 }

--- a/tests/integration/redirect/dts.test.ts
+++ b/tests/integration/redirect/dts.test.ts
@@ -141,15 +141,22 @@ test('redirect.dts.extension true', async () => {
 test('redirect.dts.extension true with dts.autoExtension true', async () => {
   expect(contents.esm3).toMatchInlineSnapshot(`
     {
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/esm/foo/foo.d.mts": "import { logRequest } from '../logger.mjs';
-    import { logger } from '../../../../compile/rslog';
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/foo.d.mts": "import { logRequest } from '../logger.mjs';
+    import { logger } from '../../../compile/rslog';
     import { logRequest as logRequest2 } from '../logger.mjs';
     export { logRequest, logRequest2, logger };
     ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/esm/foo/index.d.mts": "export type Barrel = string;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/esm/index.d.mts": "import { logRequest } from './logger.mjs';
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/foo.d.ts": "import { logRequest } from '../logger.js';
     import { logger } from '../../../compile/rslog';
+    import { logRequest as logRequest2 } from '../logger.js';
+    export { logRequest, logRequest2, logger };
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/index.d.mts": "export type Barrel = string;
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/index.d.ts": "export type Barrel = string;
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/index.d.mts": "import { logRequest } from './logger.mjs';
+    import { logger } from '../../compile/rslog';
     import type { LoggerOptions } from './types.mjs';
     import { defaultOptions } from './types.mjs';
     export { logRequest, logger, type LoggerOptions, defaultOptions };
@@ -158,14 +165,43 @@ test('redirect.dts.extension true with dts.autoExtension true', async () => {
     export * from './foo/index.mjs';
     export * from './foo/index.mjs';
     export * from './types.mjs';
-    export * from '../../../compile/rslog';
+    export * from '../../compile/rslog';
     export * from './logger.mjs';
     ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/esm/logger.d.mts": "import type { Request } from 'express';
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/index.d.ts": "import { logRequest } from './logger.js';
+    import { logger } from '../../compile/rslog';
+    import type { LoggerOptions } from './types.js';
+    import { defaultOptions } from './types.js';
+    export { logRequest, logger, type LoggerOptions, defaultOptions };
+    export type { Foo } from './types.js';
+    export type { Bar } from './types.js';
+    export * from './foo/index.js';
+    export * from './foo/index.js';
+    export * from './types.js';
+    export * from '../../compile/rslog';
+    export * from './logger.js';
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/logger.d.mts": "import type { Request } from 'express';
     import type { LoggerOptions } from './types.mjs';
     export declare function logRequest(req: Request, options: LoggerOptions): void;
     ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/esm/types.d.mts": "export interface LoggerOptions {
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/logger.d.ts": "import type { Request } from 'express';
+    import type { LoggerOptions } from './types.js';
+    export declare function logRequest(req: Request, options: LoggerOptions): void;
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/types.d.mts": "export interface LoggerOptions {
+        logLevel: 'info' | 'debug' | 'warn' | 'error';
+        logBody: boolean;
+    }
+    export declare const defaultOptions: LoggerOptions;
+    export interface Foo {
+        foo: string;
+    }
+    export interface Bar {
+        bar: string;
+    }
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/types.d.ts": "export interface LoggerOptions {
         logLevel: 'info' | 'debug' | 'warn' | 'error';
         logBody: boolean;
     }

--- a/tests/integration/redirect/dts/rslib.config.ts
+++ b/tests/integration/redirect/dts/rslib.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@rslib/core';
-import { generateBundleEsmConfig } from 'test-helper';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
 
 export default defineConfig({
   lib: [
@@ -47,7 +47,23 @@ export default defineConfig({
       },
       output: {
         distPath: {
-          root: './dist/auto-extension-true/esm',
+          root: './dist/auto-extension-true',
+        },
+      },
+      redirect: {
+        dts: {
+          extension: true,
+        },
+      },
+    }),
+    // 4 - extension: true with dts.autoExtension true
+    generateBundleCjsConfig({
+      dts: {
+        autoExtension: true,
+      },
+      output: {
+        distPath: {
+          root: './dist/auto-extension-true',
         },
       },
       redirect: {


### PR DESCRIPTION
## Summary

We should only process dts files of current format, this usally happen on multiple dts builds together in the same dist folder.

This should be a regression after #933 

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
