### PR TITLE
fix: should redirect import_require_clause statement in dts

### DIFF
--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -214,6 +214,7 @@ export async function redirectDtsImports(
   const matcher: NapiConfig = {
     rule: {
       any: [
+        // import foo from 'bar'
         {
           kind: 'import_statement',
           has: {
@@ -224,6 +225,21 @@ export async function redirectDtsImports(
             },
           },
         },
+        // import foo = require('bar')
+        {
+          kind: 'import_statement',
+          has: {
+            kind: 'import_require_clause',
+            has: {
+              field: 'source',
+              has: {
+                pattern: '$IMP',
+                kind: 'string_fragment',
+              },
+            },
+          },
+        },
+        // export { foo } from 'bar'
         {
           kind: 'export_statement',
           has: {
@@ -234,6 +250,7 @@ export async function redirectDtsImports(
             },
           },
         },
+        // require('foo') / import('foo')
         {
           any: [{ pattern: 'require($A)' }, { pattern: 'import($A)' }],
           has: {

--- a/tests/integration/redirect/dts.test.ts
+++ b/tests/integration/redirect/dts.test.ts
@@ -24,7 +24,8 @@ test('redirect.dts.path: true with redirect.dts.extension: false - default', asy
     import type { Baz } from './';
     import type { LoggerOptions } from './types';
     import { defaultOptions } from './types.js';
-    export { type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+    import sources = require('./logger');
+    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
     export type { Foo } from './types';
     export type { Bar } from './types';
     export * from './foo';
@@ -71,7 +72,8 @@ test('redirect.dts.path: false with redirect.dts.extension: false', async () => 
     import type { Baz } from 'self-entry';
     import type { LoggerOptions } from './types';
     import { defaultOptions } from './types.js';
-    export { type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+    import sources = require('@src/logger');
+    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
     export type { Foo } from '@src/types';
     export type { Bar } from 'types';
     export * from './foo';
@@ -118,7 +120,8 @@ test('redirect.dts.path: true with redirect.dts.extension: true', async () => {
     import type { Baz } from './index.js';
     import type { LoggerOptions } from './types.js';
     import { defaultOptions } from './types.js';
-    export { type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+    import sources = require('./logger.js');
+    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
     export type { Foo } from './types.js';
     export type { Bar } from './types.js';
     export * from './foo/index.js';
@@ -165,7 +168,8 @@ test('redirect.dts.path: false with dts.redirect.extension: true', async () => {
     import type { Baz } from 'self-entry';
     import type { LoggerOptions } from './types.js';
     import { defaultOptions } from './types.js';
-    export { type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+    import sources = require('@src/logger');
+    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
     export type { Foo } from '@src/types';
     export type { Bar } from 'types';
     export * from './foo/index.js';
@@ -219,7 +223,8 @@ test('redirect.dts.extension: true with dts.autoExtension: true', async () => {
     import type { Baz } from './index.mjs';
     import type { LoggerOptions } from './types.mjs';
     import { defaultOptions } from './types.mjs';
-    export { type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+    import sources = require('./logger.mjs');
+    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
     export type { Foo } from './types.mjs';
     export type { Bar } from './types.mjs';
     export * from './foo/index.mjs';
@@ -233,7 +238,8 @@ test('redirect.dts.extension: true with dts.autoExtension: true', async () => {
     import type { Baz } from './index.js';
     import type { LoggerOptions } from './types.js';
     import { defaultOptions } from './types.js';
-    export { type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+    import sources = require('./logger.js');
+    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
     export type { Foo } from './types.js';
     export type { Bar } from './types.js';
     export * from './foo/index.js';

--- a/tests/integration/redirect/dts/src/index.ts
+++ b/tests/integration/redirect/dts/src/index.ts
@@ -3,8 +3,10 @@ import { logger } from 'rslog';
 import type { Baz } from 'self-entry';
 import type { LoggerOptions } from './types';
 import { defaultOptions } from './types.js';
+import sources = require('@src/logger');
 
 export {
+  sources,
   type Baz as self,
   logRequest,
   logger,


### PR DESCRIPTION
## Summary

We should redirect import_require_clause statement in dts like below:

```ts
import sources = require("webpack-sources");
```

## Related Links

https://github.com/web-infra-dev/rspack/actions/runs/14593020719/job/40933824746
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
