### PR TITLE
chore(template): remove module field

### DIFF
--- a/packages/create-rslib/fragments/base/node-dual-js/package.json
+++ b/packages/create-rslib/fragments/base/node-dual-js/package.json
@@ -9,7 +9,6 @@
     }
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/fragments/base/node-dual-ts/package.json
+++ b/packages/create-rslib/fragments/base/node-dual-ts/package.json
@@ -10,7 +10,6 @@
     }
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/fragments/base/node-esm-js/package.json
+++ b/packages/create-rslib/fragments/base/node-esm-js/package.json
@@ -7,7 +7,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/fragments/base/node-esm-ts/package.json
+++ b/packages/create-rslib/fragments/base/node-esm-ts/package.json
@@ -8,7 +8,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/fragments/base/react-js/package.json
+++ b/packages/create-rslib/fragments/base/react-js/package.json
@@ -7,7 +7,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/fragments/base/react-ts/package.json
+++ b/packages/create-rslib/fragments/base/react-ts/package.json
@@ -8,7 +8,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[node-dual]-[]-js/package.json
+++ b/packages/create-rslib/template-[node-dual]-[]-js/package.json
@@ -9,7 +9,6 @@
     }
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[node-dual]-[]-ts/package.json
+++ b/packages/create-rslib/template-[node-dual]-[]-ts/package.json
@@ -10,7 +10,6 @@
     }
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[node-dual]-[vitest]-js/package.json
+++ b/packages/create-rslib/template-[node-dual]-[vitest]-js/package.json
@@ -9,7 +9,6 @@
     }
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[node-dual]-[vitest]-ts/package.json
+++ b/packages/create-rslib/template-[node-dual]-[vitest]-ts/package.json
@@ -10,7 +10,6 @@
     }
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[node-esm]-[]-js/package.json
+++ b/packages/create-rslib/template-[node-esm]-[]-js/package.json
@@ -7,7 +7,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[node-esm]-[]-ts/package.json
+++ b/packages/create-rslib/template-[node-esm]-[]-ts/package.json
@@ -8,7 +8,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[node-esm]-[vitest]-js/package.json
+++ b/packages/create-rslib/template-[node-esm]-[vitest]-js/package.json
@@ -7,7 +7,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[node-esm]-[vitest]-ts/package.json
+++ b/packages/create-rslib/template-[node-esm]-[vitest]-ts/package.json
@@ -8,7 +8,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[react]-[]-js/package.json
+++ b/packages/create-rslib/template-[react]-[]-js/package.json
@@ -7,7 +7,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[react]-[]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[]-ts/package.json
@@ -8,7 +8,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -7,7 +7,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -8,7 +8,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -7,7 +7,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -8,7 +8,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[react]-[vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[vitest]-js/package.json
@@ -7,7 +7,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[react]-[vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[vitest]-ts/package.json
@@ -8,7 +8,6 @@
       "import": "./dist/index.js"
     }
   },
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

Remove `module` field in template since both modern bundler and high Node.js recognize `exports` field.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
