### PR TITLE
fix: preserve worker syntax

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -576,6 +576,9 @@ const composeFormatConfig = ({
       importMeta: false,
       importDynamic: false,
     },
+    others: {
+      worker: false,
+    },
   } as const;
 
   switch (format) {
@@ -588,6 +591,7 @@ const composeFormatConfig = ({
                 javascript: {
                   ...jsParserOptions.esm,
                   ...jsParserOptions.cjs,
+                  ...jsParserOptions.others,
                 },
               },
             },
@@ -618,7 +622,11 @@ const composeFormatConfig = ({
           rspack: {
             module: {
               parser: {
-                javascript: { ...jsParserOptions.esm, ...jsParserOptions.cjs },
+                javascript: {
+                  ...jsParserOptions.esm,
+                  ...jsParserOptions.cjs,
+                  ...jsParserOptions.others,
+                },
               },
             },
             output: {
@@ -701,8 +709,8 @@ const composeFormatConfig = ({
   }
 };
 
-const formatRsbuildPlugin = (): RsbuildPlugin => ({
-  name: 'rsbuild:format',
+const disableUrlParseRsbuildPlugin = (): RsbuildPlugin => ({
+  name: 'rsbuild:disable-url-parse',
   setup(api) {
     api.modifyBundlerChain((config, { CHAIN_ID }) => {
       // Fix for https://github.com/web-infra-dev/rslib/issues/499.
@@ -761,7 +769,7 @@ const composeShimsConfig = (
         },
         plugins: [
           resolvedShims.esm.require && pluginEsmRequireShim(),
-          formatRsbuildPlugin(),
+          disableUrlParseRsbuildPlugin(),
         ].filter(Boolean),
       };
       break;
@@ -770,6 +778,7 @@ const composeShimsConfig = (
       rsbuildConfig = {
         plugins: [
           resolvedShims.cjs['import.meta.url'] && pluginCjsImportMetaUrlShim(),
+          disableUrlParseRsbuildPlugin(),
         ].filter(Boolean),
       };
       break;

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -111,7 +111,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       },
       "plugins": [
         {
-          "name": "rsbuild:format",
+          "name": "rsbuild:disable-url-parse",
           "setup": [Function],
         },
         {
@@ -189,6 +189,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                   "requireAsExpression": false,
                   "requireDynamic": false,
                   "requireResolve": false,
+                  "worker": false,
                 },
               },
             },
@@ -366,6 +367,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           "setup": [Function],
         },
         {
+          "name": "rsbuild:disable-url-parse",
+          "setup": [Function],
+        },
+        {
           "name": "rsbuild:lib-asset",
           "pre": [
             "rsbuild:svgr",
@@ -441,6 +446,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                   "requireAsExpression": false,
                   "requireDynamic": false,
                   "requireResolve": false,
+                  "worker": false,
                 },
               },
             },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1013,6 +1013,8 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0
 
+  tests/integration/worker: {}
+
   tests/scripts: {}
 
   website:

--- a/tests/integration/worker/index.test.ts
+++ b/tests/integration/worker/index.test.ts
@@ -1,0 +1,26 @@
+import { buildAndGetResults, queryContent } from 'test-helper';
+import { expect, test } from 'vitest';
+
+test('new Worker(new URL(...)) should be preserved', async () => {
+  process.env.NODE_ENV = 'production';
+  const fixturePath = __dirname;
+  const { contents } = await buildAndGetResults({
+    fixturePath,
+  });
+
+  expect(contents.esm).toMatchInlineSnapshot(`
+    {
+      "<ROOT>/tests/integration/worker/dist/esm/index.js": "const worker = new Worker(new URL('./worker.js', import.meta.url), {
+        name: 'my-worker'
+    });
+    export { worker };
+    ",
+      "<ROOT>/tests/integration/worker/dist/esm/worker.js": "console.log('Hello from worker', self.name);
+    ",
+    }
+  `);
+
+  expect(queryContent(contents.cjs, /\/index\.js/).content).toContain(
+    "new Worker(new URL('./worker.js', __rslib_import_meta_url__)",
+  );
+});

--- a/tests/integration/worker/package.json
+++ b/tests/integration/worker/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "worker-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/worker/rslib.config.ts
+++ b/tests/integration/worker/rslib.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      autoExtension: false,
+      source: {
+        entry: {
+          index: './src/index.ts',
+          worker: './src/worker.ts',
+        },
+      },
+    }),
+    generateBundleCjsConfig({
+      autoExtension: false,
+      source: {
+        entry: {
+          index: './src/index.ts',
+          worker: './src/worker.ts',
+        },
+      },
+    }),
+  ],
+});

--- a/tests/integration/worker/src/index.ts
+++ b/tests/integration/worker/src/index.ts
@@ -1,0 +1,3 @@
+export const worker = new Worker(new URL('./worker.js', import.meta.url), {
+  name: 'my-worker',
+});

--- a/tests/integration/worker/src/worker.ts
+++ b/tests/integration/worker/src/worker.ts
@@ -1,0 +1,1 @@
+console.log('Hello from worker', self.name);


### PR DESCRIPTION
## Summary

Preserve worker syntax, do not transform to Rspack runtime based output.

## Related Links

https://github.com/web-infra-dev/rslib/issues/929

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
