### PR TITLE
docs(json): fix line highlighting

### DIFF
--- a/website/docs/en/guide/advanced/json-files.mdx
+++ b/website/docs/en/guide/advanced/json-files.mdx
@@ -243,7 +243,7 @@ If you want JSON / YAML / TOML files to be output to the distribution directory 
 
 For example, the following configuration will output all JSON files in the `src` directory as-is:
 
-```ts title="rslib.config.ts" {7,11-19}
+```ts title="rslib.config.ts" {7,11-12}
 export default defineConfig({
   lib: [
     {

--- a/website/docs/zh/guide/advanced/json-files.mdx
+++ b/website/docs/zh/guide/advanced/json-files.mdx
@@ -240,7 +240,7 @@ Rslib 支持在不同的打包模式下，JSON / YAML / TOML 文件以不同的�
 
 例如下面的配置将会将 `src` 目录下的所有 JSON 文件按原样输出：
 
-```ts title="rslib.config.ts" {7,11-19}
+```ts title="rslib.config.ts" {7,11-12}
 export default defineConfig({
   lib: [
     {


### PR DESCRIPTION
## Summary

Current:

<img width="949" alt="Tower 2025-05-08 20 24 52" src="https://github.com/user-attachments/assets/5ffcd0c8-872b-4a9a-b627-65e6fcf62a2d" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
