### PR TITLE
docs(deps): upgrade rspress 2.0.0-beta.5

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,5 +53,11 @@
   "[less]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "json.schemas": [
+    {
+      "fileMatch": ["**/_meta.json"],
+      "url": "./website/node_modules/rspress/meta-json-schema.json"
+    }
+  ]
 }

--- a/biome.json
+++ b/biome.json
@@ -49,6 +49,7 @@
   "linter": {
     "enabled": true,
     "ignore": [
+      "**/.rslib/*",
       "./tests/integration/**/*/src/*",
       "./tests/e2e/react-component/public/umd/*"
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3516,9 +3516,6 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001715:
-    resolution: {integrity: sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==}
-
   caniuse-lite@1.0.30001717:
     resolution: {integrity: sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==}
 
@@ -8084,7 +8081,7 @@ snapshots:
   '@modern-js/utils@2.65.1':
     dependencies:
       '@swc/helpers': 0.5.13
-      caniuse-lite: 1.0.30001715
+      caniuse-lite: 1.0.30001717
       lodash: 4.17.21
       rslog: 1.2.3
 
@@ -8765,7 +8762,7 @@ snapshots:
       '@module-federation/runtime-tools': 0.13.0
       '@rspack/binding': 1.3.8
       '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001715
+      caniuse-lite: 1.0.30001717
     optionalDependencies:
       '@swc/helpers': 0.5.17
 
@@ -9936,7 +9933,7 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001715
+      caniuse-lite: 1.0.30001717
       electron-to-chromium: 1.5.88
       node-releases: 2.0.19
       update-browserslist-db: 1.1.1(browserslist@4.24.4)
@@ -9998,8 +9995,6 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   camelcase@6.3.0: {}
-
-  caniuse-lite@1.0.30001715: {}
 
   caniuse-lite@1.0.30001717: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.13.1
-        version: 0.13.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
+        version: 0.13.1(@rsbuild/core@1.3.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
       '@rsbuild/core':
         specifier: 1.3.15
         version: 1.3.15
@@ -112,16 +112,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.13.1
-        version: 0.13.1(@rspack/core@1.3.8(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
+        version: 0.13.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
       '@module-federation/rsbuild-plugin':
         specifier: ^0.13.1
-        version: 0.13.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
+        version: 0.13.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
       '@module-federation/storybook-addon':
         specifier: ^4.0.15
-        version: 4.0.15(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(@storybook/core@8.6.12(prettier@3.5.3)(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)
+        version: 4.0.15(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(@storybook/core@8.6.12(prettier@3.5.3)(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)
       '@rsbuild/plugin-react':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.3.15)
+        version: 1.3.0(@rsbuild/core@1.3.17)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -142,10 +142,10 @@ importers:
         version: 8.6.12(prettier@3.5.3)
       storybook-addon-rslib:
         specifier: ^1.0.1
-        version: 1.0.1(@rsbuild/core@1.3.15)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3))(typescript@5.8.3)
+        version: 1.0.1(@rsbuild/core@1.3.17)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3))(typescript@5.8.3)
       storybook-react-rsbuild:
         specifier: ^1.0.1
-        version: 1.0.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3)(webpack@5.98.0)
+        version: 1.0.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3)(webpack@5.98.0)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -158,7 +158,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.13.1
-        version: 0.13.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
+        version: 0.13.1(@rsbuild/core@1.3.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
       '@rsbuild/core':
         specifier: 1.3.15
         version: 1.3.15
@@ -179,10 +179,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@1.3.15)(preact@10.26.5)
+        version: 1.3.1(@rsbuild/core@1.3.17)(preact@10.26.5)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@1.3.15)
+        version: 1.3.1(@rsbuild/core@1.3.17)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -194,10 +194,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.3.15)
+        version: 1.3.0(@rsbuild/core@1.3.17)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@1.3.15)
+        version: 1.3.1(@rsbuild/core@1.3.17)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -212,10 +212,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.3.15)
+        version: 1.3.0(@rsbuild/core@1.3.17)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@1.3.15)
+        version: 1.3.1(@rsbuild/core@1.3.17)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -230,10 +230,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.3.15)
+        version: 1.3.0(@rsbuild/core@1.3.17)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@1.3.15)
+        version: 1.3.1(@rsbuild/core@1.3.17)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -248,13 +248,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.3.15)
+        version: 1.0.5(@rsbuild/core@1.3.17)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@1.3.15)
+        version: 1.3.1(@rsbuild/core@1.3.17)
       '@rsbuild/plugin-solid':
         specifier: ^1.0.5
-        version: 1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.3.15)(solid-js@1.9.6)
+        version: 1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.3.17)(solid-js@1.9.6)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -269,7 +269,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@1.3.15)(vue@3.5.13(typescript@5.8.3))
+        version: 1.0.7(@rsbuild/core@1.3.17)(vue@3.5.13(typescript@5.8.3))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -297,7 +297,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.13.1
-        version: 0.13.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
+        version: 0.13.1(@rsbuild/core@1.3.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -358,7 +358,7 @@ importers:
         version: 11.3.0
       rsbuild-plugin-publint:
         specifier: ^0.3.1
-        version: 0.3.1(@rsbuild/core@1.3.15)
+        version: 0.3.1(@rsbuild/core@1.3.17)
       rslib:
         specifier: npm:@rslib/core@0.6.8
         version: '@rslib/core@0.6.8(@microsoft/api-extractor@7.52.7(@types/node@22.8.1))(typescript@5.8.3)'
@@ -422,7 +422,7 @@ importers:
         version: 4.0.1(vite@6.0.11(@types/node@22.8.1)(jiti@2.4.2)(sass-embedded@1.86.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.6.1))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.8.1)(jiti@2.4.2)(sass-embedded@1.86.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.6.1))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.13.1
-        version: 0.13.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
+        version: 0.13.1(@rsbuild/core@1.3.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
       '@playwright/test':
         specifier: 1.52.0
         version: 1.52.0
@@ -511,7 +511,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.3.15)
+        version: 1.3.0(@rsbuild/core@1.3.17)
 
   tests/integration/asset/json: {}
 
@@ -527,10 +527,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.3.15)
+        version: 1.3.0(@rsbuild/core@1.3.17)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.3.15)(typescript@5.8.3)
+        version: 1.2.0(@rsbuild/core@1.3.17)(typescript@5.8.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -624,10 +624,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.3.15)
+        version: 1.3.0(@rsbuild/core@1.3.17)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.3.15)(typescript@5.8.3)
+        version: 1.2.0(@rsbuild/core@1.3.17)(typescript@5.8.3)
 
   tests/integration/cli/build: {}
 
@@ -799,7 +799,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.3.15)
+        version: 1.3.0(@rsbuild/core@1.3.17)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -809,7 +809,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.3.15)
+        version: 1.3.0(@rsbuild/core@1.3.17)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -827,7 +827,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.3.15)
+        version: 1.0.5(@rsbuild/core@1.3.17)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.12.0
         version: 0.12.0(@babel/core@7.26.10)
@@ -956,13 +956,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(webpack@5.98.0)
+        version: 1.1.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(webpack@5.98.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(webpack@5.98.0)
+        version: 1.1.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(webpack@5.98.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -1031,11 +1031,14 @@ importers:
         specifier: workspace:*
         version: link:../scripts/tsconfig
       '@rspress/plugin-llms':
-        specifier: 2.0.0-beta.3
-        version: 2.0.0-beta.3(@rspress/core@2.0.0-beta.3(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0))
+        specifier: 2.0.0-beta.5
+        version: 2.0.0-beta.5(@rspress/core@2.0.0-beta.5(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0))
       '@rstack-dev/doc-ui':
         specifier: 1.8.0
         version: 1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@shikijs/transformers':
+        specifier: ^3.4.0
+        version: 3.4.0
       '@types/node':
         specifier: ^22.8.1
         version: 22.8.1
@@ -1055,8 +1058,8 @@ importers:
         specifier: 1.0.3
         version: 1.0.3(@rsbuild/core@1.3.15)
       rspress:
-        specifier: 2.0.0-beta.3
-        version: 2.0.0-beta.3(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0)
+        specifier: 2.0.0-beta.5
+        version: 2.0.0-beta.5(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0)
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
@@ -1416,11 +1419,6 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
       vitest: '>=1.2.2'
-
-  '@dr.pogodin/react-helmet@2.0.4':
-    resolution: {integrity: sha512-NXSgzBKiyvHF4UvR40fKRB0gTIlezfnyvmTqJKZy5Gbtv23SXMuneZbtovvG/sKxbOYPVn1lZl211bTKhd5g4w==}
-    peerDependencies:
-      react: '19'
 
   '@emnapi/core@1.2.0':
     resolution: {integrity: sha512-E7Vgw78I93we4ZWdYCb4DGAwRROGkMIXk7/y87UmANR+J6qsWusmC3gLt0H+O0KOt5e6O38U8oJamgbudrES/w==}
@@ -2309,11 +2307,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.3.13':
-    resolution: {integrity: sha512-FIRV1ncOYYLCEGJDL8ZPKyH4J15lJS54KfeGf3Eacy5zUhT+dAkI2+0ZWH/s9NlaXA/vlRq6SJF9Z2Y96dO13Q==}
-    engines: {node: '>=16.10.0'}
-    hasBin: true
-
   '@rsbuild/core@1.3.14':
     resolution: {integrity: sha512-sfG/+23qVFbFj9CgglHaSRKxAuLbTQgOE2Iz6lpA8bRE56L2aZsSQl4v+p513lib6OH6PYttQdbLO9K8aVOfWg==}
     engines: {node: '>=16.10.0'}
@@ -2321,6 +2314,11 @@ packages:
 
   '@rsbuild/core@1.3.15':
     resolution: {integrity: sha512-hI4gMzigWXaCkfmCYkxegindckQ6lcVsMcNR5qrPaWjtUC9KL6s/c1DK93J7Ui/LgkeLkBu0fMKfO8M/SDxqQQ==}
+    engines: {node: '>=16.10.0'}
+    hasBin: true
+
+  '@rsbuild/core@1.3.17':
+    resolution: {integrity: sha512-vDRUjPws7vUcdn2uXOSOknGRF9Jt0wQRH6AU0G7O0GsX8liUmE/I7+EpYvhuQIRp2ekOz1cmmSTrRntEjp7WoQ==}
     engines: {node: '>=16.10.0'}
     hasBin: true
 
@@ -2349,11 +2347,6 @@ packages:
 
   '@rsbuild/plugin-preact@1.3.1':
     resolution: {integrity: sha512-gFkR00vxWpW2gZEk37kpeMERei9+g8nCrO76mblbqZ0/6e4LSTqKr6smljcHbCxKU8snFLecfURSvfsg7uQbsw==}
-    peerDependencies:
-      '@rsbuild/core': 1.x
-
-  '@rsbuild/plugin-react@1.1.1':
-    resolution: {integrity: sha512-gkATKrOQauXMMtrYA5jbTQkhmYTE0VXoknPLtVpiXtwDbBUwgX23LFf1XJ51YOwqYpP7g5SfPEMgD2FENtCq0A==}
     peerDependencies:
       '@rsbuild/core': 1.x
 
@@ -2432,19 +2425,14 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.3.7':
-    resolution: {integrity: sha512-/5k4H0M7vvu7uorhc0OQKdQ7ybcjcJA//ptfYB646Ca/XY8FI1T/H88prPNrLNu97FGqUT4QWo5AHj01XymfDw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@1.3.8':
     resolution: {integrity: sha512-FlfWZzwCxDfLwyiqGaCSINHt2Er1Wno9xZrf2QM7Ss00HyocPo4BUYGYBEi4dai/fPFoeYKeEAdsNdrVmFH4+g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.3.7':
-    resolution: {integrity: sha512-/eNcZFDHxo5RVmIxgVM5zxCXmufeWpvviWJMDjhycS175nJb6103YWpu6H0lHgbj0GnHM/Q2VjVRFNhaGbXqdA==}
-    cpu: [x64]
+  '@rspack/binding-darwin-arm64@1.3.9':
+    resolution: {integrity: sha512-lfTmsbUGab9Ak/X6aPLacHLe4MBRra+sLmhoNK8OKEN3qQCjDcomwW5OlmBRV5bcUYWdbK8vgDk2HUUXRuibVg==}
+    cpu: [arm64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@1.3.8':
@@ -2452,18 +2440,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.3.7':
-    resolution: {integrity: sha512-bSxA4MgGOdSvf/nTqNMuLeeyWS4Okh1iPskGuyAv/Sdf7cGbflUyZe6+w7A9BZEFR0CVTfj3f8kt73N+lu72Kg==}
-    cpu: [arm64]
-    os: [linux]
+  '@rspack/binding-darwin-x64@1.3.9':
+    resolution: {integrity: sha512-rYuOUINhnhLDbG5LHHKurRSuKIsw0LKUHcd6AAsFmijo4RMnGBJ4NOI4tOLAQvkoSTQ+HU5wiTGSQOgHVhYreQ==}
+    cpu: [x64]
+    os: [darwin]
 
   '@rspack/binding-linux-arm64-gnu@1.3.8':
     resolution: {integrity: sha512-PU9fv8knPvbxQb8NrDmTrLVpy8QY0vuhzk69/ZuLRW89c0P14HovYeHV+38cQHho4++avUQgVp6vnJI9vSQjtg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.3.7':
-    resolution: {integrity: sha512-i6QK6YodCA5R8/ShRylkyunwvNcRx/Q7af14jSCa7TPOi6pPoDUL2pmwGcJBk1uPc2wjQwAMZzfJjTWNjEyW2Q==}
+  '@rspack/binding-linux-arm64-gnu@1.3.9':
+    resolution: {integrity: sha512-pBKnS2Fbn9cDtWe1KcD1qRjQlJwQhP9pFW2KpxdjE7qXbaO11IHtem6dLZwdpNqbDn9QgyfdVGXBDvBaP1tGwA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2472,9 +2460,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.3.7':
-    resolution: {integrity: sha512-6AmOHLOv4XAK7Y5cFDBtnetIZ44MqG8Q6wZ20zjql/khTxsRZa/edis/eUppGb8fy5gzi+qqSAznEZ+Qj3LMrQ==}
-    cpu: [x64]
+  '@rspack/binding-linux-arm64-musl@1.3.9':
+    resolution: {integrity: sha512-0B+iiINW0qOEkBE9exsRcdmcHtYIWAoJGnXrz9tUiiewRxX0Cmm0MjD2HAVUAggJZo+9IN8RGz5PopCjJ/dn1g==}
+    cpu: [arm64]
     os: [linux]
 
   '@rspack/binding-linux-x64-gnu@1.3.8':
@@ -2482,8 +2470,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.3.7':
-    resolution: {integrity: sha512-rPt0c9UHp5AxWHhjziEtd2uwiWyzM4UZLFJV6hawBWOoIQf2uLSl3fp0HTqxpslfTh3uo5ymhHN/bV48m5THzg==}
+  '@rspack/binding-linux-x64-gnu@1.3.9':
+    resolution: {integrity: sha512-82izGJw/qxJ4xaHJy/A4MF7aTRT9tE6VlWoWM4rJmqRszfujN/w54xJRie9jkt041TPvJWGNpYD4Hjpt0/n/oA==}
     cpu: [x64]
     os: [linux]
 
@@ -2492,19 +2480,19 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-win32-arm64-msvc@1.3.7':
-    resolution: {integrity: sha512-+Db7NGBzad1dCcSm94uARkIIhbVv1+BXAl1duLBnYQMfqsu/pirsInE9wbp7WVUbSl2hmdRi9MYgWACjoReo4g==}
-    cpu: [arm64]
-    os: [win32]
+  '@rspack/binding-linux-x64-musl@1.3.9':
+    resolution: {integrity: sha512-V9nDg63iPI6Z7kM11UPV5kBdOdLXPIu3IgI2ObON5Rd4KEZr7RLo/Q4HKzj0IH27Zwl5qeBJdx69zZdu66eOqg==}
+    cpu: [x64]
+    os: [linux]
 
   '@rspack/binding-win32-arm64-msvc@1.3.8':
     resolution: {integrity: sha512-84tifCsYhir/p5GH0knBOXtLpfRzIFDxF4nF4bHsuwaA1uqwyk0WlWGt4ZwRUtyzh0TN4cJdnqJl/f5209BdLw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.3.7':
-    resolution: {integrity: sha512-VPqqC0U6FolGoonmZYBBiFyWjQ4+X+e/l/t4QZP2DRonlpE418+MdCxq2ldVGgvtxwERNlz61zxEX9yh/8KOfw==}
-    cpu: [ia32]
+  '@rspack/binding-win32-arm64-msvc@1.3.9':
+    resolution: {integrity: sha512-owWCJTezFkiBOSRzH+eOTN15H5QYyThHE5crZ0I30UmpoSEchcPSCvddliA0W62ZJIOgG4IUSNamKBiiTwdjLQ==}
+    cpu: [arm64]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@1.3.8':
@@ -2512,9 +2500,9 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.3.7':
-    resolution: {integrity: sha512-zi9tKxlq85lSYTb1sbEluLjZlkbjuoJoy2TaNzVlfNkmiJ6EiqBbyCWoPPBJRP6HQ9pG25W0y4NWKp7iVhiBvg==}
-    cpu: [x64]
+  '@rspack/binding-win32-ia32-msvc@1.3.9':
+    resolution: {integrity: sha512-YUuNA8lkGSXJ07fOjkX+yuWrWcsU5x5uGFuAYsglw+rDTWCS6m9HSwQjbCp7HUp81qPszjSk+Ore5XVh07FKeQ==}
+    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-x64-msvc@1.3.8':
@@ -2522,14 +2510,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.3.7':
-    resolution: {integrity: sha512-jSXLktIGmNNZssxT+fjZ31IyUO7lRoFrFO+XuqKlMpbnHE8yCrpaHE6rLyDPVO4Vnl6xx/df8usUXtZwIc4jrw==}
+  '@rspack/binding-win32-x64-msvc@1.3.9':
+    resolution: {integrity: sha512-E0gtYBVt5vRj0zBeplEf8wsVDPDQ6XBdRiFVUgmgwYUYYkXaalaIvbD1ioB8cA05vfz8HrPGXcMrgletUP4ojA==}
+    cpu: [x64]
+    os: [win32]
 
   '@rspack/binding@1.3.8':
     resolution: {integrity: sha512-0oGrPgnwDsrDN7Swk7OZGvee8y/AdvDXF3f1QewkueJ5uyDaGszDxipEpf644HWIcj11fgNJQEphGEhaAVjofw==}
 
-  '@rspack/core@1.3.7':
-    resolution: {integrity: sha512-InXnEmImLKkxzkY7XaAozycjMvS5myf/o3zu1rw5tNq3ONxWvW0QOHVTcrF0FbeKQ/jCOFSfdaoFjbXjdUs38w==}
+  '@rspack/binding@1.3.9':
+    resolution: {integrity: sha512-3FFen1/0F2aP5uuCm8vPaJOrzM3karCPNMsc5gLCGfEy2rsK38Qinf9W4p1bw7+FhjOTzoSdkX+LFHeMDVxJhw==}
+
+  '@rspack/core@1.3.8':
+    resolution: {integrity: sha512-1zefymDypUROYzGGNa553JR1Ah8En25npwSRIZCuZvfjo6nME6XvjkMxQwhjzMStoqRmFD9+nKUHSiN5jVWWyw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -2537,8 +2530,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@1.3.8':
-    resolution: {integrity: sha512-1zefymDypUROYzGGNa553JR1Ah8En25npwSRIZCuZvfjo6nME6XvjkMxQwhjzMStoqRmFD9+nKUHSiN5jVWWyw==}
+  '@rspack/core@1.3.9':
+    resolution: {integrity: sha512-u7usd9srCBPBfNJCSvsfh14AOPq6LCVna0Vb/aA2nyJTawHqzfAMz1QRb/e27nP3NrV6RPiwx03W494Dd6r6wg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -2556,14 +2549,6 @@ packages:
       '@prefresh/core': ^1.5.0
       '@prefresh/utils': ^1.2.0
 
-  '@rspack/plugin-react-refresh@1.0.1':
-    resolution: {integrity: sha512-KSBc3bsr3mrAPViv7w9MpE9KEWm6q87EyRXyHlRfJ9PpQ56NbX9KZ7AXo7jPeECb0q5sfpM2PSEf+syBiMgLSw==}
-    peerDependencies:
-      react-refresh: '>=0.10.0 <1.0.0'
-    peerDependenciesMeta:
-      react-refresh:
-        optional: true
-
   '@rspack/plugin-react-refresh@1.4.1':
     resolution: {integrity: sha512-bRALP4qEauvrB7RcMQ95rUHu1dw19V6c6uYukUTpA2OZDyMHTQ9cpEe28kaDwH/xsAuDNuYqnUZOW3NdLO/q3A==}
     peerDependencies:
@@ -2573,8 +2558,8 @@ packages:
       webpack-hot-middleware:
         optional: true
 
-  '@rspress/core@2.0.0-beta.3':
-    resolution: {integrity: sha512-YVmHK+26by2VTieA6tkdzDQ8GYszGaRCI3COONr4Co0mAFfGn54zxnDLIq29/Ox7oVv8A7ZjfIp40AQr47No1w==}
+  '@rspress/core@2.0.0-beta.5':
+    resolution: {integrity: sha512-DLNE3cpLW2/QT+Bi7+FIdq5VIMhY9m6cEtbNDXSGIm2kF91oiHlgTnP2wSEeAAuPBBW+47WjkcDHwybhSDkD2g==}
     engines: {node: '>=18.0.0'}
 
   '@rspress/mdx-rs-darwin-arm64@0.6.6':
@@ -2629,39 +2614,43 @@ packages:
     resolution: {integrity: sha512-NpNhTKBIlV3O6ADhoZkgHvBFvXMW2TYlIWmIT1ysJESUBqDpaN9H3Teve5fugjU2pQ2ORBZO6SQGKliMw/8m/Q==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@2.0.0-beta.3':
-    resolution: {integrity: sha512-gN/oIsmjiOw3i1jiq5VVlrHNFfp5eJnSlWaOjEOERXM5OijONo5U+GTHXIao17IylyAYJiLvGiw66eZq5yG+NA==}
+  '@rspress/plugin-auto-nav-sidebar@2.0.0-beta.5':
+    resolution: {integrity: sha512-qeRzA45ZN2Bvanoe6Nr4b6q+TEUSzTLxH14Qp51d4CYfactYtCjgwmJJOFIV+7TEBVCK2575QTKVN5DCDhK4bQ==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/plugin-container-syntax@2.0.0-beta.3':
-    resolution: {integrity: sha512-d7oPMbsQb+Wq2yUtuIuJ+hmfZKO1B6gAP2+CyBBmLTKWlJBC9N870MNyuq0aqiajDDnGpBHTzJ/55lQwksw5Lg==}
+  '@rspress/plugin-container-syntax@2.0.0-beta.5':
+    resolution: {integrity: sha512-x2mDzH3Bb9/EzUHAcDmvd+GTLz5UY3TlfD/PaxYHBQBE/2F0M8mQUYYWHQ2ccmPCIaOGnjZw8KEbIVZLy7WrHA==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/plugin-last-updated@2.0.0-beta.3':
-    resolution: {integrity: sha512-8Q169M2SnyJ0U1NIl7SvrUGanBl1J/TGbxihsitp5SOseS7BKWTYm5+lnpPCy7QJsF64GfiLBb1uWD+kg/GzKg==}
+  '@rspress/plugin-last-updated@2.0.0-beta.5':
+    resolution: {integrity: sha512-Bx8935t5Vn7zpzhSH6nrf5keQG/Pgz3GqkFGSl8Nq/niP4KQmNLtIYTe3/u7/nkRNBWKsbq7KKEsRawKozdoTg==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/plugin-llms@2.0.0-beta.3':
-    resolution: {integrity: sha512-JHjR2Ft5QXuklfDOuul7+p1nd/hGdUZOwvqqx4nNpoYlTT/c475lI+d0u+5kI+PmK0olOmZt72zKWAX+y9cn0w==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@rspress/core': ^2.0.0-beta.3
-
-  '@rspress/plugin-medium-zoom@2.0.0-beta.3':
-    resolution: {integrity: sha512-2d5MlqU/2bygtZq2ZFFsDY4e7pnHm52wt2Bs+OyoCD/nqFTbaR4OloC2mIxAm+fwpVFnEgLBgTRne/UIzLglZw==}
+  '@rspress/plugin-llms@2.0.0-beta.5':
+    resolution: {integrity: sha512-lQ+q+mXbEGas4lqTE5XL1GRxpBB1ezr2k4uSp6zBf/HEbpwnSYqj/RC1CTVIYBoDF686lQYlbccbsuDUEojp5w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@rspress/runtime': ^2.0.0-beta.3
+      '@rspress/core': ^2.0.0-beta.5
 
-  '@rspress/runtime@2.0.0-beta.3':
-    resolution: {integrity: sha512-1KF8v75ZIpSwoM75xv9ssyHs1AD2hICjwCXT9ppcd4AagctdAgT+jZMpZGGpx1ioMPi5rjwTY4rOiD6BeTj+1A==}
+  '@rspress/plugin-medium-zoom@2.0.0-beta.5':
+    resolution: {integrity: sha512-dgH3gnUxoYwv8r7riEbHKNjhzjAd1r3N9kOxbkhWoH0usWK11Ks2nC6C5N88qryrtTEZ493Xg3GVyebduuhgqw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@rspress/runtime': ^2.0.0-beta.5
+
+  '@rspress/plugin-shiki@2.0.0-beta.5':
+    resolution: {integrity: sha512-LK9UH7PzxwDg89cbeCBPxYtIO3gQol5xzoXYoeTsD7If9UIxVGFCJVF6BvHdes24fZa39jtiomxUDOXF6LuT7w==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/shared@2.0.0-beta.3':
-    resolution: {integrity: sha512-SX6kNBcn6sWRiWmRzA0JqlXyp+tmmEo2gPBoY5E55E7Od5EjkkNXqAcWsEvgxAufTdrUe0Ek/gwlvKJDH7lqSQ==}
+  '@rspress/runtime@2.0.0-beta.5':
+    resolution: {integrity: sha512-A6GzOdNnMoYUOWlhehmhvhXrRd/1Jp6PXd25Bxe4ySKSd4K35Lf0+HkocR3ZLAKrwMc/iClyecsPtLt0UUcgJw==}
+    engines: {node: '>=18.0.0'}
 
-  '@rspress/theme-default@2.0.0-beta.3':
-    resolution: {integrity: sha512-0hSlQkY02ybmly/hZJddPBGt4KbjR4HXft3uIarjjNtY2s4sbZo7tE2GjyDPdaClBrSCgwzgRIC8PJuizdHQPw==}
+  '@rspress/shared@2.0.0-beta.5':
+    resolution: {integrity: sha512-6vQ1i5RiXUzj7KNIkMnVirgHjfW/hAqstbxLv/6T29wOfezXkY8hscPEgMvVZskqyGpceZp1OKrf+FX1Me4T5Q==}
+
+  '@rspress/theme-default@2.0.0-beta.5':
+    resolution: {integrity: sha512-cgS/hQVF6q1HLcaGG79TMtenPeaRjp/1oUKZ9yr5YkhWYsAiVday0Ie4dtH98IVOCV9BW520GIBfcYGVyUwxLw==}
     engines: {node: '>=18.0.0'}
 
   '@rstack-dev/doc-ui@1.8.0':
@@ -2691,6 +2680,33 @@ packages:
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@shikijs/core@3.4.0':
+    resolution: {integrity: sha512-0YOzTSRDn/IAfQWtK791gs1u8v87HNGToU6IwcA3K7nPoVOrS2Dh6X6A6YfXgPTSkTwR5y6myk0MnI0htjnwrA==}
+
+  '@shikijs/engine-javascript@3.4.0':
+    resolution: {integrity: sha512-1ywDoe+z/TPQKj9Jw0eU61B003J9DqUFRfH+DVSzdwPUFhR7yOmfyLzUrFz0yw8JxFg/NgzXoQyyykXgO21n5Q==}
+
+  '@shikijs/engine-oniguruma@3.4.0':
+    resolution: {integrity: sha512-zwcWlZ4OQuJ/+1t32ClTtyTU1AiDkK1lhtviRWoq/hFqPjCNyLj22bIg9rB7BfoZKOEOfrsGz7No33BPCf+WlQ==}
+
+  '@shikijs/langs@3.4.0':
+    resolution: {integrity: sha512-bQkR+8LllaM2duU9BBRQU0GqFTx7TuF5kKlw/7uiGKoK140n1xlLAwCgXwSxAjJ7Htk9tXTFwnnsJTCU5nDPXQ==}
+
+  '@shikijs/rehype@3.4.0':
+    resolution: {integrity: sha512-wm7RTSmrcmjZg+F9JRrsH0Brwi36joUMXkUWIDmBGW+XExNEi8Xjmmp2NOBXa3DujZtnL6Dbcg7V6gtZabGoXw==}
+
+  '@shikijs/themes@3.4.0':
+    resolution: {integrity: sha512-YPP4PKNFcFGLxItpbU0ZW1Osyuk8AyZ24YEFaq04CFsuCbcqydMvMUTi40V2dkc0qs1U2uZFrnU6s5zI6IH+uA==}
+
+  '@shikijs/transformers@3.4.0':
+    resolution: {integrity: sha512-GrGaOj1/I6h75IU0VvjdWDpqGCynx0bqHzd1rErBTGxrcmusYIBhrV7aEySWyJ6HHb9figeXfcNxUFS1HKUfBw==}
+
+  '@shikijs/types@3.4.0':
+    resolution: {integrity: sha512-EUT/0lGiE//7j5N/yTMNMT3eCWNcHJLrRKxT0NDXWIfdfSmFJKfPX7nMmRBrQnWboAzIsUziCThrYMMhjbMS1A==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -3035,6 +3051,11 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+
+  '@unhead/react@2.0.8':
+    resolution: {integrity: sha512-H/DmGG2Nz2OU3ASEZzLOIlwzQl027yOl0YhnlLEu3y6pvV/myLtgogcb68hXyHAtmpMAfnxhivUxCaiuFW7C6w==}
+    peerDependencies:
+      react: '>=18'
 
   '@vercel/ncc@0.38.3':
     resolution: {integrity: sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==}
@@ -3497,6 +3518,9 @@ packages:
 
   caniuse-lite@1.0.30001715:
     resolution: {integrity: sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==}
+
+  caniuse-lite@1.0.30001717:
+    resolution: {integrity: sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==}
 
   case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
@@ -4507,8 +4531,14 @@ packages:
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -4540,6 +4570,9 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
   html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
@@ -4558,6 +4591,9 @@ packages:
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -4640,9 +4676,6 @@ packages:
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
-
-  invariant@2.2.4:
-    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -5402,6 +5435,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.1:
+    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+
+  oniguruma-to-es@4.3.3:
+    resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
+
   only@0.0.2:
     resolution: {integrity: sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==}
 
@@ -5802,9 +5841,6 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
-  react-fast-compare@3.2.2:
-    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
-
   react-focus-lock@2.13.2:
     resolution: {integrity: sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==}
     peerDependencies:
@@ -5822,10 +5858,6 @@ packages:
 
   react-lazy-with-preload@2.2.1:
     resolution: {integrity: sha512-ONSb8gizLE5jFpdHAclZ6EAAKuFX2JydnFXPPPjoUImZlLjGtKzyBS8SJgJq7CpLgsGKh9QCZdugJyEEOVC16Q==}
-
-  react-refresh@0.16.0:
-    resolution: {integrity: sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==}
-    engines: {node: '>=0.10.0'}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -5913,6 +5945,15 @@ packages:
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.0.1:
+    resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
 
   rehype-external-links@3.0.0:
     resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
@@ -6070,8 +6111,8 @@ packages:
   rspress-plugin-font-open-sans@1.0.0:
     resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
 
-  rspress@2.0.0-beta.3:
-    resolution: {integrity: sha512-D4a+WxtIQr512KkI+v815W4nvxCvLC0VCyq1YFHiOWkAnUrvRFYjetpviyPXzxm4er1IyHPo/6+blVH0/X48xQ==}
+  rspress@2.0.0-beta.5:
+    resolution: {integrity: sha512-UTN5Ja+2W0chLrDFTed7pLz+EsLkXVkqjdz6VC+8VQdqk230g7TBi0NuuNTLuPrBq07WBUZxK5oelA8zNvey2Q==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -6312,6 +6353,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki@3.4.0:
+    resolution: {integrity: sha512-Ni80XHcqhOEXv5mmDAvf5p6PAJqbUc/RzFeaOqk+zP5DLvTPS3j0ckvA+MI87qoxTQ5RGJDVTbdl/ENLSyyAnQ==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -6797,6 +6841,9 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  unhead@2.0.8:
+    resolution: {integrity: sha512-63WR+y08RZE7ChiFdgNY64haAkhCtUS5/HM7xo4Q83NA63txWbEh2WGmrKbArdQmSct+XlqbFN8ZL1yWpQEHEA==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -7639,13 +7686,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@dr.pogodin/react-helmet@2.0.4(react@19.1.0)':
-    dependencies:
-      invariant: 2.2.4
-      react: 19.1.0
-      react-fast-compare: 3.2.2
-      shallowequal: 1.1.0
-
   '@emnapi/core@1.2.0':
     dependencies:
       '@emnapi/wasi-threads': 1.0.1
@@ -8104,7 +8144,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.13.1(@rspack/core@1.3.8(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)':
+  '@module-federation/enhanced@0.13.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.13.1
       '@module-federation/cli': 0.13.1(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
@@ -8114,7 +8154,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.13.1(@module-federation/runtime-tools@0.13.1)
       '@module-federation/managers': 0.13.1
       '@module-federation/manifest': 0.13.1(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
-      '@module-federation/rspack': 0.13.1(@rspack/core@1.3.8(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/rspack': 0.13.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/runtime-tools': 0.13.1
       '@module-federation/sdk': 0.13.1
       btoa: 1.2.1
@@ -8162,9 +8202,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.13.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)':
+  '@module-federation/rsbuild-plugin@0.13.1(@rsbuild/core@1.3.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)':
     dependencies:
-      '@module-federation/enhanced': 0.13.1(@rspack/core@1.3.8(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
+      '@module-federation/enhanced': 0.13.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
       '@module-federation/sdk': 0.13.1
     optionalDependencies:
       '@rsbuild/core': 1.3.15
@@ -8180,7 +8220,25 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.13.1(@rspack/core@1.3.8(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
+  '@module-federation/rsbuild-plugin@0.13.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)':
+    dependencies:
+      '@module-federation/enhanced': 0.13.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
+      '@module-federation/sdk': 0.13.1
+    optionalDependencies:
+      '@rsbuild/core': 1.3.17
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - debug
+      - react
+      - react-dom
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - webpack
+
+  '@module-federation/rspack@0.13.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.13.1
       '@module-federation/dts-plugin': 0.13.1(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
@@ -8189,7 +8247,7 @@ snapshots:
       '@module-federation/manifest': 0.13.1(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/runtime-tools': 0.13.1
       '@module-federation/sdk': 0.13.1
-      '@rspack/core': 1.3.8(@swc/helpers@0.5.17)
+      '@rspack/core': 1.3.9(@swc/helpers@0.5.17)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.8.3
@@ -8236,12 +8294,12 @@ snapshots:
 
   '@module-federation/sdk@0.13.1': {}
 
-  '@module-federation/storybook-addon@4.0.15(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(@storybook/core@8.6.12(prettier@3.5.3)(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)':
+  '@module-federation/storybook-addon@4.0.15(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(@storybook/core@8.6.12(prettier@3.5.3)(storybook@8.6.12(prettier@3.5.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)(webpack@5.98.0)':
     dependencies:
-      '@module-federation/enhanced': 0.13.1(@rspack/core@1.3.8(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
+      '@module-federation/enhanced': 0.13.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack@5.98.0)
       '@module-federation/sdk': 0.13.1
     optionalDependencies:
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
       '@storybook/core': 8.6.12(prettier@3.5.3)(storybook@8.6.12(prettier@3.5.3))
       webpack: 5.98.0
       webpack-virtual-modules: 0.6.2
@@ -8409,14 +8467,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.39.0':
     optional: true
 
-  '@rsbuild/core@1.3.13':
-    dependencies:
-      '@rspack/core': 1.3.7(@swc/helpers@0.5.17)
-      '@rspack/lite-tapable': 1.0.1
-      '@swc/helpers': 0.5.17
-      core-js: 3.41.0
-      jiti: 2.4.2
-
   '@rsbuild/core@1.3.14':
     dependencies:
       '@rspack/core': 1.3.8(@swc/helpers@0.5.17)
@@ -8433,13 +8483,21 @@ snapshots:
       core-js: 3.42.0
       jiti: 2.4.2
 
-  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.3.15)':
+  '@rsbuild/core@1.3.17':
+    dependencies:
+      '@rspack/core': 1.3.9(@swc/helpers@0.5.17)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.17
+      core-js: 3.42.0
+      jiti: 2.4.2
+
+  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.3.17)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -8447,13 +8505,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@1.0.5(@rsbuild/core@1.3.15)':
+  '@rsbuild/plugin-babel@1.0.5(@rsbuild/core@1.3.17)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -8467,7 +8525,7 @@ snapshots:
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
-  '@rsbuild/plugin-node-polyfill@1.3.0(@rsbuild/core@1.3.15)':
+  '@rsbuild/plugin-node-polyfill@1.3.0(@rsbuild/core@1.3.17)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -8493,27 +8551,29 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
 
-  '@rsbuild/plugin-preact@1.3.1(@rsbuild/core@1.3.15)(preact@10.26.5)':
+  '@rsbuild/plugin-preact@1.3.1(@rsbuild/core@1.3.17)(preact@10.26.5)':
     dependencies:
       '@prefresh/core': 1.5.3(preact@10.26.5)
       '@prefresh/utils': 1.2.0
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
       '@rspack/plugin-preact-refresh': 1.1.2(@prefresh/core@1.5.3(preact@10.26.5))(@prefresh/utils@1.2.0)
       '@swc/plugin-prefresh': 6.2.0
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@1.1.1(@rsbuild/core@1.3.13)':
-    dependencies:
-      '@rsbuild/core': 1.3.13
-      '@rspack/plugin-react-refresh': 1.0.1(react-refresh@0.16.0)
-      react-refresh: 0.16.0
-
   '@rsbuild/plugin-react@1.3.0(@rsbuild/core@1.3.15)':
     dependencies:
       '@rsbuild/core': 1.3.15
+      '@rspack/plugin-react-refresh': 1.4.1(react-refresh@0.17.0)
+      react-refresh: 0.17.0
+    transitivePeerDependencies:
+      - webpack-hot-middleware
+
+  '@rsbuild/plugin-react@1.3.0(@rsbuild/core@1.3.17)':
+    dependencies:
+      '@rsbuild/core': 1.3.17
       '@rspack/plugin-react-refresh': 1.4.1(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
@@ -8528,10 +8588,19 @@ snapshots:
       reduce-configs: 1.1.0
       sass-embedded: 1.86.0
 
-  '@rsbuild/plugin-solid@1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.3.15)(solid-js@1.9.6)':
+  '@rsbuild/plugin-sass@1.3.1(@rsbuild/core@1.3.17)':
     dependencies:
-      '@rsbuild/core': 1.3.15
-      '@rsbuild/plugin-babel': 1.0.4(@rsbuild/core@1.3.15)
+      '@rsbuild/core': 1.3.17
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.5.3
+      reduce-configs: 1.1.0
+      sass-embedded: 1.86.0
+
+  '@rsbuild/plugin-solid@1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.3.17)(solid-js@1.9.6)':
+    dependencies:
+      '@rsbuild/core': 1.3.17
+      '@rsbuild/plugin-babel': 1.0.4(@rsbuild/core@1.3.17)
       babel-preset-solid: 1.9.5(@babel/core@7.26.10)
       solid-refresh: 0.6.3(solid-js@1.9.6)
     transitivePeerDependencies:
@@ -8539,22 +8608,22 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@1.1.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(webpack@5.98.0)':
+  '@rsbuild/plugin-stylus@1.1.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(webpack@5.98.0)':
     dependencies:
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
       stylus: 0.64.0
-      stylus-loader: 8.1.1(@rspack/core@1.3.8(@swc/helpers@0.5.17))(stylus@0.64.0)(webpack@5.98.0)
+      stylus-loader: 8.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(stylus@0.64.0)(webpack@5.98.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.2.0(@rsbuild/core@1.3.15)(typescript@5.8.3)':
+  '@rsbuild/plugin-svgr@1.2.0(@rsbuild/core@1.3.17)(typescript@5.8.3)':
     dependencies:
-      '@rsbuild/core': 1.3.15
-      '@rsbuild/plugin-react': 1.3.0(@rsbuild/core@1.3.15)
+      '@rsbuild/core': 1.3.17
+      '@rsbuild/plugin-react': 1.3.0(@rsbuild/core@1.3.17)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)
@@ -8571,14 +8640,14 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.3.15
 
-  '@rsbuild/plugin-type-check@1.2.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(typescript@5.8.3)':
+  '@rsbuild/plugin-type-check@1.2.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(typescript@5.8.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.0
-      ts-checker-rspack-plugin: 1.1.1(@rspack/core@1.3.8(@swc/helpers@0.5.17))(typescript@5.8.3)
+      ts-checker-rspack-plugin: 1.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(typescript@5.8.3)
     optionalDependencies:
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
@@ -8587,9 +8656,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.3.15
 
-  '@rsbuild/plugin-vue@1.0.7(@rsbuild/core@1.3.15)(vue@3.5.13(typescript@5.8.3))':
+  '@rsbuild/plugin-vue@1.0.7(@rsbuild/core@1.3.17)(vue@3.5.13(typescript@5.8.3))':
     dependencies:
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
       vue-loader: 17.4.2(vue@3.5.13(typescript@5.8.3))(webpack@5.98.0)
       webpack: 5.98.0
     transitivePeerDependencies:
@@ -8613,71 +8682,59 @@ snapshots:
       '@microsoft/api-extractor': 7.52.7(@types/node@22.8.1)
       typescript: 5.8.3
 
-  '@rspack/binding-darwin-arm64@1.3.7':
-    optional: true
-
   '@rspack/binding-darwin-arm64@1.3.8':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.3.7':
+  '@rspack/binding-darwin-arm64@1.3.9':
     optional: true
 
   '@rspack/binding-darwin-x64@1.3.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.3.7':
+  '@rspack/binding-darwin-x64@1.3.9':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.3.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.3.7':
+  '@rspack/binding-linux-arm64-gnu@1.3.9':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.3.8':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.3.7':
+  '@rspack/binding-linux-arm64-musl@1.3.9':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.3.8':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.3.7':
+  '@rspack/binding-linux-x64-gnu@1.3.9':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.3.8':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.3.7':
+  '@rspack/binding-linux-x64-musl@1.3.9':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.3.8':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.3.7':
+  '@rspack/binding-win32-arm64-msvc@1.3.9':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.3.8':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.3.7':
+  '@rspack/binding-win32-ia32-msvc@1.3.9':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.3.8':
     optional: true
 
-  '@rspack/binding@1.3.7':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.3.7
-      '@rspack/binding-darwin-x64': 1.3.7
-      '@rspack/binding-linux-arm64-gnu': 1.3.7
-      '@rspack/binding-linux-arm64-musl': 1.3.7
-      '@rspack/binding-linux-x64-gnu': 1.3.7
-      '@rspack/binding-linux-x64-musl': 1.3.7
-      '@rspack/binding-win32-arm64-msvc': 1.3.7
-      '@rspack/binding-win32-ia32-msvc': 1.3.7
-      '@rspack/binding-win32-x64-msvc': 1.3.7
+  '@rspack/binding-win32-x64-msvc@1.3.9':
+    optional: true
 
   '@rspack/binding@1.3.8':
     optionalDependencies:
@@ -8691,14 +8748,17 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.3.8
       '@rspack/binding-win32-x64-msvc': 1.3.8
 
-  '@rspack/core@1.3.7(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.13.0
-      '@rspack/binding': 1.3.7
-      '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001715
+  '@rspack/binding@1.3.9':
     optionalDependencies:
-      '@swc/helpers': 0.5.17
+      '@rspack/binding-darwin-arm64': 1.3.9
+      '@rspack/binding-darwin-x64': 1.3.9
+      '@rspack/binding-linux-arm64-gnu': 1.3.9
+      '@rspack/binding-linux-arm64-musl': 1.3.9
+      '@rspack/binding-linux-x64-gnu': 1.3.9
+      '@rspack/binding-linux-x64-musl': 1.3.9
+      '@rspack/binding-win32-arm64-msvc': 1.3.9
+      '@rspack/binding-win32-ia32-msvc': 1.3.9
+      '@rspack/binding-win32-x64-msvc': 1.3.9
 
   '@rspack/core@1.3.8(@swc/helpers@0.5.17)':
     dependencies:
@@ -8709,6 +8769,15 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.17
 
+  '@rspack/core@1.3.9(@swc/helpers@0.5.17)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.13.1
+      '@rspack/binding': 1.3.9
+      '@rspack/lite-tapable': 1.0.1
+      caniuse-lite: 1.0.30001717
+    optionalDependencies:
+      '@swc/helpers': 0.5.17
+
   '@rspack/lite-tapable@1.0.1': {}
 
   '@rspack/plugin-preact-refresh@1.1.2(@prefresh/core@1.5.3(preact@10.26.5))(@prefresh/utils@1.2.0)':
@@ -8716,35 +8785,30 @@ snapshots:
       '@prefresh/core': 1.5.3(preact@10.26.5)
       '@prefresh/utils': 1.2.0
 
-  '@rspack/plugin-react-refresh@1.0.1(react-refresh@0.16.0)':
-    dependencies:
-      error-stack-parser: 2.1.4
-      html-entities: 2.6.0
-    optionalDependencies:
-      react-refresh: 0.16.0
-
   '@rspack/plugin-react-refresh@1.4.1(react-refresh@0.17.0)':
     dependencies:
       error-stack-parser: 2.1.4
       html-entities: 2.6.0
       react-refresh: 0.17.0
 
-  '@rspress/core@2.0.0-beta.3(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0)':
+  '@rspress/core@2.0.0-beta.5(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0)':
     dependencies:
-      '@dr.pogodin/react-helmet': 2.0.4(react@19.1.0)
       '@mdx-js/loader': 3.1.0(acorn@8.14.0)(webpack@5.98.0)
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       '@mdx-js/react': 3.1.0(@types/react@19.1.3)(react@19.1.0)
-      '@rsbuild/core': 1.3.13
-      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.3.13)
+      '@rsbuild/core': 1.3.17
+      '@rsbuild/plugin-react': 1.3.0(@rsbuild/core@1.3.17)
       '@rspress/mdx-rs': 0.6.6
-      '@rspress/plugin-auto-nav-sidebar': 2.0.0-beta.3
-      '@rspress/plugin-container-syntax': 2.0.0-beta.3
-      '@rspress/plugin-last-updated': 2.0.0-beta.3
-      '@rspress/plugin-medium-zoom': 2.0.0-beta.3(@rspress/runtime@2.0.0-beta.3)
-      '@rspress/runtime': 2.0.0-beta.3
-      '@rspress/shared': 2.0.0-beta.3
-      '@rspress/theme-default': 2.0.0-beta.3
+      '@rspress/plugin-auto-nav-sidebar': 2.0.0-beta.5
+      '@rspress/plugin-container-syntax': 2.0.0-beta.5
+      '@rspress/plugin-last-updated': 2.0.0-beta.5
+      '@rspress/plugin-medium-zoom': 2.0.0-beta.5(@rspress/runtime@2.0.0-beta.5)
+      '@rspress/plugin-shiki': 2.0.0-beta.5
+      '@rspress/runtime': 2.0.0-beta.5
+      '@rspress/shared': 2.0.0-beta.5
+      '@rspress/theme-default': 2.0.0-beta.5
+      '@types/unist': 3.0.3
+      '@unhead/react': 2.0.8(react@19.1.0)
       enhanced-resolve: 5.18.1
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -8771,6 +8835,7 @@ snapshots:
       - acorn
       - supports-color
       - webpack
+      - webpack-hot-middleware
 
   '@rspress/mdx-rs-darwin-arm64@0.6.6':
     optional: true
@@ -8807,22 +8872,22 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.6
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.6
 
-  '@rspress/plugin-auto-nav-sidebar@2.0.0-beta.3':
+  '@rspress/plugin-auto-nav-sidebar@2.0.0-beta.5':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.3
+      '@rspress/shared': 2.0.0-beta.5
 
-  '@rspress/plugin-container-syntax@2.0.0-beta.3':
+  '@rspress/plugin-container-syntax@2.0.0-beta.5':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.3
+      '@rspress/shared': 2.0.0-beta.5
 
-  '@rspress/plugin-last-updated@2.0.0-beta.3':
+  '@rspress/plugin-last-updated@2.0.0-beta.5':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.3
+      '@rspress/shared': 2.0.0-beta.5
 
-  '@rspress/plugin-llms@2.0.0-beta.3(@rspress/core@2.0.0-beta.3(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0))':
+  '@rspress/plugin-llms@2.0.0-beta.5(@rspress/core@2.0.0-beta.5(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0))':
     dependencies:
-      '@rspress/core': 2.0.0-beta.3(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0)
-      '@rspress/shared': 2.0.0-beta.3
+      '@rspress/core': 2.0.0-beta.5(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0)
+      '@rspress/shared': 2.0.0-beta.5
       remark-mdx: 3.1.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -8832,32 +8897,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rspress/plugin-medium-zoom@2.0.0-beta.3(@rspress/runtime@2.0.0-beta.3)':
+  '@rspress/plugin-medium-zoom@2.0.0-beta.5(@rspress/runtime@2.0.0-beta.5)':
     dependencies:
-      '@rspress/runtime': 2.0.0-beta.3
+      '@rspress/runtime': 2.0.0-beta.5
       medium-zoom: 1.1.0
 
-  '@rspress/runtime@2.0.0-beta.3':
+  '@rspress/plugin-shiki@2.0.0-beta.5':
     dependencies:
-      '@dr.pogodin/react-helmet': 2.0.4(react@19.1.0)
-      '@rspress/shared': 2.0.0-beta.3
+      '@rspress/shared': 2.0.0-beta.5
+      '@shikijs/rehype': 3.4.0
+      hast-util-from-html: 2.0.3
+      shiki: 3.4.0
+
+  '@rspress/runtime@2.0.0-beta.5':
+    dependencies:
+      '@rspress/shared': 2.0.0-beta.5
+      '@unhead/react': 2.0.8(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.29.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  '@rspress/shared@2.0.0-beta.3':
+  '@rspress/shared@2.0.0-beta.5':
     dependencies:
-      '@rsbuild/core': 1.3.13
+      '@rsbuild/core': 1.3.17
+      '@shikijs/rehype': 3.4.0
       gray-matter: 4.0.3
       lodash-es: 4.17.21
       unified: 11.0.5
 
-  '@rspress/theme-default@2.0.0-beta.3':
+  '@rspress/theme-default@2.0.0-beta.5':
     dependencies:
-      '@dr.pogodin/react-helmet': 2.0.4(react@19.1.0)
       '@mdx-js/react': 2.3.0(react@19.1.0)
-      '@rspress/runtime': 2.0.0-beta.3
-      '@rspress/shared': 2.0.0-beta.3
+      '@rspress/runtime': 2.0.0-beta.5
+      '@rspress/shared': 2.0.0-beta.5
+      '@unhead/react': 2.0.8(react@19.1.0)
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.7.43
@@ -8915,6 +8988,53 @@ snapshots:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.11.0
+
+  '@shikijs/core@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.3
+
+  '@shikijs/engine-oniguruma@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
+
+  '@shikijs/rehype@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
+      '@types/hast': 3.0.4
+      hast-util-to-string: 3.0.1
+      shiki: 3.4.0
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+
+  '@shikijs/themes@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
+
+  '@shikijs/transformers@3.4.0':
+    dependencies:
+      '@shikijs/core': 3.4.0
+      '@shikijs/types': 3.4.0
+
+  '@shikijs/types@3.4.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -9311,6 +9431,11 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.2.0': {}
+
+  '@unhead/react@2.0.8(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      unhead: 2.0.8
 
   '@vercel/ncc@0.38.3': {}
 
@@ -9875,6 +10000,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001715: {}
+
+  caniuse-lite@1.0.30001717: {}
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
 
@@ -11008,6 +11135,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.0
+      property-information: 7.0.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.7
@@ -11027,6 +11168,10 @@ snapshots:
       vfile-message: 4.0.2
     transitivePeerDependencies:
       - supports-color
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -11066,6 +11211,8 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
+  hookable@5.5.3: {}
+
   html-encoding-sniffer@3.0.0:
     dependencies:
       whatwg-encoding: 2.0.0
@@ -11091,6 +11238,8 @@ snapshots:
       dom-serializer: 2.0.0
       htmlparser2: 8.0.2
       selderee: 0.11.0
+
+  html-void-elements@3.0.0: {}
 
   htmlparser2@6.1.0:
     dependencies:
@@ -11197,10 +11346,6 @@ snapshots:
   ini@1.3.8: {}
 
   inline-style-parser@0.2.4: {}
-
-  invariant@2.2.4:
-    dependencies:
-      loose-envify: 1.4.0
 
   ipaddr.js@1.9.1: {}
 
@@ -12195,6 +12340,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  oniguruma-parser@0.12.1: {}
+
+  oniguruma-to-es@4.3.3:
+    dependencies:
+      oniguruma-parser: 0.12.1
+      regex: 6.0.1
+      regex-recursion: 6.0.2
+
   only@0.0.2: {}
 
   open@8.4.2:
@@ -12612,8 +12765,6 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
-  react-fast-compare@3.2.2: {}
-
   react-focus-lock@2.13.2(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.24.8
@@ -12629,8 +12780,6 @@ snapshots:
   react-is@18.3.1: {}
 
   react-lazy-with-preload@2.2.1: {}
-
-  react-refresh@0.16.0: {}
 
   react-refresh@0.17.0: {}
 
@@ -12759,6 +12908,16 @@ snapshots:
       prismjs: 1.27.0
 
   regenerator-runtime@0.14.1: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.0.1:
+    dependencies:
+      regex-utilities: 2.3.0
 
   rehype-external-links@3.0.0:
     dependencies:
@@ -12945,12 +13104,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.3.15
 
-  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.3.15):
+  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.3.17):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
 
   rsbuild-plugin-publint@0.3.1(@rsbuild/core@1.3.15):
     dependencies:
@@ -12958,6 +13117,13 @@ snapshots:
       publint: 0.3.12
     optionalDependencies:
       '@rsbuild/core': 1.3.15
+
+  rsbuild-plugin-publint@0.3.1(@rsbuild/core@1.3.17):
+    dependencies:
+      picocolors: 1.1.1
+      publint: 0.3.12
+    optionalDependencies:
+      '@rsbuild/core': 1.3.17
 
   rslog@1.2.3: {}
 
@@ -12967,11 +13133,11 @@ snapshots:
 
   rspress-plugin-font-open-sans@1.0.0: {}
 
-  rspress@2.0.0-beta.3(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0):
+  rspress@2.0.0-beta.5(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0):
     dependencies:
-      '@rsbuild/core': 1.3.13
-      '@rspress/core': 2.0.0-beta.3(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0)
-      '@rspress/shared': 2.0.0-beta.3
+      '@rsbuild/core': 1.3.17
+      '@rspress/core': 2.0.0-beta.5(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0)
+      '@rspress/shared': 2.0.0-beta.5
       cac: 6.7.14
       chokidar: 3.6.0
       picocolors: 1.1.1
@@ -12980,6 +13146,7 @@ snapshots:
       - acorn
       - supports-color
       - webpack
+      - webpack-hot-middleware
 
   run-parallel@1.2.0:
     dependencies:
@@ -13197,6 +13364,17 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shiki@3.4.0:
+    dependencies:
+      '@shikijs/core': 3.4.0
+      '@shikijs/engine-javascript': 3.4.0
+      '@shikijs/engine-oniguruma': 3.4.0
+      '@shikijs/langs': 3.4.0
+      '@shikijs/themes': 3.4.0
+      '@shikijs/types': 3.4.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -13321,18 +13499,18 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@1.0.1(@rsbuild/core@1.3.15)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3))(typescript@5.8.3):
+  storybook-addon-rslib@1.0.1(@rsbuild/core@1.3.17)(@rslib/core@packages+core)(storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3))(typescript@5.8.3):
     dependencies:
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 1.0.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 1.0.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3)
     optionalDependencies:
       typescript: 5.8.3
 
-  storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3):
+  storybook-builder-rsbuild@1.0.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3):
     dependencies:
-      '@rsbuild/core': 1.3.15
-      '@rsbuild/plugin-type-check': 1.2.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(typescript@5.8.3)
+      '@rsbuild/core': 1.3.17
+      '@rsbuild/plugin-type-check': 1.2.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(typescript@5.8.3)
       '@storybook/addon-docs': 8.4.2(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(webpack-sources@3.2.3)
       '@storybook/core-webpack': 8.4.2(storybook@8.6.12(prettier@3.5.3))
       browser-assert: 1.2.1
@@ -13345,7 +13523,7 @@ snapshots:
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.3.15)
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.3.17)
       sirv: 2.0.4
       storybook: 8.6.12(prettier@3.5.3)
       ts-dedent: 2.2.0
@@ -13359,10 +13537,10 @@ snapshots:
       - '@types/react'
       - webpack-sources
 
-  storybook-react-rsbuild@1.0.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3)(webpack@5.98.0):
+  storybook-react-rsbuild@1.0.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(@types/react@19.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3)(webpack@5.98.0):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.39.0)
-      '@rsbuild/core': 1.3.15
+      '@rsbuild/core': 1.3.17
       '@storybook/react': 8.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.3)(webpack@5.98.0)
       '@types/node': 18.19.64
@@ -13374,7 +13552,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       resolve: 1.22.10
       storybook: 8.6.12(prettier@3.5.3)
-      storybook-builder-rsbuild: 1.0.1(@rsbuild/core@1.3.15)(@rspack/core@1.3.8(@swc/helpers@0.5.17))(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3)
+      storybook-builder-rsbuild: 1.0.1(@rsbuild/core@1.3.17)(@rspack/core@1.3.9(@swc/helpers@0.5.17))(@types/react@19.1.3)(storybook@8.6.12(prettier@3.5.3))(typescript@5.8.3)(webpack-sources@3.2.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.8.3
@@ -13476,13 +13654,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  stylus-loader@8.1.1(@rspack/core@1.3.8(@swc/helpers@0.5.17))(stylus@0.64.0)(webpack@5.98.0):
+  stylus-loader@8.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(stylus@0.64.0)(webpack@5.98.0):
     dependencies:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 1.3.8(@swc/helpers@0.5.17)
+      '@rspack/core': 1.3.9(@swc/helpers@0.5.17)
       webpack: 5.98.0
 
   stylus@0.64.0:
@@ -13664,7 +13842,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.1.1(@rspack/core@1.3.8(@swc/helpers@0.5.17))(typescript@5.8.3):
+  ts-checker-rspack-plugin@1.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))(typescript@5.8.3):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@rspack/lite-tapable': 1.0.1
@@ -13674,7 +13852,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.8.3
     optionalDependencies:
-      '@rspack/core': 1.3.8(@swc/helpers@0.5.17)
+      '@rspack/core': 1.3.9(@swc/helpers@0.5.17)
 
   ts-dedent@2.2.0: {}
 
@@ -13725,6 +13903,10 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.19.8: {}
+
+  unhead@2.0.8:
+    dependencies:
+      hookable: 5.5.3
 
   unicorn-magic@0.1.0: {}
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -110,6 +110,8 @@ rspress
 rstack
 selfsign
 selfsigned
+shiki
+shikijs
 sirv
 sokra
 speedscope

--- a/tests/e2e/react-component/index.pw.test.ts
+++ b/tests/e2e/react-component/index.pw.test.ts
@@ -1,12 +1,6 @@
 import assert from 'node:assert';
-import fs from 'node:fs';
-import path from 'node:path';
 import { type Page, expect, test } from '@playwright/test';
 import { dev } from 'test-helper/rsbuild';
-
-function getCwdByExample(exampleName: string) {
-  return path.join(__dirname, '../../../examples', exampleName);
-}
 
 async function counterCompShouldWork(page: Page) {
   const h2El = page.locator('h2');
@@ -101,14 +95,6 @@ test('should render example "react-component-bundle-false" successfully', async 
 test('should render example "react-component-umd" successfully', async ({
   page,
 }) => {
-  const umdPath = path.resolve(
-    getCwdByExample('react-component-umd'),
-    './dist/umd/index.js',
-  );
-  fs.mkdirSync(path.resolve(__dirname, './public/umd'), { recursive: true });
-  fs.copyFileSync(umdPath, path.resolve(__dirname, './public/umd/index.js'));
-  fs.copyFileSync(umdPath, path.resolve(__dirname, './public/umd/index.css'));
-
   const rsbuild = await dev({
     cwd: __dirname,
     page,

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -26,12 +26,12 @@ Configure the generation of the TypeScript declaration files.
 
 Declaration files generation is an optional feature, you can set `dts: true` to enable [bundleless declaration files](/guide/advanced/dts#bundleless-declaration-files) generation.
 
-```ts title="rslib.config.ts" {5}
+```ts
 export default {
   lib: [
     {
       format: 'esm',
-      dts: true,
+      dts: true, // [!code highlight]
     },
   ],
 };
@@ -39,12 +39,12 @@ export default {
 
 If you want to disable declaration files generation, you can set `dts: false` or do not specify the `dts` option.
 
-```ts title="rslib.config.ts" {5}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'esm',
-      dts: false,
+      dts: false, // [!code highlight]
     },
   ],
 };
@@ -73,14 +73,15 @@ import { PackageManagerTabs } from '@theme';
 
 2. Set `dts.bundle` to `true`.
 
-```ts title="rslib.config.ts" {5-7}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'esm',
       dts: {
-        bundle: true,
-      },
+        // [!code highlight]
+        bundle: true, // [!code highlight]
+      }, // [!code highlight]
     },
   ],
 };
@@ -106,14 +107,15 @@ The default value follows the priority below:
 
 #### Example
 
-```ts title="rslib.config.ts" {5-7}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'esm',
       dts: {
-        distPath: './dist-types',
-      },
+        // [!code highlight]
+        distPath: './dist-types', // [!code highlight]
+      }, // [!code highlight]
     },
   ],
 };
@@ -143,14 +145,15 @@ By default, type errors will cause the build to fail.
 
 When `abortOnError` is set to `false` like below, the build will still succeed even if there are type issues in the code.
 
-```ts title="rslib.config.ts" {5-7}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'esm',
       dts: {
-        abortOnError: false,
-      },
+        // [!code highlight]
+        abortOnError: false, // [!code highlight]
+      }, // [!code highlight]
     },
   ],
 };

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -78,10 +78,10 @@ export default {
   lib: [
     {
       format: 'esm',
+      // [!code highlight:3]
       dts: {
-        // [!code highlight]
-        bundle: true, // [!code highlight]
-      }, // [!code highlight]
+        bundle: true,
+      },
     },
   ],
 };
@@ -112,10 +112,10 @@ export default {
   lib: [
     {
       format: 'esm',
+      // [!code highlight:3]
       dts: {
-        // [!code highlight]
-        distPath: './dist-types', // [!code highlight]
-      }, // [!code highlight]
+        distPath: './dist-types',
+      },
     },
   ],
 };
@@ -150,10 +150,10 @@ export default {
   lib: [
     {
       format: 'esm',
+      // [!code highlight:3]
       dts: {
-        // [!code highlight]
-        abortOnError: false, // [!code highlight]
-      }, // [!code highlight]
+        abortOnError: false,
+      },
     },
   ],
 };

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -26,7 +26,7 @@ Configure the generation of the TypeScript declaration files.
 
 Declaration files generation is an optional feature, you can set `dts: true` to enable [bundleless declaration files](/guide/advanced/dts#bundleless-declaration-files) generation.
 
-```ts
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {

--- a/website/docs/en/config/lib/external-helpers.mdx
+++ b/website/docs/en/config/lib/external-helpers.mdx
@@ -94,8 +94,9 @@ export default {
 Below is the output JavaScript file, the highlighted code is importing helper functions:
 
 ```js title="index.js"
-import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__ from '@swc/helpers/_/_class_call_check'; // [!code highlight]
-import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__ from '@swc/helpers/_/_create_class'; // [!code highlight]
+// [!code highlight:2]
+import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__ from '@swc/helpers/_/_class_call_check';
+import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__ from '@swc/helpers/_/_create_class';
 var src_FOO = /*#__PURE__*/ (function () {
   'use strict';
   function FOO() {

--- a/website/docs/en/config/lib/external-helpers.mdx
+++ b/website/docs/en/config/lib/external-helpers.mdx
@@ -29,12 +29,12 @@ export default class FOO {
 
 When `externalHelpers` is disabled, the output JavaScript will inline helper functions.
 
-```ts title="rslib.config.ts" {5}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       syntax: 'es5',
-      externalHelpers: false,
+      externalHelpers: false, // [!code highlight]
     },
   ],
 };
@@ -42,7 +42,8 @@ export default {
 
 Below is the output JavaScript file, the highlighted code is the inlined helper functions:
 
-```js title="index.js" {1-18}
+```js title="index.js"
+// [!code highlight:18]
 function _class_call_check(instance, Constructor) {
   if (!(instance instanceof Constructor))
     throw new TypeError('Cannot call a class as a function');
@@ -79,12 +80,12 @@ export { src_FOO as default };
 
 When `externalHelpers` is enabled, the output JavaScript will import helper functions from the external module `@swc/helpers`.
 
-```ts title="rslib.config.ts" {5}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       syntax: 'es5',
-      externalHelpers: true,
+      externalHelpers: true, // [!code highlight]
     },
   ],
 };
@@ -92,9 +93,9 @@ export default {
 
 Below is the output JavaScript file, the highlighted code is importing helper functions:
 
-```js title="index.js" {1-2}
-import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__ from '@swc/helpers/_/_class_call_check';
-import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__ from '@swc/helpers/_/_create_class';
+```js title="index.js"
+import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__ from '@swc/helpers/_/_class_call_check'; // [!code highlight]
+import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__ from '@swc/helpers/_/_create_class'; // [!code highlight]
 var src_FOO = /*#__PURE__*/ (function () {
   'use strict';
   function FOO() {

--- a/website/docs/en/config/lib/umd-name.mdx
+++ b/website/docs/en/config/lib/umd-name.mdx
@@ -15,12 +15,12 @@ The module name of the UMD bundle must not conflict with the global variable nam
 
 The UMD bundle will be mounted to `global.MyLibrary`.
 
-```ts title="rslib.config.ts" {5}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'umd',
-      umdName: 'MyLibrary',
+      umdName: 'MyLibrary', // [!code highlight]
     },
   ],
 };

--- a/website/docs/en/guide/advanced/json-files.mdx
+++ b/website/docs/en/guide/advanced/json-files.mdx
@@ -243,19 +243,19 @@ If you want JSON / YAML / TOML files to be output to the distribution directory 
 
 For example, the following configuration will output all JSON files in the `src` directory as-is:
 
-```ts title="rslib.config.ts" {7,11-12}
+```ts title="rslib.config.ts"
 export default defineConfig({
   lib: [
     {
       bundle: false,
       source: {
         entry: {
-          index: ['./src/**', '!./src/**/*.json'],
+          index: ['./src/**', '!./src/**/*.json'], // [!code highlight]
         },
       },
       output: {
-        copy: [{ from: './**/*.json', context: './src' }],
-        externals: [/.*\.json$/],
+        copy: [{ from: './**/*.json', context: './src' }], // [!code highlight]
+        externals: [/.*\.json$/], // [!code highlight]
       },
     },
   ],

--- a/website/docs/en/guide/advanced/json-files.mdx
+++ b/website/docs/en/guide/advanced/json-files.mdx
@@ -254,8 +254,9 @@ export default defineConfig({
         },
       },
       output: {
-        copy: [{ from: './**/*.json', context: './src' }], // [!code highlight]
-        externals: [/.*\.json$/], // [!code highlight]
+        // [!code highlight:2]
+        copy: [{ from: './**/*.json', context: './src' }],
+        externals: [/.*\.json$/],
       },
     },
   ],

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -38,7 +38,7 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     // ... other format
-    // [!code highlight:35]
+    // [!code highlight:37]
     {
       format: 'mf',
       output: {
@@ -126,23 +126,24 @@ import { pluginReact } from '@rsbuild/plugin-react';
 export default defineConfig({
   plugins: [
     pluginReact(),
-    pluginModuleFederation({ // [!code highlight]
-      name: 'rsbuild_host', // [!code highlight]
-      remotes: { // [!code highlight]
-        rslib: 'rslib@http://localhost:3001/mf/mf-manifest.json', // [!code highlight]
-      }, // [!code highlight]
-      shared: { // [!code highlight]
-        react: { // [!code highlight]
-          singleton: true, // [!code highlight]
-        }, // [!code highlight]
-        'react-dom': { // [!code highlight]
-          singleton: true, // [!code highlight]
-        }, // [!code highlight]
-      }, // [!code highlight]
-      // Enable this when the output of Rslib is build under 'production' mode, while the host app is 'development'. // [!code highlight]
-      // Reference: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs // [!code highlight]
-      shareStrategy: 'loaded-first', // [!code highlight]
-    }), // [!code highlight]
+    // [!code highlight:17]
+    pluginModuleFederation({
+      name: 'rsbuild_host',
+      remotes: {
+        rslib: 'rslib@http://localhost:3001/mf/mf-manifest.json',
+      },
+      shared: {
+        react: {
+          singleton: true,
+        },
+        'react-dom': {
+          singleton: true,
+        },
+      },
+      // Enable this when the output of Rslib is build under 'production' mode, while the host app is 'development'.
+      // Reference: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs
+      shareStrategy: 'loaded-first',
+    }),
   ],
 });
 ```
@@ -200,7 +201,8 @@ First, set up Storybook with the Rslib project. You can refer to the [Storybook 
        options: {},
      },
      addons: [
-       { // [!code highlight:20]
+       // [!code highlight:21]
+       {
          name: getAbsolutePath('storybook-addon-rslib'),
          options: {
            rslib: {
@@ -233,8 +235,9 @@ Import components from remote module.
 
 ```ts title="stories/index.stories.tsx"
 import React from 'react';
-// Load your remote module here, Storybook will act as the host app. // [!code highlight]
-import { Counter } from 'rslib-module'; // [!code highlight]
+// [!code highlight:2]
+// Load your remote module here, Storybook will act as the host app.
+import { Counter } from 'rslib-module';
 
 const Component = () => <Counter />;
 

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -38,6 +38,7 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     // ... other format
+    // [!code highlight:35]
     {
       format: 'mf',
       output: {

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -30,7 +30,7 @@ import { PackageManagerTabs } from '@theme';
 
 Then register the plugin in the `rslib.config.ts` file:
 
-```ts title='rslib.config.ts' {8-43}
+```ts title='rslib.config.ts'
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
@@ -118,7 +118,7 @@ with Hot Module Replacement (HMR).
 Set up the host app to consume the Rslib Module Federation library. Check out the [@module-federation/rsbuild-plugin
 ](https://www.npmjs.com/package/@module-federation/rsbuild-plugin) for more information.
 
-```ts title="rsbuild.config.ts" {8-24}
+```ts title="rsbuild.config.ts"
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
@@ -126,23 +126,23 @@ import { pluginReact } from '@rsbuild/plugin-react';
 export default defineConfig({
   plugins: [
     pluginReact(),
-    pluginModuleFederation({
-      name: 'rsbuild_host',
-      remotes: {
-        rslib: 'rslib@http://localhost:3001/mf/mf-manifest.json',
-      },
-      shared: {
-        react: {
-          singleton: true,
-        },
-        'react-dom': {
-          singleton: true,
-        },
-      },
-      // Enable this when the output of Rslib is build under 'production' mode, while the host app is 'development'.
-      // Reference: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs
-      shareStrategy: 'loaded-first',
-    }),
+    pluginModuleFederation({ // [!code highlight]
+      name: 'rsbuild_host', // [!code highlight]
+      remotes: { // [!code highlight]
+        rslib: 'rslib@http://localhost:3001/mf/mf-manifest.json', // [!code highlight]
+      }, // [!code highlight]
+      shared: { // [!code highlight]
+        react: { // [!code highlight]
+          singleton: true, // [!code highlight]
+        }, // [!code highlight]
+        'react-dom': { // [!code highlight]
+          singleton: true, // [!code highlight]
+        }, // [!code highlight]
+      }, // [!code highlight]
+      // Enable this when the output of Rslib is build under 'production' mode, while the host app is 'development'. // [!code highlight]
+      // Reference: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs // [!code highlight]
+      shareStrategy: 'loaded-first', // [!code highlight]
+    }), // [!code highlight]
   ],
 });
 ```
@@ -182,7 +182,7 @@ First, set up Storybook with the Rslib project. You can refer to the [Storybook 
 
 2. Then set up the Storybook configuration file `.storybook/main.ts`, specify the stories and addons, and set the framework with corresponding framework integration.
 
-   ```ts title=".storybook/main.ts" {18-38}
+   ```ts title=".storybook/main.ts"
    import { dirname, join } from 'node:path';
    import type { StorybookConfig } from 'storybook-react-rsbuild';
 
@@ -200,7 +200,7 @@ First, set up Storybook with the Rslib project. You can refer to the [Storybook 
        options: {},
      },
      addons: [
-       {
+       { // [!code highlight:20]
          name: getAbsolutePath('storybook-addon-rslib'),
          options: {
            rslib: {
@@ -231,10 +231,10 @@ First, set up Storybook with the Rslib project. You can refer to the [Storybook 
 
 Import components from remote module.
 
-```ts title="stories/index.stories.tsx" {2-3}
+```ts title="stories/index.stories.tsx"
 import React from 'react';
-// Load your remote module here, Storybook will act as the host app.
-import { Counter } from 'rslib-module';
+// Load your remote module here, Storybook will act as the host app. // [!code highlight]
+import { Counter } from 'rslib-module'; // [!code highlight]
 
 const Component = () => <Counter />;
 

--- a/website/docs/en/guide/advanced/output-compatibility.mdx
+++ b/website/docs/en/guide/advanced/output-compatibility.mdx
@@ -35,8 +35,8 @@ And install [core-js-pure](https://www.npmjs.com/package/core-js-pure) as the ru
 
 Configure the Babel plugin with polyfill options, set the [targets](https://babeljs.io/docs/options#targets) field to specify the target browser version.
 
-```ts title="rslib.config.ts" {1,11-24}
-import { pluginBabel } from '@rsbuild/plugin-babel';
+```ts title="rslib.config.ts"
+import { pluginBabel } from '@rsbuild/plugin-babel'; // [!code highlight]
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
@@ -46,20 +46,20 @@ export default defineConfig({
     },
   ],
   plugins: [
-    pluginBabel({
-      babelLoaderOptions: {
-        plugins: [
-          [
-            require('babel-plugin-polyfill-corejs3'),
-            {
-              method: 'usage-pure',
-              targets: { ie: '10' },
-              version: '3.29',
-            },
-          ],
-        ],
-      },
-    }),
+    pluginBabel({ // [!code highlight]
+      babelLoaderOptions: { // [!code highlight]
+        plugins: [ // [!code highlight]
+          [ // [!code highlight]
+            require('babel-plugin-polyfill-corejs3'), // [!code highlight]
+            { // [!code highlight]
+              method: 'usage-pure', // [!code highlight]
+              targets: { ie: '10' }, // [!code highlight]
+              version: '3.29', // [!code highlight]
+            }, // [!code highlight]
+          ], // [!code highlight]
+        ], // [!code highlight]
+      }, // [!code highlight]
+    }), // [!code highlight]
   ],
 });
 ```

--- a/website/docs/en/guide/advanced/output-compatibility.mdx
+++ b/website/docs/en/guide/advanced/output-compatibility.mdx
@@ -46,20 +46,21 @@ export default defineConfig({
     },
   ],
   plugins: [
-    pluginBabel({ // [!code highlight]
-      babelLoaderOptions: { // [!code highlight]
-        plugins: [ // [!code highlight]
-          [ // [!code highlight]
-            require('babel-plugin-polyfill-corejs3'), // [!code highlight]
-            { // [!code highlight]
-              method: 'usage-pure', // [!code highlight]
-              targets: { ie: '10' }, // [!code highlight]
-              version: '3.29', // [!code highlight]
-            }, // [!code highlight]
-          ], // [!code highlight]
-        ], // [!code highlight]
-      }, // [!code highlight]
-    }), // [!code highlight]
+    // [!code highlight:14]
+    pluginBabel({
+      babelLoaderOptions: {
+        plugins: [
+          [
+            require('babel-plugin-polyfill-corejs3'),
+            {
+              method: 'usage-pure',
+              targets: { ie: '10' },
+              version: '3.29',
+            },
+          ],
+        ],
+      },
+    }),
   ],
 });
 ```

--- a/website/docs/en/guide/basic/output-format.mdx
+++ b/website/docs/en/guide/basic/output-format.mdx
@@ -104,11 +104,12 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     {
-      format: 'umd', // [!code highlight]
-      umdName: 'RslibUmdExample', // [!code highlight]
+      // [!code highlight:6]
+      format: 'umd',
+      umdName: 'RslibUmdExample',
       output: {
         externals: {
-          react: 'React', // [!code highlight]
+          react: 'React',
         },
         distPath: {
           root: './dist/umd',

--- a/website/docs/en/guide/basic/output-format.mdx
+++ b/website/docs/en/guide/basic/output-format.mdx
@@ -97,18 +97,18 @@ The following Rslib config is an example to build a UMD library.
 - `output.externals.react: 'React'`: specify the external dependency `react` could be accessed by `window.React`.
 - `runtime: 'classic'`: use the classic runtime of React to support applications that using React version under 18.
 
-```ts title="rslib.config.ts" {7-12,22}
+```ts title="rslib.config.ts"
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
     {
-      format: 'umd',
-      umdName: 'RslibUmdExample',
+      format: 'umd', // [!code highlight]
+      umdName: 'RslibUmdExample', // [!code highlight]
       output: {
         externals: {
-          react: 'React',
+          react: 'React', // [!code highlight]
         },
         distPath: {
           root: './dist/umd',
@@ -122,7 +122,7 @@ export default defineConfig({
   plugins: [
     pluginReact({
       swcReactOptions: {
-        runtime: 'classic',
+        runtime: 'classic', // [!code highlight]
       },
     }),
   ],

--- a/website/docs/en/guide/solution/react.mdx
+++ b/website/docs/en/guide/solution/react.mdx
@@ -35,10 +35,11 @@ export default defineConfig({
   lib: [
     // ...
   ],
+  // [!code highlight:4]
   output: {
-    target: 'web', // [!code highlight]
+    target: 'web',
   },
-  plugins: [pluginReact(/** options here */)], // [!code highlight]
+  plugins: [pluginReact(/** options here */)],
 });
 ```
 
@@ -66,9 +67,10 @@ export default defineConfig({
   },
   plugins: [
     pluginReact({
-      swcReactOptions: { // [!code highlight]
-        runtime: 'classic', // [!code highlight]
-      }, // [!code highlight]
+      // [!code highlight:3]
+      swcReactOptions: {
+        runtime: 'classic',
+      },
     }),
   ],
 });
@@ -96,9 +98,10 @@ export default defineConfig({
   },
   plugins: [
     pluginReact({
-      swcReactOptions: { // [!code highlight]
-        importSource: '@emotion/react', // [!code highlight]
-      }, // [!code highlight]
+      // [!code highlight:3]
+      swcReactOptions: {
+        importSource: '@emotion/react',
+      },
     }),
   ],
 });

--- a/website/docs/en/guide/solution/react.mdx
+++ b/website/docs/en/guide/solution/react.mdx
@@ -27,18 +27,18 @@ To compile React (JSX and TSX), you need to register the Rsbuild [React Plugin](
 
 For example, register in `rslib.config.ts`:
 
-```ts title="rslib.config.ts" {2,8-11}
+```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
-import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginReact } from '@rsbuild/plugin-react'; // [!code highlight]
 
 export default defineConfig({
   lib: [
     // ...
   ],
   output: {
-    target: 'web',
+    target: 'web', // [!code highlight]
   },
-  plugins: [pluginReact(/** options here */)],
+  plugins: [pluginReact(/** options here */)], // [!code highlight]
 });
 ```
 
@@ -53,7 +53,7 @@ By default, Rsbuild uses the new JSX transform, which is `runtime: 'automatic'`.
 
 To change the JSX transform, you can pass the [swcReactOptions](https://rsbuild.dev/plugins/list/plugin-react#swcreactoptionsruntime) option to the React plugin. For example, to use the classic runtime:
 
-```ts title="rslib.config.ts" {13-15}
+```ts title="rslib.config.ts"
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
@@ -66,9 +66,9 @@ export default defineConfig({
   },
   plugins: [
     pluginReact({
-      swcReactOptions: {
-        runtime: 'classic',
-      },
+      swcReactOptions: { // [!code highlight]
+        runtime: 'classic', // [!code highlight]
+      }, // [!code highlight]
     }),
   ],
 });
@@ -83,7 +83,7 @@ When `runtime` is set to `'automatic'`, you can specify the import path of the J
 
 For example, when using [Emotion](https://emotion.sh/), you can set `importSource` to `'@emotion/react'`:
 
-```ts title="rslib.config.ts" {13-15}
+```ts title="rslib.config.ts"
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
@@ -96,9 +96,9 @@ export default defineConfig({
   },
   plugins: [
     pluginReact({
-      swcReactOptions: {
-        importSource: '@emotion/react',
-      },
+      swcReactOptions: { // [!code highlight]
+        importSource: '@emotion/react', // [!code highlight]
+      }, // [!code highlight]
     }),
   ],
 });

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -78,8 +78,9 @@ export default {
   lib: [
     {
       format: 'esm',
+      // [!code highlight:3]
       dts: {
-        bundle: true, // [!code highlight]
+        bundle: true,
       },
     },
   ],
@@ -111,8 +112,9 @@ export default {
   lib: [
     {
       format: 'esm',
+      // [!code highlight:3]
       dts: {
-        distPath: './dist-types', // [!code highlight]
+        distPath: './dist-types',
       },
     },
   ],
@@ -148,8 +150,9 @@ export default {
   lib: [
     {
       format: 'esm',
+      // [!code highlight:3]
       dts: {
-        abortOnError: false, // [!code highlight]
+        abortOnError: false,
       },
     },
   ],

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -26,12 +26,12 @@ type Dts =
 
 类型声明文件生成是一个可选功能，你可以设置 `dts: true` 来启用 [bundleless 类型](/guide/advanced/dts#bundleless-类型) 生成。
 
-```ts title="rslib.config.ts" {5}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'esm',
-      dts: true,
+      dts: true, // [!code highlight]
     },
   ],
 };
@@ -39,12 +39,12 @@ export default {
 
 如果你想要禁用类型声明文件生成，可以设置 `dts: false` 或者不指定 `dts` 选项。
 
-```ts title="rslib.config.ts" {5}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'esm',
-      dts: false,
+      dts: false, // [!code highlight]
     },
   ],
 };
@@ -73,13 +73,13 @@ import { PackageManagerTabs } from '@theme';
 
 2. 将 `dts.bundle` 设置为 `true`。
 
-```ts title="rslib.config.ts" {5-7}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'esm',
       dts: {
-        bundle: true,
+        bundle: true, // [!code highlight]
       },
     },
   ],
@@ -106,13 +106,13 @@ export default {
 
 #### 示例
 
-```ts title="rslib.config.ts" {5-7}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'esm',
       dts: {
-        distPath: './dist-types',
+        distPath: './dist-types', // [!code highlight]
       },
     },
   ],
@@ -143,13 +143,13 @@ export default {
 
 当 `abortOnError` 设置为 `false` 时（如下所示），即使代码中存在类型问题，构建仍然会成功。
 
-```ts title="rslib.config.ts" {5-7}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'esm',
       dts: {
-        abortOnError: false,
+        abortOnError: false, // [!code highlight]
       },
     },
   ],

--- a/website/docs/zh/config/lib/external-helpers.mdx
+++ b/website/docs/zh/config/lib/external-helpers.mdx
@@ -29,12 +29,12 @@ export default class FOO {
 
 当 `externalHelpers` 禁用时，输出的 JavaScript 将内联辅助函数。
 
-```ts title="rslib.config.ts" {5}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       syntax: 'es5',
-      externalHelpers: false,
+      externalHelpers: false, // [!code highlight]
     },
   ],
 };
@@ -42,7 +42,8 @@ export default {
 
 以下是输出的 JavaScript 文件，高亮部分是内联的辅助函数：
 
-```js title="index.js" {1-18}
+```js title="index.js"
+// [!code highlight:18]
 function _class_call_check(instance, Constructor) {
   if (!(instance instanceof Constructor))
     throw new TypeError('Cannot call a class as a function');
@@ -79,12 +80,12 @@ export { src_FOO as default };
 
 当启用 `externalHelpers` 时，输出的 JavaScript 将从外部模块 `@swc/helpers` 导入辅助函数。
 
-```ts title="rslib.config.ts" {5}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       syntax: 'es5',
-      externalHelpers: true,
+      externalHelpers: true, // [!code highlight]
     },
   ],
 };
@@ -92,7 +93,8 @@ export default {
 
 以下是输出的 JavaScript 文件，高亮部分是导入的辅助函数：
 
-```js title="index.js" {1-2}
+```js title="index.js"
+// [!code highlight:2]
 import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_class_call_check__ from '@swc/helpers/_/_class_call_check';
 import * as __WEBPACK_EXTERNAL_MODULE__swc_helpers_create_class__ from '@swc/helpers/_/_create_class';
 var src_FOO = /*#__PURE__*/ (function () {

--- a/website/docs/zh/config/lib/umd-name.mdx
+++ b/website/docs/zh/config/lib/umd-name.mdx
@@ -15,12 +15,12 @@ UMD 包的模块名称不能与全局变量名称冲突。
 
 UMD 包将会挂载到 `global.MyLibrary`。
 
-```ts title="rslib.config.ts" {5}
+```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'umd',
-      umdName: 'MyLibrary',
+      umdName: 'MyLibrary', // [!code highlight]
     },
   ],
 };

--- a/website/docs/zh/guide/advanced/json-files.mdx
+++ b/website/docs/zh/guide/advanced/json-files.mdx
@@ -240,19 +240,19 @@ Rslib 支持在不同的打包模式下，JSON / YAML / TOML 文件以不同的�
 
 例如下面的配置将会将 `src` 目录下的所有 JSON 文件按原样输出：
 
-```ts title="rslib.config.ts" {7,11-12}
+```ts title="rslib.config.ts"
 export default defineConfig({
   lib: [
     {
       bundle: false,
       source: {
         entry: {
-          index: ['./src/**', '!./src/**/*.json'],
+          index: ['./src/**', '!./src/**/*.json'], // [!code highlight]
         },
       },
       output: {
-        copy: [{ from: './**/*.json', context: './src' }],
-        externals: [/.*\.json$/],
+        copy: [{ from: './**/*.json', context: './src' }], // [!code highlight]
+        externals: [/.*\.json$/], // [!code highlight]
       },
     },
   ],

--- a/website/docs/zh/guide/advanced/json-files.mdx
+++ b/website/docs/zh/guide/advanced/json-files.mdx
@@ -251,8 +251,9 @@ export default defineConfig({
         },
       },
       output: {
-        copy: [{ from: './**/*.json', context: './src' }], // [!code highlight]
-        externals: [/.*\.json$/], // [!code highlight]
+        // [!code highlight:2]
+        copy: [{ from: './**/*.json', context: './src' }],
+        externals: [/.*\.json$/],
       },
     },
   ],

--- a/website/docs/zh/guide/advanced/module-federation.mdx
+++ b/website/docs/zh/guide/advanced/module-federation.mdx
@@ -30,7 +30,7 @@ import { PackageManagerTabs } from '@theme';
 
 然后在 `rslib.config.ts` 中注册插件:
 
-```ts title='rslib.config.ts' {8-43}
+```ts title='rslib.config.ts'
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
@@ -38,6 +38,7 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     // ... 其他 format
+    // [!code highlight:35]
     {
       format: 'mf',
       output: {
@@ -116,7 +117,7 @@ Rslib 支持宿主应用和 Rslib 模块联邦项目同时开发。
 设置宿主应用消费 Rslib 的模块联邦库。查看[@module-federation/rsbuild-plugin
 ](https://www.npmjs.com/package/@module-federation/rsbuild-plugin) 获取更多信息。
 
-```ts title="rsbuild.config.ts" {8-24}
+```ts title="rsbuild.config.ts"
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
@@ -124,23 +125,23 @@ import { pluginReact } from '@rsbuild/plugin-react';
 export default defineConfig({
   plugins: [
     pluginReact(),
-    pluginModuleFederation({
-      name: 'rsbuild_host',
-      remotes: {
-        rslib: 'rslib@http://localhost:3001/mf/mf-manifest.json',
-      },
-      shared: {
-        react: {
-          singleton: true,
-        },
-        'react-dom': {
-          singleton: true,
-        },
-      },
-      // 开启这个当 Rslib 产物为 'production' 模式， 但是宿主应用是 'development' 模式。
-      // 参考链接: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs
-      shareStrategy: 'loaded-first',
-    }),
+    pluginModuleFederation({ // [!code highlight]
+      name: 'rsbuild_host', // [!code highlight]
+      remotes: { // [!code highlight]
+        rslib: 'rslib@http://localhost:3001/mf/mf-manifest.json', // [!code highlight]
+      }, // [!code highlight]
+      shared: { // [!code highlight]
+        react: { // [!code highlight]
+          singleton: true, // [!code highlight]
+        }, // [!code highlight]
+        'react-dom': { // [!code highlight]
+          singleton: true, // [!code highlight]
+        }, // [!code highlight]
+      }, // [!code highlight]
+      // 开启这个当 Rslib 产物为 'production' 模式， 但是宿主应用是 'development' 模式。 // [!code highlight]
+      // 参考链接: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs // [!code highlight]
+      shareStrategy: 'loaded-first', // [!code highlight]
+    }), // [!code highlight]
   ],
 });
 ```
@@ -181,7 +182,7 @@ Rslib 支持使用 Storybook 开发 Rslib 模块联邦项目。
 
 2. 然后创建 Storybook 配置文件 `.storybook/main.ts`，指定 stories 和 addons，并设置 framework 和相应的 framework 集成。
 
-```ts title=".storybook/main.ts" {18-38}
+```ts title=".storybook/main.ts"
 import { dirname, join } from 'node:path';
 import type { StorybookConfig } from 'storybook-react-rsbuild';
 
@@ -199,7 +200,7 @@ const config: StorybookConfig = {
     options: {},
   },
   addons: [
-    {
+    { // [!code highlight:20]
       name: getAbsolutePath('storybook-addon-rslib'),
       options: {
         rslib: {
@@ -230,10 +231,10 @@ export default config;
 
 从远程模块引入组件
 
-```ts title="stories/index.stories.tsx" {2-3}
+```ts title="stories/index.stories.tsx"
 import React from 'react';
-// 在这里加载远程模块，Storybook 相当于宿主应用.
-import { Counter } from 'rslib-module';
+// 在这里加载远程模块，Storybook 相当于宿主应用. // [!code highlight]
+import { Counter } from 'rslib-module'; // [!code highlight]
 
 const Component = () => <Counter />;
 

--- a/website/docs/zh/guide/advanced/module-federation.mdx
+++ b/website/docs/zh/guide/advanced/module-federation.mdx
@@ -38,7 +38,7 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     // ... 其他 format
-    // [!code highlight:35]
+    // [!code highlight:37]
     {
       format: 'mf',
       output: {
@@ -125,23 +125,24 @@ import { pluginReact } from '@rsbuild/plugin-react';
 export default defineConfig({
   plugins: [
     pluginReact(),
-    pluginModuleFederation({ // [!code highlight]
-      name: 'rsbuild_host', // [!code highlight]
-      remotes: { // [!code highlight]
-        rslib: 'rslib@http://localhost:3001/mf/mf-manifest.json', // [!code highlight]
-      }, // [!code highlight]
-      shared: { // [!code highlight]
-        react: { // [!code highlight]
-          singleton: true, // [!code highlight]
-        }, // [!code highlight]
-        'react-dom': { // [!code highlight]
-          singleton: true, // [!code highlight]
-        }, // [!code highlight]
-      }, // [!code highlight]
-      // 开启这个当 Rslib 产物为 'production' 模式， 但是宿主应用是 'development' 模式。 // [!code highlight]
-      // 参考链接: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs // [!code highlight]
-      shareStrategy: 'loaded-first', // [!code highlight]
-    }), // [!code highlight]
+    // [!code highlight:17]
+    pluginModuleFederation({
+      name: 'rsbuild_host',
+      remotes: {
+        rslib: 'rslib@http://localhost:3001/mf/mf-manifest.json',
+      },
+      shared: {
+        react: {
+          singleton: true,
+        },
+        'react-dom': {
+          singleton: true,
+        },
+      },
+      // 开启这个当 Rslib 产物为 'production' 模式， 但是宿主应用是 'development' 模式。
+      // 参考链接: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs
+      shareStrategy: 'loaded-first',
+    }),
   ],
 });
 ```
@@ -200,7 +201,8 @@ const config: StorybookConfig = {
     options: {},
   },
   addons: [
-    { // [!code highlight:20]
+    // [!code highlight:21]
+    {
       name: getAbsolutePath('storybook-addon-rslib'),
       options: {
         rslib: {
@@ -233,8 +235,9 @@ export default config;
 
 ```ts title="stories/index.stories.tsx"
 import React from 'react';
-// 在这里加载远程模块，Storybook 相当于宿主应用. // [!code highlight]
-import { Counter } from 'rslib-module'; // [!code highlight]
+// [!code highlight:2]
+// 在这里加载远程模块，Storybook 相当于宿主应用.
+import { Counter } from 'rslib-module';
 
 const Component = () => <Counter />;
 

--- a/website/docs/zh/guide/advanced/output-compatibility.mdx
+++ b/website/docs/zh/guide/advanced/output-compatibility.mdx
@@ -35,8 +35,8 @@ polyfill 依赖于 Babel 注入 polyfill 代码，因此你需要安装 [Rsbuild
 
 配置 Babel 插件，设置 [targets](https://babeljs.io/docs/options#targets) 字段以指定目标浏览器版本。
 
-```ts title="rslib.config.ts" {1,11-24}
-import { pluginBabel } from '@rsbuild/plugin-babel';
+```ts title="rslib.config.ts"
+import { pluginBabel } from '@rsbuild/plugin-babel'; // [!code highlight]
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
@@ -46,6 +46,7 @@ export default defineConfig({
     },
   ],
   plugins: [
+    // [!code highlight:14]
     pluginBabel({
       babelLoaderOptions: {
         plugins: [

--- a/website/docs/zh/guide/basic/output-format.mdx
+++ b/website/docs/zh/guide/basic/output-format.mdx
@@ -99,11 +99,12 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     {
-      format: 'umd', // [!code highlight]
-      umdName: 'RslibUmdExample', // [!code highlight]
+      // [!code highlight:6]
+      format: 'umd',
+      umdName: 'RslibUmdExample',
       output: {
         externals: {
-          react: 'React', // [!code highlight]
+          react: 'React',
         },
         distPath: {
           root: './dist/umd',

--- a/website/docs/zh/guide/basic/output-format.mdx
+++ b/website/docs/zh/guide/basic/output-format.mdx
@@ -92,18 +92,18 @@ StackOverflow 上的详细回答：[什么是通用模块定义 (UMD)？](https:
 - `output.externals.react: 'React'`: 指定外部依赖 `react` 可以通过 `window.React` 访问。
 - `runtime: 'classic'`: 使用 React 的 classic 运行时，以支持使用 React 版本低于 18 的应用程序。
 
-```ts title="rslib.config.ts" {7-12,22}
+```ts title="rslib.config.ts"
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   lib: [
     {
-      format: 'umd',
-      umdName: 'RslibUmdExample',
+      format: 'umd', // [!code highlight]
+      umdName: 'RslibUmdExample', // [!code highlight]
       output: {
         externals: {
-          react: 'React',
+          react: 'React', // [!code highlight]
         },
         distPath: {
           root: './dist/umd',
@@ -117,7 +117,7 @@ export default defineConfig({
   plugins: [
     pluginReact({
       swcReactOptions: {
-        runtime: 'classic',
+        runtime: 'classic', // [!code highlight]
       },
     }),
   ],

--- a/website/docs/zh/guide/solution/react.mdx
+++ b/website/docs/zh/guide/solution/react.mdx
@@ -27,18 +27,18 @@ import { PackageManagerTabs } from '@theme';
 
 例如，在 `rslib.config.ts` 中注册:
 
-```ts title="rslib.config.ts" {2,8-11}
+```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
-import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginReact } from '@rsbuild/plugin-react'; // [!code highlight]
 
 export default defineConfig({
   lib: [
     // ...
   ],
   output: {
-    target: 'web',
+    target: 'web', // [!code highlight]
   },
-  plugins: [pluginReact(/** options here */)],
+  plugins: [pluginReact(/** options here */)], // [!code highlight]
 });
 ```
 
@@ -53,7 +53,7 @@ React 引入了一个 [新的 JSX transform](https://legacy.reactjs.org/blog/202
 
 要更改 JSX transform，可以传递 [swcReactOptions](https://rsbuild.dev/zh/plugins/list/plugin-react#swcreactoptionsruntime) 给 React plugin. 比如要使用 classic runtime 时:
 
-```ts title="rslib.config.ts" {13-15}
+```ts title="rslib.config.ts"
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
@@ -66,9 +66,9 @@ export default defineConfig({
   },
   plugins: [
     pluginReact({
-      swcReactOptions: {
-        runtime: 'classic',
-      },
+      swcReactOptions: { // [!code highlight]
+        runtime: 'classic', // [!code highlight]
+      }, // [!code highlight]
     }),
   ],
 });
@@ -83,7 +83,7 @@ export default defineConfig({
 
 例如，当使用 [Emotion](https://emotion.sh/)，你可以设置 `importSource` 为 `'@emotion/react'`:
 
-```ts title="rslib.config.ts" {13-15}
+```ts title="rslib.config.ts"
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
@@ -96,9 +96,9 @@ export default defineConfig({
   },
   plugins: [
     pluginReact({
-      swcReactOptions: {
-        importSource: '@emotion/react',
-      },
+      swcReactOptions: { // [!code highlight]
+        importSource: '@emotion/react', // [!code highlight]
+      }, // [!code highlight]
     }),
   ],
 });

--- a/website/docs/zh/guide/solution/react.mdx
+++ b/website/docs/zh/guide/solution/react.mdx
@@ -35,10 +35,11 @@ export default defineConfig({
   lib: [
     // ...
   ],
+  // [!code highlight:4]
   output: {
-    target: 'web', // [!code highlight]
+    target: 'web',
   },
-  plugins: [pluginReact(/** options here */)], // [!code highlight]
+  plugins: [pluginReact(/** options here */)],
 });
 ```
 
@@ -66,9 +67,10 @@ export default defineConfig({
   },
   plugins: [
     pluginReact({
-      swcReactOptions: { // [!code highlight]
-        runtime: 'classic', // [!code highlight]
-      }, // [!code highlight]
+      // [!code highlight:3]
+      swcReactOptions: {
+        runtime: 'classic',
+      },
     }),
   ],
 });
@@ -96,9 +98,10 @@ export default defineConfig({
   },
   plugins: [
     pluginReact({
-      swcReactOptions: { // [!code highlight]
-        importSource: '@emotion/react', // [!code highlight]
-      }, // [!code highlight]
+      // [!code highlight:3]
+      swcReactOptions: {
+        importSource: '@emotion/react',
+      },
     }),
   ],
 });

--- a/website/package.json
+++ b/website/package.json
@@ -12,15 +12,16 @@
     "@rsbuild/core": "1.3.15",
     "@rsbuild/plugin-sass": "^1.3.1",
     "@rslib/tsconfig": "workspace:*",
-    "@rspress/plugin-llms": "2.0.0-beta.3",
+    "@rspress/plugin-llms": "2.0.0-beta.5",
     "@rstack-dev/doc-ui": "1.8.0",
+    "@shikijs/transformers": "^3.4.0",
     "@types/node": "^22.8.1",
     "@types/react": "^19.1.3",
     "@types/react-dom": "^19.1.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "rsbuild-plugin-google-analytics": "1.0.3",
-    "rspress": "2.0.0-beta.3",
+    "rspress": "2.0.0-beta.5",
     "rspress-plugin-font-open-sans": "1.0.0"
   }
 }

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginLlms } from '@rspress/plugin-llms';
+import { transformerNotationHighlight } from '@shikijs/transformers';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
 import { defineConfig } from 'rspress/config';
@@ -18,6 +19,9 @@ export default defineConfig({
   logoText: 'Rslib',
   markdown: {
     checkDeadLinks: true,
+    shiki: {
+      transformers: [transformerNotationHighlight()],
+    },
   },
   search: {
     codeBlocks: true,

--- a/website/theme/components/RsbuildDocBadge.tsx
+++ b/website/theme/components/RsbuildDocBadge.tsx
@@ -15,7 +15,12 @@ export function RsbuildDocBadge({ path, text, alt }: Props) {
   const href = `https://rsbuild.dev${langPrefix}${path}`;
 
   return (
-    <Link href={href} target="_blank" rel="noreferrer">
+    <Link
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="rspress-toc-exclude"
+    >
       <Badge type="info">
         <img
           alt={alt || text}


### PR DESCRIPTION
## Summary

## Related Links

https://github.com/web-infra-dev/rspress/releases/tag/v2.0.0-beta.5

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
