### PR TITLE
feat: format default to `'esm'`

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1512,7 +1512,7 @@ async function composeLibRsbuildConfig(
   const syntaxConfig = composeSyntaxConfig(target, config?.syntax);
   const autoExternalConfig = composeAutoExternalConfig({
     bundle,
-    format: format,
+    format,
     autoExternal,
     pkgJson,
     userExternals: config.output?.externals,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1472,7 +1472,7 @@ async function composeLibRsbuildConfig(
     shims,
   );
   const formatConfig = composeFormatConfig({
-    format: format,
+    format,
     pkgJson: pkgJson!,
     bundle,
     umdName,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -215,7 +215,7 @@ export interface LibConfig extends EnvironmentConfig {
   id?: string;
   /**
    * Output format for the generated JavaScript files.
-   * @defaultValue `undefined`
+   * @defaultValue `'esm'`
    * @see {@link https://lib.rsbuild.dev/config/lib/format}
    */
   format?: Format;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -781,7 +781,11 @@ importers:
         specifier: ^4.17.16
         version: 4.17.16
 
-  tests/integration/format: {}
+  tests/integration/format/cjs-static-export: {}
+
+  tests/integration/format/default: {}
+
+  tests/integration/format/import-meta-url: {}
 
   tests/integration/json: {}
 

--- a/tests/integration/format/cjs-static-export/package.json
+++ b/tests/integration/format/cjs-static-export/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "format-cjs-static-export-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/format/default/package.json
+++ b/tests/integration/format/default/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "format-test",
+  "name": "format-default-test",
   "version": "1.0.0",
   "private": true,
   "type": "module"

--- a/tests/integration/format/default/rslib.config.ts
+++ b/tests/integration/format/default/rslib.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      output: {
+        distPath: {
+          root: './dist/bundle-esm',
+        },
+      },
+    }),
+    generateBundleCjsConfig({
+      output: {
+        distPath: {
+          root: './dist/bundle-cjs',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      bundle: false,
+      output: {
+        distPath: {
+          root: './dist/bundleless-esm',
+        },
+      },
+    }),
+    generateBundleCjsConfig({
+      bundle: false,
+      output: {
+        distPath: {
+          root: './dist/bundleless-cjs',
+        },
+      },
+    }),
+  ],
+});

--- a/tests/integration/format/default/src/foo.js
+++ b/tests/integration/format/default/src/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/tests/integration/format/default/src/index.js
+++ b/tests/integration/format/default/src/index.js
@@ -1,0 +1,3 @@
+import { foo } from './foo';
+
+export const str = 'hello' + foo + ' world';

--- a/tests/integration/format/import-meta-url/package.json
+++ b/tests/integration/format/import-meta-url/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "format-import-meta-url-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/format/index.test.ts
+++ b/tests/integration/format/index.test.ts
@@ -1,6 +1,54 @@
+import exp from 'node:constants';
 import path from 'node:path';
 import { buildAndGetResults } from 'test-helper';
 import { expect, test } from 'vitest';
+
+test('format default to esm', async () => {
+  const fixturePath = path.resolve(__dirname, 'default');
+  const { files, contents } = await buildAndGetResults({
+    fixturePath,
+  });
+
+  expect(files).toMatchInlineSnapshot(`
+    {
+      "cjs0": [
+        "<ROOT>/tests/integration/format/default/dist/bundle-cjs/index.cjs",
+      ],
+      "cjs1": [
+        "<ROOT>/tests/integration/format/default/dist/bundleless-cjs/foo.cjs",
+        "<ROOT>/tests/integration/format/default/dist/bundleless-cjs/index.cjs",
+      ],
+      "esm0": [
+        "<ROOT>/tests/integration/format/default/dist/bundle-esm/index.js",
+      ],
+      "esm1": [
+        "<ROOT>/tests/integration/format/default/dist/bundleless-esm/foo.js",
+        "<ROOT>/tests/integration/format/default/dist/bundleless-esm/index.js",
+      ],
+    }
+  `);
+
+  expect(contents.esm0).toMatchInlineSnapshot(`
+    {
+      "<ROOT>/tests/integration/format/default/dist/bundle-esm/index.js": "const foo = 'foo';
+    const str = 'hello' + foo + ' world';
+    export { str };
+    ",
+    }
+  `);
+
+  expect(contents.esm1).toMatchInlineSnapshot(`
+    {
+      "<ROOT>/tests/integration/format/default/dist/bundleless-esm/foo.js": "const foo = 'foo';
+    export { foo };
+    ",
+      "<ROOT>/tests/integration/format/default/dist/bundleless-esm/index.js": "import * as __WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__ from "./foo.js";
+    const str = 'hello' + __WEBPACK_EXTERNAL_MODULE__foo_js_fdf5aa2d__.foo + ' world';
+    export { str };
+    ",
+    }
+  `);
+});
 
 test('import.meta.url should be preserved', async () => {
   const fixturePath = path.resolve(__dirname, 'import-meta-url');

--- a/tests/integration/format/index.test.ts
+++ b/tests/integration/format/index.test.ts
@@ -1,4 +1,3 @@
-import exp from 'node:constants';
 import path from 'node:path';
 import { buildAndGetResults } from 'test-helper';
 import { expect, test } from 'vitest';

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -67,7 +67,7 @@ describe('minify config (mf)', () => {
     expect(mfExposeEntry).toMatchInlineSnapshot(`
       ""use strict";
       (globalThis["disable_minify"] = globalThis["disable_minify"] || []).push([["249"], {
-      729: (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+      759: (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
       __webpack_require__.r(__webpack_exports__);
       __webpack_require__.d(__webpack_exports__, {
         Button: () => (Button),

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -67,7 +67,7 @@ describe('minify config (mf)', () => {
     expect(mfExposeEntry).toMatchInlineSnapshot(`
       ""use strict";
       (globalThis["disable_minify"] = globalThis["disable_minify"] || []).push([["249"], {
-      759: (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+      729: (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
       __webpack_require__.r(__webpack_exports__);
       __webpack_require__.d(__webpack_exports__, {
         Button: () => (Button),

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -20,7 +20,6 @@ export function getCwdByExample(exampleName: string) {
 
 export function generateBundleEsmConfig(config: LibConfig = {}): LibConfig {
   const esmBasicConfig: LibConfig = {
-    format: 'esm',
     output: {
       distPath: {
         root: './dist/esm',
@@ -107,19 +106,19 @@ export async function getResults(
   let key = '';
 
   const formatCount: Record<Format, number> = rslibConfig.lib.reduce(
-    (acc, { format }) => {
-      acc[format!] = (acc[format!] ?? 0) + 1;
+    (acc, { format = 'esm' }) => {
+      acc[format] = (acc[format] ?? 0) + 1;
       return acc;
     },
     {} as Record<Format, number>,
   );
 
   for (const libConfig of rslibConfig.lib) {
-    const { format } = libConfig;
-    const currentFormatCount = formatCount[format!];
-    const currentFormatIndex = formatIndex[format!]++;
+    const { format = 'esm' } = libConfig;
+    const currentFormatCount = formatCount[format];
+    const currentFormatIndex = formatIndex[format]++;
 
-    key = currentFormatCount === 1 ? format! : `${format}${currentFormatIndex}`;
+    key = currentFormatCount === 1 ? format : `${format}${currentFormatIndex}`;
 
     let globFolder = '';
     if (type === 'js' || type === 'css') {

--- a/website/docs/en/config/lib/format.mdx
+++ b/website/docs/en/config/lib/format.mdx
@@ -1,8 +1,7 @@
 # lib.format
 
 - **Type:** `'esm' | 'cjs' | 'umd' | 'mf'`
-- **Default:** `undefined`
-- **Required**: true
+- **Default:** `'esm'`
 
 Specify the output format for the generated JavaScript output files.
 

--- a/website/docs/zh/config/lib/format.mdx
+++ b/website/docs/zh/config/lib/format.mdx
@@ -1,8 +1,7 @@
 # lib.format
 
 - **类型：** `'esm' | 'cjs' | 'umd' | 'mf'`
-- **默认值：** `undefined`
-- **必填：** 是
+- **默认值：** `'esm'`
 
 指定生成的 JavaScript 产物的输出格式。
 


### PR DESCRIPTION
## Summary

In this PR, `lib.format` is default from `undefined` to `'esm'` to simplify user configuration and encourage the use of pure esm package.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
