### PR TITLE
test: optimize test logs

### DIFF
--- a/tests/integration/cli/build-watch/build.test.ts
+++ b/tests/integration/cli/build-watch/build.test.ts
@@ -83,6 +83,9 @@ export default defineConfig({
       index: ['./test-temp-src/**'],
     },
   },
+  performance: {
+    printFileSize: false,
+  }
 });
 `,
     );

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -75,11 +75,13 @@ describe('dts when bundle: false', () => {
   });
 
   test('abortOnError: false', async () => {
+    const { restore } = proxyConsole();
     const fixturePath = join(__dirname, 'bundle-false', 'abort-on-error');
     const { isSuccess } = await buildAndGetResults({
       fixturePath,
       type: 'dts',
     });
+    restore();
 
     expect(isSuccess).toBe(true);
   });
@@ -243,10 +245,12 @@ describe('dts when bundle: true', () => {
 
   test('abortOnError: false', async () => {
     const fixturePath = join(__dirname, 'bundle', 'abort-on-error');
+    const { restore } = proxyConsole();
     const { isSuccess } = await buildAndGetResults({
       fixturePath,
       type: 'dts',
     });
+    restore();
 
     expect(isSuccess).toBe(true);
   });
@@ -478,10 +482,12 @@ describe('dts when build: true', () => {
 
   test('abortOnError: false', async () => {
     const fixturePath = join(__dirname, 'build', 'abort-on-error');
+    const { restore } = proxyConsole();
     const { isSuccess } = await buildAndGetResults({
       fixturePath,
       type: 'dts',
     });
+    restore();
 
     expect(isSuccess).toBe(true);
 
@@ -566,10 +572,12 @@ describe('dts when composite: true', () => {
 
   test('abortOnError: false', async () => {
     const fixturePath = join(__dirname, 'composite', 'abort-on-error');
+    const { restore } = proxyConsole();
     const { isSuccess } = await buildAndGetResults({
       fixturePath,
       type: 'dts',
     });
+    restore();
 
     expect(isSuccess).toBe(true);
 

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -6,13 +6,17 @@ import { composeModuleImportWarn } from '../../../packages/core/src/config';
 
 test('should fail to build when `output.target` is not "node"', async () => {
   const fixturePath = join(__dirname, 'browser');
+  const { restore } = proxyConsole();
   const build = buildAndGetResults({ fixturePath });
   await expect(build).rejects.toThrowError('Rspack build failed.');
+  restore();
 });
 
 test('auto externalize Node.js built-in modules when `output.target` is "node"', async () => {
   const fixturePath = join(__dirname, 'node');
+  const { restore } = proxyConsole();
   const { entries } = await buildAndGetResults({ fixturePath });
+  restore();
 
   for (const external of [
     'import * as __WEBPACK_EXTERNAL_MODULE_fs__ from "fs"',
@@ -70,7 +74,9 @@ test('should get warn when use require in ESM', async () => {
 
 test('require ESM from CJS', async () => {
   const fixturePath = join(__dirname, 'node');
+  const { restore } = proxyConsole();
   const { entryFiles } = await buildAndGetResults({ fixturePath });
+  restore();
   const baz = (await import(entryFiles.cjs)).baz;
   const bazValue = await baz();
   expect(bazValue).toBe('baz');

--- a/tests/integration/redirect/dts.test.ts
+++ b/tests/integration/redirect/dts.test.ts
@@ -7,7 +7,7 @@ let contents: Awaited<ReturnType<typeof buildAndGetResults>>['contents'];
 beforeAll(async () => {
   const fixturePath = path.resolve(__dirname, './dts');
   contents = (await buildAndGetResults({ fixturePath, type: 'dts' })).contents;
-}, 15000);
+}, 20000);
 
 test('redirect.dts.path: true with redirect.dts.extension: false - default', async () => {
   expect(contents.esm0).toMatchInlineSnapshot(`

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -191,6 +191,15 @@ export async function getResults(
   };
 }
 
+const updateConfigForTest = (rslibConfig: RslibConfig) => {
+  Object.assign(rslibConfig, {
+    performance: {
+      // Do not print file size in tests
+      printFileSize: false,
+    },
+  });
+};
+
 export async function rslibBuild({
   cwd,
   path,
@@ -242,6 +251,7 @@ export async function buildAndGetResults({
   const { rsbuildInstance, rslibConfig } = await rslibBuild({
     cwd: fixturePath,
     path: configPath,
+    modifyConfig: updateConfigForTest,
     lib,
   });
   const {


### PR DESCRIPTION
## Summary

1. Do not print file size when running tests.
2. Use `proxyConsole` to hide some logs in main process.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
