### PR TITLE
feat(create-rslib): syntax default to esnext

### DIFF
--- a/packages/create-rslib/fragments/base/node-dual-js/rslib.config.mjs
+++ b/packages/create-rslib/fragments/base/node-dual-js/rslib.config.mjs
@@ -4,11 +4,11 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
     {
       format: 'cjs',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
   ],
 });

--- a/packages/create-rslib/fragments/base/node-dual-ts/rslib.config.ts
+++ b/packages/create-rslib/fragments/base/node-dual-ts/rslib.config.ts
@@ -4,12 +4,12 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
       dts: true,
     },
     {
       format: 'cjs',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
   ],
 });

--- a/packages/create-rslib/fragments/base/node-esm-js/rslib.config.mjs
+++ b/packages/create-rslib/fragments/base/node-esm-js/rslib.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
   ],
 });

--- a/packages/create-rslib/fragments/base/node-esm-ts/rslib.config.ts
+++ b/packages/create-rslib/fragments/base/node-esm-ts/rslib.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
       dts: true,
     },
   ],

--- a/packages/create-rslib/template-[node-dual]-[]-js/rslib.config.mjs
+++ b/packages/create-rslib/template-[node-dual]-[]-js/rslib.config.mjs
@@ -4,11 +4,11 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
     {
       format: 'cjs',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
   ],
 });

--- a/packages/create-rslib/template-[node-dual]-[]-ts/rslib.config.ts
+++ b/packages/create-rslib/template-[node-dual]-[]-ts/rslib.config.ts
@@ -4,12 +4,12 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
       dts: true,
     },
     {
       format: 'cjs',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
   ],
 });

--- a/packages/create-rslib/template-[node-dual]-[vitest]-js/rslib.config.mjs
+++ b/packages/create-rslib/template-[node-dual]-[vitest]-js/rslib.config.mjs
@@ -4,11 +4,11 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
     {
       format: 'cjs',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
   ],
 });

--- a/packages/create-rslib/template-[node-dual]-[vitest]-ts/rslib.config.ts
+++ b/packages/create-rslib/template-[node-dual]-[vitest]-ts/rslib.config.ts
@@ -4,12 +4,12 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
       dts: true,
     },
     {
       format: 'cjs',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
   ],
 });

--- a/packages/create-rslib/template-[node-esm]-[]-js/rslib.config.mjs
+++ b/packages/create-rslib/template-[node-esm]-[]-js/rslib.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
   ],
 });

--- a/packages/create-rslib/template-[node-esm]-[]-ts/rslib.config.ts
+++ b/packages/create-rslib/template-[node-esm]-[]-ts/rslib.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
       dts: true,
     },
   ],

--- a/packages/create-rslib/template-[node-esm]-[vitest]-js/rslib.config.mjs
+++ b/packages/create-rslib/template-[node-esm]-[vitest]-js/rslib.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
     },
   ],
 });

--- a/packages/create-rslib/template-[node-esm]-[vitest]-ts/rslib.config.ts
+++ b/packages/create-rslib/template-[node-esm]-[vitest]-ts/rslib.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'esnext',
       dts: true,
     },
   ],


### PR DESCRIPTION
## Summary

Set `syntax` to `esnext` in `create-rslib` to align with the default value we set.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
