### PR TITLE
chore: throw error when using bundleless mode with mf format

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -680,6 +680,12 @@ const composeFormatConfig = ({
       return config;
     }
     case 'mf':
+      if (bundle === false) {
+        throw new Error(
+          'When using "mf" format, "bundle" must be set to "true". Since the default value for "bundle" is "true", so you can either explicitly set it to "true" or remove the field entirely.',
+        );
+      }
+
       return {
         dev: {
           writeToDisk: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -787,6 +787,8 @@ importers:
 
   tests/integration/format/import-meta-url: {}
 
+  tests/integration/format/mf-bundle-false: {}
+
   tests/integration/json: {}
 
   tests/integration/minify/config/disabled: {}

--- a/tests/integration/format/index.test.ts
+++ b/tests/integration/format/index.test.ts
@@ -100,3 +100,14 @@ test('CJS exports should be statically analyzable (cjs-module-lexer for Node.js)
     }
   `);
 });
+
+test('throw error when using mf with `bundle: false`', async () => {
+  const fixturePath = path.resolve(__dirname, 'mf-bundle-false');
+  const build = buildAndGetResults({
+    fixturePath,
+  });
+
+  await expect(build).rejects.toThrowErrorMatchingInlineSnapshot(
+    `[Error: When using "mf" format, "bundle" must be set to "true". Since the default value for "bundle" is "true", so you can either explicitly set it to "true" or remove the field entirely.]`,
+  );
+});

--- a/tests/integration/format/mf-bundle-false/package.json
+++ b/tests/integration/format/mf-bundle-false/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "format-mf-bundle-false-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/format/mf-bundle-false/rslib.config.ts
+++ b/tests/integration/format/mf-bundle-false/rslib.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleMFConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleMFConfig(
+      {
+        name: 'test',
+      },
+      {
+        bundle: false,
+      },
+    ),
+  ],
+});

--- a/tests/integration/format/mf-bundle-false/src/index.js
+++ b/tests/integration/format/mf-bundle-false/src/index.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';


### PR DESCRIPTION
## Summary

We should throw error when using mf format with bundleless mode.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
