### PR TITLE
feat(create-rslib): syntax default to node 18

### DIFF
--- a/packages/create-rslib/fragments/base/node-dual-js/rslib.config.mjs
+++ b/packages/create-rslib/fragments/base/node-dual-js/rslib.config.mjs
@@ -4,11 +4,11 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
     {
       format: 'cjs',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
   ],
 });

--- a/packages/create-rslib/fragments/base/node-dual-ts/rslib.config.ts
+++ b/packages/create-rslib/fragments/base/node-dual-ts/rslib.config.ts
@@ -4,12 +4,12 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
       dts: true,
     },
     {
       format: 'cjs',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
   ],
 });

--- a/packages/create-rslib/fragments/base/node-esm-js/rslib.config.mjs
+++ b/packages/create-rslib/fragments/base/node-esm-js/rslib.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
   ],
 });

--- a/packages/create-rslib/fragments/base/node-esm-ts/rslib.config.ts
+++ b/packages/create-rslib/fragments/base/node-esm-ts/rslib.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
       dts: true,
     },
   ],

--- a/packages/create-rslib/template-[node-dual]-[]-js/rslib.config.mjs
+++ b/packages/create-rslib/template-[node-dual]-[]-js/rslib.config.mjs
@@ -4,11 +4,11 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
     {
       format: 'cjs',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
   ],
 });

--- a/packages/create-rslib/template-[node-dual]-[]-ts/rslib.config.ts
+++ b/packages/create-rslib/template-[node-dual]-[]-ts/rslib.config.ts
@@ -4,12 +4,12 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
       dts: true,
     },
     {
       format: 'cjs',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
   ],
 });

--- a/packages/create-rslib/template-[node-dual]-[vitest]-js/rslib.config.mjs
+++ b/packages/create-rslib/template-[node-dual]-[vitest]-js/rslib.config.mjs
@@ -4,11 +4,11 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
     {
       format: 'cjs',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
   ],
 });

--- a/packages/create-rslib/template-[node-dual]-[vitest]-ts/rslib.config.ts
+++ b/packages/create-rslib/template-[node-dual]-[vitest]-ts/rslib.config.ts
@@ -4,12 +4,12 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
       dts: true,
     },
     {
       format: 'cjs',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
   ],
 });

--- a/packages/create-rslib/template-[node-esm]-[]-js/rslib.config.mjs
+++ b/packages/create-rslib/template-[node-esm]-[]-js/rslib.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
   ],
 });

--- a/packages/create-rslib/template-[node-esm]-[]-ts/rslib.config.ts
+++ b/packages/create-rslib/template-[node-esm]-[]-ts/rslib.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
       dts: true,
     },
   ],

--- a/packages/create-rslib/template-[node-esm]-[vitest]-js/rslib.config.mjs
+++ b/packages/create-rslib/template-[node-esm]-[vitest]-js/rslib.config.mjs
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
     },
   ],
 });

--- a/packages/create-rslib/template-[node-esm]-[vitest]-ts/rslib.config.ts
+++ b/packages/create-rslib/template-[node-esm]-[vitest]-ts/rslib.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'esnext',
+      syntax: ['node 18'],
       dts: true,
     },
   ],


### PR DESCRIPTION
## Summary

See https://github.com/web-infra-dev/rslib/pull/982#issuecomment-2876010743, in template, we need to align with usage in most sceniros, so we default syntax to browserlist `['node 18']`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
