### PR TITLE
docs: add Rstest to homepage

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,8 +1043,8 @@ importers:
         specifier: 2.0.0-beta.5
         version: 2.0.0-beta.5(rspress@2.0.0-beta.5(@types/react@19.1.3)(acorn@8.14.0)(webpack@5.98.0))
       '@rstack-dev/doc-ui':
-        specifier: 1.8.0
-        version: 1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 1.9.0
+        version: 1.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@shikijs/transformers':
         specifier: ^3.4.0
         version: 3.4.0
@@ -2586,8 +2586,8 @@ packages:
     resolution: {integrity: sha512-cgS/hQVF6q1HLcaGG79TMtenPeaRjp/1oUKZ9yr5YkhWYsAiVday0Ie4dtH98IVOCV9BW520GIBfcYGVyUwxLw==}
     engines: {node: '>=18.0.0'}
 
-  '@rstack-dev/doc-ui@1.8.0':
-    resolution: {integrity: sha512-ejQxDIX/nghX/k6g0Uhmvw/1Y2vNlMfA82Jb9zlhh8pwGQ4jwXTFIFwkfVW09NuLg2RlLOAONLPfrCYZ91x8Wg==}
+  '@rstack-dev/doc-ui@1.9.0':
+    resolution: {integrity: sha512-ybP6NKT+OHtHdF6xIfmAXKpPt/TSTXln205g1+VcqIXeMREzHwza5KJtwYOoOMFLoMbVh9sIq4dYy8OaX4EWFQ==}
 
   '@rushstack/node-core-library@5.13.1':
     resolution: {integrity: sha512-5yXhzPFGEkVc9Fu92wsNJ9jlvdwz4RNb2bMso+/+TH0nMm1jDDDsOIf4l8GAkPxGuwPw5DH24RliWVfSPhlW/Q==}
@@ -4265,8 +4265,8 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  framer-motion@12.6.5:
-    resolution: {integrity: sha512-MKvnWov0paNjvRJuIy6x418w23tFqRfS6CXHhZrCiSEpXVlo/F+usr8v4/3G6O0u7CpsaO1qop+v4Ip7PRCBqQ==}
+  framer-motion@12.11.3:
+    resolution: {integrity: sha512-ksUtDFBZtrbQFt4bEMFrFgo7camhmXcLeuylKQxEYSd9czkZ4tZmFROxWczWeu51WqC2m91ifpvgGCBLd0uviQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -5234,11 +5234,11 @@ packages:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
 
-  motion-dom@12.6.5:
-    resolution: {integrity: sha512-jpM9TQLXzYMWMJ7Ec7sAj0iis8oIuu6WvjI3yNKJLdrZyrsI/b2cRInDVL8dCl683zQQq19DpL9cSMP+k8T1NA==}
+  motion-dom@12.11.2:
+    resolution: {integrity: sha512-wZ396XNNTI9GOkyrr80wFSbZc1JbIHSHTbLdririSbkEgahWWKmsHzsxyxqBBvuBU/iaQWVu1YCjdpXYNfo2yQ==}
 
-  motion-utils@12.6.5:
-    resolution: {integrity: sha512-IsOeKsOF+FWBhxQEDFBO6ZYC8/jlidmVbbLpe9/lXSA9j9kzGIMUuIBx2SZY+0reAS0DjZZ1i7dJp4NHrjocPw==}
+  motion-utils@12.9.4:
+    resolution: {integrity: sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -8796,9 +8796,9 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       react-syntax-highlighter: 15.6.1(react@19.1.0)
 
-  '@rstack-dev/doc-ui@1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rstack-dev/doc-ui@1.9.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      framer-motion: 12.6.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      framer-motion: 12.11.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
@@ -10739,10 +10739,10 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  framer-motion@12.6.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  framer-motion@12.11.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      motion-dom: 12.6.5
-      motion-utils: 12.6.5
+      motion-dom: 12.11.2
+      motion-utils: 12.9.4
       tslib: 2.8.1
     optionalDependencies:
       react: 19.1.0
@@ -12043,11 +12043,11 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
-  motion-dom@12.6.5:
+  motion-dom@12.11.2:
     dependencies:
-      motion-utils: 12.6.5
+      motion-utils: 12.9.4
 
-  motion-utils@12.6.5: {}
+  motion-utils@12.9.4: {}
 
   mri@1.2.0: {}
 

--- a/website/i18n.json
+++ b/website/i18n.json
@@ -14,13 +14,5 @@
   "slogan": {
     "en": "Create JavaScript libraries in a simple and intuitive way",
     "zh": "以简单直观的方式创建 JavaScript 库"
-  },
-  "toolStackTitle": {
-    "en": "Tool Stack",
-    "zh": "工具栈"
-  },
-  "toolStackDesc": {
-    "en": "High-performance tool stack built around Rspack to boost modern web development",
-    "zh": "围绕 Rspack 打造的高性能工具栈，助力现代 Web 开发"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "@rslib/tsconfig": "workspace:*",
     "@rspress/plugin-llms": "2.0.0-beta.5",
     "@rspress/plugin-rss": "2.0.0-beta.5",
-    "@rstack-dev/doc-ui": "1.8.0",
+    "@rstack-dev/doc-ui": "1.9.0",
     "@shikijs/transformers": "^3.4.0",
     "@types/node": "^22.8.1",
     "@types/react": "^19.1.3",

--- a/website/theme/components/ToolStack.tsx
+++ b/website/theme/components/ToolStack.tsx
@@ -1,26 +1,12 @@
-import {
-  containerStyle,
-  descStyle,
-  innerContainerStyle,
-  titleAndDescStyle,
-  titleStyle,
-} from '@rstack-dev/doc-ui/section-style';
+import { containerStyle } from '@rstack-dev/doc-ui/section-style';
 import { ToolStack as BaseToolStack } from '@rstack-dev/doc-ui/tool-stack';
 import { useLang } from 'rspress/runtime';
-import { useI18n } from 'rspress/runtime';
 
 export function ToolStack() {
-  const t = useI18n<typeof import('i18n')>();
   const lang = useLang();
   return (
     <section className={containerStyle}>
-      <div className={innerContainerStyle}>
-        <div className={titleAndDescStyle}>
-          <h1 className={titleStyle}>{t('toolStackTitle')}</h1>
-          <p className={descStyle}>{t('toolStackDesc')}</p>
-        </div>
-        <BaseToolStack lang={lang} />
-      </div>
+      <BaseToolStack lang={lang} />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Update @rstack-dev/doc-ui to 1.9.0 to add Rstest to homepage.
- This update also includes some UI and text improvements.

Related: https://github.com/rspack-contrib/rstack-doc-ui/releases/tag/v1.9.0

## Before

![image](https://github.com/user-attachments/assets/ff30108d-35a8-4dc6-bbe0-fa8ebe792461)

## After

![image](https://github.com/user-attachments/assets/3b1839bf-6593-4545-8539-10d4273327d4)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
