### PR TITLE
docs: optimize `source.exclude` description

### DIFF
--- a/website/docs/en/config/rsbuild/source.mdx
+++ b/website/docs/en/config/rsbuild/source.mdx
@@ -52,7 +52,7 @@ Exclude JavaScript or TypeScript files that do not need to be transformed by [SW
 
 ::: note
 
-Files configured in `source.exclude` will not be translated by SWC, but the referenced files will still be bundled into the outputs.
+Files configured in `source.exclude` will not be transformed by SWC, but the referenced files will still be bundled into the outputs.
 
 If you want certain files not to be bundled into the outputs, you can use the following methods:
 

--- a/website/docs/en/config/rsbuild/source.mdx
+++ b/website/docs/en/config/rsbuild/source.mdx
@@ -48,7 +48,18 @@ Check out the [lib.bundle](/config/lib/bundle#set-entry) to learn more about how
 
 ## source.exclude <RsbuildDocBadge path="/config/source/exclude" text="source.exclude" />
 
-Specifies JavaScript/TypeScript files that do not need to be compiled.
+Exclude JavaScript or TypeScript files that do not need to be compiled by [SWC](https://rsbuild.dev/guide/configuration/swc).
+
+::: note
+
+Files configured in `source.exclude` will not be translated by SWC, but the referenced files will still be bundled into the outputs.
+
+If you want certain files not to be bundled into the outputs, you can use the following methods:
+
+- **bundle mode**: Use Rspack's [IgnorePlugin](https://rspack.dev/plugins/webpack/ignore-plugin).
+- **bundleless mode**: Use `source.entry` to configure the corresponding glob expression, refer to [Set entry](/config/lib/bundle#bundle-false).
+
+:::
 
 ## source.include <RsbuildDocBadge path="/config/source/include" text="source.include" />
 

--- a/website/docs/en/config/rsbuild/source.mdx
+++ b/website/docs/en/config/rsbuild/source.mdx
@@ -48,7 +48,7 @@ Check out the [lib.bundle](/config/lib/bundle#set-entry) to learn more about how
 
 ## source.exclude <RsbuildDocBadge path="/config/source/exclude" text="source.exclude" />
 
-Exclude JavaScript or TypeScript files that do not need to be compiled by [SWC](https://rsbuild.dev/guide/configuration/swc).
+Exclude JavaScript or TypeScript files that do not need to be transformed by [SWC](https://rsbuild.dev/guide/configuration/swc).
 
 ::: note
 

--- a/website/docs/zh/config/rsbuild/source.mdx
+++ b/website/docs/zh/config/rsbuild/source.mdx
@@ -47,7 +47,7 @@ const defaultEntry = {
 
 ## source.exclude <RsbuildDocBadge path="/config/source/exclude" text="source.exclude" />
 
-排除不需要被 [SWC](https://rsbuild.dev/zh/guide/configuration/swc) 编译的 JavaScript 或 TypeScript 文件。
+排除不需要被 [SWC](https://rsbuild.dev/zh/guide/configuration/swc) 转译的 JavaScript 或 TypeScript 文件。
 
 ::: note
 

--- a/website/docs/zh/config/rsbuild/source.mdx
+++ b/website/docs/zh/config/rsbuild/source.mdx
@@ -47,7 +47,18 @@ const defaultEntry = {
 
 ## source.exclude <RsbuildDocBadge path="/config/source/exclude" text="source.exclude" />
 
-指定不需要编译的 JavaScript/TypeScript 文件。
+排除不需要被 [SWC](https://rsbuild.dev/zh/guide/configuration/swc) 编译的 JavaScript 或 TypeScript 文件。
+
+::: note
+
+在 `source.exclude` 中配置的文件不会经过 SWC 转译，但被引用的文件仍然会被打包到产物中。
+
+如果你希望某些文件不被打包到产物中，可以使用以下方法：
+
+- **bundle 模式**：使用 Rspack 的 [IgnorePlugin](https://rspack.dev/zh/plugins/webpack/ignore-plugin)。
+- **bundleless 模式**：使用 `source.entry` 配置相应的 glob 表达式，参考 [设置入口](/config/lib/bundle#bundle-false)。
+
+:::
 
 ## source.include <RsbuildDocBadge path="/config/source/include" text="source.include" />
 


### PR DESCRIPTION
## Summary

This pull request updates the documentation for the `source.exclude` configuration in both English and Chinese to provide more clarity and additional guidance. The changes include a detailed explanation of how excluded files are handled and alternative methods for excluding files from the output.

Documentation updates:

* [`website/docs/en/config/rsbuild/source.mdx`](diffhunk://#diff-1f8928b3b498e56bd57bfb986458699df0a4be504e487364d3a0e355010c7579L51-R62): Enhanced the description of `source.exclude` to clarify that excluded files are not translated by SWC but are still bundled into the output. Added a note with methods to prevent files from being bundled, including using Rspack's `IgnorePlugin` in bundle mode or configuring `source.entry` in bundleless mode.
* [`website/docs/zh/config/rsbuild/source.mdx`](diffhunk://#diff-22bc930e740adffeae317d5fad8e524ce56e4e04a87a2b2b65a350abb8f7a24eL50-R61): Updated the Chinese documentation for `source.exclude` with the same enhancements, including the explanation of SWC behavior and alternative methods for excluding files.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
