### PR TITLE
docs: add how to preserve module variables

### DIFF
--- a/website/docs/en/config/rsbuild/source.mdx
+++ b/website/docs/en/config/rsbuild/source.mdx
@@ -17,7 +17,7 @@ If [experimentalDecorators](https://www.typescriptlang.org/tsconfig/#experimenta
 
 ## source.define <RsbuildDocBadge path="/config/source/define" text="source.define" />
 
-Replaces variables in your code with other values or expressions at compile time. This can be useful for allowing different behavior between development builds and production builds.
+Replaces variables in your code with other values or expressions at compile time. This can be useful for injecting env variables and other information to the code during build time.
 
 ## source.entry <RsbuildDocBadge path="/config/source/entry" text="source.entry" />
 

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -114,7 +114,7 @@ export default {
 };
 ```
 
-## Others
+## Miscellaneous
 
 ### How to preserve module variables such as `__webpack_hash__` in the source code when generating outputs?
 

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -35,6 +35,33 @@ export default defineConfig({
 });
 ```
 
+## Output related
+
+### How to preserve module variables such as `__webpack_hash__` in the source code when generating outputs?
+
+Rslib based on Rspack will transform [module variables](https://rspack.dev/api/runtime-api/module-variables) like `__webpack_hash__`, `__webpack_nonce__`, `__webpack_public_path__`, etc. to runtime code containing `__webpack_require__` by default during build process. If you need to preserve these module variables in the outputs, you can configure [source.define](/config/rsbuild/source#sourcedefine) as follows:
+
+1. Replace the module variables that need to be preserved in the source code with a unique name, such as `__webpack_hash__` with `WEBPACK_HASH`, `__webpack_nonce__` with `WEBPACK_NONCE`, `__webpack_public_path__` with `WEBPACK_PUBLIC_PATH`, etc.
+
+```ts
+const isUpdateAvailable = () => lastCompilationHash !== __webpack_hash__; // [!code --]
+const isUpdateAvailable = () => lastCompilationHash !== WEBPACK_HASH; // [!code ++]
+```
+
+2. Add the module variables that need to be preserved in `source.define`. The key of the passed configuration object is the replaced variable name in the source code, and the value is the module variable that needs to be preserved in the outputs.
+
+```ts title="rslib.config.ts"
+export default defineConfig({
+  source: {
+    define: {
+      WEBPACK_HASH: '__webpack_hash__',
+      WEBPACK_NONCE: '__webpack_nonce__',
+      WEBPACK_PUBLIC_PATH: '__webpack_public_path__',
+    },
+  },
+});
+```
+
 ## Code minification
 
 ### How to preserve all comments in the output files?
@@ -48,7 +75,7 @@ By default, Rslib uses SWC to remove comments. The corresponding SWC [jsc.minify
 }
 ```
 
-This will only preserve some legal comments and annotations. If you want to preserve all comments, you can refer to the following configuration
+This will only preserve some legal comments and annotations. If you want to preserve all comments, you can refer to the following configuration:
 
 ```ts title="rslib.config.ts"
 export default {

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -35,33 +35,6 @@ export default defineConfig({
 });
 ```
 
-## Output related
-
-### How to preserve module variables such as `__webpack_hash__` in the source code when generating outputs?
-
-Rslib based on Rspack will transform [module variables](https://rspack.dev/api/runtime-api/module-variables) like `__webpack_hash__`, `__webpack_nonce__`, `__webpack_public_path__`, etc. to runtime code containing `__webpack_require__` by default during build process. If you need to preserve these module variables in the outputs, you can configure [source.define](/config/rsbuild/source#sourcedefine) as follows:
-
-1. Replace the module variables that need to be preserved in the source code with a unique name, such as `__webpack_hash__` with `WEBPACK_HASH`, `__webpack_nonce__` with `WEBPACK_NONCE`, `__webpack_public_path__` with `WEBPACK_PUBLIC_PATH`, etc.
-
-```ts
-const isUpdateAvailable = () => lastCompilationHash !== __webpack_hash__; // [!code --]
-const isUpdateAvailable = () => lastCompilationHash !== WEBPACK_HASH; // [!code ++]
-```
-
-2. Add the module variables that need to be preserved in `source.define`. The key of the passed configuration object is the replaced variable name in the source code, and the value is the module variable that needs to be preserved in the outputs.
-
-```ts title="rslib.config.ts"
-export default defineConfig({
-  source: {
-    define: {
-      WEBPACK_HASH: '__webpack_hash__',
-      WEBPACK_NONCE: '__webpack_nonce__',
-      WEBPACK_PUBLIC_PATH: '__webpack_public_path__',
-    },
-  },
-});
-```
-
 ## Code minification
 
 ### How to preserve all comments in the output files?
@@ -139,4 +112,31 @@ export default {
     externals: ['@types/react'],
   },
 };
+```
+
+## Others
+
+### How to preserve module variables such as `__webpack_hash__` in the source code when generating outputs?
+
+Rslib based on Rspack will transform [module variables](https://rspack.dev/api/runtime-api/module-variables) like `__webpack_hash__`, `__webpack_nonce__`, `__webpack_public_path__`, etc. to runtime code containing `__webpack_require__` by default during build process. If you need to preserve these module variables in the outputs, you can configure [source.define](/config/rsbuild/source#sourcedefine) as follows:
+
+1. Replace the module variables that need to be preserved in the source code with a unique name, such as `__webpack_hash__` with `WEBPACK_HASH`, `__webpack_nonce__` with `WEBPACK_NONCE`, `__webpack_public_path__` with `WEBPACK_PUBLIC_PATH`, etc.
+
+```ts
+const isUpdateAvailable = () => lastCompilationHash !== __webpack_hash__; // [!code --]
+const isUpdateAvailable = () => lastCompilationHash !== WEBPACK_HASH; // [!code ++]
+```
+
+2. Add the module variables that need to be preserved in `source.define`. The key of the passed configuration object is the replaced variable name in the source code, and the value is the module variable that needs to be preserved in the outputs.
+
+```ts title="rslib.config.ts"
+export default defineConfig({
+  source: {
+    define: {
+      WEBPACK_HASH: '__webpack_hash__',
+      WEBPACK_NONCE: '__webpack_nonce__',
+      WEBPACK_PUBLIC_PATH: '__webpack_public_path__',
+    },
+  },
+});
 ```

--- a/website/docs/zh/config/rsbuild/source.mdx
+++ b/website/docs/zh/config/rsbuild/source.mdx
@@ -16,7 +16,7 @@ import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
 
 ## source.define <RsbuildDocBadge path="/config/source/define" text="source.define" />
 
-构建时将代码中的变量替换成其它值或者表达式，可以用于在代码逻辑中区分开发模式与生产模式等场景。
+构建时将代码中的变量替换成其它值或者表达式，可以用于在构建时向代码注入环境变量等信息。
 
 ## source.entry <RsbuildDocBadge path="/config/source/entry" text="source.entry" />
 

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -35,6 +35,33 @@ export default defineConfig({
 });
 ```
 
+## 产物相关
+
+### 如何在生成产物时保留源码中的 `__webpack_hash__` 等模块变量？
+
+Rslib 底层使用的 Rspack，在构建时会默认将 `__webpack_hash__`、`__webpack_nonce__`、`__webpack_public_path__` 等 [模块变量](https://rspack.dev/zh/api/runtime-api/module-variables) 转换为包含 `__webpack_require__` 的运行时代码。如果你需要在产物中保留这些模块变量，可以通过配置 [source.define](/config/rsbuild/source#sourcedefine) 来实现，如下所示：
+
+1. 在源码中将需要保留的模块变量替换为一个特征名称，如 `__webpack_hash__` 替换为 `WEBPACK_HASH`，`__webpack_nonce__` 替换为 `WEBPACK_NONCE`，`__webpack_public_path__` 替换为 `WEBPACK_PUBLIC_PATH` 等。
+
+```ts
+const isUpdateAvailable = () => lastCompilationHash !== __webpack_hash__; // [!code --]
+const isUpdateAvailable = () => lastCompilationHash !== WEBPACK_HASH; // [!code ++]
+```
+
+2. 在 `source.define` 中添加需要保留的模块变量，传入的配置对象的键名是源码中替换后的变量名称，值是需要在产物中保留的模块变量。
+
+```ts title="rslib.config.ts"
+export default defineConfig({
+  source: {
+    define: {
+      WEBPACK_HASH: '__webpack_hash__',
+      WEBPACK_NONCE: '__webpack_nonce__',
+      WEBPACK_PUBLIC_PATH: '__webpack_public_path__',
+    },
+  },
+});
+```
+
 ## 代码压缩
 
 ### 如何保留产物文件代码中的注释？
@@ -48,7 +75,7 @@ export default defineConfig({
 }
 ```
 
-这将仅保留部分 legal 注释及 annotations。如果你想保留所有注释，可以参考如下配置
+这将仅保留部分 legal 注释及 annotations。如果你想保留所有注释，可以参考如下配置：
 
 ```ts title="rslib.config.ts"
 export default {

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -35,33 +35,6 @@ export default defineConfig({
 });
 ```
 
-## 产物相关
-
-### 如何在生成产物时保留源码中的 `__webpack_hash__` 等模块变量？
-
-Rslib 底层使用的 Rspack，在构建时会默认将 `__webpack_hash__`、`__webpack_nonce__`、`__webpack_public_path__` 等 [模块变量](https://rspack.dev/zh/api/runtime-api/module-variables) 转换为包含 `__webpack_require__` 的运行时代码。如果你需要在产物中保留这些模块变量，可以通过配置 [source.define](/config/rsbuild/source#sourcedefine) 来实现，如下所示：
-
-1. 在源码中将需要保留的模块变量替换为一个特征名称，如 `__webpack_hash__` 替换为 `WEBPACK_HASH`，`__webpack_nonce__` 替换为 `WEBPACK_NONCE`，`__webpack_public_path__` 替换为 `WEBPACK_PUBLIC_PATH` 等。
-
-```ts
-const isUpdateAvailable = () => lastCompilationHash !== __webpack_hash__; // [!code --]
-const isUpdateAvailable = () => lastCompilationHash !== WEBPACK_HASH; // [!code ++]
-```
-
-2. 在 `source.define` 中添加需要保留的模块变量，传入的配置对象的键名是源码中替换后的变量名称，值是需要在产物中保留的模块变量。
-
-```ts title="rslib.config.ts"
-export default defineConfig({
-  source: {
-    define: {
-      WEBPACK_HASH: '__webpack_hash__',
-      WEBPACK_NONCE: '__webpack_nonce__',
-      WEBPACK_PUBLIC_PATH: '__webpack_public_path__',
-    },
-  },
-});
-```
-
 ## 代码压缩
 
 ### 如何保留产物文件代码中的注释？
@@ -139,4 +112,31 @@ export default {
     externals: ['@types/react'],
   },
 };
+```
+
+## 其他
+
+### 如何在生成产物时保留源码中的 `__webpack_hash__` 等模块变量？
+
+Rslib 底层使用的 Rspack，在构建时会默认将 `__webpack_hash__`、`__webpack_nonce__`、`__webpack_public_path__` 等 [模块变量](https://rspack.dev/zh/api/runtime-api/module-variables) 转换为包含 `__webpack_require__` 的运行时代码。如果你需要在产物中保留这些模块变量，可以通过配置 [source.define](/config/rsbuild/source#sourcedefine) 来实现，如下所示：
+
+1. 在源码中将需要保留的模块变量替换为一个特征名称，如 `__webpack_hash__` 替换为 `WEBPACK_HASH`，`__webpack_nonce__` 替换为 `WEBPACK_NONCE`，`__webpack_public_path__` 替换为 `WEBPACK_PUBLIC_PATH` 等。
+
+```ts
+const isUpdateAvailable = () => lastCompilationHash !== __webpack_hash__; // [!code --]
+const isUpdateAvailable = () => lastCompilationHash !== WEBPACK_HASH; // [!code ++]
+```
+
+2. 在 `source.define` 中添加需要保留的模块变量，传入的配置对象的键名是源码中替换后的变量名称，值是需要在产物中保留的模块变量。
+
+```ts title="rslib.config.ts"
+export default defineConfig({
+  source: {
+    define: {
+      WEBPACK_HASH: '__webpack_hash__',
+      WEBPACK_NONCE: '__webpack_nonce__',
+      WEBPACK_PUBLIC_PATH: '__webpack_public_path__',
+    },
+  },
+});
 ```

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -2,7 +2,10 @@ import path from 'node:path';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginLlms } from '@rspress/plugin-llms';
 import { pluginRss } from '@rspress/plugin-rss';
-import { transformerNotationHighlight } from '@shikijs/transformers';
+import {
+  transformerNotationDiff,
+  transformerNotationHighlight,
+} from '@shikijs/transformers';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
@@ -53,7 +56,7 @@ export default defineConfig({
   markdown: {
     checkDeadLinks: true,
     shiki: {
-      transformers: [transformerNotationHighlight()],
+      transformers: [transformerNotationHighlight(), transformerNotationDiff()],
     },
   },
   search: {


### PR DESCRIPTION
## Summary

This pull request introduces several documentation updates and a minor configuration enhancement. The documentation changes improve clarity and add new examples for preserving module variables during builds, while the configuration update adds a new transformer for handling notation diffs in markdown processing.

### Documentation Updates:

* Updated the description of `source.define` in both English (`website/docs/en/config/rsbuild/source.mdx`) and Chinese (`website/docs/zh/config/rsbuild/source.mdx`) to highlight its use for injecting environment variables during build time. [[1]](diffhunk://#diff-1f8928b3b498e56bd57bfb986458699df0a4be504e487364d3a0e355010c7579L20-R20) [[2]](diffhunk://#diff-22bc930e740adffeae317d5fad8e524ce56e4e04a87a2b2b65a350abb8f7a24eL19-R19)
* Added a new FAQ section in both English (`website/docs/en/guide/faq/features.mdx`) and Chinese (`website/docs/zh/guide/faq/features.mdx`) explaining how to preserve module variables like `__webpack_hash__` in build outputs using `source.define`. [[1]](diffhunk://#diff-d2069aa9cc6c8ac25a412229b8dd2c2db0e5e0fa47d39419403e01a25be60d11R38-R64) [[2]](diffhunk://#diff-493b8a0236936d5e03b414398243d388719f2f032aa7905f5c9156c53ad0913fR38-R64)
* Fixed minor grammatical issues in the FAQ sections for preserving comments in both English and Chinese documentation. [[1]](diffhunk://#diff-d2069aa9cc6c8ac25a412229b8dd2c2db0e5e0fa47d39419403e01a25be60d11L51-R78) [[2]](diffhunk://#diff-493b8a0236936d5e03b414398243d388719f2f032aa7905f5c9156c53ad0913fL51-R78)

### Configuration Enhancement:

* Added the `transformerNotationDiff` transformer to the markdown configuration in `website/rspress.config.ts` to support notation diffs alongside notation highlights. [[1]](diffhunk://#diff-ac9159c101c501657108310a713e6f3f24644489b77c8340d9122dab8469c7c7L5-R8) [[2]](diffhunk://#diff-ac9159c101c501657108310a713e6f3f24644489b77c8340d9122dab8469c7c7L56-R59)

## Related Links

#1000 
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
