### PR TITLE
chore(renovate): update Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,7 +41,7 @@
     },
     {
       groupName: 'types',
-      matchPackageNames: ['/^@types//'],
+      matchPackageNames: ['/^@types/'],
       groupSlug: 'types',
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,36 +15,33 @@
       rangeStrategy: 'bump',
     },
     {
-      groupName: 'babel',
-      matchPackageNames: ['**babel**'],
+      groupName: 'Babel',
+      matchPackageNames: ['/babel/'],
       groupSlug: 'babel',
     },
     {
-      groupName: 'rsbuild',
-      matchPackageNames: ['@rsbuild/**'],
+      groupName: 'Rsbuild',
+      matchPackageNames: ['/rsbuild/'],
       groupSlug: 'rsbuild',
-      extends: ['schedule:daily'],
     },
     {
-      groupName: 'rslib',
-      matchPackageNames: ['rslib'],
+      groupName: 'Rslib',
+      matchPackageNames: ['/rslib/'],
       groupSlug: 'rslib',
-      extends: ['schedule:daily'],
     },
     {
-      groupName: 'rspress',
-      matchPackageNames: ['@rspress/**'],
+      groupName: 'Rspress',
+      matchPackageNames: ['/rspress/'],
       groupSlug: 'rspress',
-      extends: ['schedule:daily'],
     },
     {
-      groupName: 'modern-js',
-      matchPackageNames: ['@modern-js/**'],
-      groupSlug: 'modern-js',
+      groupName: 'Module Federation',
+      matchPackageNames: ['/module-federation/'],
+      groupSlug: 'module-federation',
     },
     {
       groupName: 'types',
-      matchPackageNames: ['@types/**'],
+      matchPackageNames: ['/^@types//'],
       groupSlug: 'types',
     },
     {
@@ -58,14 +55,13 @@
       matchDepTypes: ['peerDependencies'],
       enabled: false,
     },
+    {
+      matchPackageNames: ['pnpm'],
+      matchUpdateTypes: ['patch'],
+      enabled: false,
+    },
   ],
   ignoreDeps: [
-    // manually update some packages
-    'pnpm',
-    '@rspack/core',
-    '@rspack/core-canary',
-    // align Node.js version minimum requirements
-    '@types/node',
     'node',
     // umd tests need to lock this version
     'react-18',


### PR DESCRIPTION
## Summary

Allow to update `@types/node` and non-patch `pnpm` version.

This pull request updates the `.github/renovate.json5` file to improve package grouping and dependency management. Key changes include standardizing naming conventions for package groups, modifying match patterns for better accuracy, and revising the handling of specific dependencies.

### Improvements to package grouping:

* Updated group names to use consistent capitalization (e.g., `Babel`, `Rsbuild`, `Rspress`) and replaced wildcard match patterns with regex patterns for better precision.
* Renamed the `modern-js` group to `Module Federation` and updated its match pattern to align with the new naming convention.

### Dependency management updates:

* Added a new configuration to disable patch updates for the `pnpm` package by specifying it in the `matchPackageNames` and `matchUpdateTypes` fields.
* Removed several dependencies (`pnpm`, `@rspack/core`, `@rspack/core-canary`, `@types/node`) from the `ignoreDeps` list, likely indicating a shift in how these are managed.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
