### PR TITLE
feat: support `umdName` of array and object type

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -565,7 +565,7 @@ const composeFormatConfig = ({
   format: Format;
   pkgJson: PkgJson;
   bundle?: boolean;
-  umdName?: string;
+  umdName?: Rspack.LibraryName;
 }): EnvironmentConfig => {
   const jsParserOptions = {
     cjs: {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -297,7 +297,7 @@ export interface LibConfig extends EnvironmentConfig {
    * @defaultValue `undefined`
    * @see {@link https://lib.rsbuild.dev/config/lib/umd-name}
    */
-  umdName?: string;
+  umdName?: Rspack.LibraryName;
   /**
    * The base directory of the output files.
    * @defaultValue `undefined`

--- a/tests/integration/umd-library-name/index.test.ts
+++ b/tests/integration/umd-library-name/index.test.ts
@@ -17,8 +17,15 @@ test('correct read UMD name from CommonJS', async () => {
     globalThis: mockGlobalThis,
   });
 
-  vm.runInContext(entries.umd, context);
+  vm.runInContext(entries.umd0!, context);
 
   // @ts-expect-error
   expect(await mockGlobalThis.MyLibrary.fn('ok')).toBe('DEBUG:1.2.3/ok');
+
+  vm.runInContext(entries.umd1!, context);
+
+  // @ts-expect-error
+  expect(await mockGlobalThis.MyLibrary1.MyLibrary2.fn('ok')).toBe(
+    'DEBUG:1.2.3/ok',
+  );
 });

--- a/tests/integration/umd-library-name/index.test.ts
+++ b/tests/integration/umd-library-name/index.test.ts
@@ -13,7 +13,7 @@ test('correct read UMD name from CommonJS', async () => {
       version: '1.2.3',
     },
   };
-  const context = vm.createContext({
+  let context = vm.createContext({
     globalThis: mockGlobalThis,
   });
 
@@ -22,10 +22,12 @@ test('correct read UMD name from CommonJS', async () => {
   // @ts-expect-error
   expect(await mockGlobalThis.MyLibrary.fn('ok')).toBe('DEBUG:1.2.3/ok');
 
+  context = vm.createContext({
+    globalThis: mockGlobalThis,
+  });
+
   vm.runInContext(entries.umd1!, context);
 
   // @ts-expect-error
-  expect(await mockGlobalThis.MyLibrary1.MyLibrary2.fn('ok')).toBe(
-    'DEBUG:1.2.3/ok',
-  );
+  expect(await mockGlobalThis.MyLibrary.Utils.fn('ok')).toBe('DEBUG:1.2.3/ok');
 });

--- a/tests/integration/umd-library-name/rslib.config.ts
+++ b/tests/integration/umd-library-name/rslib.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
       },
     }),
     generateBundleUmdConfig({
-      umdName: ['MyLibrary1', 'MyLibrary2'],
+      umdName: ['MyLibrary', 'Utils'],
       output: {
         distPath: {
           root: './dist/array',

--- a/tests/integration/umd-library-name/rslib.config.ts
+++ b/tests/integration/umd-library-name/rslib.config.ts
@@ -5,6 +5,19 @@ export default defineConfig({
   lib: [
     generateBundleUmdConfig({
       umdName: 'MyLibrary',
+      output: {
+        distPath: {
+          root: './dist/string',
+        },
+      },
+    }),
+    generateBundleUmdConfig({
+      umdName: ['MyLibrary1', 'MyLibrary2'],
+      output: {
+        distPath: {
+          root: './dist/array',
+        },
+      },
     }),
   ],
   source: {

--- a/website/docs/en/config/lib/index.mdx
+++ b/website/docs/en/config/lib/index.mdx
@@ -15,7 +15,7 @@ interface LibConfig extends EnvironmentConfig {
   footer?: BannerAndFooter;
   shims?: Shims;
   dts?: Dts;
-  umdName?: string;
+  umdName?: Rspack.LibraryName;
 }
 
 interface RslibConfig extends RsbuildConfig {

--- a/website/docs/en/config/lib/umd-name.mdx
+++ b/website/docs/en/config/lib/umd-name.mdx
@@ -13,7 +13,7 @@ The module name of the UMD bundle must not conflict with the global variable nam
 
 ## Example
 
-- Mount the UMD bundle to `globalThis.MyLibrary`.
+- Mount the UMD bundle to `global.MyLibrary`.
 
 ```ts title="rslib.config.ts"
 export default {
@@ -26,7 +26,7 @@ export default {
 };
 ```
 
-- Mount the UMD bundle to `globalThis.MyLibrary1.MyLibrary2`.
+- Mount the UMD bundle to `global.MyLibrary1.MyLibrary2`.
 
 ```ts title="rslib.config.ts"
 export default {

--- a/website/docs/en/config/lib/umd-name.mdx
+++ b/website/docs/en/config/lib/umd-name.mdx
@@ -1,6 +1,6 @@
 # lib.umdName
 
-- **Type:** `string`
+- **Type:** `string | string[] | { amd?: string, commonjs?: string, root?: string | string[] }`
 - **Default:** `undefined`
 
 The export name of the [UMD](/guide/basic/output-format#umd) bundle.
@@ -13,7 +13,7 @@ The module name of the UMD bundle must not conflict with the global variable nam
 
 ## Example
 
-The UMD bundle will be mounted to `global.MyLibrary`.
+- Mount the UMD bundle to `globalThis.MyLibrary`.
 
 ```ts title="rslib.config.ts"
 export default {
@@ -21,6 +21,19 @@ export default {
     {
       format: 'umd',
       umdName: 'MyLibrary', // [!code highlight]
+    },
+  ],
+};
+```
+
+- Mount the UMD bundle to `globalThis.MyLibrary1.MyLibrary2`.
+
+```ts title="rslib.config.ts"
+export default {
+  lib: [
+    {
+      format: 'umd',
+      umdName: ['MyLibrary1', 'MyLibrary2'], // [!code highlight]
     },
   ],
 };

--- a/website/docs/en/config/lib/umd-name.mdx
+++ b/website/docs/en/config/lib/umd-name.mdx
@@ -26,14 +26,14 @@ export default {
 };
 ```
 
-- Mount the UMD bundle to `global.MyLibrary1.MyLibrary2`.
+- Mount the UMD bundle to `global.MyLibrary.Utils`.
 
 ```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'umd',
-      umdName: ['MyLibrary1', 'MyLibrary2'], // [!code highlight]
+      umdName: ['MyLibrary', 'Utils'], // [!code highlight]
     },
   ],
 };

--- a/website/docs/zh/config/lib/index.mdx
+++ b/website/docs/zh/config/lib/index.mdx
@@ -15,7 +15,7 @@ interface LibConfig extends EnvironmentConfig {
   footer?: BannerAndFooter;
   shims?: Shims;
   dts?: Dts;
-  umdName?: string;
+  umdName?: Rspack.LibraryName;
 }
 
 interface RslibConfig extends RsbuildConfig {

--- a/website/docs/zh/config/lib/umd-name.mdx
+++ b/website/docs/zh/config/lib/umd-name.mdx
@@ -13,7 +13,7 @@ UMD 包的模块名称不能与全局变量名称冲突。
 
 ## 示例
 
-- 将 UMD 包挂载到 `globalThis.MyLibrary`。
+- 将 UMD 包挂载到 `global.MyLibrary`。
 
 ```ts title="rslib.config.ts"
 export default {
@@ -26,7 +26,7 @@ export default {
 };
 ```
 
-- 将 UMD 包挂载到 `globalThis.MyLibrary1.MyLibrary2`。
+- 将 UMD 包挂载到 `global.MyLibrary1.MyLibrary2`。
 
 ```ts title="rslib.config.ts"
 export default {

--- a/website/docs/zh/config/lib/umd-name.mdx
+++ b/website/docs/zh/config/lib/umd-name.mdx
@@ -26,14 +26,14 @@ export default {
 };
 ```
 
-- 将 UMD 包挂载到 `global.MyLibrary1.MyLibrary2`。
+- 将 UMD 包挂载到 `global.MyLibrary.Utils`。
 
 ```ts title="rslib.config.ts"
 export default {
   lib: [
     {
       format: 'umd',
-      umdName: ['MyLibrary1', 'MyLibrary2'], // [!code highlight]
+      umdName: ['MyLibrary', 'Utils'], // [!code highlight]
     },
   ],
 };

--- a/website/docs/zh/config/lib/umd-name.mdx
+++ b/website/docs/zh/config/lib/umd-name.mdx
@@ -1,6 +1,6 @@
 # lib.umdName
 
-- **类型：** `string`
+- **类型：** `string | string[] | { amd?: string, commonjs?: string, root?: string | string[] }`
 - **默认值：** `undefined`
 
 [UMD](/guide/basic/output-format#umd) 包的导出名称。
@@ -13,7 +13,7 @@ UMD 包的模块名称不能与全局变量名称冲突。
 
 ## 示例
 
-UMD 包将会挂载到 `global.MyLibrary`。
+- 将 UMD 包挂载到 `globalThis.MyLibrary`。
 
 ```ts title="rslib.config.ts"
 export default {
@@ -21,6 +21,19 @@ export default {
     {
       format: 'umd',
       umdName: 'MyLibrary', // [!code highlight]
+    },
+  ],
+};
+```
+
+- 将 UMD 包挂载到 `globalThis.MyLibrary1.MyLibrary2`。
+
+```ts title="rslib.config.ts"
+export default {
+  lib: [
+    {
+      format: 'umd',
+      umdName: ['MyLibrary1', 'MyLibrary2'], // [!code highlight]
     },
   ],
 };


### PR DESCRIPTION
## Summary

support `umdName` of array and object type to keep align with `Rspack.LibraryName`.

## Related Links

close: #1017

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
