### PR TITLE
chore(deps): change @rsbuild/core from caret (^) to tilde (~) range

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.14.1",
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rsbuild/plugin-react": "^1.3.1",
     "@types/react": "^19.1.5",
     "@types/react-dom": "^19.1.5",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.14.1",
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rsbuild/plugin-react": "^1.3.1",
     "@types/react": "^19.1.5",
     "@types/react-dom": "^19.1.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "rsbuild-plugin-dts": "workspace:*",
     "tinyglobby": "^0.2.14"
   },

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",
     "@storybook/addon-links": "^8.6.14",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",
     "@storybook/addon-links": "^8.6.14",

--- a/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",
     "@storybook/addon-links": "^8.6.14",

--- a/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",
     "@storybook/addon-links": "^8.6.14",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rsbuild/plugin-react": "^1.3.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.14",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rsbuild/plugin-react": "^1.3.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.14",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -17,7 +17,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rsbuild/plugin-react": "^1.3.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.14",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rsbuild/plugin-react": "^1.3.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.14",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",

--- a/packages/create-rslib/template-[vue]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-js/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",

--- a/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rslib/core": "workspace:*",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.52.8",
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rslib/tsconfig": "workspace:*",
     "rsbuild-plugin-publint": "^0.3.2",
     "rslib": "npm:@rslib/core@0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1(@rsbuild/core@1.3.21)(@rspack/core@1.3.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@rsbuild/core':
-        specifier: ^1.3.21
+        specifier: ~1.3.21
         version: 1.3.21
       '@rsbuild/plugin-react':
         specifier: ^1.3.1
@@ -160,7 +160,7 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1(@rsbuild/core@1.3.21)(@rspack/core@1.3.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@rsbuild/core':
-        specifier: ^1.3.21
+        specifier: ~1.3.21
         version: 1.3.21
       '@rsbuild/plugin-react':
         specifier: ^1.3.1
@@ -334,7 +334,7 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ^1.3.21
+        specifier: ~1.3.21
         version: 1.3.21
       rsbuild-plugin-dts:
         specifier: workspace:*
@@ -439,7 +439,7 @@ importers:
         specifier: ^7.52.8
         version: 7.52.8(@types/node@22.15.21)
       '@rsbuild/core':
-        specifier: ^1.3.21
+        specifier: ~1.3.21
         version: 1.3.21
       '@rslib/tsconfig':
         specifier: workspace:*
@@ -475,7 +475,7 @@ importers:
         specifier: 1.52.0
         version: 1.52.0
       '@rsbuild/core':
-        specifier: ^1.3.21
+        specifier: ~1.3.21
         version: 1.3.21
       '@rsbuild/plugin-less':
         specifier: ^1.2.4
@@ -1090,7 +1090,7 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: ^1.3.21
+        specifier: ~1.3.21
         version: 1.3.21
       '@rsbuild/plugin-sass':
         specifier: ^1.3.1

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^0.14.1",
     "@playwright/test": "1.52.0",
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rsbuild/plugin-less": "^1.2.4",
     "@rsbuild/plugin-react": "^1.3.1",
     "@rsbuild/plugin-sass": "^1.3.1",

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "rspress preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "^1.3.21",
+    "@rsbuild/core": "~1.3.21",
     "@rsbuild/plugin-sass": "^1.3.1",
     "@rslib/tsconfig": "workspace:*",
     "@rspress/plugin-algolia": "2.0.0-beta.7",


### PR DESCRIPTION
## Summary

Change `@rsbuild/core` from caret (^) to tilde (~) range in storybook template to ensure users only automatically accept patch-level updates to prevent potential minor version breaking changes causing by SWC.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
