### PR TITLE
docs: update Rslib website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following diagram illustrates the relationship between Rslib and other tools
 
 ## 📚 Getting started
 
-To get started with Rslib, see the [Quick Start](https://rslib.rs/guide/start/quick-start).
+To get started with Rslib, see the [Quick start](https://rslib.rs/guide/start/quick-start).
 
 ## 🦀 Rstack
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following diagram illustrates the relationship between Rslib and other tools
 
 ## 📚 Getting started
 
-To get started with Rslib, see the [Quick Start](https://lib.rsbuild.dev/guide/start/quick-start).
+To get started with Rslib, see the [Quick Start](https://rslib.rs/guide/start/quick-start).
 
 ## 🦀 Rstack
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,7 @@ Rslib 基于 Rsbuild 实现，并完全复用 Rsbuild 的能力和生态系统�
 
 ## 📚 快速上手
 
-你可以参考 [快速上手](https://lib.rsbuild.dev/zh/guide/start/quick-start) 来开始体验 Rslib。
+你可以参考 [快速上手](https://rslib.rs/zh/guide/start/quick-start) 来开始体验 Rslib。
 
 ## 🦀 Rstack
 

--- a/examples/module-federation/mf-host/rsbuild.config.ts
+++ b/examples/module-federation/mf-host/rsbuild.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         },
       },
       // Enable this when the output of Rslib is build under 'production' mode, while the host app is 'development'.
-      // Reference: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs
+      // Reference: https://rslib.rs/guide/advanced/module-federation#faqs
       shareStrategy: 'loaded-first',
     }),
   ],

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@ Rslib is a library development tool powered by [Rsbuild](https://rsbuild.dev). I
 
 ## Documentation
 
-https://lib.rsbuild.dev/
+https://rslib.rs/
 
 ## Contributing
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@rslib/core",
   "version": "0.9.0",
   "description": "The Rsbuild-based library development tool.",
-  "homepage": "https://lib.rsbuild.dev",
+  "homepage": "https://rslib.rs",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rslib/issues"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1043,7 +1043,7 @@ const composeEntryConfig = async (
     throw new Error(
       `The ${color.cyan('source.entry')} configuration should be an object, but received ${typeof entries}: ${color.cyan(
         entries,
-      )}. Checkout ${color.green('https://lib.rsbuild.dev/config/rsbuild/source#sourceentry')} for more details.`,
+      )}. Checkout ${color.green('https://rslib.rs/config/rsbuild/source#sourceentry')} for more details.`,
     );
   }
 
@@ -1054,7 +1054,7 @@ const composeEntryConfig = async (
         ? entry
         : path.resolve(root, entry);
       const isDirLike = path.extname(entryAbsPath) === '';
-      const dirError = `Glob pattern ${color.cyan(`"${entry}"`)} is not supported when "bundle" is "true", considering "bundle" to "false" to use bundleless mode, or specify a file entry to bundle. See ${color.green('https://lib.rsbuild.dev/guide/basic/output-structure')} for more details.`;
+      const dirError = `Glob pattern ${color.cyan(`"${entry}"`)} is not supported when "bundle" is "true", considering "bundle" to "false" to use bundleless mode, or specify a file entry to bundle. See ${color.green('https://rslib.rs/guide/basic/output-structure')} for more details.`;
 
       if (fs.existsSync(entryAbsPath)) {
         const stats = fs.statSync(entryAbsPath);

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -52,31 +52,31 @@ export type Dts =
       /**
        * Whether to bundle the declaration files.
        * @defaultValue `false`
-       * @see {@link https://lib.rsbuild.dev/config/lib/dts#dtsbundle}
+       * @see {@link https://rslib.rs/config/lib/dts#dtsbundle}
        */
       bundle?: boolean;
       /**
        * The output directory of declaration files.
-       * @defaultValue {@link https://lib.rsbuild.dev/config/lib/dts#default-value}
-       * @see {@link https://lib.rsbuild.dev/config/lib/dts#dtsdistpath}
+       * @defaultValue {@link https://rslib.rs/config/lib/dts#default-value}
+       * @see {@link https://rslib.rs/config/lib/dts#dtsdistpath}
        */
       distPath?: string;
       /**
        * Whether to generate declaration files with building the project references.
        * @defaultValue `false`
-       * @see {@link https://lib.rsbuild.dev/config/lib/dts#dtsbuild}
+       * @see {@link https://rslib.rs/config/lib/dts#dtsbuild}
        */
       build?: boolean;
       /**
        * Whether to abort the build process when an error occurs during declaration files generation.
        * @defaultValue `true`
-       * @see {@link https://lib.rsbuild.dev/config/lib/dts#dtsabortonerror}
+       * @see {@link https://rslib.rs/config/lib/dts#dtsabortonerror}
        */
       abortOnError?: boolean;
       /**
        * Whether to automatically set the declaration file extension based on the {@link format} option.
        * @defaultValue `false`
-       * @see {@link https://lib.rsbuild.dev/config/lib/dts#dtsautoextension}
+       * @see {@link https://rslib.rs/config/lib/dts#dtsautoextension}
        */
       autoExtension?: boolean;
     }
@@ -88,25 +88,25 @@ export type AutoExternal =
       /**
        * Whether to automatically externalize dependencies of type `dependencies`.
        * @defaultValue `true`
-       * @see {@link https://lib.rsbuild.dev/config/lib/auto-external#autoexternaldependencies}
+       * @see {@link https://rslib.rs/config/lib/auto-external#autoexternaldependencies}
        */
       dependencies?: boolean;
       /**
        * Whether to automatically externalize dependencies of type `optionalDependencies`.
        * @defaultValue `true`
-       * @see {@link https://lib.rsbuild.dev/config/lib/auto-external#autoexternaloptionaldependencies}
+       * @see {@link https://rslib.rs/config/lib/auto-external#autoexternaloptionaldependencies}
        */
       optionalDependencies?: boolean;
       /**
        * Whether to automatically externalize dependencies of type `peerDependencies`.
        * @defaultValue `true`
-       * @see {@link https://lib.rsbuild.dev/config/lib/auto-external#autoexternalpeerdependencies}
+       * @see {@link https://rslib.rs/config/lib/auto-external#autoexternalpeerdependencies}
        */
       peerDependencies?: boolean;
       /**
        * Whether to automatically externalize dependencies of type `devDependencies`.
        * @defaultValue `false`
-       * @see {@link https://lib.rsbuild.dev/config/lib/auto-external#autoexternaldevdependencies}
+       * @see {@link https://rslib.rs/config/lib/auto-external#autoexternaldevdependencies}
        */
       devDependencies?: boolean;
     };
@@ -120,37 +120,37 @@ export type BannerAndFooter = {
 export type Shims = {
   /**
    * Configure the shims for CommonJS output.
-   * @see {@link https://lib.rsbuild.dev/config/lib/shims#shimscjs}
+   * @see {@link https://rslib.rs/config/lib/shims#shimscjs}
    */
   cjs?: {
     /**
      * Whether to inject shims for the `import.meta.url` in CommonJS output.
      * @defaultValue `true`
-     * @see {@link https://lib.rsbuild.dev/config/lib/shims#shimscjsimportmetaurl}
+     * @see {@link https://rslib.rs/config/lib/shims#shimscjsimportmetaurl}
      */
     'import.meta.url'?: boolean;
   };
   /**
    * Configure the shims for ESM output.
-   * @see {@link https://lib.rsbuild.dev/config/lib/shims#shimsesm}
+   * @see {@link https://rslib.rs/config/lib/shims#shimsesm}
    */
   esm?: {
     /**
      * Whether to inject shims for the global `__filename` of CommonJS in ESM output.
      * @defaultValue `false`
-     * @see {@link https://lib.rsbuild.dev/config/lib/shims#shimsesm__filename}
+     * @see {@link https://rslib.rs/config/lib/shims#shimsesm__filename}
      */
     __filename?: boolean;
     /**
      * Whether to inject shims for the global `__dirname` of CommonJS in ESM output.
      * @defaultValue `false`
-     * @see {@link https://lib.rsbuild.dev/config/lib/shims#shimsesm__dirname}
+     * @see {@link https://rslib.rs/config/lib/shims#shimsesm__dirname}
      */
     __dirname?: boolean;
     /**
      * Whether to inject shims for the global `require` of CommonJS in ESM output.
      * @defaultValue `false`
-     * @see {@link https://lib.rsbuild.dev/config/lib/shims#shimsesmrequire}
+     * @see {@link https://rslib.rs/config/lib/shims#shimsesmrequire}
      */
     require?: boolean;
   };
@@ -210,61 +210,61 @@ export interface LibConfig extends EnvironmentConfig {
   /**
    * The unique identifier of the library.
    * @defaultValue `undefined`
-   * @see {@link https://lib.rsbuild.dev/config/lib/id}
+   * @see {@link https://rslib.rs/config/lib/id}
    */
   id?: string;
   /**
    * Output format for the generated JavaScript files.
    * @defaultValue `'esm'`
-   * @see {@link https://lib.rsbuild.dev/config/lib/format}
+   * @see {@link https://rslib.rs/config/lib/format}
    */
   format?: Format;
   /**
    * Whether to bundle the library.
    * @defaultValue `true`
-   * @see {@link https://lib.rsbuild.dev/config/lib/bundle}
+   * @see {@link https://rslib.rs/config/lib/bundle}
    */
   bundle?: boolean;
   /**
    * Whether to automatically set the file extension based on {@link format} option in the JavaScript output files.
    * @defaultValue `true`
-   * @see {@link https://lib.rsbuild.dev/config/lib/auto-extension}
+   * @see {@link https://rslib.rs/config/lib/auto-extension}
    */
   autoExtension?: boolean;
   /**
    * Whether to automatically externalize dependencies of different dependency types and do not bundle them.
    * @defaultValue `true` when {@link format} is `cjs` or `esm`, `false` when {@link format} is `umd` or `mf`.
-   * @see {@link https://lib.rsbuild.dev/config/lib/auto-external}
+   * @see {@link https://rslib.rs/config/lib/auto-external}
    */
   autoExternal?: AutoExternal;
   /**
    * Configure the redirect of the import paths, applicable {@link bundle} is set to `false`.
    * @defaultValue `{}`
-   * @see {@link https://lib.rsbuild.dev/config/lib/redirect}
+   * @see {@link https://rslib.rs/config/lib/redirect}
    */
   redirect?: Redirect;
   /**
    * Configure the syntax to which JavaScript and CSS will be downgraded.
    * @defaultValue `'esnext'`
-   * @see {@link https://lib.rsbuild.dev/config/lib/syntax}
+   * @see {@link https://rslib.rs/config/lib/syntax}
    */
   syntax?: Syntax;
   /**
    * Whether to import SWC helper functions from `@swc/helpers` instead of inlining them.
    * @defaultValue `false`
-   * @see {@link https://lib.rsbuild.dev/config/lib/external-helpers}
+   * @see {@link https://rslib.rs/config/lib/external-helpers}
    */
   externalHelpers?: boolean;
   /**
    * Inject content into the top of each JavaScript, CSS or declaration file.
    * @defaultValue `{}`
-   * @see {@link https://lib.rsbuild.dev/config/lib/banner}
+   * @see {@link https://rslib.rs/config/lib/banner}
    */
   banner?: BannerAndFooter;
   /**
    * Inject content into the bottom of each JavaScript, CSS or declaration file.
    * @defaultValue `{}`
-   * @see {@link https://lib.rsbuild.dev/config/lib/footer}
+   * @see {@link https://rslib.rs/config/lib/footer}
    */
   footer?: BannerAndFooter;
   /**
@@ -283,25 +283,25 @@ export interface LibConfig extends EnvironmentConfig {
    *   },
    * };
    * ```
-   * @see {@link https://lib.rsbuild.dev/config/lib/shims}
+   * @see {@link https://rslib.rs/config/lib/shims}
    */
   shims?: Shims;
   /**
    * Configure the generation of the TypeScript declaration files.
    * @defaultValue `false`
-   * @see {@link https://lib.rsbuild.dev/config/lib/dts}
+   * @see {@link https://rslib.rs/config/lib/dts}
    */
   dts?: Dts;
   /**
    * The export name of the UMD bundle.
    * @defaultValue `undefined`
-   * @see {@link https://lib.rsbuild.dev/config/lib/umd-name}
+   * @see {@link https://rslib.rs/config/lib/umd-name}
    */
   umdName?: Rspack.LibraryName;
   /**
    * The base directory of the output files.
    * @defaultValue `undefined`
-   * @see {@link https://lib.rsbuild.dev/config/lib/out-base}
+   * @see {@link https://rslib.rs/config/lib/out-base}
    */
   outBase?: string;
   /**
@@ -328,7 +328,7 @@ interface RslibOutputConfig extends OutputConfig {
    * When minify is not specified, Rslib will use a sane default for minify options.
    * The default options will only perform dead code elimination and unused code elimination.
    *
-   * @see {@link https://lib.rsbuild.dev/config/rsbuild/output#outputminify}
+   * @see {@link https://rslib.rs/config/rsbuild/output#outputminify}
    */
   minify?: OutputConfig['minify'];
 }

--- a/packages/create-rslib/README.md
+++ b/packages/create-rslib/README.md
@@ -8,7 +8,7 @@ Rslib is a library development tool powered by [Rsbuild](https://rsbuild.dev). I
 
 ## Documentation
 
-https://lib.rsbuild.dev/
+https://rslib.rs/
 
 ## Contributing
 

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -2,7 +2,7 @@
   "name": "create-rslib",
   "version": "0.9.0",
   "description": "Create a new Rslib project",
-  "homepage": "https://lib.rsbuild.dev",
+  "homepage": "https://rslib.rs",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/web-infra-dev/rslib.git",

--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -8,7 +8,7 @@ An [Rsbuild plugin](https://www.npmjs.com/package/rsbuild-plugin-dts) to emit de
 
 ## Using in Rslib
 
-Read [Declaration files](https://lib.rsbuild.dev/guide/advanced/dts) and [lib.dts](https://lib.rsbuild.dev/config/lib/dts) for more details.
+Read [Declaration files](https://rslib.rs/guide/advanced/dts) and [lib.dts](https://rslib.rs/config/lib/dts) for more details.
 
 ## Using in Rsbuild
 
@@ -38,7 +38,7 @@ export default {
 
 Whether to bundle the declaration files.
 
-If you want to [bundle declaration files](https://lib.rsbuild.dev/guide/advanced/dts#bundle-declaration-files) files, you should:
+If you want to [bundle declaration files](https://rslib.rs/guide/advanced/dts#bundle-declaration-files) files, you should:
 
 1. Install `@microsoft/api-extractor` as a development dependency, which is the underlying tool used for bundling declaration files.
 

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -2,7 +2,7 @@
   "name": "rsbuild-plugin-dts",
   "version": "0.9.0",
   "description": "Rsbuild plugin that supports emitting declaration files for TypeScript.",
-  "homepage": "https://lib.rsbuild.dev",
+  "homepage": "https://rslib.rs",
   "bugs": {
     "url": "https://github.com/web-infra-dev/rslib/issues"
   },

--- a/packages/plugin-dts/src/apiExtractor.ts
+++ b/packages/plugin-dts/src/apiExtractor.ts
@@ -25,7 +25,7 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
     apiExtractor = await import('@microsoft/api-extractor');
   } catch {
     throw new Error(
-      `${color.cyan('@microsoft/api-extractor')} is required when ${color.cyan('dts.bundle')} is set to ${color.cyan('true')}, please make sure it is installed. You could check https://lib.rsbuild.dev/guide/advanced/dts#how-to-generate-declaration-files-in-rslib for more details.`,
+      `${color.cyan('@microsoft/api-extractor')} is required when ${color.cyan('dts.bundle')} is set to ${color.cyan('true')}, please make sure it is installed. You could check https://rslib.rs/guide/advanced/dts#how-to-generate-declaration-files-in-rslib for more details.`,
     );
   }
 

--- a/tests/integration/entry/index.test.ts
+++ b/tests/integration/entry/index.test.ts
@@ -126,9 +126,9 @@ test('validate entry and throw errors', async () => {
   }
 
   expect(stripAnsi(errMsg)).toMatchInlineSnapshot(`
-    "Error: Glob pattern "./src" is not supported when "bundle" is "true", considering "bundle" to "false" to use bundleless mode, or specify a file entry to bundle. See https://lib.rsbuild.dev/guide/basic/output-structure for more details.
+    "Error: Glob pattern "./src" is not supported when "bundle" is "true", considering "bundle" to "false" to use bundleless mode, or specify a file entry to bundle. See https://rslib.rs/guide/basic/output-structure for more details.
 
-    Error: Glob pattern "!./src/ignored" is not supported when "bundle" is "true", considering "bundle" to "false" to use bundleless mode, or specify a file entry to bundle. See https://lib.rsbuild.dev/guide/basic/output-structure for more details."
+    Error: Glob pattern "!./src/ignored" is not supported when "bundle" is "true", considering "bundle" to "false" to use bundleless mode, or specify a file entry to bundle. See https://rslib.rs/guide/basic/output-structure for more details."
   `);
 
   try {
@@ -154,7 +154,7 @@ test('validate entry and throw errors', async () => {
   }
 
   expect(stripAnsi(errMsg)).toMatchInlineSnapshot(
-    `"The source.entry configuration should be an object, but received string: ./src/**. Checkout https://lib.rsbuild.dev/config/rsbuild/source#sourceentry for more details."`,
+    `"The source.entry configuration should be an object, but received string: ./src/**. Checkout https://rslib.rs/config/rsbuild/source#sourceentry for more details."`,
   );
 });
 

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -141,7 +141,7 @@ export default defineConfig({
         },
       },
       // Enable this when the output of Rslib is build under 'production' mode, while the host app is 'development'.
-      // Reference: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs
+      // Reference: https://rslib.rs/guide/advanced/module-federation#faqs
       shareStrategy: 'loaded-first',
     }),
   ],

--- a/website/docs/en/guide/migration/modernjs-module.mdx
+++ b/website/docs/en/guide/migration/modernjs-module.mdx
@@ -8,7 +8,7 @@ This section introduces how to migrate a project using Modern.js Module to Rslib
 
 `Rslib` has a minimal dependency footprint. For the basic functionality you only need the package `@rslib/core`.
 
-You can create a new Rslib project by following the [Quick Start](/guide/start/quick-start) to see the `package.json` file. Then update your existing `package.json` file like below:
+You can create a new Rslib project by following the [Quick start](/guide/start/quick-start) to see the `package.json` file. Then update your existing `package.json` file like below:
 
 - Remove the fields `main`, `lint-staged`, `simple-git-hooks`, `sideEffects` and `publishConfig`
 - Change the `types` field from `./dist/types/index.d.ts` to `./dist/index.d.ts`

--- a/website/docs/zh/guide/advanced/module-federation.mdx
+++ b/website/docs/zh/guide/advanced/module-federation.mdx
@@ -140,7 +140,7 @@ export default defineConfig({
         },
       },
       // 开启这个当 Rslib 产物为 'production' 模式， 但是宿主应用是 'development' 模式。
-      // 参考链接: https://lib.rsbuild.dev/guide/advanced/module-federation#faqs
+      // 参考链接: https://rslib.rs/guide/advanced/module-federation#faqs
       shareStrategy: 'loaded-first',
     }),
   ],

--- a/website/i18n.json
+++ b/website/i18n.json
@@ -4,7 +4,7 @@
     "zh": "介绍"
   },
   "quickStart": {
-    "en": "Quick Start",
+    "en": "Quick start",
     "zh": "快速上手"
   },
   "subtitle": {

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -12,7 +12,7 @@ import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
 import { defineConfig } from 'rspress/config';
 
-const siteUrl = 'https://lib.rsbuild.dev';
+const siteUrl = 'https://rslib.rs';
 const description = 'The Rsbuild-based library development tool';
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Update Rslib website URL, Rslib now uses the shorter [rslib.rs](https://rslib.rs/) instead of lib.rsbuild.dev

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
