### PR TITLE
docs: redirect lib.rsbuild.dev to rslib.rs

### DIFF
--- a/website/docs/public/netlify.toml
+++ b/website/docs/public/netlify.toml
@@ -2,3 +2,10 @@
 from = "/*"
 to = "/404.html"
 status = 404
+
+# Redirect lib.rsbuild.dev to rslib.rs
+[[redirects]]
+from = "https://lib.rsbuild.dev/*"
+to = "https://rslib.rs/:splat"
+status = 301
+force = true


### PR DESCRIPTION
## Summary

Redirect lib.rsbuild.dev to rslib.rs to ensure that users access the same domain name.

## Related Links

See: https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
