### PR TITLE
docs: update redirect rules order

### DIFF
--- a/website/docs/public/netlify.toml
+++ b/website/docs/public/netlify.toml
@@ -1,11 +1,11 @@
-[[redirects]]
-from = "/*"
-to = "/404.html"
-status = 404
-
 # Redirect lib.rsbuild.dev to rslib.rs
 [[redirects]]
 from = "https://lib.rsbuild.dev/*"
 to = "https://rslib.rs/:splat"
 status = 301
 force = true
+
+[[redirects]]
+from = "/*"
+to = "/404.html"
+status = 404


### PR DESCRIPTION
## Summary

Update redirect rules order, try to make the `lib.rsbuild.dev` redirection to work as expected.

## Related Links

https://github.com/web-infra-dev/rslib/pull/1027

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
