### PR TITLE
docs: disable domain redirection

### DIFF
--- a/website/docs/public/netlify.toml
+++ b/website/docs/public/netlify.toml
@@ -1,9 +1,9 @@
 # Redirect lib.rsbuild.rs to rslib.rs
-[[redirects]]
-from = "https://lib.rsbuild.rs/*"
-to = "https://rslib.rs/:splat"
-status = 301
-force = true
+# [[redirects]]
+# from = "https://lib.rsbuild.rs/*"
+# to = "https://rslib.rs/:splat"
+# status = 301
+# force = true
 
 [[redirects]]
 from = "/*"


### PR DESCRIPTION
## Summary

Disable domain redirection as DNS records need time to propagate (spread) across DNS servers worldwide. 

https://www.whatsmydns.net/#NS/rslib.rs

![image](https://github.com/user-attachments/assets/ee6da9fb-2d65-4427-b11f-fa7d35a734af)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
