### PR TITLE
fix(shims): require shims should inject to mjs as well

### DIFF
--- a/packages/core/src/plugins/shims.ts
+++ b/packages/core/src/plugins/shims.ts
@@ -32,7 +32,7 @@ export const pluginEsmRequireShim = (): RsbuildPlugin => ({
           // Just before minify stage, to perform tree shaking.
           stage: rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE - 1,
           raw: true,
-          include: /\.(js|cjs)$/,
+          include: /\.(js|mjs)$/,
         }),
       );
     });

--- a/tests/integration/shims/esm/rslib.config.ts
+++ b/tests/integration/shims/esm/rslib.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
       },
     }),
     generateBundleEsmConfig({
-      shims: { esm: { __dirname: true, __filename: true } },
+      shims: { esm: { __dirname: true, __filename: true, require: true } },
       syntax: 'esnext',
       source: {
         entry: {

--- a/tests/integration/shims/esm/src/require.ts
+++ b/tests/integration/shims/esm/src/require.ts
@@ -1,4 +1,1 @@
-const ok = require != null && require('./ok.cjs');
-const okPath = require.resolve('./ok.cjs');
-
-export { ok, okPath };
+export const randomFile = require(process.env.RANDOM_FILE!);

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -49,9 +49,13 @@ describe('ESM shims', async () => {
   });
 
   test('require', async () => {
-    const { ok, okPath } = await import(entryFiles.esm2!);
-    expect(ok).toBe('ok');
-    expect(okPath).toBe(path.resolve(path.dirname(entryFiles.esm2!), 'ok.cjs'));
+    expect(entries.esm2).toMatchInlineSnapshot(`
+      "import __rslib_shim_module__ from 'module';
+      const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(import.meta.url);
+      const randomFile = require(process.env.RANDOM_FILE);
+      export { randomFile };
+      "
+    `);
   });
 });
 


### PR DESCRIPTION
## Summary

1. Fix shims test case
2. ESM shims should hit `.mjs` files

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
