### PR TITLE
test: filter the tsconfig error log

### DIFF
--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -163,7 +163,11 @@ describe('dts when bundle: false', () => {
     try {
       await buildAndGetResults({ fixturePath, type: 'dts' });
     } catch (err: any) {
-      expect(logs.map((log) => stripAnsi(log)).join('')).toMatchInlineSnapshot(
+      expect(
+        logs
+          .map((log) => stripAnsi(log))
+          .find((log) => log.includes('Failed to resolve tsconfig file')),
+      ).toMatchInlineSnapshot(
         `"error   Failed to resolve tsconfig file "<ROOT>/tests/integration/dts/bundle-false/tsconfig-path/path_not_exist/tsconfig.json" from <ROOT>/tests/integration/dts/bundle-false/tsconfig-path. Please ensure that the file exists."`,
       );
     }


### PR DESCRIPTION
## Summary

Filter the tsconfig error log to fix Rsbuild ecosystem CI:

![image](https://github.com/user-attachments/assets/fbb11812-29f2-4776-a632-6d9193283985)

## Related Links

- https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/15458968100/job/43516378819

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
