### PR TITLE
docs: reopen domain redirection

### DIFF
--- a/website/docs/public/netlify.toml
+++ b/website/docs/public/netlify.toml
@@ -1,9 +1,9 @@
 # Redirect lib.rsbuild.rs to rslib.rs
-# [[redirects]]
-# from = "https://lib.rsbuild.rs/*"
-# to = "https://rslib.rs/:splat"
-# status = 301
-# force = true
+[[redirects]]
+from = "https://lib.rsbuild.rs/*"
+to = "https://rslib.rs/:splat"
+status = 301
+force = true
 
 [[redirects]]
 from = "/*"

--- a/website/docs/public/netlify.toml
+++ b/website/docs/public/netlify.toml
@@ -1,6 +1,6 @@
-# Redirect lib.rsbuild.rs to rslib.rs
+# Redirect lib.rsbuild.dev to rslib.rs
 [[redirects]]
-from = "https://lib.rsbuild.rs/*"
+from = "https://lib.rsbuild.dev/*"
 to = "https://rslib.rs/:splat"
 status = 301
 force = true


### PR DESCRIPTION
## Summary

background: https://github.com/web-infra-dev/rslib/pull/1030

Several time has passed, the global propagation of dns should be ready. 

Reopen redirection from `lib.rsbuild.dev` to `rslib.rs` again.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
