### PR TITLE
chore(deps): revert rspress 2.0.0-beta.10

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1105,14 +1105,14 @@ importers:
         specifier: workspace:*
         version: link:../scripts/tsconfig
       '@rspress/plugin-algolia':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(@algolia/client-search@5.25.0)(@rspress/runtime@2.0.0-beta.10)(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 2.0.0-beta.9
+        version: 2.0.0-beta.9(@algolia/client-search@5.25.0)(@rspress/runtime@2.0.0-beta.9)(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@rspress/plugin-llms':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(@rspress/core@2.0.0-beta.10(@types/react@19.1.6)(acorn@8.14.1))
+        specifier: 2.0.0-beta.9
+        version: 2.0.0-beta.9(@rspress/core@2.0.0-beta.9(@types/react@19.1.6)(acorn@8.14.1))
       '@rspress/plugin-rss':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(rspress@2.0.0-beta.10(@types/react@19.1.6)(acorn@8.14.1))
+        specifier: 2.0.0-beta.9
+        version: 2.0.0-beta.9(rspress@2.0.0-beta.9(@types/react@19.1.6)(acorn@8.14.1))
       '@rstack-dev/doc-ui':
         specifier: 1.10.6
         version: 1.10.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1141,8 +1141,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(@rsbuild/core@1.4.0-beta.2)
       rspress:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(@types/react@19.1.6)(acorn@8.14.1)
+        specifier: 2.0.0-beta.9
+        version: 2.0.0-beta.9(@types/react@19.1.6)(acorn@8.14.1)
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
@@ -2653,8 +2653,8 @@ packages:
       webpack-hot-middleware:
         optional: true
 
-  '@rspress/core@2.0.0-beta.10':
-    resolution: {integrity: sha512-QvN3vby24Ba3avYLur0UFbjNyh8DyIY0TYQ6zya5Nv8nO8J7dAS+Em9vTjKWWYRLnEyoRHx9ePfu6DL70WnNgw==}
+  '@rspress/core@2.0.0-beta.9':
+    resolution: {integrity: sha512-og1bSJCRmzavFSdUw9IN4UwZQPuevMWeEgXSbyXGNvNId4y8AarSa1UEmwTop5NmIvM0WIuC9RpOAxrFz/UA3Q==}
     engines: {node: '>=18.0.0'}
 
   '@rspress/mdx-rs-darwin-arm64@0.6.6':
@@ -2709,55 +2709,55 @@ packages:
     resolution: {integrity: sha512-NpNhTKBIlV3O6ADhoZkgHvBFvXMW2TYlIWmIT1ysJESUBqDpaN9H3Teve5fugjU2pQ2ORBZO6SQGKliMw/8m/Q==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-algolia@2.0.0-beta.10':
-    resolution: {integrity: sha512-Qu9iV+1eUbopY0PotW8rQXvs7x8hmyhkZDiseAVDi7UtcnDnvuUZE3v1u0T7odehD9SRcOoTOj8amluHCK6stw==}
+  '@rspress/plugin-algolia@2.0.0-beta.9':
+    resolution: {integrity: sha512-tR4rSIF5rzEfBUCQ3D/qdg6hFx9N+4EAlBWtMUdBvnEvLPwv6iRA/XXkZ32z2mdyUO9S3R8lhfwKQY6U+5miNQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@rspress/runtime': ^2.0.0-beta.10
+      '@rspress/runtime': ^2.0.0-beta.9
 
-  '@rspress/plugin-auto-nav-sidebar@2.0.0-beta.10':
-    resolution: {integrity: sha512-Ulpu3UNIiIfpt6wLZITiTnjohYNmcXrRz15iqYI7LxuBXOuXwntO4jCyUBjAYeUwlrpzD6Pin+6wSS1H7grJZA==}
+  '@rspress/plugin-auto-nav-sidebar@2.0.0-beta.9':
+    resolution: {integrity: sha512-Tiof1A5WGd5iEsB5eI9OoVHNe0aucJK5/UTJZ583vg/EyFwcQyuGAbbuuGd+StnyS5fpJt0pgYOvcRAT9vB1uw==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/plugin-container-syntax@2.0.0-beta.10':
-    resolution: {integrity: sha512-Pjbd3YVgDEoEFbIVbgB5rn4aZj3R6W7vcnrnqMyxdqP9lk7Dr/GW+TGfJrzz8DHpjeadLijZzaz+rrRAfpvVNw==}
+  '@rspress/plugin-container-syntax@2.0.0-beta.9':
+    resolution: {integrity: sha512-c47Jppi1uX5ohkuOi0v4JiIQs6urA8hdRbz5lq1UFBqorY8zkUIe/wIa0NyZYxXKDzSIg83WgmwvlQu3Mx0bSA==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/plugin-last-updated@2.0.0-beta.10':
-    resolution: {integrity: sha512-gA7UtEXt9pLrXQKjV25JbilDNOXwMTlStBBYurHxaPyVlHt6acuED/O2raIo4y7Tka3VFDfg2c7uTSReQxboRg==}
+  '@rspress/plugin-last-updated@2.0.0-beta.9':
+    resolution: {integrity: sha512-ubp7ul772beZJUxHgrmYXONyRMj0ErWnlp884wEBhRcfWkNqOOVeKTtFyBNlywUPHvLGWZ24dXkAJhjoUrecpQ==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/plugin-llms@2.0.0-beta.10':
-    resolution: {integrity: sha512-i0Yb17/nanl7y4szFHooRoocfcc/zZLuK/7Tb06CUcWHmclApTWaUdtNTe0pZtQDOa7lt3r/fJ+zvrWYzp6FMw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@rspress/core': ^2.0.0-beta.10
-
-  '@rspress/plugin-medium-zoom@2.0.0-beta.10':
-    resolution: {integrity: sha512-Elu+KntKXAd7CSVVeJpVGqX79bOVy7gv/ucbKN9otws7+i5PL65xyEArBuDY/miMYvtoGRHljh+Lb7CvEJpnyw==}
+  '@rspress/plugin-llms@2.0.0-beta.9':
+    resolution: {integrity: sha512-i9ccwilSqvgo/CdBkQaO0r7OoqmS54mdeHh6tndiRH15EHh+RfCGtVumHRRJ7qeJGRDUaOICaazAYEIq1JWjoA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@rspress/runtime': ^2.0.0-beta.10
+      '@rspress/core': ^2.0.0-beta.9
 
-  '@rspress/plugin-rss@2.0.0-beta.10':
-    resolution: {integrity: sha512-UzAbyMni2grjHm3Tnza7XuoFY0Lm5FsJGuBTboKlgmk+80YJSDiqO0sE/iPH4Q6NiqRkn7SpDnauJVEoTqP8RQ==}
+  '@rspress/plugin-medium-zoom@2.0.0-beta.9':
+    resolution: {integrity: sha512-rnMJm91vI0tA9I77sGonp8NAVX2IcCm3ydhZZEKFf4UsTXqg6aoW6wDdMs5Qsb2tonU50Z0CJcfAiQs8MQpzKA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      rspress: ^2.0.0-beta.10
+      '@rspress/runtime': ^2.0.0-beta.9
 
-  '@rspress/plugin-shiki@2.0.0-beta.10':
-    resolution: {integrity: sha512-phjrcYOMMLIzw7xXl17N9WTKKYB7IQlrV6Ez2LcvFO87XYjFfmCNxH1EAZieC82zqNpics9FFqHn1MlB+bTlEw==}
+  '@rspress/plugin-rss@2.0.0-beta.9':
+    resolution: {integrity: sha512-PRgXrtVMjuZdgHOFu8WKdwhpXlazL3GCcCe2np7a7opmsIaULDIZmNn5EihyAPzR4euqrI4SnQTWT0BIA1Hp6Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      rspress: ^2.0.0-beta.9
+
+  '@rspress/plugin-shiki@2.0.0-beta.9':
+    resolution: {integrity: sha512-tFcInbgvZyEmg2kVK+vpq6ZBPnHo/UT2IWD/t0cF0IhujoMebDCOchsM98R8ysVwfePLmHE55N0fj9eS9zoAsw==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/runtime@2.0.0-beta.10':
-    resolution: {integrity: sha512-mSecKJCZfKsxoKoK7eNbaed6Gh1JhWTXAoCq5EO7/je/XIqeqMCfJ2VncUdwE9srcySOrr77nmCmGHe3nVSyvQ==}
+  '@rspress/runtime@2.0.0-beta.9':
+    resolution: {integrity: sha512-PoS2P+Hk/d0r4SxaYFmp4mVD+TBl9TtUlFs8dECBJZ4NsAg1j/tk1d5hQ6wq2I1XNC19uIZYZjdG2V8BNrCLLQ==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/shared@2.0.0-beta.10':
-    resolution: {integrity: sha512-3HAossMllrZ3E7T+bmOpgSXREuWEUtAcSSc8rSV/ZWmxwaHRbz1LF74MDR9By5s6J6IZXs8jxlnrU6TMOct+lA==}
+  '@rspress/shared@2.0.0-beta.9':
+    resolution: {integrity: sha512-2WAQMlQALGPvKvtU2AoPcy3AseYctFl0fS60LJxpmLaCwb4az6wl115VmviVjuBNLgqlQFLkMqBsyBM0Irxb2A==}
 
-  '@rspress/theme-default@2.0.0-beta.10':
-    resolution: {integrity: sha512-27FnGIOhpbRdqmBk/21fgQtmo3zmS/OmiemZTTjqNG9FmaN+BnhgLepPpMc3h1DSN0+RTEujDlQENqfnHEcSRw==}
+  '@rspress/theme-default@2.0.0-beta.9':
+    resolution: {integrity: sha512-XzQ/JxJ6BNLXQM4L2S9RysFW93mmCLmJHgXns0SDcGCSXaKsi2NB71O37lwzTsvDXGGXqU69I/8SXAUtbXz4MA==}
     engines: {node: '>=18.0.0'}
 
   '@rstack-dev/doc-ui@1.10.6':
@@ -6520,8 +6520,8 @@ packages:
   rspress-plugin-font-open-sans@1.0.0:
     resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
 
-  rspress@2.0.0-beta.10:
-    resolution: {integrity: sha512-QemnkDtpTuAEGLRJCB2cxqYJ6oVYI/AFfdvMDUzJLgdA7is0f+DdblMaLYmkWx5CpJ0XcFSmRmvk2Q8oXQwO4w==}
+  rspress@2.0.0-beta.9:
+    resolution: {integrity: sha512-g9jRXTs80x4yfifAISVXv2U+aW7V7M8+xyvksHlKQRaRJIoRywhVTfrU1XqMDj/LTxYzGQ5OA6EUwo99LErjcw==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -9387,7 +9387,7 @@ snapshots:
       html-entities: 2.6.0
       react-refresh: 0.17.0
 
-  '@rspress/core@2.0.0-beta.10(@types/react@19.1.6)(acorn@8.14.1)':
+  '@rspress/core@2.0.0-beta.9(@types/react@19.1.6)(acorn@8.14.1)':
     dependencies:
       '@mdx-js/loader': 3.1.0(acorn@8.14.1)
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
@@ -9395,14 +9395,14 @@ snapshots:
       '@rsbuild/core': 1.3.22
       '@rsbuild/plugin-react': 1.3.2(@rsbuild/core@1.3.22)
       '@rspress/mdx-rs': 0.6.6
-      '@rspress/plugin-auto-nav-sidebar': 2.0.0-beta.10
-      '@rspress/plugin-container-syntax': 2.0.0-beta.10
-      '@rspress/plugin-last-updated': 2.0.0-beta.10
-      '@rspress/plugin-medium-zoom': 2.0.0-beta.10(@rspress/runtime@2.0.0-beta.10)
-      '@rspress/plugin-shiki': 2.0.0-beta.10
-      '@rspress/runtime': 2.0.0-beta.10
-      '@rspress/shared': 2.0.0-beta.10
-      '@rspress/theme-default': 2.0.0-beta.10
+      '@rspress/plugin-auto-nav-sidebar': 2.0.0-beta.9
+      '@rspress/plugin-container-syntax': 2.0.0-beta.9
+      '@rspress/plugin-last-updated': 2.0.0-beta.9
+      '@rspress/plugin-medium-zoom': 2.0.0-beta.9(@rspress/runtime@2.0.0-beta.9)
+      '@rspress/plugin-shiki': 2.0.0-beta.9
+      '@rspress/runtime': 2.0.0-beta.9
+      '@rspress/shared': 2.0.0-beta.9
+      '@rspress/theme-default': 2.0.0-beta.9
       '@types/unist': 3.0.3
       '@unhead/react': 2.0.10(react@19.1.0)
       enhanced-resolve: 5.18.1
@@ -9468,11 +9468,11 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.6
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.6
 
-  '@rspress/plugin-algolia@2.0.0-beta.10(@algolia/client-search@5.25.0)(@rspress/runtime@2.0.0-beta.10)(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rspress/plugin-algolia@2.0.0-beta.9(@algolia/client-search@5.25.0)(@rspress/runtime@2.0.0-beta.9)(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@docsearch/css': 3.9.0
       '@docsearch/react': 3.9.0(@algolia/client-search@5.25.0)(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@rspress/runtime': 2.0.0-beta.10
+      '@rspress/runtime': 2.0.0-beta.9
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -9480,22 +9480,22 @@ snapshots:
       - react-dom
       - search-insights
 
-  '@rspress/plugin-auto-nav-sidebar@2.0.0-beta.10':
+  '@rspress/plugin-auto-nav-sidebar@2.0.0-beta.9':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.10
+      '@rspress/shared': 2.0.0-beta.9
 
-  '@rspress/plugin-container-syntax@2.0.0-beta.10':
+  '@rspress/plugin-container-syntax@2.0.0-beta.9':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.10
+      '@rspress/shared': 2.0.0-beta.9
 
-  '@rspress/plugin-last-updated@2.0.0-beta.10':
+  '@rspress/plugin-last-updated@2.0.0-beta.9':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.10
+      '@rspress/shared': 2.0.0-beta.9
 
-  '@rspress/plugin-llms@2.0.0-beta.10(@rspress/core@2.0.0-beta.10(@types/react@19.1.6)(acorn@8.14.1))':
+  '@rspress/plugin-llms@2.0.0-beta.9(@rspress/core@2.0.0-beta.9(@types/react@19.1.6)(acorn@8.14.1))':
     dependencies:
-      '@rspress/core': 2.0.0-beta.10(@types/react@19.1.6)(acorn@8.14.1)
-      '@rspress/shared': 2.0.0-beta.10
+      '@rspress/core': 2.0.0-beta.9(@types/react@19.1.6)(acorn@8.14.1)
+      '@rspress/shared': 2.0.0-beta.9
       remark-mdx: 3.1.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -9505,33 +9505,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rspress/plugin-medium-zoom@2.0.0-beta.10(@rspress/runtime@2.0.0-beta.10)':
+  '@rspress/plugin-medium-zoom@2.0.0-beta.9(@rspress/runtime@2.0.0-beta.9)':
     dependencies:
-      '@rspress/runtime': 2.0.0-beta.10
+      '@rspress/runtime': 2.0.0-beta.9
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-rss@2.0.0-beta.10(rspress@2.0.0-beta.10(@types/react@19.1.6)(acorn@8.14.1))':
+  '@rspress/plugin-rss@2.0.0-beta.9(rspress@2.0.0-beta.9(@types/react@19.1.6)(acorn@8.14.1))':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.10
+      '@rspress/shared': 2.0.0-beta.9
       feed: 4.2.2
-      rspress: 2.0.0-beta.10(@types/react@19.1.6)(acorn@8.14.1)
+      rspress: 2.0.0-beta.9(@types/react@19.1.6)(acorn@8.14.1)
 
-  '@rspress/plugin-shiki@2.0.0-beta.10':
+  '@rspress/plugin-shiki@2.0.0-beta.9':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.10
+      '@rspress/shared': 2.0.0-beta.9
       '@shikijs/rehype': 3.4.2
       hast-util-from-html: 2.0.3
       shiki: 3.4.2
 
-  '@rspress/runtime@2.0.0-beta.10':
+  '@rspress/runtime@2.0.0-beta.9':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.10
+      '@rspress/shared': 2.0.0-beta.9
       '@unhead/react': 2.0.10(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.29.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  '@rspress/shared@2.0.0-beta.10':
+  '@rspress/shared@2.0.0-beta.9':
     dependencies:
       '@rsbuild/core': 1.3.22
       '@shikijs/rehype': 3.4.2
@@ -9539,11 +9539,11 @@ snapshots:
       lodash-es: 4.17.21
       unified: 11.0.5
 
-  '@rspress/theme-default@2.0.0-beta.10':
+  '@rspress/theme-default@2.0.0-beta.9':
     dependencies:
       '@mdx-js/react': 2.3.0(react@19.1.0)
-      '@rspress/runtime': 2.0.0-beta.10
-      '@rspress/shared': 2.0.0-beta.10
+      '@rspress/runtime': 2.0.0-beta.9
+      '@rspress/shared': 2.0.0-beta.9
       '@unhead/react': 2.0.10(react@19.1.0)
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
@@ -14152,11 +14152,11 @@ snapshots:
 
   rspress-plugin-font-open-sans@1.0.0: {}
 
-  rspress@2.0.0-beta.10(@types/react@19.1.6)(acorn@8.14.1):
+  rspress@2.0.0-beta.9(@types/react@19.1.6)(acorn@8.14.1):
     dependencies:
       '@rsbuild/core': 1.3.22
-      '@rspress/core': 2.0.0-beta.10(@types/react@19.1.6)(acorn@8.14.1)
-      '@rspress/shared': 2.0.0-beta.10
+      '@rspress/core': 2.0.0-beta.9(@types/react@19.1.6)(acorn@8.14.1)
+      '@rspress/shared': 2.0.0-beta.9
       cac: 6.7.14
       chokidar: 3.6.0
       picocolors: 1.1.1

--- a/website/package.json
+++ b/website/package.json
@@ -12,9 +12,9 @@
     "@rsbuild/core": "1.4.0-beta.2",
     "@rsbuild/plugin-sass": "^1.3.2",
     "@rslib/tsconfig": "workspace:*",
-    "@rspress/plugin-algolia": "2.0.0-beta.10",
-    "@rspress/plugin-llms": "2.0.0-beta.10",
-    "@rspress/plugin-rss": "2.0.0-beta.10",
+    "@rspress/plugin-algolia": "2.0.0-beta.9",
+    "@rspress/plugin-llms": "2.0.0-beta.9",
+    "@rspress/plugin-rss": "2.0.0-beta.9",
     "@rstack-dev/doc-ui": "1.10.6",
     "@shikijs/transformers": "^3.6.0",
     "@types/node": "^22.15.30",
@@ -24,7 +24,7 @@
     "react-dom": "^19.1.0",
     "rsbuild-plugin-google-analytics": "1.0.3",
     "rsbuild-plugin-open-graph": "^1.0.2",
-    "rspress": "2.0.0-beta.10",
+    "rspress": "2.0.0-beta.9",
     "rspress-plugin-font-open-sans": "1.0.0"
   }
 }


### PR DESCRIPTION
## Summary

style breaking changes in `2.0.0-beta.10`.

![image](https://github.com/user-attachments/assets/7c128841-b851-4570-be2a-a56031817979)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
