### PR TITLE
docs: generate the sitemap for SEO

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1146,6 +1146,9 @@ importers:
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
+      rspress-plugin-sitemap:
+        specifier: ^1.1.4
+        version: 1.1.4
 
 packages:
 
@@ -6498,6 +6501,9 @@ packages:
 
   rspress-plugin-font-open-sans@1.0.0:
     resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
+
+  rspress-plugin-sitemap@1.1.4:
+    resolution: {integrity: sha512-SnQUWU1zUw6y4er93Xb27MRbdAs8D6wlEycjU4vTq8bZdFrICp/Gxh0QaCYpZ5OeSURxUsfS6rkInPWkpSwQ7g==}
 
   rspress@2.0.0-beta.11:
     resolution: {integrity: sha512-rcJTNs+QN0yXAGAvTstHV3oIGS7S8aYmGe+AO4RE8LDcukhp+zm8womok0QTK8yo/A1eVDVPDqA+05mcJBH+Gg==}
@@ -14098,6 +14104,8 @@ snapshots:
       fs-extra: 11.3.0
 
   rspress-plugin-font-open-sans@1.0.0: {}
+
+  rspress-plugin-sitemap@1.1.4: {}
 
   rspress@2.0.0-beta.11(@types/react@19.1.6)(acorn@8.14.1):
     dependencies:

--- a/website/package.json
+++ b/website/package.json
@@ -25,6 +25,7 @@
     "rsbuild-plugin-google-analytics": "1.0.3",
     "rsbuild-plugin-open-graph": "^1.0.2",
     "rspress": "2.0.0-beta.11",
-    "rspress-plugin-font-open-sans": "1.0.0"
+    "rspress-plugin-font-open-sans": "1.0.0",
+    "rspress-plugin-sitemap": "^1.1.4"
   }
 }

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -10,6 +10,7 @@ import {
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
+import pluginSitemap from 'rspress-plugin-sitemap';
 import { defineConfig } from 'rspress/config';
 
 const siteUrl = 'https://rslib.rs';
@@ -44,6 +45,9 @@ export default defineConfig({
           },
         },
       ],
+    }),
+    pluginSitemap({
+      domain: siteUrl,
     }),
   ],
   root: path.join(__dirname, 'docs'),


### PR DESCRIPTION
## Summary

Integrate the `rspress-plugin-sitemap` to generate the sitemap for SEO.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
