### PR TITLE
test: correct test config of resolve false case

### DIFF
--- a/tests/integration/resolve/false/rslib.config.ts
+++ b/tests/integration/resolve/false/rslib.config.ts
@@ -8,4 +8,7 @@ export default defineConfig({
       index: './index.ts',
     },
   },
+  output: {
+    target: 'web',
+  },
 });


### PR DESCRIPTION
## Summary

This test case is skipped since https://github.com/web-infra-dev/rslib/issues/149, but since we modify default target to `'node'` formly, we should manually set `'web'` in this case.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
