### PR TITLE
feat: bump Rsbuild 1.4.0-beta.3 to enhance default import rename

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.15.0",
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rsbuild/plugin-react": "^1.3.2",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.15.0",
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rsbuild/plugin-react": "^1.3.2",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "rsbuild-plugin-dts": "workspace:*",
     "tinyglobby": "^0.2.14"
   },

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@storybook/addon-docs": "^9.0.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@storybook/addon-docs": "^9.0.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@storybook/addon-docs": "^9.0.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@storybook/addon-docs": "^9.0.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rsbuild/plugin-react": "^1.3.2",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.6",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rsbuild/plugin-react": "^1.3.2",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.6",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -17,7 +17,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rsbuild/plugin-react": "^1.3.2",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.6",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rsbuild/plugin-react": "^1.3.2",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.6",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-js/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.52.8",
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rslib/tsconfig": "workspace:*",
     "rsbuild-plugin-publint": "^0.3.2",
     "rslib": "npm:@rslib/core@0.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,13 +91,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.15.0
-        version: 0.15.0(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@rsbuild/core':
-        specifier: 1.4.0-beta.2
-        version: 1.4.0-beta.2
+        specifier: 1.4.0-beta.3
+        version: 1.4.0-beta.3
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@types/react':
         specifier: ^19.1.6
         version: 19.1.6
@@ -112,16 +112,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.15.0
-        version: 0.15.0(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.15.0
-        version: 0.15.0(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/storybook-addon':
         specifier: ^4.0.20
-        version: 4.0.20(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)
+        version: 4.0.20(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -142,10 +142,10 @@ importers:
         version: 9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3)
       storybook-addon-rslib:
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@1.4.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3)
+        version: 2.0.1(@rsbuild/core@1.4.0-beta.3)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3)
       storybook-react-rsbuild:
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+        version: 2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -158,13 +158,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.15.0
-        version: 0.15.0(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@rsbuild/core':
-        specifier: 1.4.0-beta.2
-        version: 1.4.0-beta.2
+        specifier: 1.4.0-beta.3
+        version: 1.4.0-beta.3
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@types/react':
         specifier: ^19.1.6
         version: 19.1.6
@@ -179,10 +179,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.4.0-beta.2)(preact@10.26.8)
+        version: 1.4.0(@rsbuild/core@1.4.0-beta.3)(preact@10.26.8)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -194,10 +194,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -212,10 +212,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -230,10 +230,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -248,13 +248,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.4.0-beta.2)
+        version: 1.0.5(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-solid':
         specifier: ^1.0.5
-        version: 1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.0-beta.2)(solid-js@1.9.7)
+        version: 1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.0-beta.3)(solid-js@1.9.7)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -311,16 +311,16 @@ importers:
         version: 9.0.6(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(vue@3.5.16(typescript@5.8.3))
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.4.0-beta.2)(@types/node@22.15.30)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(vue@3.5.16(typescript@5.8.3))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.4.0-beta.3)(@types/node@22.15.30)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(vue@3.5.16(typescript@5.8.3))(yaml@2.6.1)
       storybook:
         specifier: ^9.0.6
         version: 9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3)
       storybook-addon-rslib:
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@1.4.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3)
+        version: 2.0.1(@rsbuild/core@1.4.0-beta.3)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3)
       storybook-vue3-rsbuild:
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)(vue@3.5.16(typescript@5.8.3))
+        version: 2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)(vue@3.5.16(typescript@5.8.3))
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -334,8 +334,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: 1.4.0-beta.2
-        version: 1.4.0-beta.2
+        specifier: 1.4.0-beta.3
+        version: 1.4.0-beta.3
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
@@ -345,7 +345,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.15.0
-        version: 0.15.0(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -372,7 +372,7 @@ importers:
         version: 1.3.3(typescript@5.8.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.2
-        version: 0.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 0.3.2(@rsbuild/core@1.4.0-beta.3)
       rslib:
         specifier: npm:@rslib/core@0.9.2
         version: '@rslib/core@0.9.2(@microsoft/api-extractor@7.52.8(@types/node@22.15.30))(typescript@5.8.3)'
@@ -439,14 +439,14 @@ importers:
         specifier: ^7.52.8
         version: 7.52.8(@types/node@22.15.30)
       '@rsbuild/core':
-        specifier: 1.4.0-beta.2
-        version: 1.4.0-beta.2
+        specifier: 1.4.0-beta.3
+        version: 1.4.0-beta.3
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
       rsbuild-plugin-publint:
         specifier: ^0.3.2
-        version: 0.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 0.3.2(@rsbuild/core@1.4.0-beta.3)
       rslib:
         specifier: npm:@rslib/core@0.9.2
         version: '@rslib/core@0.9.2(@microsoft/api-extractor@7.52.8(@types/node@22.15.30))(typescript@5.8.3)'
@@ -470,31 +470,31 @@ importers:
         version: 4.0.1(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.6.1))(vitest@3.2.2(@types/debug@4.1.12)(@types/node@22.15.30)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.6.1))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.15.0
-        version: 0.15.0(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@playwright/test':
         specifier: 1.52.0
         version: 1.52.0
       '@rsbuild/core':
-        specifier: 1.4.0-beta.2
-        version: 1.4.0-beta.2
+        specifier: 1.4.0-beta.3
+        version: 1.4.0-beta.3
       '@rsbuild/plugin-less':
         specifier: ^1.2.4
-        version: 1.2.4(@rsbuild/core@1.4.0-beta.2)
+        version: 1.2.4(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-toml':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.4.0-beta.2)
+        version: 1.1.0(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.0.2(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.0.2(@rsbuild/core@1.4.0-beta.3)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -559,7 +559,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
 
   tests/integration/asset/json: {}
 
@@ -575,10 +575,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.4.0-beta.2)(typescript@5.8.3)
+        version: 1.2.0(@rsbuild/core@1.4.0-beta.3)(typescript@5.8.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -672,10 +672,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.4.0-beta.2)(typescript@5.8.3)
+        version: 1.2.0(@rsbuild/core@1.4.0-beta.3)(typescript@5.8.3)
 
   tests/integration/cli/build: {}
 
@@ -889,7 +889,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.4.0-beta.2)
+        version: 1.0.5(@rsbuild/core@1.4.0-beta.3)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.12.0
         version: 0.12.0(@babel/core@7.26.10)
@@ -1018,13 +1018,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))
+        version: 1.1.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))
+        version: 1.1.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -1081,10 +1081,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.2.4
-        version: 1.2.4(@rsbuild/core@1.4.0-beta.2)
+        version: 1.2.4(@rsbuild/core@1.4.0-beta.3)
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.4.0-beta.2)(@types/node@22.15.30)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(vue@3.5.16(typescript@5.8.3))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.4.0-beta.3)(@types/node@22.15.30)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(vue@3.5.16(typescript@5.8.3))(yaml@2.6.1)
       vue:
         specifier: ^3.5.16
         version: 3.5.16(typescript@5.8.3)
@@ -1096,11 +1096,11 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: 1.4.0-beta.2
-        version: 1.4.0-beta.2
+        specifier: 1.4.0-beta.3
+        version: 1.4.0-beta.3
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -1136,10 +1136,10 @@ importers:
         version: 19.1.0(react@19.1.0)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.3
-        version: 1.0.3(@rsbuild/core@1.4.0-beta.2)
+        version: 1.0.3(@rsbuild/core@1.4.0-beta.3)
       rsbuild-plugin-open-graph:
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.4.0-beta.2)
+        version: 1.0.2(@rsbuild/core@1.4.0-beta.3)
       rspress:
         specifier: 2.0.0-beta.11
         version: 2.0.0-beta.11(@types/react@19.1.6)(acorn@8.14.1)
@@ -2425,6 +2425,11 @@ packages:
     engines: {node: '>=16.10.0'}
     hasBin: true
 
+  '@rsbuild/core@1.4.0-beta.3':
+    resolution: {integrity: sha512-i8RP/8gCXPFZ4b8L1ekolNbSgzc61VDJy7PEoJ55gBDI7ZtXtnIH9EhYdvYIpqBZFzF43S0deFKwi2S4XaZGCA==}
+    engines: {node: '>=16.10.0'}
+    hasBin: true
+
   '@rsbuild/plugin-babel@1.0.4':
     resolution: {integrity: sha512-ZYbyC3zNYluTWTJDVrAW3eRJfvSTIQlp/bs20iY/MATm8/rRq2xtlAP5keCYxpx5CJZX7IT7i6f4z24/YrJJwA==}
     peerDependencies:
@@ -2533,6 +2538,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@1.4.0-beta.0':
+    resolution: {integrity: sha512-PQMH8mBQP8Auqw9vpoZp2Q9NbAa8yzqQ6MOq0f1NeV3XKx+Yyq6UPzMRAWcZjLK14JwQiKoSj06GBY4yN4fSGw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.3.12':
     resolution: {integrity: sha512-Sj4m+mCUxL7oCpdu7OmWT7fpBM7hywk5CM9RDc3D7StaBZbvNtNftafCrTZzTYKuZrKmemTh5SFzT5Tz7tf6GA==}
     cpu: [x64]
@@ -2540,6 +2550,11 @@ packages:
 
   '@rspack/binding-darwin-x64@1.3.15':
     resolution: {integrity: sha512-TfUvEIBqYUT2OK01BYXb2MNcZeZIhAnJy/5aj0qV0uy4KlvwW63HYcKWa1sFd4Ac7bnGShDkanvP3YEuHOFOyg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.4.0-beta.0':
+    resolution: {integrity: sha512-ydBmcIDHNOrrmyHV1sdYUdFbRlgijTEl6j5f1eD1r2t+KIDdFf1NqBcMVQ+1j93RxU4I54EI+ZbxYhy8heME9g==}
     cpu: [x64]
     os: [darwin]
 
@@ -2553,6 +2568,11 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@1.4.0-beta.0':
+    resolution: {integrity: sha512-tzLHo5upqlDWK3wSTit0m0iZ8N6pm6S42R/sfeOcPwERcTjhTrbQ6GOEbmwsay845EgzJbGWwaOzVeGLT55YCw==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-musl@1.3.12':
     resolution: {integrity: sha512-s6KKj20T9Z1bA8caIjU6EzJbwyDo1URNFgBAlafCT2UC6yX7flstDJJ38CxZacA9A2P24RuQK2/jPSZpWrTUFA==}
     cpu: [arm64]
@@ -2560,6 +2580,11 @@ packages:
 
   '@rspack/binding-linux-arm64-musl@1.3.15':
     resolution: {integrity: sha512-lJbBsPMOiR0hYPCSM42yp7QiZjfo0ALtX7ws2wURpsQp3BMfRVAmXU3Ixpo2XCRtG1zj8crHaCmAWOJTS0smsA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.4.0-beta.0':
+    resolution: {integrity: sha512-g3YZCNB+oR8+CG83iOoACZrxiM9sKlB33QmJB2PFk5TTryhkNGEq3vwiyqe7AVPWYfuCCqoRdzPNzWBIN80cEg==}
     cpu: [arm64]
     os: [linux]
 
@@ -2573,6 +2598,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@1.4.0-beta.0':
+    resolution: {integrity: sha512-TNIm9APDmcbbrwWgSxaIbq73r0cKrzyS0Ei7rB0TyX9EmFYSfsCdmdJMwG2yKP3p+egRIDMWU9AIrxL4HIMrBg==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@1.3.12':
     resolution: {integrity: sha512-jEdxkPymkRxbijDRsBGdhopcbGXiXDg59lXqIRkVklqbDmZ/O6DHm7gImmlx5q9FoWbz0gqJuOKBz4JqWxjWVA==}
     cpu: [x64]
@@ -2580,6 +2610,11 @@ packages:
 
   '@rspack/binding-linux-x64-musl@1.3.15':
     resolution: {integrity: sha512-qRn6e40fLQP+N2rQD8GAj/h4DakeTIho32VxTIaHRVuzw68ZD7VmKkwn55ssN370ejmey35ZdoNFNE12RBrMZA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@1.4.0-beta.0':
+    resolution: {integrity: sha512-PCfGShh6y0CqUX8XxuxkEKOBLELuxDZ/sacM047CBIet3CgvqmT0Ff2DKXFIu8Q+NWrKnzvopO7hPv4Zelku6A==}
     cpu: [x64]
     os: [linux]
 
@@ -2593,6 +2628,11 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rspack/binding-win32-arm64-msvc@1.4.0-beta.0':
+    resolution: {integrity: sha512-4i9LjYePVsyDHM1DChU+lYDE2Gg654kVG6LlV71u2xz6ywi5E81E6IadFkiKSpXaPhQqzWykS3E4jgHHY7nSOw==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rspack/binding-win32-ia32-msvc@1.3.12':
     resolution: {integrity: sha512-1TKPjuXStPJr14f3ZHuv40Xc/87jUXx10pzVtrPnw+f3hckECHrbYU/fvbVzZyuXbsXtkXpYca6ygCDRJAoNeQ==}
     cpu: [ia32]
@@ -2600,6 +2640,11 @@ packages:
 
   '@rspack/binding-win32-ia32-msvc@1.3.15':
     resolution: {integrity: sha512-UsaWTYCjDiSCB0A0qETgZk4QvhwfG8gCrO4SJvA+QSEWOmgSai1YV70prFtLLIiyT9mDt1eU3tPWl1UWPRU/EQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@1.4.0-beta.0':
+    resolution: {integrity: sha512-BUtCxpwDnxDniA37ia/r5kIHkT5AbKFj9nEDhYrGnRUJYWMwSg2gdDtAZvnHpqdGpGArn9UAOZ/YABEvCOkVKg==}
     cpu: [ia32]
     os: [win32]
 
@@ -2613,11 +2658,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@1.4.0-beta.0':
+    resolution: {integrity: sha512-XLqOM0VYdpChTpquR44CzkGT3d1RQfwVqhjvmXY8Jz8KFDpFf91ZLsXK4IEZhGL0p9TqegMD+GOuVlZ9NLbMKg==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@1.3.12':
     resolution: {integrity: sha512-4Ic8lV0+LCBfTlH5aIOujIRWZOtgmG223zC4L3o8WY/+ESAgpdnK6lSSMfcYgRanYLAy3HOmFIp20jwskMpbAg==}
 
   '@rspack/binding@1.3.15':
     resolution: {integrity: sha512-utNPuJglLO5lW9XbwIqjB7+2ilMo6JkuVLTVdnNVKU94FW7asn9F/qV+d+MgjUVqU1QPCGm0NuGO9xhbgeJ7pg==}
+
+  '@rspack/binding@1.4.0-beta.0':
+    resolution: {integrity: sha512-Pk/T01umu934zxHzufRx1hgkHa/RlZo/M98BCGCWH8vPcD2Xu0bcBP8GoGPcxiJWtMtCsSWJfengz8UVmdAC4g==}
 
   '@rspack/core@1.3.12':
     resolution: {integrity: sha512-mAPmV4LPPRgxpouUrGmAE4kpF1NEWJGyM5coebsjK/zaCMSjw3mkdxiU2b5cO44oIi0Ifv5iGkvwbdrZOvMyFA==}
@@ -2630,6 +2683,15 @@ packages:
 
   '@rspack/core@1.3.15':
     resolution: {integrity: sha512-QuElIC8jXSKWAp0LSx18pmbhA7NiA5HGoVYesmai90UVxz98tud0KpMxTVCg+0lrLrnKZfCWN9kwjCxM5pGnrA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@1.4.0-beta.0':
+    resolution: {integrity: sha512-rFDM8Un/ap+05omHlTgMGpIJnXiHXnkt9qNKrnWVgvIprngrusWMb/SWrLDxKZeC7MVxuXBfTHMyMpyKIpjSkw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -3953,6 +4015,9 @@ packages:
 
   core-js@3.42.0:
     resolution: {integrity: sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==}
+
+  core-js@3.43.0:
+    resolution: {integrity: sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -8729,7 +8794,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.15.0(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
+  '@module-federation/enhanced@0.15.0(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.15.0
       '@module-federation/cli': 0.15.0(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
@@ -8739,7 +8804,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.15.0(@module-federation/runtime-tools@0.15.0)
       '@module-federation/managers': 0.15.0
       '@module-federation/manifest': 0.15.0(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
-      '@module-federation/rspack': 0.15.0(@rspack/core@1.3.15(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/rspack': 0.15.0(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/runtime-tools': 0.15.0
       '@module-federation/sdk': 0.15.0
       btoa: 1.2.1
@@ -8788,9 +8853,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.7(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
+  '@module-federation/node@2.7.7(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
     dependencies:
-      '@module-federation/enhanced': 0.15.0(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/enhanced': 0.15.0(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/runtime': 0.15.0
       '@module-federation/sdk': 0.15.0
       btoa: 1.2.1
@@ -8808,14 +8873,14 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.15.0(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
+  '@module-federation/rsbuild-plugin@0.15.0(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
     dependencies:
-      '@module-federation/enhanced': 0.15.0(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
-      '@module-federation/node': 2.7.7(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/enhanced': 0.15.0(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/node': 2.7.7(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/sdk': 0.15.0
       fs-extra: 11.3.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8829,7 +8894,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.15.0(@rspack/core@1.3.15(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
+  '@module-federation/rspack@0.15.0(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.15.0
       '@module-federation/dts-plugin': 0.15.0(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
@@ -8838,7 +8903,7 @@ snapshots:
       '@module-federation/manifest': 0.15.0(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/runtime-tools': 0.15.0
       '@module-federation/sdk': 0.15.0
-      '@rspack/core': 1.3.15(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.0-beta.0(@swc/helpers@0.5.17)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.8.3
@@ -8903,12 +8968,12 @@ snapshots:
 
   '@module-federation/sdk@0.15.0': {}
 
-  '@module-federation/storybook-addon@4.0.20(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@4.0.20(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 0.15.0(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/enhanced': 0.15.0(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/sdk': 0.15.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -9095,13 +9160,21 @@ snapshots:
       core-js: 3.42.0
       jiti: 2.4.2
 
-  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.4.0-beta.2)':
+  '@rsbuild/core@1.4.0-beta.3':
+    dependencies:
+      '@rspack/core': 1.4.0-beta.0(@swc/helpers@0.5.17)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.17
+      core-js: 3.43.0
+      jiti: 2.4.2
+
+  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.4.0-beta.3)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -9109,13 +9182,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@1.0.5(@rsbuild/core@1.4.0-beta.2)':
+  '@rsbuild/plugin-babel@1.0.5(@rsbuild/core@1.4.0-beta.3)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -9123,9 +9196,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.2.4(@rsbuild/core@1.4.0-beta.2)':
+  '@rsbuild/plugin-less@1.2.4(@rsbuild/core@1.4.0-beta.3)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
@@ -9157,11 +9230,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.3.22
 
-  '@rsbuild/plugin-preact@1.4.0(@rsbuild/core@1.4.0-beta.2)(preact@10.26.8)':
+  '@rsbuild/plugin-preact@1.4.0(@rsbuild/core@1.4.0-beta.3)(preact@10.26.8)':
     dependencies:
       '@prefresh/core': 1.5.3(preact@10.26.8)
       '@prefresh/utils': 1.2.0
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       '@rspack/plugin-preact-refresh': 1.1.2(@prefresh/core@1.5.3(preact@10.26.8))(@prefresh/utils@1.2.0)
       '@swc/plugin-prefresh': 7.0.4
     transitivePeerDependencies:
@@ -9175,27 +9248,27 @@ snapshots:
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-react@1.3.2(@rsbuild/core@1.4.0-beta.2)':
+  '@rsbuild/plugin-react@1.3.2(@rsbuild/core@1.4.0-beta.3)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       '@rspack/plugin-react-refresh': 1.4.3(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.3.2(@rsbuild/core@1.4.0-beta.2)':
+  '@rsbuild/plugin-sass@1.3.2(@rsbuild/core@1.4.0-beta.3)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.4
       reduce-configs: 1.1.0
       sass-embedded: 1.89.0
 
-  '@rsbuild/plugin-solid@1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.0-beta.2)(solid-js@1.9.7)':
+  '@rsbuild/plugin-solid@1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.0-beta.3)(solid-js@1.9.7)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.2
-      '@rsbuild/plugin-babel': 1.0.4(@rsbuild/core@1.4.0-beta.2)
+      '@rsbuild/core': 1.4.0-beta.3
+      '@rsbuild/plugin-babel': 1.0.4(@rsbuild/core@1.4.0-beta.3)
       babel-preset-solid: 1.9.5(@babel/core@7.26.10)
       solid-refresh: 0.6.3(solid-js@1.9.7)
     transitivePeerDependencies:
@@ -9203,9 +9276,9 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@1.1.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))':
+  '@rsbuild/plugin-stylus@1.1.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
       stylus: 0.64.0
@@ -9215,10 +9288,10 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.2.0(@rsbuild/core@1.4.0-beta.2)(typescript@5.8.3)':
+  '@rsbuild/plugin-svgr@1.2.0(@rsbuild/core@1.4.0-beta.3)(typescript@5.8.3)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.2
-      '@rsbuild/plugin-react': 1.3.2(@rsbuild/core@1.4.0-beta.2)
+      '@rsbuild/core': 1.4.0-beta.3
+      '@rsbuild/plugin-react': 1.3.2(@rsbuild/core@1.4.0-beta.3)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)
@@ -9229,31 +9302,43 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-toml@1.1.0(@rsbuild/core@1.4.0-beta.2)':
+  '@rsbuild/plugin-toml@1.1.0(@rsbuild/core@1.4.0-beta.3)':
     dependencies:
       toml: 3.0.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
 
-  '@rsbuild/plugin-type-check@1.2.2(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(typescript@5.8.3)':
+  '@rsbuild/plugin-type-check@1.2.2(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(typescript@5.8.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.0
       ts-checker-rspack-plugin: 1.1.3(@rspack/core@1.3.15(@swc/helpers@0.5.17))(typescript@5.8.3)
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.4.0-beta.2)':
+  '@rsbuild/plugin-type-check@1.2.2(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(typescript@5.8.3)':
+    dependencies:
+      deepmerge: 4.3.1
+      json5: 2.2.3
+      reduce-configs: 1.1.0
+      ts-checker-rspack-plugin: 1.1.3(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(typescript@5.8.3)
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - typescript
 
-  '@rsbuild/plugin-yaml@1.0.2(@rsbuild/core@1.4.0-beta.2)':
+  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.4.0-beta.3)':
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
+
+  '@rsbuild/plugin-yaml@1.0.2(@rsbuild/core@1.4.0-beta.3)':
+    optionalDependencies:
+      '@rsbuild/core': 1.4.0-beta.3
 
   '@rslib/core@0.9.2(@microsoft/api-extractor@7.52.8(@types/node@22.15.30))(typescript@5.8.3)':
     dependencies:
@@ -9270,10 +9355,16 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.3.15':
     optional: true
 
+  '@rspack/binding-darwin-arm64@1.4.0-beta.0':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.3.12':
     optional: true
 
   '@rspack/binding-darwin-x64@1.3.15':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.4.0-beta.0':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.3.12':
@@ -9282,10 +9373,16 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.3.15':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@1.4.0-beta.0':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.3.12':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.3.15':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.4.0-beta.0':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.3.12':
@@ -9294,10 +9391,16 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.3.15':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@1.4.0-beta.0':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.3.12':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.3.15':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.4.0-beta.0':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.3.12':
@@ -9306,16 +9409,25 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.3.15':
     optional: true
 
+  '@rspack/binding-win32-arm64-msvc@1.4.0-beta.0':
+    optional: true
+
   '@rspack/binding-win32-ia32-msvc@1.3.12':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.3.15':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@1.4.0-beta.0':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.3.12':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.3.15':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.4.0-beta.0':
     optional: true
 
   '@rspack/binding@1.3.12':
@@ -9342,6 +9454,18 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.3.15
       '@rspack/binding-win32-x64-msvc': 1.3.15
 
+  '@rspack/binding@1.4.0-beta.0':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.4.0-beta.0
+      '@rspack/binding-darwin-x64': 1.4.0-beta.0
+      '@rspack/binding-linux-arm64-gnu': 1.4.0-beta.0
+      '@rspack/binding-linux-arm64-musl': 1.4.0-beta.0
+      '@rspack/binding-linux-x64-gnu': 1.4.0-beta.0
+      '@rspack/binding-linux-x64-musl': 1.4.0-beta.0
+      '@rspack/binding-win32-arm64-msvc': 1.4.0-beta.0
+      '@rspack/binding-win32-ia32-msvc': 1.4.0-beta.0
+      '@rspack/binding-win32-x64-msvc': 1.4.0-beta.0
+
   '@rspack/core@1.3.12(@swc/helpers@0.5.17)':
     dependencies:
       '@module-federation/runtime-tools': 0.14.0
@@ -9355,6 +9479,14 @@ snapshots:
     dependencies:
       '@module-federation/runtime-tools': 0.14.3
       '@rspack/binding': 1.3.15
+      '@rspack/lite-tapable': 1.0.1
+    optionalDependencies:
+      '@swc/helpers': 0.5.17
+
+  '@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.15.0
+      '@rspack/binding': 1.4.0-beta.0
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
       '@swc/helpers': 0.5.17
@@ -10937,6 +11069,8 @@ snapshots:
   core-js-pure@3.42.0: {}
 
   core-js@3.42.0: {}
+
+  core-js@3.43.0: {}
 
   core-util-is@1.0.3: {}
 
@@ -14028,20 +14162,20 @@ snapshots:
       '@microsoft/api-extractor': 7.52.8(@types/node@22.15.30)
       typescript: 5.8.3
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.4.0-beta.2):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.4.0-beta.3):
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
 
-  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.4.0-beta.2):
+  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.4.0-beta.3):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
 
-  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.4.0-beta.2):
+  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.4.0-beta.3):
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
 
   rsbuild-plugin-publint@0.3.2(@rsbuild/core@1.3.22):
     dependencies:
@@ -14050,12 +14184,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.3.22
 
-  rsbuild-plugin-publint@0.3.2(@rsbuild/core@1.4.0-beta.2):
+  rsbuild-plugin-publint@0.3.2(@rsbuild/core@1.4.0-beta.3):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.12
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
 
   rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.3.22)(@types/node@22.15.30)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(vue@3.5.16(typescript@5.8.3))(yaml@2.6.1):
     dependencies:
@@ -14077,11 +14211,11 @@ snapshots:
       - vue
       - yaml
 
-  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.4.0-beta.2)(@types/node@22.15.30)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(vue@3.5.16(typescript@5.8.3))(yaml@2.6.1):
+  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.4.0-beta.3)(@types/node@22.15.30)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(vue@3.5.16(typescript@5.8.3))(yaml@2.6.1):
     dependencies:
       unplugin-vue: 6.2.0(@types/node@22.15.30)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(vue@3.5.16(typescript@5.8.3))(yaml@2.6.1)
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14528,18 +14662,26 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@2.0.1(@rsbuild/core@1.4.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3):
+  storybook-addon-rslib@2.0.1(@rsbuild/core@1.4.0-beta.3)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+      storybook-builder-rsbuild: 2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
 
-  storybook-builder-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
+  storybook-addon-rslib@2.0.1(@rsbuild/core@1.4.0-beta.3)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.2
-      '@rsbuild/plugin-type-check': 1.2.2(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(typescript@5.8.3)
+      '@rsbuild/core': 1.4.0-beta.3
+      '@rslib/core': link:packages/core
+      storybook-builder-rsbuild: 2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+    optionalDependencies:
+      typescript: 5.8.3
+
+  storybook-builder-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
+    dependencies:
+      '@rsbuild/core': 1.4.0-beta.3
+      '@rsbuild/plugin-type-check': 1.2.2(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(typescript@5.8.3)
       '@storybook/addon-docs': 9.0.4(@types/react@19.1.6)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))
       '@storybook/core-webpack': 9.0.4(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))
       browser-assert: 1.2.1
@@ -14552,7 +14694,7 @@ snapshots:
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.4.0-beta.2)
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.4.0-beta.3)
       sirv: 2.0.4
       storybook: 9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3)
       ts-dedent: 2.2.0
@@ -14568,10 +14710,42 @@ snapshots:
       - '@types/react'
       - webpack-sources
 
-  storybook-react-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
+  storybook-builder-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
+    dependencies:
+      '@rsbuild/core': 1.4.0-beta.3
+      '@rsbuild/plugin-type-check': 1.2.2(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(typescript@5.8.3)
+      '@storybook/addon-docs': 9.0.4(@types/react@19.1.6)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))
+      '@storybook/core-webpack': 9.0.4(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))
+      browser-assert: 1.2.1
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      cjs-module-lexer: 1.4.3
+      constants-browserify: 1.0.0
+      es-module-lexer: 1.7.0
+      find-cache-dir: 5.0.0
+      fs-extra: 11.3.0
+      magic-string: 0.30.17
+      path-browserify: 1.0.1
+      process: 0.11.10
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.4.0-beta.3)
+      sirv: 2.0.4
+      storybook: 9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3)
+      ts-dedent: 2.2.0
+      url: 0.11.4
+      util: 0.12.5
+      util-deprecate: 1.0.2
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@types/react'
+      - webpack-sources
+
+  storybook-react-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.39.0)
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       '@storybook/react': 9.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.3)
       '@types/node': 18.19.110
@@ -14583,7 +14757,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       resolve: 1.22.10
       storybook: 9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3)
-      storybook-builder-rsbuild: 2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+      storybook-builder-rsbuild: 2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.8.3
@@ -14595,12 +14769,12 @@ snapshots:
       - webpack
       - webpack-sources
 
-  storybook-vue3-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)(vue@3.5.16(typescript@5.8.3)):
+  storybook-vue3-rsbuild@2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)(vue@3.5.16(typescript@5.8.3)):
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.2
+      '@rsbuild/core': 1.4.0-beta.3
       '@storybook/vue3': 9.0.6(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(vue@3.5.16(typescript@5.8.3))
       storybook: 9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3)
-      storybook-builder-rsbuild: 2.0.1(@rsbuild/core@1.4.0-beta.2)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+      storybook-builder-rsbuild: 2.0.1(@rsbuild/core@1.4.0-beta.3)(@rspack/core@1.3.15(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.6(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
       vue: 3.5.16(typescript@5.8.3)
       vue-docgen-loader: 1.5.1
     transitivePeerDependencies:
@@ -14936,6 +15110,19 @@ snapshots:
       typescript: 5.8.3
     optionalDependencies:
       '@rspack/core': 1.3.15(@swc/helpers@0.5.17)
+
+  ts-checker-rspack-plugin@1.1.3(@rspack/core@1.4.0-beta.0(@swc/helpers@0.5.17))(typescript@5.8.3):
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@rspack/lite-tapable': 1.0.1
+      chokidar: 3.6.0
+      is-glob: 4.0.3
+      memfs: 4.17.2
+      minimatch: 9.0.5
+      picocolors: 1.1.1
+      typescript: 5.8.3
+    optionalDependencies:
+      '@rspack/core': 1.4.0-beta.0(@swc/helpers@0.5.17)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -35,8 +35,8 @@ test('set the size threshold to inline static assets', async () => {
   const { content: indexJs2 } = queryContent(contents.esm2!, /index\.js/);
   const { content: logoJs2 } = queryContent(contents.esm2!, /assets\/logo\.js/);
   expect(indexJs2).toMatchInlineSnapshot(`
-    "import logo_js_default from "./assets/logo.js";
-    const src = logo_js_default;
+    "import logo from "./assets/logo.js";
+    const src = logo;
     export { src as default };
     "
   `);

--- a/tests/integration/auto-external/index.test.ts
+++ b/tests/integration/auto-external/index.test.ts
@@ -8,9 +8,7 @@ test('auto external default should works', async () => {
   const fixturePath = join(__dirname, 'default');
   const { js, dts } = await buildAndGetResults({ fixturePath, type: 'all' });
 
-  expect(js.entries.esm).toContain(
-    'import external_react_default from "react";',
-  );
+  expect(js.entries.esm).toContain('import react from "react";');
 
   expect(js!.entries.cjs).toContain(
     'const external_react_namespaceObject = require("react");',
@@ -25,10 +23,8 @@ test('auto external sub path should works', async () => {
   const fixturePath = join(__dirname, 'external-sub-path');
   const { entries } = await buildAndGetResults({ fixturePath });
 
-  expect(entries.esm).toContain('import external_react_default from "react"');
-  expect(entries.esm).toContain(
-    'import jsx_runtime_default from "react/jsx-runtime"',
-  );
+  expect(entries.esm).toContain('import react from "react"');
+  expect(entries.esm).toContain('import jsx_runtime from "react/jsx-runtime"');
 
   expect(entries.cjs).toContain(
     'const external_react_namespaceObject = require("react");',
@@ -43,7 +39,7 @@ test('auto external should be disabled when bundle is false', async () => {
   const { js } = await buildAndGetResults({ fixturePath, type: 'all' });
 
   expect(Object.values(js.contents.esm)[0]).toContain(
-    'import external_react_default from "react"',
+    'import react from "react"',
   );
 
   expect(Object.values(js.contents.cjs)[0]).toContain(
@@ -55,9 +51,7 @@ test('auto external false should works', async () => {
   const fixturePath = join(__dirname, 'false');
   const { js, dts } = await buildAndGetResults({ fixturePath, type: 'all' });
 
-  expect(js.entries.esm).not.toContain(
-    'import external_react_default from "react"',
-  );
+  expect(js.entries.esm).not.toContain('import react from "react"');
 
   expect(js.entries.cjs).not.toContain(
     'const external_react_namespaceObject = require("react");',
@@ -72,7 +66,7 @@ test('externals should overrides auto external', async () => {
   const fixturePath = join(__dirname, 'with-externals');
   const { entries } = await buildAndGetResults({ fixturePath });
 
-  expect(entries.esm).toContain(`import external_react1_default from "react1"`);
+  expect(entries.esm).toContain(`import react1 from "react1"`);
 
   expect(entries.cjs).toContain(
     'const external_react1_namespaceObject = require("react1");',

--- a/tests/integration/bundle-false/index.test.ts
+++ b/tests/integration/bundle-false/index.test.ts
@@ -115,8 +115,8 @@ test('monorepo', async () => {
       basename: true,
     }).content,
   ).toMatchInlineSnapshot(`
-    "import external_bundle_false_monorepo_importee_test_default from "bundle-false-monorepo-importee-test";
-    const src = external_bundle_false_monorepo_importee_test_default;
+    "import bundle_false_monorepo_importee_test from "bundle-false-monorepo-importee-test";
+    const src = bundle_false_monorepo_importee_test;
     export { src as default };
     "
   `);

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -21,9 +21,9 @@ test('auto externalize Node.js built-in modules when `output.target` is "node"',
   for (const external of [
     'import * as __WEBPACK_EXTERNAL_MODULE_bar__ from "bar"',
     'import { createRequire as __WEBPACK_EXTERNAL_createRequire } from "node:module"',
-    'import external_fs_default from "fs"',
-    'import external_node_assert_default from "node:assert"',
-    'import external_react_default from "react"',
+    'import fs from "fs"',
+    'import node_assert from "node:assert"',
+    'import react from "react"',
   ]) {
     expect(entries.esm).toContain(external);
   }
@@ -92,11 +92,11 @@ test('user externals', async () => {
   const { entries, contents } = await buildAndGetResults({ fixturePath });
   expect(entries.esm0).toMatchInlineSnapshot(
     `
-    "import external_node_fs_default from "node:fs";
-    import external_lodash_default from "lodash";
-    import zip_default from "lodash/zip";
+    "import node_fs from "node:fs";
+    import lodash from "lodash";
+    import zip from "lodash/zip";
     const foo = 'foo';
-    console.log(external_node_fs_default, external_lodash_default.add, zip_default, foo);
+    console.log(node_fs, lodash.add, zip, foo);
     "
   `,
   );
@@ -104,11 +104,11 @@ test('user externals', async () => {
   expect(
     queryContent(contents.esm1!, 'index.js', { basename: true }).content,
   ).toMatchInlineSnapshot(`
-    "import external_node_fs_default from "node:fs";
-    import external_lodash_default from "lodash";
-    import zip_default from "lodash/zip";
+    "import node_fs from "node:fs";
+    import lodash from "lodash";
+    import zip from "lodash/zip";
     import { foo } from "./foo2";
-    console.log(external_node_fs_default, external_lodash_default.add, zip_default, foo);
+    console.log(node_fs, lodash.add, zip, foo);
     "
   `);
 });

--- a/tests/integration/format/index.test.ts
+++ b/tests/integration/format/index.test.ts
@@ -62,8 +62,8 @@ test('import.meta.url should be preserved', async () => {
     }
   `);
   expect(entries.esm).toMatchInlineSnapshot(`
-    "import external_node_url_default from "node:url";
-    const packageDirectory = external_node_url_default.fileURLToPath(new URL('.', import.meta.url));
+    "import node_url from "node:url";
+    const packageDirectory = node_url.fileURLToPath(new URL('.', import.meta.url));
     const foo = 'foo';
     export { foo, packageDirectory };
     "

--- a/tests/integration/polyfill/index.test.ts
+++ b/tests/integration/polyfill/index.test.ts
@@ -13,7 +13,7 @@ describe('polyfill', async () => {
   test('should polyfill in ESM', async () => {
     expect(entries.esm0).not.toContain(globalPolyfillResult);
     expect(entries.esm0).toMatch(
-      /import splice_js_default from "core-js-pure\/stable\/instance\/splice.js"/,
+      /import splice from "core-js-pure\/stable\/instance\/splice.js"/,
     );
     const result = (await import(entryFiles.esm0!)).value;
     expect(result).toEqual(['1']);

--- a/tests/integration/redirect/asset.test.ts
+++ b/tests/integration/redirect/asset.test.ts
@@ -13,7 +13,7 @@ test('0. default', async () => {
   const { content: indexJs } = queryContent(contents.esm0!, /index\.js/);
   const { content: indexCjs } = queryContent(contents.cjs0!, /index\.cjs/);
   expect(indexJs).toMatchInlineSnapshot(`
-    "import logo_js_default from "./assets/logo.js";
+    "import logo from "./assets/logo.js";
     "
   `);
   expect(indexCjs).toContain('require("./assets/logo.cjs")');
@@ -23,7 +23,7 @@ test('1. redirect.asset = false', async () => {
   const { content: indexJs } = queryContent(contents.esm1!, /index\.js/);
   const { content: indexCjs } = queryContent(contents.cjs1!, /index\.cjs/);
   expect(indexJs).toMatchInlineSnapshot(`
-    "import logo_svg_default from "./assets/logo.svg";
+    "import logo from "./assets/logo.svg";
     "
   `);
   expect(indexCjs).toContain('require("./assets/logo.svg")');

--- a/tests/integration/redirect/js.test.ts
+++ b/tests/integration/redirect/js.test.ts
@@ -20,12 +20,12 @@ test('redirect.js default', async () => {
   );
 
   expect(indexContent).toMatchInlineSnapshot(`
-    "import external_lodash_default from "lodash";
-    import external_prettier_default from "prettier";
+    "import lodash from "lodash";
+    import prettier from "prettier";
     import { bar } from "./bar/index.js";
     import { foo } from "./foo.js";
     import { baz } from "./baz.js";
-    const src = external_lodash_default.toUpper(foo + bar + foo + bar + baz + typeof external_prettier_default.version);
+    const src = lodash.toUpper(foo + bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
   `);
@@ -44,14 +44,14 @@ test('redirect.js.path false', async () => {
   );
 
   expect(indexContent).toMatchInlineSnapshot(`
-    "import external_lodash_default from "lodash";
-    import external_prettier_default from "prettier";
+    "import lodash from "lodash";
+    import prettier from "prettier";
     import { bar } from "@/bar";
     import { foo } from "@/foo";
     import { baz } from "~/baz";
     import { bar as external_bar_js_bar } from "./bar.js";
     import { foo as external_foo_js_foo } from "./foo.js";
-    const src = external_lodash_default.toUpper(external_foo_js_foo + external_bar_js_bar + foo + bar + baz + typeof external_prettier_default.version);
+    const src = lodash.toUpper(external_foo_js_foo + external_bar_js_bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
   `);
@@ -68,14 +68,14 @@ test('redirect.js.path with user override externals', async () => {
   );
 
   expect(indexContent).toMatchInlineSnapshot(`
-    "import external_lodash_default from "lodash";
-    import external_prettier_default from "prettier";
+    "import lodash from "lodash";
+    import prettier from "prettier";
     import { bar } from "./others/bar/index.js";
     import { foo } from "./others/foo.js";
     import { baz } from "./baz.js";
     import { bar as index_js_bar } from "./bar/index.js";
     import { foo as external_foo_js_foo } from "./foo.js";
-    const src = external_lodash_default.toUpper(external_foo_js_foo + index_js_bar + foo + bar + baz + typeof external_prettier_default.version);
+    const src = lodash.toUpper(external_foo_js_foo + index_js_bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
   `);
@@ -100,14 +100,14 @@ test('redirect.js.path with user override alias', async () => {
   );
 
   expect(indexContent).toMatchInlineSnapshot(`
-    "import external_lodash_default from "lodash";
-    import external_prettier_default from "prettier";
+    "import lodash from "lodash";
+    import prettier from "prettier";
     import { bar } from "./others/bar/index.js";
     import { foo } from "./others/foo.js";
     import { baz } from "./baz.js";
     import { bar as index_js_bar } from "./bar/index.js";
     import { foo as external_foo_js_foo } from "./foo.js";
-    const src = external_lodash_default.toUpper(external_foo_js_foo + index_js_bar + foo + bar + baz + typeof external_prettier_default.version);
+    const src = lodash.toUpper(external_foo_js_foo + index_js_bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
   `);
@@ -127,12 +127,12 @@ test('redirect.js.extension: false', async () => {
     /esm\/index\.js/,
   );
   expect(indexContent).toMatchInlineSnapshot(`
-    "import external_lodash_default from "lodash";
-    import external_prettier_default from "prettier";
+    "import lodash from "lodash";
+    import prettier from "prettier";
     import { bar } from "./bar/index.ts";
     import { foo } from "./foo.ts";
     import { baz } from "./baz.ts";
-    const src = external_lodash_default.toUpper(foo + bar + foo + bar + baz + typeof external_prettier_default.version);
+    const src = lodash.toUpper(foo + bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
   `);

--- a/tests/integration/redirect/jsNotResolved.test.ts
+++ b/tests/integration/redirect/jsNotResolved.test.ts
@@ -13,11 +13,11 @@ test('redirect.js default', async () => {
   );
 
   expect(indexContent).toMatchInlineSnapshot(`
-    "import external_lodash_default from "lodash";
-    import external_prettier_default from "prettier";
-    import external_bar_js_default from "./bar.js";
-    import external_foo_js_default from "./foo.js";
-    const src = external_lodash_default.toUpper(external_foo_js_default + external_bar_js_default + typeof external_prettier_default.version);
+    "import lodash from "lodash";
+    import prettier from "prettier";
+    import bar from "./bar.js";
+    import foo from "./foo.js";
+    const src = lodash.toUpper(foo + bar + typeof prettier.version);
     export { src as default };
     "
   `);
@@ -34,11 +34,11 @@ test('redirect.js.path false', async () => {
   );
 
   expect(indexContent).toMatchInlineSnapshot(`
-    "import external_lodash_default from "lodash";
-    import external_prettier_default from "prettier";
-    import external_bar_js_default from "./bar.js";
-    import external_foo_js_default from "./foo.js";
-    const src = external_lodash_default.toUpper(external_foo_js_default + external_bar_js_default + typeof external_prettier_default.version);
+    "import lodash from "lodash";
+    import prettier from "prettier";
+    import bar from "./bar.js";
+    import foo from "./foo.js";
+    const src = lodash.toUpper(foo + bar + typeof prettier.version);
     export { src as default };
     "
   `);
@@ -55,11 +55,11 @@ test('redirect.js.extension: false', async () => {
   );
 
   expect(indexContent).toMatchInlineSnapshot(`
-    "import external_lodash_default from "lodash";
-    import external_prettier_default from "prettier";
-    import external_bar_js_default from "./bar.js";
-    import external_foo_default from "./foo";
-    const src = external_lodash_default.toUpper(external_foo_default + external_bar_js_default + typeof external_prettier_default.version);
+    "import lodash from "lodash";
+    import prettier from "prettier";
+    import bar from "./bar.js";
+    import foo from "./foo";
+    const src = lodash.toUpper(foo + bar + typeof prettier.version);
     export { src as default };
     "
   `);

--- a/tests/integration/redirect/style.test.ts
+++ b/tests/integration/redirect/style.test.ts
@@ -33,7 +33,7 @@ test('0. default', async () => {
     /cjs\/module\/index\.cjs/,
   );
   expect(cssModuleIndexJs).toMatchInlineSnapshot(`
-    "import external_index_module_js_default from "./index.module.js";
+    "import index_module from "./index.module.js";
     "
   `);
   expect(cssModuleIndexCjs).toContain(
@@ -65,7 +65,7 @@ test('1. style.path: false', () => {
     /cjs\/module\/index\.cjs/,
   );
   expect(cssModuleIndexJs).toMatchInlineSnapshot(`
-    "import index_module_js_default from "@/module/index.module.js";
+    "import index_module from "@/module/index.module.js";
     "
   `);
   expect(cssModuleIndexCjs).toContain(
@@ -97,7 +97,7 @@ test('2. style.extension: false', async () => {
     /cjs\/module\/index\.cjs/,
   );
   expect(cssModuleIndexJs).toMatchInlineSnapshot(`
-    "import external_index_module_less_default from "./index.module.less";
+    "import index_module from "./index.module.less";
     "
   `);
   expect(cssModuleIndexCjs).toContain(
@@ -129,7 +129,7 @@ test('3. style.path: false, style.extension: false', async () => {
     /cjs\/module\/index\.cjs/,
   );
   expect(cssModuleIndexJs).toMatchInlineSnapshot(`
-    "import index_module_less_default from "@/module/index.module.less";
+    "import index_module from "@/module/index.module.less";
     "
   `);
   expect(cssModuleIndexCjs).toContain(

--- a/tests/integration/resolve/index.test.ts
+++ b/tests/integration/resolve/index.test.ts
@@ -30,8 +30,8 @@ test('resolve node protocol', async () => {
 
   expect(isSuccess).toBeTruthy();
   expect(entries.esm).toMatchInlineSnapshot(`
-    "import external_node_path_default from "node:path";
-    const { join } = external_node_path_default;
+    "import node_path from "node:path";
+    const { join } = node_path;
     export { join };
     "
   `);

--- a/tests/integration/style/stylus/index.test.ts
+++ b/tests/integration/style/stylus/index.test.ts
@@ -101,7 +101,7 @@ test('should extract css with pluginStylus in bundle-false', async () => {
   );
   expectFileContainContent(jsContents.esm, 'index.js', [
     'import "./a.css"',
-    'import external_b_module_js_default from "./b.module.js"',
+    'import b_module from "./b.module.js"',
   ]);
 
   expect(cjsCssFiles).toMatchInlineSnapshot(`

--- a/tests/integration/transform-import/index.test.ts
+++ b/tests/integration/transform-import/index.test.ts
@@ -10,7 +10,7 @@ test('transformImport with arco-design', async () => {
   for (const format of formats) {
     expect(Object.values(contents[format]!)[0]).toContain(
       format.startsWith('esm')
-        ? 'import button_default from "@arco-design/web-react/es/button"'
+        ? 'import es_button from "@arco-design/web-react/es/button"'
         : 'const button_namespaceObject = require("@arco-design/web-react/es/button")',
     );
     expect(Object.values(contents[format]!)[0]).toContain(
@@ -29,12 +29,12 @@ test('transformImport with lodash', async () => {
   for (const format of formats) {
     expect(Object.values(contents[format]!)[0]).toContain(
       format.startsWith('esm')
-        ? 'import get_default from "lodash/get"'
+        ? 'import get from "lodash/get"'
         : 'const get_namespaceObject = require("lodash/get")',
     );
     expect(Object.values(contents[format]!)[0]).toContain(
       format.startsWith('esm')
-        ? 'import add_default from "lodash/fp/add"'
+        ? 'import add from "lodash/fp/add"'
         : 'const add_namespaceObject = require("lodash/fp/add")',
     );
   }

--- a/tests/integration/vue/index.test.ts
+++ b/tests/integration/vue/index.test.ts
@@ -152,8 +152,8 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
       ]);
       export { Button as default };
       ",
-        "<ROOT>/tests/integration/vue/dist/bundleless/Button/index.js": "import external_Button_js_default from "./Button.js";
-      export { external_Button_js_default as default };
+        "<ROOT>/tests/integration/vue/dist/bundleless/Button/index.js": "import Button from "./Button.js";
+      export { Button as default };
       ",
         "<ROOT>/tests/integration/vue/dist/bundleless/Card.js": "import { createElementBlock, openBlock, ref, toDisplayString } from "vue";
       const _00_2Fplugin_vue_2Fexport_helper = (sfc, props)=>{
@@ -195,9 +195,9 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
       ]);
       export { Card as default };
       ",
-        "<ROOT>/tests/integration/vue/dist/bundleless/index.js": "import index_js_default from "./Button/index.js";
-      import external_Card_js_default from "./Card.js";
-      export { index_js_default as Button, external_Card_js_default as Card };
+        "<ROOT>/tests/integration/vue/dist/bundleless/index.js": "import Button from "./Button/index.js";
+      import Card from "./Card.js";
+      export { Button, Card };
       ",
       }
     `);

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^0.15.0",
     "@playwright/test": "1.52.0",
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rsbuild/plugin-less": "^1.2.4",
     "@rsbuild/plugin-react": "^1.3.2",
     "@rsbuild/plugin-sass": "^1.3.2",

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "rspress preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.2",
+    "@rsbuild/core": "1.4.0-beta.3",
     "@rsbuild/plugin-sass": "^1.3.2",
     "@rslib/tsconfig": "workspace:*",
     "@rspress/plugin-algolia": "2.0.0-beta.11",


### PR DESCRIPTION
## Summary

bump Rsbuild `1.4.0-beta.3`.

Further optimization of esm external render after https://github.com/web-infra-dev/rslib/pull/1042.

Related to default import, now it is shorter, e.g. `external_node_path_default` -> `node_path`.

### Source

```ts
import path from "node:path";
console.log(path.join("bar"));

```

### Before

```js
import external_node_path_default from "node:path";
console.log(external_node_path_default.join("bar"));
```

### Now

```js
import node_path from "node:path";
console.log(node_path.join("bar"));

```


## Related Links

- https://github.com/web-infra-dev/rsbuild/releases/tag/v1.4.0-beta.3
- https://github.com/web-infra-dev/rspack/pull/10598

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
