### PR TITLE
test: do not display expected error logs in terminal during testing

### DIFF
--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -539,9 +539,7 @@ describe('dts when build: true', () => {
     const stdoutOutput = result.stdout ? result.stdout.toString() : '';
 
     expect(result.status).toBe(1);
-    expect(stdoutOutput).toContain(
-      'Please set declarationDir: "./dist/esm" in /Users/bytedance/codes/rslib/tests/integration/dts/build/tsconfig/tsconfig.json to keep it same as "dts.distPath" or "output.distPath.root" field in lib config.',
-    );
+    expect(stdoutOutput).toContain('Please set declarationDir: "./dist/esm"');
   });
 
   test('should clean dts dist files', async () => {

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join, normalize } from 'node:path';
 import stripAnsi from 'strip-ansi';
@@ -75,15 +76,15 @@ describe('dts when bundle: false', () => {
   });
 
   test('abortOnError: false', async () => {
-    const { restore } = proxyConsole();
     const fixturePath = join(__dirname, 'bundle-false', 'abort-on-error');
-    const { isSuccess } = await buildAndGetResults({
-      fixturePath,
-      type: 'dts',
-    });
-    restore();
 
-    expect(isSuccess).toBe(true);
+    const result = spawnSync('npx', ['rslib', 'build'], {
+      cwd: fixturePath,
+      // do not show output in test console
+      stdio: 'ignore',
+    });
+
+    expect(result.status).toBe(0);
   });
 
   test('autoExtension: true', async () => {
@@ -249,14 +250,14 @@ describe('dts when bundle: true', () => {
 
   test('abortOnError: false', async () => {
     const fixturePath = join(__dirname, 'bundle', 'abort-on-error');
-    const { restore } = proxyConsole();
-    const { isSuccess } = await buildAndGetResults({
-      fixturePath,
-      type: 'dts',
-    });
-    restore();
 
-    expect(isSuccess).toBe(true);
+    const result = spawnSync('npx', ['rslib', 'build'], {
+      cwd: fixturePath,
+      // do not show output in test console
+      stdio: 'ignore',
+    });
+
+    expect(result.status).toBe(0);
   });
 
   test('autoExtension: true', async () => {
@@ -513,14 +514,14 @@ describe('dts when build: true', () => {
 
   test('abortOnError: false', async () => {
     const fixturePath = join(__dirname, 'build', 'abort-on-error');
-    const { restore } = proxyConsole();
-    const { isSuccess } = await buildAndGetResults({
-      fixturePath,
-      type: 'dts',
-    });
-    restore();
 
-    expect(isSuccess).toBe(true);
+    const result = spawnSync('npx', ['rslib', 'build'], {
+      cwd: fixturePath,
+      // do not show output in test console
+      stdio: 'ignore',
+    });
+
+    expect(result.status).toBe(0);
 
     const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
     expect(existsSync(buildInfoPath)).toBeTruthy();
@@ -528,17 +529,19 @@ describe('dts when build: true', () => {
 
   test('tsconfig missing some fields - declarationDir or outDir', async () => {
     const fixturePath = join(__dirname, 'build', 'tsconfig');
-    try {
-      await buildAndGetResults({
-        fixturePath,
-        type: 'dts',
-      });
-    } catch (err: any) {
-      // not easy to proxy child process stdout
-      expect(err.message).toBe(
-        'Error occurred in esm declaration files generation.',
-      );
-    }
+
+    const result = spawnSync('npx', ['rslib', 'build'], {
+      cwd: fixturePath,
+      // do not show output in test console
+      stdio: 'pipe',
+    });
+
+    const stdoutOutput = result.stdout ? result.stdout.toString() : '';
+
+    expect(result.status).toBe(1);
+    expect(stdoutOutput).toContain(
+      'Please set declarationDir: "./dist/esm" in /Users/bytedance/codes/rslib/tests/integration/dts/build/tsconfig/tsconfig.json to keep it same as "dts.distPath" or "output.distPath.root" field in lib config.',
+    );
   });
 
   test('should clean dts dist files', async () => {
@@ -603,14 +606,14 @@ describe('dts when composite: true', () => {
 
   test('abortOnError: false', async () => {
     const fixturePath = join(__dirname, 'composite', 'abort-on-error');
-    const { restore } = proxyConsole();
-    const { isSuccess } = await buildAndGetResults({
-      fixturePath,
-      type: 'dts',
-    });
-    restore();
 
-    expect(isSuccess).toBe(true);
+    const result = spawnSync('npx', ['rslib', 'build'], {
+      cwd: fixturePath,
+      // do not show output in test console
+      stdio: 'ignore',
+    });
+
+    expect(result.status).toBe(0);
 
     const buildInfoPath = join(fixturePath, 'tsconfig.tsbuildinfo');
     expect(existsSync(buildInfoPath)).toBeTruthy();

--- a/tests/integration/dts/index.test.ts
+++ b/tests/integration/dts/index.test.ts
@@ -82,6 +82,7 @@ describe('dts when bundle: false', () => {
       cwd: fixturePath,
       // do not show output in test console
       stdio: 'ignore',
+      shell: true,
     });
 
     expect(result.status).toBe(0);
@@ -255,6 +256,7 @@ describe('dts when bundle: true', () => {
       cwd: fixturePath,
       // do not show output in test console
       stdio: 'ignore',
+      shell: true,
     });
 
     expect(result.status).toBe(0);
@@ -519,6 +521,7 @@ describe('dts when build: true', () => {
       cwd: fixturePath,
       // do not show output in test console
       stdio: 'ignore',
+      shell: true,
     });
 
     expect(result.status).toBe(0);
@@ -534,6 +537,7 @@ describe('dts when build: true', () => {
       cwd: fixturePath,
       // do not show output in test console
       stdio: 'pipe',
+      shell: true,
     });
 
     const stdoutOutput = result.stdout ? result.stdout.toString() : '';
@@ -609,6 +613,7 @@ describe('dts when composite: true', () => {
       cwd: fixturePath,
       // do not show output in test console
       stdio: 'ignore',
+      shell: true,
     });
 
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary

do not display error logs in terminal during testing to avoid affecting the judgment of CI results when CI failed.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
