### PR TITLE
fix: do not redirect third party css file

### DIFF
--- a/packages/core/src/css/cssConfig.ts
+++ b/packages/core/src/css/cssConfig.ts
@@ -98,10 +98,11 @@ export async function cssExternalHandler(
   let resolvedRequest = request;
 
   if (styleRedirectPath) {
-    const resolved = await redirectPath(resolvedRequest);
-    if (resolved) {
-      resolvedRequest = resolved;
+    const redirectedPath = await redirectPath(resolvedRequest);
+    if (redirectedPath === undefined) {
+      return callback(undefined, request);
     }
+    resolvedRequest = redirectedPath;
   }
 
   if (!isCssFile(resolvedRequest)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,9 +918,15 @@ importers:
       '@types/lodash':
         specifier: ^4.17.17
         version: 4.17.17
+      '@types/lodash.merge':
+        specifier: ^4.6.9
+        version: 4.6.9
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      lodash.merge:
+        specifier: ^4.6.2
+        version: 4.6.2
 
   tests/integration/redirect/js-not-resolve: {}
 
@@ -3194,6 +3200,9 @@ packages:
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
+  '@types/lodash.merge@4.6.9':
+    resolution: {integrity: sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==}
+
   '@types/lodash@4.17.17':
     resolution: {integrity: sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==}
 
@@ -5292,6 +5301,9 @@ packages:
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -10135,6 +10147,10 @@ snapshots:
     dependencies:
       '@types/node': 22.15.31
 
+  '@types/lodash.merge@4.6.9':
+    dependencies:
+      '@types/lodash': 4.17.17
+
   '@types/lodash@4.17.17': {}
 
   '@types/mdast@4.0.4':
@@ -12539,6 +12555,8 @@ snapshots:
   lodash.clonedeepwith@4.5.0: {}
 
   lodash.debounce@4.0.8: {}
+
+  lodash.merge@4.6.2: {}
 
   lodash.startcase@4.4.0: {}
 

--- a/tests/integration/redirect/js.test.ts
+++ b/tests/integration/redirect/js.test.ts
@@ -21,11 +21,12 @@ test('redirect.js default', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import lodash from "lodash";
+    import lodash_merge from "lodash.merge";
     import prettier from "prettier";
     import { bar } from "./bar/index.js";
     import { foo } from "./foo.js";
     import { baz } from "./baz.js";
-    const src = lodash.toUpper(foo + bar + foo + bar + baz + typeof prettier.version);
+    const src = lodash.toUpper(lodash_merge(foo) + bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
   `);
@@ -45,13 +46,14 @@ test('redirect.js.path false', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import lodash from "lodash";
+    import lodash_merge from "lodash.merge";
     import prettier from "prettier";
     import { bar } from "@/bar";
     import { foo } from "@/foo";
     import { baz } from "~/baz";
     import { bar as external_bar_js_bar } from "./bar.js";
     import { foo as external_foo_js_foo } from "./foo.js";
-    const src = lodash.toUpper(external_foo_js_foo + external_bar_js_bar + foo + bar + baz + typeof prettier.version);
+    const src = lodash.toUpper(lodash_merge(external_foo_js_foo) + external_bar_js_bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
   `);
@@ -69,13 +71,14 @@ test('redirect.js.path with user override externals', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import lodash from "lodash";
+    import lodash_merge from "lodash.merge";
     import prettier from "prettier";
     import { bar } from "./others/bar/index.js";
     import { foo } from "./others/foo.js";
     import { baz } from "./baz.js";
     import { bar as index_js_bar } from "./bar/index.js";
     import { foo as external_foo_js_foo } from "./foo.js";
-    const src = lodash.toUpper(external_foo_js_foo + index_js_bar + foo + bar + baz + typeof prettier.version);
+    const src = lodash.toUpper(lodash_merge(external_foo_js_foo) + index_js_bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
   `);
@@ -101,13 +104,14 @@ test('redirect.js.path with user override alias', async () => {
 
   expect(indexContent).toMatchInlineSnapshot(`
     "import lodash from "lodash";
+    import lodash_merge from "lodash.merge";
     import prettier from "prettier";
     import { bar } from "./others/bar/index.js";
     import { foo } from "./others/foo.js";
     import { baz } from "./baz.js";
     import { bar as index_js_bar } from "./bar/index.js";
     import { foo as external_foo_js_foo } from "./foo.js";
-    const src = lodash.toUpper(external_foo_js_foo + index_js_bar + foo + bar + baz + typeof prettier.version);
+    const src = lodash.toUpper(lodash_merge(external_foo_js_foo) + index_js_bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
   `);
@@ -128,11 +132,12 @@ test('redirect.js.extension: false', async () => {
   );
   expect(indexContent).toMatchInlineSnapshot(`
     "import lodash from "lodash";
+    import lodash_merge from "lodash.merge";
     import prettier from "prettier";
     import { bar } from "./bar/index.ts";
     import { foo } from "./foo.ts";
     import { baz } from "./baz.ts";
-    const src = lodash.toUpper(foo + bar + foo + bar + baz + typeof prettier.version);
+    const src = lodash.toUpper(lodash_merge(foo) + bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
   `);

--- a/tests/integration/redirect/js/package.json
+++ b/tests/integration/redirect/js/package.json
@@ -5,9 +5,8 @@
   "type": "module",
   "devDependencies": {
     "@types/lodash": "^4.17.17",
-    "lodash": "^4.17.21"
-  },
-  "peerDependencies": {
-    "lodash": "^4.17.21"
+    "@types/lodash.merge": "^4.6.9",
+    "lodash": "^4.17.21",
+    "lodash.merge": "^4.6.2"
   }
 }

--- a/tests/integration/redirect/js/src/index.ts
+++ b/tests/integration/redirect/js/src/index.ts
@@ -1,14 +1,17 @@
 // can not be resolved
 import lodash from 'lodash';
+// can be resolved, 3rd packages
+import merge from 'lodash.merge';
 // can be resolved but not specified -- phantom dependency
 import prettier from 'prettier';
 
 import { bar as bar2 } from '@/bar';
 import { foo as foo2 } from '@/foo';
+// @ts-expect-error test case for unresolved paths import
 import { baz } from '~/baz';
 import { bar } from './bar';
 import { foo } from './foo';
 
 export default lodash.toUpper(
-  foo + bar + foo2 + bar2 + baz + typeof prettier.version,
+  merge(foo) + bar + foo2 + bar2 + baz + typeof prettier.version,
 );

--- a/tests/integration/redirect/js/src/index.ts
+++ b/tests/integration/redirect/js/src/index.ts
@@ -1,6 +1,6 @@
 // can not be resolved
 import lodash from 'lodash';
-// can be resolved, 3rd packages
+// can be resolved, 3rd party packages
 import merge from 'lodash.merge';
 // can be resolved but not specified -- phantom dependency
 import prettier from 'prettier';

--- a/tests/integration/redirect/style.test.ts
+++ b/tests/integration/redirect/style.test.ts
@@ -159,10 +159,12 @@ test('should external 3rd packages CSS', async () => {
   expect(pkgIndexJs).toMatchInlineSnapshot(`
     "import "element-ui/lib/theme-chunk/index.css";
     import "element-ui/lib/theme-chunk/index";
+    import "third-party/index.module.scss";
     "
   `);
   expect(pkgIndexCjs).toContain(
     `require("element-ui/lib/theme-chunk/index.css");
-require("element-ui/lib/theme-chunk/index");`,
+require("element-ui/lib/theme-chunk/index");
+require("third-party/index.module.scss");`,
   );
 });

--- a/tests/integration/redirect/style/.gitignore
+++ b/tests/integration/redirect/style/.gitignore
@@ -1,0 +1,1 @@
+!node_modules/

--- a/tests/integration/redirect/style/node_modules/third-party/index.module.scss
+++ b/tests/integration/redirect/style/node_modules/third-party/index.module.scss
@@ -1,0 +1,30 @@
+$primary-color: #007acc;
+$hover-color: #005fa3;
+$padding: 16px;
+
+.container {
+  padding: $padding;
+  background-color: #f9f9f9;
+  font-family: sans-serif;
+
+  &__header {
+    font-size: 24px;
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 12px;
+  }
+  
+  &__button {
+    background-color: $primary-color;
+    color: #fff;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 4px;
+    transition: background-color 0.3s ease;
+    cursor: pointer;
+    
+    &:hover {
+      background-color: $hover-color;
+    }
+  }
+}

--- a/tests/integration/redirect/style/node_modules/third-party/package.json
+++ b/tests/integration/redirect/style/node_modules/third-party/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "third-party",
+  "version": "1.0.0"
+}

--- a/tests/integration/redirect/style/src/pkg/index.ts
+++ b/tests/integration/redirect/style/src/pkg/index.ts
@@ -1,5 +1,5 @@
 // https://github.com/web-infra-dev/rslib/issues/617
 import 'element-ui/lib/theme-chunk/index.css';
 import 'element-ui/lib/theme-chunk/index';
-// can be resolved, 3rd packages
+// can be resolved, 3rd party packages
 import 'third-party/index.module.scss';

--- a/tests/integration/redirect/style/src/pkg/index.ts
+++ b/tests/integration/redirect/style/src/pkg/index.ts
@@ -1,3 +1,5 @@
 // https://github.com/web-infra-dev/rslib/issues/617
 import 'element-ui/lib/theme-chunk/index.css';
 import 'element-ui/lib/theme-chunk/index';
+// can be resolved, 3rd packages
+import 'third-party/index.module.scss';


### PR DESCRIPTION
## Summary

Do not redirect third party css, use same strategy with js redirect.

## Related Links

fix: #1066 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
