### PR TITLE
fix(dts): collect all kinds of diagnostics when composite is true

### DIFF
--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -268,9 +268,14 @@ export async function emitDts(
       });
 
       const emitResult = program.emit();
-      const allDiagnostics = program
-        .getConfigFileParsingDiagnostics()
-        .concat(emitResult.diagnostics);
+      const allDiagnostics = [
+        ...program.getConfigFileParsingDiagnostics(),
+        ...program.getOptionsDiagnostics(),
+        ...program.getSyntacticDiagnostics(),
+        ...program.getSemanticDiagnostics(),
+        ...program.getDeclarationDiagnostics(),
+        ...emitResult.diagnostics,
+      ];
 
       await handleDiagnosticsAndProcessFiles(
         allDiagnostics,


### PR DESCRIPTION
## Summary

Since `createIncrementalProgram` does not have a `getPreEmitDiagnostics` method, merge all kinds of diagnostics by api.

wrong modify in  https://github.com/web-infra-dev/rslib/pull/1081

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
