### PR TITLE
chore(deps): bump Rsbuild 1.4.0-rc.0

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.15.0",
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rsbuild/plugin-react": "^1.3.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.15.0",
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rsbuild/plugin-react": "^1.3.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "rsbuild-plugin-dts": "workspace:*",
     "tinyglobby": "^0.2.14"
   },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -504,9 +504,6 @@ export async function createConstantRsbuildConfig(): Promise<EnvironmentConfig> 
   // When the default configuration is inconsistent with rsbuild, remember to modify the type hints
   // see https://github.com/web-infra-dev/rslib/discussions/856
   return defineRsbuildConfig({
-    dev: {
-      progressBar: false,
-    },
     performance: {
       chunkSplit: {
         strategy: 'custom',

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -4,9 +4,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
 [
   {
     "config": {
-      "dev": {
-        "progressBar": false,
-      },
       "output": {
         "assetPrefix": "auto",
         "dataUriLimit": 0,
@@ -257,9 +254,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   {
     "config": {
-      "dev": {
-        "progressBar": false,
-      },
       "output": {
         "assetPrefix": "auto",
         "dataUriLimit": 0,
@@ -505,9 +499,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   {
     "config": {
-      "dev": {
-        "progressBar": false,
-      },
       "output": {
         "distPath": {
           "css": "./",
@@ -726,9 +717,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   {
     "config": {
-      "dev": {
-        "progressBar": false,
-      },
       "output": {
         "distPath": {
           "css": "./",
@@ -952,7 +940,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   {
     "config": {
       "dev": {
-        "progressBar": false,
         "writeToDisk": true,
       },
       "output": {

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@storybook/addon-docs": "^9.0.12",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@storybook/addon-docs": "^9.0.12",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@storybook/addon-docs": "^9.0.12",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@storybook/addon-docs": "^9.0.12",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rsbuild/plugin-react": "^1.3.2",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.12",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rsbuild/plugin-react": "^1.3.2",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.12",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -17,7 +17,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rsbuild/plugin-react": "^1.3.2",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.12",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rsbuild/plugin-react": "^1.3.2",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.12",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.12",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.12",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-js/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.12",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.12",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.52.8",
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rslib/tsconfig": "workspace:*",
     "rsbuild-plugin-publint": "^0.3.2",
     "rslib": "npm:@rslib/core@0.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,13 +91,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.15.0
-        version: 0.15.0(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@rsbuild/core':
-        specifier: 1.4.0-beta.5
-        version: 1.4.0-beta.5
+        specifier: 1.4.0-rc.0
+        version: 1.4.0-rc.0
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8
@@ -112,16 +112,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.15.0
-        version: 0.15.0(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.15.0
-        version: 0.15.0(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/storybook-addon':
         specifier: ^4.0.20
-        version: 4.0.20(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)
+        version: 4.0.20(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -142,10 +142,10 @@ importers:
         version: 9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3)
       storybook-addon-rslib:
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@1.4.0-beta.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3)
+        version: 2.0.2(@rsbuild/core@1.4.0-rc.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3)
       storybook-react-rsbuild:
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+        version: 2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -158,13 +158,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.15.0
-        version: 0.15.0(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@rsbuild/core':
-        specifier: 1.4.0-beta.5
-        version: 1.4.0-beta.5
+        specifier: 1.4.0-rc.0
+        version: 1.4.0-rc.0
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8
@@ -179,10 +179,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.4.0-beta.5)(preact@10.26.9)
+        version: 1.4.0(@rsbuild/core@1.4.0-rc.0)(preact@10.26.9)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -194,10 +194,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -212,10 +212,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -230,10 +230,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -248,13 +248,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.4.0-beta.5)
+        version: 1.0.5(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-solid':
         specifier: ^1.0.5
-        version: 1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.0-beta.5)(solid-js@1.9.7)
+        version: 1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.0-rc.0)(solid-js@1.9.7)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -311,16 +311,16 @@ importers:
         version: 9.0.12(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(vue@3.5.17(typescript@5.8.3))
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.4.0-beta.5)(@types/node@22.15.32)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.4.0-rc.0)(@types/node@22.15.32)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.6.1)
       storybook:
         specifier: ^9.0.12
         version: 9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3)
       storybook-addon-rslib:
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@1.4.0-beta.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3)
+        version: 2.0.2(@rsbuild/core@1.4.0-rc.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3)
       storybook-vue3-rsbuild:
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))
+        version: 2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -334,8 +334,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: 1.4.0-beta.5
-        version: 1.4.0-beta.5
+        specifier: 1.4.0-rc.0
+        version: 1.4.0-rc.0
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
@@ -345,7 +345,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.15.0
-        version: 0.15.0(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -372,7 +372,7 @@ importers:
         version: 1.3.3(typescript@5.8.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.2
-        version: 0.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 0.3.2(@rsbuild/core@1.4.0-rc.0)
       rslib:
         specifier: npm:@rslib/core@0.10.2
         version: '@rslib/core@0.10.2(@microsoft/api-extractor@7.52.8(@types/node@22.15.32))(typescript@5.8.3)'
@@ -439,14 +439,14 @@ importers:
         specifier: ^7.52.8
         version: 7.52.8(@types/node@22.15.32)
       '@rsbuild/core':
-        specifier: 1.4.0-beta.5
-        version: 1.4.0-beta.5
+        specifier: 1.4.0-rc.0
+        version: 1.4.0-rc.0
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
       rsbuild-plugin-publint:
         specifier: ^0.3.2
-        version: 0.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 0.3.2(@rsbuild/core@1.4.0-rc.0)
       rslib:
         specifier: npm:@rslib/core@0.10.2
         version: '@rslib/core@0.10.2(@microsoft/api-extractor@7.52.8(@types/node@22.15.32))(typescript@5.8.3)'
@@ -470,31 +470,31 @@ importers:
         version: 4.0.1(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.6.1))(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.6.1))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.15.0
-        version: 0.15.0(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+        version: 0.15.0(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@playwright/test':
         specifier: 1.53.1
         version: 1.53.1
       '@rsbuild/core':
-        specifier: 1.4.0-beta.5
-        version: 1.4.0-beta.5
+        specifier: 1.4.0-rc.0
+        version: 1.4.0-rc.0
       '@rsbuild/plugin-less':
         specifier: ^1.2.4
-        version: 1.2.4(@rsbuild/core@1.4.0-beta.5)
+        version: 1.2.4(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-toml':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.4.0-beta.5)
+        version: 1.1.0(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.0.2(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.0.2(@rsbuild/core@1.4.0-rc.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -559,7 +559,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
 
   tests/integration/asset/json: {}
 
@@ -575,10 +575,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.4.0-beta.5)(typescript@5.8.3)
+        version: 1.2.0(@rsbuild/core@1.4.0-rc.0)(typescript@5.8.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -672,10 +672,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.4.0-beta.5)(typescript@5.8.3)
+        version: 1.2.0(@rsbuild/core@1.4.0-rc.0)(typescript@5.8.3)
 
   tests/integration/cli/build: {}
 
@@ -889,7 +889,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.4.0-beta.5)
+        version: 1.0.5(@rsbuild/core@1.4.0-rc.0)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.12.0
         version: 0.12.0(@babel/core@7.26.10)
@@ -1024,13 +1024,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))
+        version: 1.1.1(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))
+        version: 1.1.1(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -1087,10 +1087,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.2.4
-        version: 1.2.4(@rsbuild/core@1.4.0-beta.5)
+        version: 1.2.4(@rsbuild/core@1.4.0-rc.0)
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.4.0-beta.5)(@types/node@22.15.32)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.4.0-rc.0)(@types/node@22.15.32)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.6.1)
       vue:
         specifier: ^3.5.17
         version: 3.5.17(typescript@5.8.3)
@@ -1102,11 +1102,11 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: 1.4.0-beta.5
-        version: 1.4.0-beta.5
+        specifier: 1.4.0-rc.0
+        version: 1.4.0-rc.0
       '@rsbuild/plugin-sass':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -1142,10 +1142,10 @@ importers:
         version: 19.1.0(react@19.1.0)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.3
-        version: 1.0.3(@rsbuild/core@1.4.0-beta.5)
+        version: 1.0.3(@rsbuild/core@1.4.0-rc.0)
       rsbuild-plugin-open-graph:
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.4.0-beta.5)
+        version: 1.0.2(@rsbuild/core@1.4.0-rc.0)
       rspress:
         specifier: 2.0.0-beta.16
         version: 2.0.0-beta.16(@types/react@19.1.8)(acorn@8.14.1)
@@ -2416,8 +2416,8 @@ packages:
     engines: {node: '>=16.10.0'}
     hasBin: true
 
-  '@rsbuild/core@1.4.0-beta.5':
-    resolution: {integrity: sha512-p9/ShPxTo0Jc/umZOHKOefBLydCKXnBxck50y1bLjwpiiK13+vN09l8L/GM9G7sALhVIzWxcMFBt39IdV1ePFA==}
+  '@rsbuild/core@1.4.0-rc.0':
+    resolution: {integrity: sha512-GgiHay9R5AdYXgboMwhKoaCZibfy39pZ+jlnAA9YQiorIgvPDZe58U/RWMx4q7amWzgTyge/wvMkNM1ifZR/3w==}
     engines: {node: '>=16.10.0'}
     hasBin: true
 
@@ -2529,6 +2529,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@1.4.0-rc.0':
+    resolution: {integrity: sha512-4fJ577AVWSHHsY+FEozxhYpnSGZmIneusFhIpbkf7l3x8hh5SdL6hE2y3lNeE9BHgjHPfdMJogoz/VNYcTWG/A==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.3.12':
     resolution: {integrity: sha512-Sj4m+mCUxL7oCpdu7OmWT7fpBM7hywk5CM9RDc3D7StaBZbvNtNftafCrTZzTYKuZrKmemTh5SFzT5Tz7tf6GA==}
     cpu: [x64]
@@ -2536,6 +2541,11 @@ packages:
 
   '@rspack/binding-darwin-x64@1.4.0-beta.1':
     resolution: {integrity: sha512-MadQU+i4aseveEcX+UJ+EbpEaKuVaL4H064Hl0vJE/83VMX/ICPLc4rfl3rrUfStji+jB+7FSFykPqtarUnQAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.4.0-rc.0':
+    resolution: {integrity: sha512-6r4l/2VhPuHrQrDYazQl4GNTSPvPPXEZwee2fYVO6YeWiPPJFNAUyIT0DjXtAMuJ2zDBOH0DkJ6dqkLf9/kn8Q==}
     cpu: [x64]
     os: [darwin]
 
@@ -2549,6 +2559,11 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@1.4.0-rc.0':
+    resolution: {integrity: sha512-K6VLea9StRkOltXqyxNzKeNR3cAFsOpHoNDc8lg0zZNAr1Rn1f+8THqFlWfDV1djXvhM/LsBM+rG97yQFYh/zg==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-musl@1.3.12':
     resolution: {integrity: sha512-s6KKj20T9Z1bA8caIjU6EzJbwyDo1URNFgBAlafCT2UC6yX7flstDJJ38CxZacA9A2P24RuQK2/jPSZpWrTUFA==}
     cpu: [arm64]
@@ -2556,6 +2571,11 @@ packages:
 
   '@rspack/binding-linux-arm64-musl@1.4.0-beta.1':
     resolution: {integrity: sha512-zJ6/F4KCiREVSeDC4/4x4CSRge7ymBeRG7S4zVR4EeYyWPBVVqzzextJhyozPPgeEat9eagUMYZRys3ON4DEVQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.4.0-rc.0':
+    resolution: {integrity: sha512-/xAgd0ObvI9ggJWMHDI8WHFCeuqi7gMnzdeN8QWO82dzlwO/0rgBqQkULS1hUDlV47Hh03BwjUz9sbuXCnelqg==}
     cpu: [arm64]
     os: [linux]
 
@@ -2569,6 +2589,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@1.4.0-rc.0':
+    resolution: {integrity: sha512-2u6ytaatpksqUfEn16M/8ppkYaurQpPgZ7cCy3iFpVi6w+7loXWz0X+xklsuBH8H0ie4CZkLmiJIhkW2hFn8KA==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@1.3.12':
     resolution: {integrity: sha512-jEdxkPymkRxbijDRsBGdhopcbGXiXDg59lXqIRkVklqbDmZ/O6DHm7gImmlx5q9FoWbz0gqJuOKBz4JqWxjWVA==}
     cpu: [x64]
@@ -2579,8 +2604,17 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-musl@1.4.0-rc.0':
+    resolution: {integrity: sha512-ilSb6GDz/0A+qlnPFZJuw9DtFH/ENf09f7raXxye3faZw/GH8aJ9H3X8VNeMR1QrYwFFk8LLB402EtZHETyz7Q==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-wasm32-wasi@1.4.0-beta.1':
     resolution: {integrity: sha512-B1+gtkjvXnXcoUU5+ETO3NEiH4Zub3bFJu38sSNp4blsG9cRSbHtyNTpZ3M81LttltMJpcwlprXvfu42RSbfSA==}
+    cpu: [wasm32]
+
+  '@rspack/binding-wasm32-wasi@1.4.0-rc.0':
+    resolution: {integrity: sha512-NsnAfBrQDlZTgudxG2YNgnOsZgaE4Vqm1pM0OXWd6NOhSGwGQ6T/rka99dHiUTxxAb6AOqI/avVn1NYsPHsqIQ==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.3.12':
@@ -2590,6 +2624,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@1.4.0-beta.1':
     resolution: {integrity: sha512-sI809RYsqjNzoIB+xvUjU1oVL19rr3Zcyk9d/MOFy0oMeFqKPBQYJy6li9/tUu1oACYpA1QtPjL8RpaLS//KWQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@1.4.0-rc.0':
+    resolution: {integrity: sha512-dT7FZz0dbWKzb3Ka6OD0TkOhGS/qC2/tWJ98nIxXMFCW2ZcULJhwcnRe95KBEwVDzwHgcTTzVa3fUFuTmcL87w==}
     cpu: [arm64]
     os: [win32]
 
@@ -2603,6 +2642,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@1.4.0-rc.0':
+    resolution: {integrity: sha512-0Q8+vWvT6zZPkNqaUvBIfXUSC3ZHsu/2on1bX9bGWLVfG4Or1QWY9vNA3vPX8DsK3XiHwixX+iLo95tmQgasNw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@1.3.12':
     resolution: {integrity: sha512-lCR0JfnYKpV+a6r2A2FdxyUKUS4tajePgpPJN5uXDgMGwrDtRqvx+d0BHhwjFudQVJq9VVbRaL89s2MQ6u+xYw==}
     cpu: [x64]
@@ -2613,11 +2657,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@1.4.0-rc.0':
+    resolution: {integrity: sha512-bsKJGM6Tu6aqyt6QTDEPL0BCtJ/HWHF3phdCP9XBUcmlSvjIwemekTs/QO/k2ZKXQ93j9Sz8J92WWmNQp0Mp8w==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@1.3.12':
     resolution: {integrity: sha512-4Ic8lV0+LCBfTlH5aIOujIRWZOtgmG223zC4L3o8WY/+ESAgpdnK6lSSMfcYgRanYLAy3HOmFIp20jwskMpbAg==}
 
   '@rspack/binding@1.4.0-beta.1':
     resolution: {integrity: sha512-cHtpiH0Iv7MrTrQCTPGwm0ourL6X82BCSK4tfmkwEOodMfCVkezG16bC0MCRKdaJCG/dehj594TnghwGldzj1A==}
+
+  '@rspack/binding@1.4.0-rc.0':
+    resolution: {integrity: sha512-kBEzks6RymjBLYF84TkUP895yCqqlodHDmBsWKbJGOokNKx+0ohnoWxXws5oZca/j9DSKCdEsA8VyROtqdMujw==}
 
   '@rspack/core@1.3.12':
     resolution: {integrity: sha512-mAPmV4LPPRgxpouUrGmAE4kpF1NEWJGyM5coebsjK/zaCMSjw3mkdxiU2b5cO44oIi0Ifv5iGkvwbdrZOvMyFA==}
@@ -2630,6 +2682,15 @@ packages:
 
   '@rspack/core@1.4.0-beta.1':
     resolution: {integrity: sha512-9CeiopvdgUP+TOWx/pkDbPYG0xEammaVJAvDx13MH2qVdFPr5im1/D/D9yc0LOHirTEQ9txfzEtkriWHevhcSw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@1.4.0-rc.0':
+    resolution: {integrity: sha512-yO4AP7sgptepks2kNLFvLipdonGv6OKDUIKEl0c7SpbBmPEspd3vsYxE/T5hruFVDnq0GPEePKA1GOjRCKGR8A==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -8739,7 +8800,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.15.0(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
+  '@module-federation/enhanced@0.15.0(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.15.0
       '@module-federation/cli': 0.15.0(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
@@ -8749,7 +8810,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.15.0(@module-federation/runtime-tools@0.15.0)
       '@module-federation/managers': 0.15.0
       '@module-federation/manifest': 0.15.0(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
-      '@module-federation/rspack': 0.15.0(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/rspack': 0.15.0(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/runtime-tools': 0.15.0
       '@module-federation/sdk': 0.15.0
       btoa: 1.2.1
@@ -8796,9 +8857,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.7(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
+  '@module-federation/node@2.7.7(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
     dependencies:
-      '@module-federation/enhanced': 0.15.0(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/enhanced': 0.15.0(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/runtime': 0.15.0
       '@module-federation/sdk': 0.15.0
       btoa: 1.2.1
@@ -8816,14 +8877,14 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.15.0(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
+  '@module-federation/rsbuild-plugin@0.15.0(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
     dependencies:
-      '@module-federation/enhanced': 0.15.0(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
-      '@module-federation/node': 2.7.7(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/enhanced': 0.15.0(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/node': 2.7.7(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/sdk': 0.15.0
       fs-extra: 11.3.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8837,7 +8898,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.15.0(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
+  '@module-federation/rspack@0.15.0(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.15.0
       '@module-federation/dts-plugin': 0.15.0(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
@@ -8846,7 +8907,7 @@ snapshots:
       '@module-federation/manifest': 0.15.0(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/runtime-tools': 0.15.0
       '@module-federation/sdk': 0.15.0
-      '@rspack/core': 1.4.0-beta.1(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.0-rc.0(@swc/helpers@0.5.17)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.8.3
@@ -8893,12 +8954,12 @@ snapshots:
 
   '@module-federation/sdk@0.15.0': {}
 
-  '@module-federation/storybook-addon@4.0.20(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@4.0.20(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 0.15.0(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@module-federation/enhanced': 0.15.0(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
       '@module-federation/sdk': 0.15.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -9087,21 +9148,21 @@ snapshots:
       core-js: 3.43.0
       jiti: 2.4.2
 
-  '@rsbuild/core@1.4.0-beta.5':
+  '@rsbuild/core@1.4.0-rc.0':
     dependencies:
-      '@rspack/core': 1.4.0-beta.1(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.0-rc.0(@swc/helpers@0.5.17)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.17
       core-js: 3.43.0
       jiti: 2.4.2
 
-  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.4.0-beta.5)':
+  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.4.0-rc.0)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -9109,13 +9170,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@1.0.5(@rsbuild/core@1.4.0-beta.5)':
+  '@rsbuild/plugin-babel@1.0.5(@rsbuild/core@1.4.0-rc.0)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -9123,9 +9184,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.2.4(@rsbuild/core@1.4.0-beta.5)':
+  '@rsbuild/plugin-less@1.2.4(@rsbuild/core@1.4.0-rc.0)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
@@ -9157,11 +9218,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.3.22
 
-  '@rsbuild/plugin-preact@1.4.0(@rsbuild/core@1.4.0-beta.5)(preact@10.26.9)':
+  '@rsbuild/plugin-preact@1.4.0(@rsbuild/core@1.4.0-rc.0)(preact@10.26.9)':
     dependencies:
       '@prefresh/core': 1.5.3(preact@10.26.9)
       '@prefresh/utils': 1.2.0
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       '@rspack/plugin-preact-refresh': 1.1.2(@prefresh/core@1.5.3(preact@10.26.9))(@prefresh/utils@1.2.0)
       '@swc/plugin-prefresh': 7.0.4
     transitivePeerDependencies:
@@ -9175,27 +9236,27 @@ snapshots:
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-react@1.3.2(@rsbuild/core@1.4.0-beta.5)':
+  '@rsbuild/plugin-react@1.3.2(@rsbuild/core@1.4.0-rc.0)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       '@rspack/plugin-react-refresh': 1.4.3(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.3.2(@rsbuild/core@1.4.0-beta.5)':
+  '@rsbuild/plugin-sass@1.3.2(@rsbuild/core@1.4.0-rc.0)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.6
       reduce-configs: 1.1.0
       sass-embedded: 1.89.0
 
-  '@rsbuild/plugin-solid@1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.0-beta.5)(solid-js@1.9.7)':
+  '@rsbuild/plugin-solid@1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.0-rc.0)(solid-js@1.9.7)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
-      '@rsbuild/plugin-babel': 1.0.4(@rsbuild/core@1.4.0-beta.5)
+      '@rsbuild/core': 1.4.0-rc.0
+      '@rsbuild/plugin-babel': 1.0.4(@rsbuild/core@1.4.0-rc.0)
       babel-preset-solid: 1.9.5(@babel/core@7.26.10)
       solid-refresh: 0.6.3(solid-js@1.9.7)
     transitivePeerDependencies:
@@ -9203,9 +9264,9 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@1.1.1(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))':
+  '@rsbuild/plugin-stylus@1.1.1(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
       stylus: 0.64.0
@@ -9215,10 +9276,10 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.2.0(@rsbuild/core@1.4.0-beta.5)(typescript@5.8.3)':
+  '@rsbuild/plugin-svgr@1.2.0(@rsbuild/core@1.4.0-rc.0)(typescript@5.8.3)':
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
-      '@rsbuild/plugin-react': 1.3.2(@rsbuild/core@1.4.0-beta.5)
+      '@rsbuild/core': 1.4.0-rc.0
+      '@rsbuild/plugin-react': 1.3.2(@rsbuild/core@1.4.0-rc.0)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)
@@ -9229,43 +9290,43 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-toml@1.1.0(@rsbuild/core@1.4.0-beta.5)':
+  '@rsbuild/plugin-toml@1.1.0(@rsbuild/core@1.4.0-rc.0)':
     dependencies:
       toml: 3.0.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
 
-  '@rsbuild/plugin-type-check@1.2.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(typescript@5.8.3)':
+  '@rsbuild/plugin-type-check@1.2.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(typescript@5.8.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.0
       ts-checker-rspack-plugin: 1.1.3(@rspack/core@1.3.12(@swc/helpers@0.5.17))(typescript@5.8.3)
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-type-check@1.2.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(typescript@5.8.3)':
+  '@rsbuild/plugin-type-check@1.2.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(typescript@5.8.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.0
-      ts-checker-rspack-plugin: 1.1.3(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(typescript@5.8.3)
+      ts-checker-rspack-plugin: 1.1.3(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(typescript@5.8.3)
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.4.0-beta.5)':
+  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.4.0-rc.0)':
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
 
-  '@rsbuild/plugin-yaml@1.0.2(@rsbuild/core@1.4.0-beta.5)':
+  '@rsbuild/plugin-yaml@1.0.2(@rsbuild/core@1.4.0-rc.0)':
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
 
   '@rslib/core@0.10.2(@microsoft/api-extractor@7.52.8(@types/node@22.15.32))(typescript@5.8.3)':
     dependencies:
@@ -9282,10 +9343,16 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.4.0-beta.1':
     optional: true
 
+  '@rspack/binding-darwin-arm64@1.4.0-rc.0':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.3.12':
     optional: true
 
   '@rspack/binding-darwin-x64@1.4.0-beta.1':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.4.0-rc.0':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.3.12':
@@ -9294,10 +9361,16 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.4.0-beta.1':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@1.4.0-rc.0':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.3.12':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.4.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.4.0-rc.0':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.3.12':
@@ -9306,13 +9379,24 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.4.0-beta.1':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@1.4.0-rc.0':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.3.12':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.4.0-beta.1':
     optional: true
 
+  '@rspack/binding-linux-x64-musl@1.4.0-rc.0':
+    optional: true
+
   '@rspack/binding-wasm32-wasi@1.4.0-beta.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.11
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@1.4.0-rc.0':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.11
     optional: true
@@ -9323,16 +9407,25 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.4.0-beta.1':
     optional: true
 
+  '@rspack/binding-win32-arm64-msvc@1.4.0-rc.0':
+    optional: true
+
   '@rspack/binding-win32-ia32-msvc@1.3.12':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.4.0-beta.1':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@1.4.0-rc.0':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.3.12':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.4.0-beta.1':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.4.0-rc.0':
     optional: true
 
   '@rspack/binding@1.3.12':
@@ -9360,6 +9453,19 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.4.0-beta.1
       '@rspack/binding-win32-x64-msvc': 1.4.0-beta.1
 
+  '@rspack/binding@1.4.0-rc.0':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.4.0-rc.0
+      '@rspack/binding-darwin-x64': 1.4.0-rc.0
+      '@rspack/binding-linux-arm64-gnu': 1.4.0-rc.0
+      '@rspack/binding-linux-arm64-musl': 1.4.0-rc.0
+      '@rspack/binding-linux-x64-gnu': 1.4.0-rc.0
+      '@rspack/binding-linux-x64-musl': 1.4.0-rc.0
+      '@rspack/binding-wasm32-wasi': 1.4.0-rc.0
+      '@rspack/binding-win32-arm64-msvc': 1.4.0-rc.0
+      '@rspack/binding-win32-ia32-msvc': 1.4.0-rc.0
+      '@rspack/binding-win32-x64-msvc': 1.4.0-rc.0
+
   '@rspack/core@1.3.12(@swc/helpers@0.5.17)':
     dependencies:
       '@module-federation/runtime-tools': 0.14.0
@@ -9373,6 +9479,14 @@ snapshots:
     dependencies:
       '@module-federation/runtime-tools': 0.15.0
       '@rspack/binding': 1.4.0-beta.1
+      '@rspack/lite-tapable': 1.0.1
+    optionalDependencies:
+      '@swc/helpers': 0.5.17
+
+  '@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.15.0
+      '@rspack/binding': 1.4.0-rc.0
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
       '@swc/helpers': 0.5.17
@@ -14051,20 +14165,20 @@ snapshots:
       '@microsoft/api-extractor': 7.52.8(@types/node@22.15.32)
       typescript: 5.8.3
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.4.0-beta.5):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.4.0-rc.0):
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
 
-  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.4.0-beta.5):
+  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.4.0-rc.0):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
 
-  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.4.0-beta.5):
+  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.4.0-rc.0):
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
 
   rsbuild-plugin-publint@0.3.2(@rsbuild/core@1.3.22):
     dependencies:
@@ -14073,12 +14187,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.3.22
 
-  rsbuild-plugin-publint@0.3.2(@rsbuild/core@1.4.0-beta.5):
+  rsbuild-plugin-publint@0.3.2(@rsbuild/core@1.4.0-rc.0):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.12
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
 
   rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.3.22)(@types/node@22.15.32)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.6.1):
     dependencies:
@@ -14100,11 +14214,11 @@ snapshots:
       - vue
       - yaml
 
-  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.4.0-beta.5)(@types/node@22.15.32)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.6.1):
+  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.4.0-rc.0)(@types/node@22.15.32)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.6.1):
     dependencies:
       unplugin-vue: 6.2.0(@types/node@22.15.32)(jiti@2.4.2)(sass-embedded@1.89.0)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.6.1)
     optionalDependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14551,26 +14665,26 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@2.0.2(@rsbuild/core@1.4.0-beta.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3):
+  storybook-addon-rslib@2.0.2(@rsbuild/core@1.4.0-rc.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
 
-  storybook-addon-rslib@2.0.2(@rsbuild/core@1.4.0-beta.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3):
+  storybook-addon-rslib@2.0.2(@rsbuild/core@1.4.0-rc.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
 
-  storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
+  storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
-      '@rsbuild/plugin-type-check': 1.2.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(typescript@5.8.3)
+      '@rsbuild/core': 1.4.0-rc.0
+      '@rsbuild/plugin-type-check': 1.2.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(typescript@5.8.3)
       '@storybook/addon-docs': 9.0.12(@types/react@19.1.8)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))
       '@storybook/core-webpack': 9.0.12(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))
       browser-assert: 1.2.1
@@ -14583,7 +14697,7 @@ snapshots:
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.4.0-beta.5)
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.4.0-rc.0)
       sirv: 2.0.4
       storybook: 9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3)
       ts-dedent: 2.2.0
@@ -14599,10 +14713,10 @@ snapshots:
       - '@types/react'
       - webpack-sources
 
-  storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
+  storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
-      '@rsbuild/plugin-type-check': 1.2.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(typescript@5.8.3)
+      '@rsbuild/core': 1.4.0-rc.0
+      '@rsbuild/plugin-type-check': 1.2.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(typescript@5.8.3)
       '@storybook/addon-docs': 9.0.12(@types/react@19.1.8)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))
       '@storybook/core-webpack': 9.0.12(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))
       browser-assert: 1.2.1
@@ -14615,7 +14729,7 @@ snapshots:
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.4.0-beta.5)
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.4.0-rc.0)
       sirv: 2.0.4
       storybook: 9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3)
       ts-dedent: 2.2.0
@@ -14631,10 +14745,10 @@ snapshots:
       - '@types/react'
       - webpack-sources
 
-  storybook-react-rsbuild@2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
+  storybook-react-rsbuild@2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.39.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.39.0)
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       '@storybook/react': 9.0.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.3)
       '@types/node': 18.19.110
@@ -14646,7 +14760,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       resolve: 1.22.10
       storybook: 9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3)
-      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.8.3
@@ -14658,12 +14772,12 @@ snapshots:
       - webpack
       - webpack-sources
 
-  storybook-vue3-rsbuild@2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3)):
+  storybook-vue3-rsbuild@2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3)):
     dependencies:
-      '@rsbuild/core': 1.4.0-beta.5
+      '@rsbuild/core': 1.4.0-rc.0
       '@storybook/vue3': 9.0.12(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(vue@3.5.17(typescript@5.8.3))
       storybook: 9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3)
-      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.0-beta.5)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
+      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.0-rc.0)(@rspack/core@1.3.12(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.12(@testing-library/dom@10.4.0)(prettier@3.5.3))(typescript@5.8.3)
       vue: 3.5.17(typescript@5.8.3)
       vue-docgen-loader: 1.5.1
     transitivePeerDependencies:
@@ -15004,7 +15118,7 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.3.12(@swc/helpers@0.5.17)
 
-  ts-checker-rspack-plugin@1.1.3(@rspack/core@1.4.0-beta.1(@swc/helpers@0.5.17))(typescript@5.8.3):
+  ts-checker-rspack-plugin@1.1.3(@rspack/core@1.4.0-rc.0(@swc/helpers@0.5.17))(typescript@5.8.3):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@rspack/lite-tapable': 1.0.1
@@ -15015,7 +15129,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.8.3
     optionalDependencies:
-      '@rspack/core': 1.4.0-beta.1(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.0-rc.0(@swc/helpers@0.5.17)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^0.15.0",
     "@playwright/test": "1.53.1",
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rsbuild/plugin-less": "^1.2.4",
     "@rsbuild/plugin-react": "^1.3.2",
     "@rsbuild/plugin-sass": "^1.3.2",

--- a/tests/scripts/rsbuild.ts
+++ b/tests/scripts/rsbuild.ts
@@ -71,9 +71,6 @@ const updateConfigForTest = async (
   });
 
   const baseConfig: RsbuildConfig = {
-    dev: {
-      progressBar: false,
-    },
     server: {
       // make port random to avoid conflict
       port: await getRandomPort(),

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "rspress preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.4.0-beta.5",
+    "@rsbuild/core": "1.4.0-rc.0",
     "@rsbuild/plugin-sass": "^1.3.2",
     "@rslib/tsconfig": "workspace:*",
     "@rspress/plugin-algolia": "2.0.0-beta.16",


### PR DESCRIPTION
## Summary

- bump Rsbuild 1.4.0-rc.0
- `dev.progressBar` now default to `false` in Rsbuild, remove configurations in Rslib

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v1.4.0-rc.0
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
