### PR TITLE
chore: move pnpm config from `.npmrc` to `pnpm-workspace.yaml`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,1 @@
 registry = 'https://registry.npmjs.org/'
-strict-peer-dependencies=false
-auto-install-peers=false
-hoist-patterns[]=[]

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,3 +17,7 @@ onlyBuiltDependencies:
 
 overrides:
   'zx>@types/node': '-'
+
+strictPeerDependencies: false
+autoInstallPeers: false
+hoistPattern: []


### PR DESCRIPTION
## Summary

chore: move pnpm config from `.npmrc` to `pnpm-workspace.yaml`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
