### PR TITLE
chore: correct check-dependency-version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:examples": "cross-env NX_DAEMON=false nx run-many -t build --projects @examples/* --parallel=10",
     "change": "changeset",
     "changeset": "changeset",
-    "check-dependency-version": "check-dependency-version-consistency .",
+    "check-dependency-version": "f() { check-dependency-version-consistency .; }; f",
     "check-spell": "pnpx cspell && heading-case",
     "format": "prettier . --write && biome check --write && heading-case --write",
     "generate-release-pr": "zx scripts/generateReleasePr.mjs",


### PR DESCRIPTION
## Summary

`check-dependency-version` 5.0.1 update command from v12 to v13 which will throw an error with excessArguments

![image](https://github.com/user-attachments/assets/76cd08a0-d586-4401-ab21-09ccdf06a92a)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
