### PR TITLE
fix: improve formatting of minutes in build time

### DIFF
--- a/packages/plugin-dts/rstest.config.ts
+++ b/packages/plugin-dts/rstest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from '@rstest/core';
 import { shared } from '../../rstest.workspace';
 
+// Disable color in test
+process.env.NO_COLOR = '1';
+
 export default defineConfig({
   ...shared,
   name: 'unit-dts',

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -136,8 +136,19 @@ export const prettyTime = (seconds: number): string => {
     return `${format(seconds.toFixed(1))} s`;
   }
 
-  const minutes = seconds / 60;
-  return `${format(minutes.toFixed(2))} m`;
+  const minutes = Math.floor(seconds / 60);
+  const minutesLabel = `${format(minutes.toFixed(0))} m`;
+  const remainingSeconds = seconds % 60;
+
+  if (remainingSeconds === 0) {
+    return minutesLabel;
+  }
+
+  const secondsLabel = `${format(
+    remainingSeconds.toFixed(remainingSeconds % 1 === 0 ? 0 : 1),
+  )} s`;
+
+  return `${minutesLabel} ${secondsLabel}`;
 };
 
 // tinyglobby only accepts posix path

--- a/packages/plugin-dts/tests/utils.test.ts
+++ b/packages/plugin-dts/tests/utils.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@rstest/core';
+import { prettyTime } from '../src/utils';
+
+test('should pretty time correctly', () => {
+  expect(prettyTime(0.0012)).toEqual('0.001 s');
+  expect(prettyTime(0.0123)).toEqual('0.01 s');
+  expect(prettyTime(0.1234)).toEqual('0.12 s');
+  expect(prettyTime(1.234)).toEqual('1.23 s');
+  expect(prettyTime(12.34)).toEqual('12.3 s');
+  expect(prettyTime(120)).toEqual('2 m');
+  expect(prettyTime(123.4)).toEqual('2 m 3.4 s');
+  expect(prettyTime(1234)).toEqual('20 m 34 s');
+  expect(prettyTime(1234.5)).toEqual('20 m 34.5 s');
+});


### PR DESCRIPTION
## Summary

Updates the `prettyTime` function to improve how time is formatted for better readability and accuracy.

- before: `20.57 m`
- after: `20 m 34 s`

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/5555

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
