### PR TITLE
fix(dts): preserve importer if resolved to node_modules folder

### DIFF
--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -307,11 +307,16 @@ export async function redirectDtsImports(
         '.mts',
         '.cjs',
         '.cts',
+        '.d.ts',
       ]);
 
       let redirectImportPath = importPath;
 
-      if (absoluteImportPath && redirect.path) {
+      if (
+        absoluteImportPath &&
+        !absoluteImportPath.includes('node_modules') &&
+        redirect.path
+      ) {
         const relativeRootDir = path.relative(
           normalize(rootDir),
           normalize(absoluteImportPath),
@@ -407,7 +412,12 @@ export async function processDtsFiles(
       return;
     }
 
-    const { absoluteBaseUrl, paths, mainFields, addMatchAll } = result;
+    const { absoluteBaseUrl, paths, addMatchAll } = result;
+    const mainFields: string[] = [];
+    /**
+     * resolve paths priorities:
+     * see https://github.com/jonaskello/tsconfig-paths/blob/098e066632f5b9f35c956803fe60d17ffc60b688/src/match-path-sync.ts#L18-L26
+     */
     matchPath = createMatchPath(
       absoluteBaseUrl,
       paths,

--- a/tests/integration/redirect/dts.test.ts
+++ b/tests/integration/redirect/dts.test.ts
@@ -29,6 +29,7 @@ test('redirect.dts.path: true with redirect.dts.extension: false - default', asy
     export * from './foo';
     export * from './logger';
     export type { Foo } from './types';
+    export { Router } from 'express';
     export * from '../../../compile/prebundle-pkg';
     export type { Bar } from './types';
     export * from './foo';
@@ -77,6 +78,7 @@ test('redirect.dts.path: false with redirect.dts.extension: false', async () => 
     export * from '@src/foo';
     export * from '@src/logger';
     export type { Foo } from '@src/types';
+    export { Router } from 'express';
     export * from 'prebundle-pkg';
     export type { Bar } from 'types';
     export * from './foo';
@@ -125,6 +127,7 @@ test('redirect.dts.path: true with redirect.dts.extension: true', async () => {
     export * from './foo/index.js';
     export * from './logger.js';
     export type { Foo } from './types.js';
+    export { Router } from 'express';
     export * from '../../../compile/prebundle-pkg';
     export type { Bar } from './types.js';
     export * from './foo/index.js';
@@ -173,6 +176,7 @@ test('redirect.dts.path: false with dts.redirect.extension: true', async () => {
     export * from '@src/foo';
     export * from '@src/logger';
     export type { Foo } from '@src/types';
+    export { Router } from 'express';
     export * from 'prebundle-pkg';
     export type { Bar } from 'types';
     export * from './foo/index.js';
@@ -228,6 +232,7 @@ test('redirect.dts.extension: true with dts.autoExtension: true', async () => {
     export * from './foo/index.mjs';
     export * from './logger.mjs';
     export type { Foo } from './types.mjs';
+    export { Router } from 'express';
     export * from '../../compile/prebundle-pkg';
     export type { Bar } from './types.mjs';
     export * from './foo/index.mjs';
@@ -243,6 +248,7 @@ test('redirect.dts.extension: true with dts.autoExtension: true', async () => {
     export * from './foo/index.js';
     export * from './logger.js';
     export type { Foo } from './types.js';
+    export { Router } from 'express';
     export * from '../../compile/prebundle-pkg';
     export type { Bar } from './types.js';
     export * from './foo/index.js';

--- a/tests/integration/redirect/dts/src/index.ts
+++ b/tests/integration/redirect/dts/src/index.ts
@@ -18,6 +18,7 @@ export {
 export * from '@src/foo';
 export * from '@src/logger';
 export type { Foo } from '@src/types';
+export { Router } from 'express';
 export * from 'prebundle-pkg';
 export type { Bar } from 'types';
 export * from './foo';

--- a/tests/integration/redirect/dts/tsconfig.json
+++ b/tests/integration/redirect/dts/tsconfig.json
@@ -3,10 +3,11 @@
     "strict": true,
     "skipLibCheck": true,
     "paths": {
-      "*": ["./src/*"],
       "@src/*": ["./src/*"],
       "prebundle-pkg": ["./compile/prebundle-pkg"],
-      "self-entry": ["./src"]
+      "self-entry": ["./src"],
+      "express": ["./node_modules/express"],
+      "*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## Summary

Usually developers will unify the versions of related types and solve the problem of multiple instances by writing the following in the `paths` of `tsconfig.json`. In this case, we do not need to redirect it to `../node_modules/foo`, just keep the original request.

```json
{
  "compilerOptions": {
    "paths": {
      "foo": ["./node_modules/foo"],
      "bar": ["./node_modules/@types/bar"],
    }
  },
}
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
