### PR TITLE
Release v0.11.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslib/core",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "The Rsbuild-based library development tool.",
   "homepage": "https://rslib.rs",
   "bugs": {

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rslib",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "Create a new Rslib project",
   "homepage": "https://rslib.rs",
   "repository": {

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsbuild-plugin-dts",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "Rsbuild plugin that supports emitting declaration files for TypeScript.",
   "homepage": "https://rslib.rs",
   "bugs": {


### PR DESCRIPTION
## Breaking changes 🚨

### redirect.asset

Boolean values are no longer supported for `redirect.asset`, see the documentation of [redirect.asset](https://lib.rsbuild.dev/config/lib/redirect#redirectasset) for more details. ([#1119](https://github.com/web-infra-dev/rslib/pull/1119))

Please note the following changes that may require adjustments to your configurations:

```diff
export default defineConfig({
  lib: [
    {
      redirect: {
-        asset: true,
+        asset: {
+          path: true,
+          extension: true,
+        },
      },
    },
  ],
});
```

```diff
export default defineConfig({
  lib: [
    {
      redirect: {
-        asset: false,
+        asset: {
+          path: false,
+          extension: false,
+        },
      },
    },
  ],
});
```