### PR TITLE
fix: should not throw minify error when using import.meta in iife output

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -695,6 +695,15 @@ const composeFormatConfig = ({
       }
 
       const config: EnvironmentConfig = {
+        output: {
+          minify: {
+            jsOptions: {
+              minimizerOptions: {
+                module: true,
+              },
+            },
+          },
+        },
         tools: {
           rspack: {
             module: {

--- a/tests/integration/iife/index.test.ts
+++ b/tests/integration/iife/index.test.ts
@@ -24,7 +24,10 @@ test('iife', async () => {
     "(()=>{
         "use strict";
         const external_globalHelper_namespaceObject = globalThis.globalHelper;
-        const addPrefix = (prefix, str, env)=>\`\${env}: \${prefix}\${str}\`;
+        const addPrefix = (prefix, str, env)=>{
+            console.log(import.meta.dirname);
+            return \`\${env}: \${prefix}\${str}\`;
+        };
         globalThis.addPrefix = (str)=>addPrefix(external_globalHelper_namespaceObject.helperName, str, "production");
     })();
     "

--- a/tests/integration/iife/src/utils.ts
+++ b/tests/integration/iife/src/utils.ts
@@ -1,4 +1,6 @@
-const addPrefix = (prefix: string, str: string, env: string) =>
-  `${env}: ${prefix}${str}`;
+const addPrefix = (prefix: string, str: string, env: string): string => {
+  console.log(import.meta.dirname);
+  return `${env}: ${prefix}${str}`;
+};
 
 export { addPrefix };


### PR DESCRIPTION
## Summary

should not throw minify error when using import.meta in iife output

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
