### PR TITLE
feat(create-rslib): add main/module fields for better compatibility

### DIFF
--- a/packages/create-rslib/fragments/base/react-js/package.json
+++ b/packages/create-rslib/fragments/base/react-js/package.json
@@ -7,6 +7,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/fragments/base/react-ts/package.json
+++ b/packages/create-rslib/fragments/base/react-ts/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/fragments/base/vue-js/package.json
+++ b/packages/create-rslib/fragments/base/vue-js/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/fragments/base/vue-ts/package.json
+++ b/packages/create-rslib/fragments/base/vue-ts/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[react]-[]-js/package.json
+++ b/packages/create-rslib/template-[react]-[]-js/package.json
@@ -7,6 +7,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[react]-[]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[]-ts/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -7,6 +7,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -7,6 +7,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[react]-[vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[vitest]-js/package.json
@@ -7,6 +7,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-[react]-[vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[vitest]-ts/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[vue]-[]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[]-js/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[vue]-[]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[]-ts/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[vue]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-js/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[vue]-[vitest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[vitest]-js/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/create-rslib/template-[vue]-[vitest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[vitest]-ts/package.json
@@ -8,6 +8,8 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
#1128 
Add explicit `main` and `module` fields to support:
1. Webpack4 and other legacy bundlers (via `main`)
2. Modern ES modules consumers (via `module`)
3. Maintain backward compatibility with `exports` field

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
