### PR TITLE
fix: determine wasmLoading by target

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -613,7 +613,6 @@ const composeFormatConfig = ({
               },
               chunkLoading: 'import',
               workerChunkLoading: 'import',
-              wasmLoading: 'fetch',
             },
             experiments: {
               outputModule: true,
@@ -643,7 +642,6 @@ const composeFormatConfig = ({
               },
               chunkLoading: 'require',
               workerChunkLoading: 'async-node',
-              wasmLoading: 'async-node',
             },
             plugins,
           },

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -216,7 +216,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                 "type": "modern-module",
               },
               "module": true,
-              "wasmLoading": "fetch",
               "workerChunkLoading": "import",
             },
             "plugins": [
@@ -482,7 +481,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
               "library": {
                 "type": "commonjs-static",
               },
-              "wasmLoading": "async-node",
               "workerChunkLoading": "async-node",
             },
             "plugins": [


### PR DESCRIPTION
## Summary

[wasmLoaing](https://rspack.rs/config/output#outputwasmloading) can be correctly inferred by Rspack. it should not be determined by module format.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
