### PR TITLE
chore(deps): bump Rsbuild 1.4.12

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.17.1",
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rsbuild/plugin-react": "^1.3.4",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.17.1",
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rsbuild/plugin-react": "^1.3.4",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "rsbuild-plugin-dts": "workspace:*",
     "tinyglobby": "^0.2.14"
   },

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rsbuild/plugin-react": "^1.3.4",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.18",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rsbuild/plugin-react": "^1.3.4",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.18",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -17,7 +17,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rsbuild/plugin-react": "^1.3.4",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.18",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rsbuild/plugin-react": "^1.3.4",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.18",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-js/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.0.18",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.52.9",
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rslib/tsconfig": "workspace:*",
     "rsbuild-plugin-publint": "^0.3.2",
     "rslib": "npm:@rslib/core@0.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,13 +91,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.17.1
-        version: 0.17.1(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+        version: 0.17.1(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@rsbuild/core':
-        specifier: ~1.4.11
-        version: 1.4.11
+        specifier: ~1.4.12
+        version: 1.4.12
       '@rsbuild/plugin-react':
         specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.11)
+        version: 1.3.4(@rsbuild/core@1.4.12)
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8
@@ -112,16 +112,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.17.1
-        version: 0.17.1(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+        version: 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.17.1
-        version: 0.17.1(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+        version: 0.17.1(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@module-federation/storybook-addon':
         specifier: ^4.0.23
-        version: 4.0.23(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))(webpack-virtual-modules@0.6.2)
+        version: 4.0.23(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))(webpack-virtual-modules@0.6.2)
       '@rsbuild/plugin-react':
         specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.11)
+        version: 1.3.4(@rsbuild/core@1.4.12)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -142,10 +142,10 @@ importers:
         version: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       storybook-addon-rslib:
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@1.4.11)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3))(typescript@5.8.3)
+        version: 2.0.2(@rsbuild/core@1.4.12)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3))(typescript@5.8.3)
       storybook-react-rsbuild:
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.44.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
+        version: 2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.44.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -158,13 +158,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.17.1
-        version: 0.17.1(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+        version: 0.17.1(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@rsbuild/core':
-        specifier: ~1.4.11
-        version: 1.4.11
+        specifier: ~1.4.12
+        version: 1.4.12
       '@rsbuild/plugin-react':
         specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.11)
+        version: 1.3.4(@rsbuild/core@1.4.12)
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8
@@ -179,10 +179,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@1.4.11)(preact@10.26.9)
+        version: 1.5.1(@rsbuild/core@1.4.12)(preact@10.26.9)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.3
-        version: 1.3.3(@rsbuild/core@1.4.11)
+        version: 1.3.3(@rsbuild/core@1.4.12)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -194,10 +194,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.11)
+        version: 1.3.4(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.3
-        version: 1.3.3(@rsbuild/core@1.4.11)
+        version: 1.3.3(@rsbuild/core@1.4.12)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -212,10 +212,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.11)
+        version: 1.3.4(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.3
-        version: 1.3.3(@rsbuild/core@1.4.11)
+        version: 1.3.3(@rsbuild/core@1.4.12)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -230,10 +230,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.11)
+        version: 1.3.4(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.3
-        version: 1.3.3(@rsbuild/core@1.4.11)
+        version: 1.3.3(@rsbuild/core@1.4.12)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -248,13 +248,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.4.11)
+        version: 1.0.5(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.3
-        version: 1.3.3(@rsbuild/core@1.4.11)
+        version: 1.3.3(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-solid':
         specifier: ^1.0.5
-        version: 1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.11)(solid-js@1.9.7)
+        version: 1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.12)(solid-js@1.9.7)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -272,7 +272,7 @@ importers:
         version: link:../../packages/core
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.4.11)(@types/node@22.16.5)(jiti@2.5.1)(sass-embedded@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(vue@3.5.18(typescript@5.8.3))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.4.12)(@types/node@22.16.5)(jiti@2.5.1)(sass-embedded@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(vue@3.5.18(typescript@5.8.3))(yaml@2.6.1)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -311,16 +311,16 @@ importers:
         version: 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vue@3.5.18(typescript@5.8.3))
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.4.11)(@types/node@22.16.5)(jiti@2.5.1)(sass-embedded@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(vue@3.5.18(typescript@5.8.3))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.4.12)(@types/node@22.16.5)(jiti@2.5.1)(sass-embedded@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(vue@3.5.18(typescript@5.8.3))(yaml@2.6.1)
       storybook:
         specifier: ^9.0.18
         version: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       storybook-addon-rslib:
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@1.4.11)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3))(typescript@5.8.3)
+        version: 2.0.2(@rsbuild/core@1.4.12)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3))(typescript@5.8.3)
       storybook-vue3-rsbuild:
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vue@3.5.18(typescript@5.8.3))
+        version: 2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vue@3.5.18(typescript@5.8.3))
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -334,8 +334,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~1.4.11
-        version: 1.4.11
+        specifier: ~1.4.12
+        version: 1.4.12
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
@@ -345,7 +345,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.17.1
-        version: 0.17.1(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+        version: 0.17.1(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -372,7 +372,7 @@ importers:
         version: 1.4.0(typescript@5.8.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.2
-        version: 0.3.2(@rsbuild/core@1.4.11)
+        version: 0.3.2(@rsbuild/core@1.4.12)
       rslib:
         specifier: npm:@rslib/core@0.11.0
         version: '@rslib/core@0.11.0(@microsoft/api-extractor@7.52.9(@types/node@22.16.5))(typescript@5.8.3)'
@@ -406,7 +406,7 @@ importers:
         version: 11.3.0
       rsbuild-plugin-publint:
         specifier: ^0.3.2
-        version: 0.3.2(@rsbuild/core@1.4.11)
+        version: 0.3.2(@rsbuild/core@1.4.12)
       rslib:
         specifier: npm:@rslib/core@0.11.0
         version: '@rslib/core@0.11.0(@microsoft/api-extractor@7.52.9(@types/node@22.16.5))(typescript@5.8.3)'
@@ -439,14 +439,14 @@ importers:
         specifier: ^7.52.9
         version: 7.52.9(@types/node@22.16.5)
       '@rsbuild/core':
-        specifier: ~1.4.11
-        version: 1.4.11
+        specifier: ~1.4.12
+        version: 1.4.12
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
       rsbuild-plugin-publint:
         specifier: ^0.3.2
-        version: 0.3.2(@rsbuild/core@1.4.11)
+        version: 0.3.2(@rsbuild/core@1.4.12)
       rslib:
         specifier: npm:@rslib/core@0.11.0
         version: '@rslib/core@0.11.0(@microsoft/api-extractor@7.52.9(@types/node@22.16.5))(typescript@5.8.3)'
@@ -470,31 +470,31 @@ importers:
         version: 4.0.1(vite@6.3.5(@types/node@22.16.5)(jiti@2.5.1)(sass-embedded@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.17.1
-        version: 0.17.1(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+        version: 0.17.1(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@playwright/test':
         specifier: 1.54.1
         version: 1.54.1
       '@rsbuild/core':
-        specifier: ~1.4.11
-        version: 1.4.11
+        specifier: ~1.4.12
+        version: 1.4.12
       '@rsbuild/plugin-less':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.4.11)
+        version: 1.3.0(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-react':
         specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.11)
+        version: 1.3.4(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-sass':
         specifier: ^1.3.3
-        version: 1.3.3(@rsbuild/core@1.4.11)
+        version: 1.3.3(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-toml':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.4.11)
+        version: 1.1.0(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.4.11)
+        version: 1.0.2(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.4.11)
+        version: 1.0.2(@rsbuild/core@1.4.12)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -559,7 +559,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.11)
+        version: 1.3.4(@rsbuild/core@1.4.12)
 
   tests/integration/asset/json: {}
 
@@ -575,10 +575,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.11)
+        version: 1.3.4(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.1
-        version: 1.2.1(@rsbuild/core@1.4.11)(typescript@5.8.3)
+        version: 1.2.1(@rsbuild/core@1.4.12)(typescript@5.8.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -672,10 +672,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.11)
+        version: 1.3.4(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.1
-        version: 1.2.1(@rsbuild/core@1.4.11)(typescript@5.8.3)
+        version: 1.2.1(@rsbuild/core@1.4.12)(typescript@5.8.3)
 
   tests/integration/cli/build: {}
 
@@ -865,7 +865,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.11)
+        version: 1.3.2(@rsbuild/core@1.4.12)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -875,7 +875,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@1.4.11)
+        version: 1.3.2(@rsbuild/core@1.4.12)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -893,7 +893,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@1.4.11)
+        version: 1.0.5(@rsbuild/core@1.4.12)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.13.0
         version: 0.13.0(@babel/core@7.26.10)
@@ -1026,13 +1026,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))
+        version: 1.1.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))
+        version: 1.1.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -1089,10 +1089,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.3.0
-        version: 1.3.0(@rsbuild/core@1.4.11)
+        version: 1.3.0(@rsbuild/core@1.4.12)
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.4.11)(@types/node@22.16.5)(jiti@2.5.1)(sass-embedded@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(vue@3.5.18(typescript@5.8.3))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.4.12)(@types/node@22.16.5)(jiti@2.5.1)(sass-embedded@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(vue@3.5.18(typescript@5.8.3))(yaml@2.6.1)
       vue:
         specifier: ^3.5.18
         version: 3.5.18(typescript@5.8.3)
@@ -1104,11 +1104,11 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~1.4.11
-        version: 1.4.11
+        specifier: ~1.4.12
+        version: 1.4.12
       '@rsbuild/plugin-sass':
         specifier: ^1.3.3
-        version: 1.3.3(@rsbuild/core@1.4.11)
+        version: 1.3.3(@rsbuild/core@1.4.12)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../scripts/tsconfig
@@ -1147,10 +1147,10 @@ importers:
         version: 19.1.0(react@19.1.0)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.3
-        version: 1.0.3(@rsbuild/core@1.4.11)
+        version: 1.0.3(@rsbuild/core@1.4.12)
       rsbuild-plugin-open-graph:
         specifier: ^1.0.2
-        version: 1.0.2(@rsbuild/core@1.4.11)
+        version: 1.0.2(@rsbuild/core@1.4.12)
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
@@ -2298,8 +2298,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.4.11':
-    resolution: {integrity: sha512-G5x7jUGxVw0Z984IEKmOP/tW8gslhUjN81D3fuogKb95hlESWpc+LuckuA5iO1ydbLVrhuYKLv1tC8wTAIDsqA==}
+  '@rsbuild/core@1.4.12':
+    resolution: {integrity: sha512-9IDAwZH8OVdq3ZUbh8IyOpwWxOU/67gD+UbSlvGschjhjMqhlLZ7hvsEqi8xfuPvgV0AhKXBZ4Ui1CN9pp1Hqg==}
     engines: {node: '>=16.10.0'}
     hasBin: true
 
@@ -2406,8 +2406,8 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.4.10':
-    resolution: {integrity: sha512-PraYGuVSzvEwdoYC8T70qI/8j1QeUe2sysiWmjSdxUpxJsDfw35hK9TfxULeAJULlAUAiiXs03hdZk29DBc3ow==}
+  '@rspack/binding-darwin-arm64@1.4.11':
+    resolution: {integrity: sha512-PrmBVhR8MC269jo6uQ+BMy1uwIDx0HAJYLQRQur8gXiehWabUBCRg/d4U9KR7rLzdaSScRyc5JWXR52T7/4MfA==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2416,8 +2416,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.4.10':
-    resolution: {integrity: sha512-rWTSJ08TE0uqUjqAHkTmWqJu+FLSJ70A199Fk9k/FLZTS8UtHjuzZW7rv4qIN2nwJJLherxFUnP6y69cHuaGNw==}
+  '@rspack/binding-darwin-x64@1.4.11':
+    resolution: {integrity: sha512-YIV8Wzy+JY0SoSsVtN4wxFXOjzxxVPnVXNswrrfqVUTPr9jqGOFYUWCGpbt8lcCgfuBFm6zN8HpOsKm1xUNsVA==}
     cpu: [x64]
     os: [darwin]
 
@@ -2426,8 +2426,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.4.10':
-    resolution: {integrity: sha512-cs6yu250FzRU1hl+02VLoJRdzbAveTOqvREeHgqL5AiTc6q1dQo1IZ16/Qt4+g0DMjnvM66pELRIO2nphXL8aA==}
+  '@rspack/binding-linux-arm64-gnu@1.4.11':
+    resolution: {integrity: sha512-ms6uwECUIcu+6e82C5HJhRMHnfsI+l33v7XQezntzRPN0+sG3EpikEoT7SGbgt4vDwaWLR7wS20suN4qd5r3GA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2436,8 +2436,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.4.10':
-    resolution: {integrity: sha512-NnOAoWkpZvOa+xM7NAJg25O+tSKt6xCXoga+gOw5XPni1NxHDc3PNh5bU6fAmc2Z29YLLdxeVqPmIDfdk1EkDg==}
+  '@rspack/binding-linux-arm64-musl@1.4.11':
+    resolution: {integrity: sha512-9evq0DOdxMN/H8VM8ZmyY9NSuBgILNVV6ydBfVPMHPx4r1E7JZGpWeKDegZcS5Erw3sS9kVSIxyX78L5PDzzKw==}
     cpu: [arm64]
     os: [linux]
 
@@ -2446,8 +2446,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.4.10':
-    resolution: {integrity: sha512-FcaBqMclADWiqX+Mez15kggwaVYZkoEqDiQwYRpYDbBMsiJEtfp41GnNRstTWxYxFbcmuWoZl2cYy+LepR21ag==}
+  '@rspack/binding-linux-x64-gnu@1.4.11':
+    resolution: {integrity: sha512-bHYFLxPPYBOSaHdQbEoCYGMQ1gOrEWj7Mro/DLfSHZi1a0okcQ2Q1y0i1DczReim3ZhLGNrK7k1IpFXCRbAobQ==}
     cpu: [x64]
     os: [linux]
 
@@ -2456,8 +2456,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.4.10':
-    resolution: {integrity: sha512-vgRQhCw+C/Nxv6MZVNUkPzSXs6kIWHIrGKUvOM1ceeAkT+jNFEQdukkQ5LsYgEqEwP9ezWubxN3IGrMxyimlPw==}
+  '@rspack/binding-linux-x64-musl@1.4.11':
+    resolution: {integrity: sha512-wrm4E7q2k4+cwT6Uhp6hIQ3eUe/YoaUttj6j5TqHYZX6YeLrNPtD9+ne6lQQ17BV8wmm6NZsmoFIJ5xIptpRhQ==}
     cpu: [x64]
     os: [linux]
 
@@ -2466,16 +2466,16 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-wasm32-wasi@1.4.10':
-    resolution: {integrity: sha512-lk647+Ob3yvVS2FgW0vCfo/gz9h0Q7v9HGBFcsD1uW0/tSqXMa2s9ZvIn+B7S9tRgIoosXEAuq8NeCXKGWVj5Q==}
+  '@rspack/binding-wasm32-wasi@1.4.11':
+    resolution: {integrity: sha512-hiYxHZjaZ17wQtXyLCK0IdtOvMWreGVTiGsaHCxyeT+SldDG+r16bXNjmlqfZsjlfl1mkAqKz1dg+mMX28OTqw==}
     cpu: [wasm32]
 
   '@rspack/binding-wasm32-wasi@1.4.9':
     resolution: {integrity: sha512-yWd5llZHBCsA0S5W0UGuXdQQ5zkZC4PQbOQS7XiblBII9RIMZZKJV/3AsYAHUeskTBPnwYMQsm8QCV52BNAE9A==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@1.4.10':
-    resolution: {integrity: sha512-9mB3kh4pKaY4wFosZwuxb5EUtt7vv/uKW3OF4TJDC35bH7r54s+YYpHyXROT304r6URl4b6HNHlysL2m7BLihg==}
+  '@rspack/binding-win32-arm64-msvc@1.4.11':
+    resolution: {integrity: sha512-+HF/mnjmTr8PC1dccRt1bkrD2tPDGeqvXC1BBLYd/Klq1VbtIcnrhfmvQM6KaXbiLcY9VWKzcZPOTmnyZ8TaHQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -2484,8 +2484,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.4.10':
-    resolution: {integrity: sha512-DPlyLZDUWkNcFI7zp1BQVVnihd4j/hCIbxqvIKvUt7whIVYMP52i8lCsa52uNGBSj7BcbcKAFElXC9dHVvoQGA==}
+  '@rspack/binding-win32-ia32-msvc@1.4.11':
+    resolution: {integrity: sha512-EU2fQGwrRfwFd/tcOInlD0jy6gNQE4Q3Ayj0Is+cX77sbhPPyyOz0kZDEaQ4qaN2VU8w4Hu/rrD7c0GAKLFvCw==}
     cpu: [ia32]
     os: [win32]
 
@@ -2494,8 +2494,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.4.10':
-    resolution: {integrity: sha512-FEE6OM0Wh7nj90+1ARXojT0Dnqox9UlIUIj7MQmX09yeMtckR+HITeq75F8y0l7HUvKOl2zQovmenk1KgyJV8Q==}
+  '@rspack/binding-win32-x64-msvc@1.4.11':
+    resolution: {integrity: sha512-1Nc5ZzWqfvE+iJc47qtHFzYYnHsC3awavXrCo74GdGip1vxtksM3G30BlvAQHHVtEmULotWqPbjZpflw/Xk9Ag==}
     cpu: [x64]
     os: [win32]
 
@@ -2504,14 +2504,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.4.10':
-    resolution: {integrity: sha512-awiXN7qTTTLWFThbJFL+M4k1if4sb17xKA5TaHbbxs0qKSlpe3adwNrNHaNU2WOQz+PbuF++OMyd+4gUusKuVg==}
+  '@rspack/binding@1.4.11':
+    resolution: {integrity: sha512-maGl/zRwnl0QVwkBCkgjn5PH20L9HdlRIdkYhEsfTepy5x2QZ0ti/0T49djjTJQrqb+S1i6wWQymMMMMMsxx6Q==}
 
   '@rspack/binding@1.4.9':
     resolution: {integrity: sha512-9EY8OMCNZrwCupQMZccMgrTxWGUQvZGFrLFw/rxfTt+uT4fS4CAbNwHVFxsnROaRd+EE6EXfUpUYu66j6vd4qA==}
 
-  '@rspack/core@1.4.10':
-    resolution: {integrity: sha512-eK3H328pihiM1323OlaClKJ9WlqgGBZpcR5AqFoWsG0KD01tKCJOeZEgtCY6paRLrsQrEJwBrLntkG0fE7WNGg==}
+  '@rspack/core@1.4.11':
+    resolution: {integrity: sha512-JtKnL6p7Kc/YgWQJF3Woo4OccbgKGyT/4187W4dyex8BMkdQcbqCNIdi6dFk02hwQzxpOOxRSBI4hlGRbz7oYQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -8444,7 +8444,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.17.1(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))':
+  '@module-federation/enhanced@0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.17.1
       '@module-federation/cli': 0.17.1(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
@@ -8454,7 +8454,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.17.1(@module-federation/runtime-tools@0.17.1)
       '@module-federation/managers': 0.17.1
       '@module-federation/manifest': 0.17.1(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
-      '@module-federation/rspack': 0.17.1(@rspack/core@1.4.10(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+      '@module-federation/rspack': 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@module-federation/runtime-tools': 0.17.1
       '@module-federation/sdk': 0.17.1
       btoa: 1.2.1
@@ -8501,9 +8501,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.10(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))':
+  '@module-federation/node@2.7.10(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))':
     dependencies:
-      '@module-federation/enhanced': 0.17.1(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+      '@module-federation/enhanced': 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@module-federation/runtime': 0.17.1
       '@module-federation/sdk': 0.17.1
       btoa: 1.2.1
@@ -8521,14 +8521,14 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.17.1(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))':
+  '@module-federation/rsbuild-plugin@0.17.1(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))':
     dependencies:
-      '@module-federation/enhanced': 0.17.1(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
-      '@module-federation/node': 2.7.10(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+      '@module-federation/enhanced': 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+      '@module-federation/node': 2.7.10(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@module-federation/sdk': 0.17.1
       fs-extra: 11.3.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8542,7 +8542,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.17.1(@rspack/core@1.4.10(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))':
+  '@module-federation/rspack@0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.17.1
       '@module-federation/dts-plugin': 0.17.1(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
@@ -8551,7 +8551,7 @@ snapshots:
       '@module-federation/manifest': 0.17.1(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@module-federation/runtime-tools': 0.17.1
       '@module-federation/sdk': 0.17.1
-      '@rspack/core': 1.4.10(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.8.3
@@ -8598,12 +8598,12 @@ snapshots:
 
   '@module-federation/sdk@0.17.1': {}
 
-  '@module-federation/storybook-addon@4.0.23(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@4.0.23(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 0.17.1(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
+      '@module-federation/enhanced': 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(vue-tsc@3.0.4(typescript@5.8.3))
       '@module-federation/sdk': 0.17.1
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -8787,9 +8787,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.44.1':
     optional: true
 
-  '@rsbuild/core@1.4.11':
+  '@rsbuild/core@1.4.12':
     dependencies:
-      '@rspack/core': 1.4.10(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.17
       core-js: 3.44.0
@@ -8803,13 +8803,13 @@ snapshots:
       core-js: 3.44.0
       jiti: 2.5.1
 
-  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.4.11)':
+  '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@1.4.12)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -8817,13 +8817,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@1.0.5(@rsbuild/core@1.4.11)':
+  '@rsbuild/plugin-babel@1.0.5(@rsbuild/core@1.4.12)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
@@ -8831,13 +8831,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.3.0(@rsbuild/core@1.4.11)':
+  '@rsbuild/plugin-less@1.3.0(@rsbuild/core@1.4.12)':
     dependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
-  '@rsbuild/plugin-node-polyfill@1.3.2(@rsbuild/core@1.4.11)':
+  '@rsbuild/plugin-node-polyfill@1.3.2(@rsbuild/core@1.4.12)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -8863,39 +8863,39 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
 
-  '@rsbuild/plugin-preact@1.5.1(@rsbuild/core@1.4.11)(preact@10.26.9)':
+  '@rsbuild/plugin-preact@1.5.1(@rsbuild/core@1.4.12)(preact@10.26.9)':
     dependencies:
       '@prefresh/core': 1.5.5(preact@10.26.9)
       '@prefresh/utils': 1.2.1
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       '@rspack/plugin-preact-refresh': 1.1.2(@prefresh/core@1.5.5(preact@10.26.9))(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh': 9.0.0
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@1.3.4(@rsbuild/core@1.4.11)':
+  '@rsbuild/plugin-react@1.3.4(@rsbuild/core@1.4.12)':
     dependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       '@rspack/plugin-react-refresh': 1.4.3(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.3.3(@rsbuild/core@1.4.11)':
+  '@rsbuild/plugin-sass@1.3.3(@rsbuild/core@1.4.12)':
     dependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.6
       reduce-configs: 1.1.0
       sass-embedded: 1.89.2
 
-  '@rsbuild/plugin-solid@1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.11)(solid-js@1.9.7)':
+  '@rsbuild/plugin-solid@1.0.5(@babel/core@7.26.10)(@rsbuild/core@1.4.12)(solid-js@1.9.7)':
     dependencies:
-      '@rsbuild/core': 1.4.11
-      '@rsbuild/plugin-babel': 1.0.4(@rsbuild/core@1.4.11)
+      '@rsbuild/core': 1.4.12
+      '@rsbuild/plugin-babel': 1.0.4(@rsbuild/core@1.4.12)
       babel-preset-solid: 1.9.5(@babel/core@7.26.10)
       solid-refresh: 0.6.3(solid-js@1.9.7)
     transitivePeerDependencies:
@@ -8903,22 +8903,22 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@1.1.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))':
+  '@rsbuild/plugin-stylus@1.1.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))':
     dependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
       stylus: 0.64.0
-      stylus-loader: 8.1.1(@rspack/core@1.4.10(@swc/helpers@0.5.17))(stylus@0.64.0)
+      stylus-loader: 8.1.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(stylus@0.64.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.2.1(@rsbuild/core@1.4.11)(typescript@5.8.3)':
+  '@rsbuild/plugin-svgr@1.2.1(@rsbuild/core@1.4.12)(typescript@5.8.3)':
     dependencies:
-      '@rsbuild/core': 1.4.11
-      '@rsbuild/plugin-react': 1.3.4(@rsbuild/core@1.4.11)
+      '@rsbuild/core': 1.4.12
+      '@rsbuild/plugin-react': 1.3.4(@rsbuild/core@1.4.12)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)
@@ -8929,78 +8929,78 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-toml@1.1.0(@rsbuild/core@1.4.11)':
+  '@rsbuild/plugin-toml@1.1.0(@rsbuild/core@1.4.12)':
     dependencies:
       toml: 3.0.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
 
-  '@rsbuild/plugin-type-check@1.2.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(typescript@5.8.3)':
+  '@rsbuild/plugin-type-check@1.2.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.0
-      ts-checker-rspack-plugin: 1.1.3(@rspack/core@1.4.10(@swc/helpers@0.5.17))(typescript@5.8.3)
+      ts-checker-rspack-plugin: 1.1.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3)
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.4.11)':
+  '@rsbuild/plugin-typed-css-modules@1.0.2(@rsbuild/core@1.4.12)':
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
 
-  '@rsbuild/plugin-yaml@1.0.2(@rsbuild/core@1.4.11)':
+  '@rsbuild/plugin-yaml@1.0.2(@rsbuild/core@1.4.12)':
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
 
   '@rslib/core@0.11.0(@microsoft/api-extractor@7.52.9(@types/node@22.16.5))(typescript@5.8.3)':
     dependencies:
-      '@rsbuild/core': 1.4.11
-      rsbuild-plugin-dts: 0.11.0(@microsoft/api-extractor@7.52.9(@types/node@22.16.5))(@rsbuild/core@1.4.11)(typescript@5.8.3)
+      '@rsbuild/core': 1.4.12
+      rsbuild-plugin-dts: 0.11.0(@microsoft/api-extractor@7.52.9(@types/node@22.16.5))(@rsbuild/core@1.4.12)(typescript@5.8.3)
       tinyglobby: 0.2.14
     optionalDependencies:
       '@microsoft/api-extractor': 7.52.9(@types/node@22.16.5)
       typescript: 5.8.3
 
-  '@rspack/binding-darwin-arm64@1.4.10':
+  '@rspack/binding-darwin-arm64@1.4.11':
     optional: true
 
   '@rspack/binding-darwin-arm64@1.4.9':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.4.10':
+  '@rspack/binding-darwin-x64@1.4.11':
     optional: true
 
   '@rspack/binding-darwin-x64@1.4.9':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.4.10':
+  '@rspack/binding-linux-arm64-gnu@1.4.11':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.4.9':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.4.10':
+  '@rspack/binding-linux-arm64-musl@1.4.11':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.4.9':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.4.10':
+  '@rspack/binding-linux-x64-gnu@1.4.11':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.4.9':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.4.10':
+  '@rspack/binding-linux-x64-musl@1.4.11':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.4.9':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.4.10':
+  '@rspack/binding-wasm32-wasi@1.4.11':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.1
     optional: true
@@ -9010,36 +9010,36 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.1
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.4.10':
+  '@rspack/binding-win32-arm64-msvc@1.4.11':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.4.9':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.4.10':
+  '@rspack/binding-win32-ia32-msvc@1.4.11':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.4.9':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.4.10':
+  '@rspack/binding-win32-x64-msvc@1.4.11':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.4.9':
     optional: true
 
-  '@rspack/binding@1.4.10':
+  '@rspack/binding@1.4.11':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.4.10
-      '@rspack/binding-darwin-x64': 1.4.10
-      '@rspack/binding-linux-arm64-gnu': 1.4.10
-      '@rspack/binding-linux-arm64-musl': 1.4.10
-      '@rspack/binding-linux-x64-gnu': 1.4.10
-      '@rspack/binding-linux-x64-musl': 1.4.10
-      '@rspack/binding-wasm32-wasi': 1.4.10
-      '@rspack/binding-win32-arm64-msvc': 1.4.10
-      '@rspack/binding-win32-ia32-msvc': 1.4.10
-      '@rspack/binding-win32-x64-msvc': 1.4.10
+      '@rspack/binding-darwin-arm64': 1.4.11
+      '@rspack/binding-darwin-x64': 1.4.11
+      '@rspack/binding-linux-arm64-gnu': 1.4.11
+      '@rspack/binding-linux-arm64-musl': 1.4.11
+      '@rspack/binding-linux-x64-gnu': 1.4.11
+      '@rspack/binding-linux-x64-musl': 1.4.11
+      '@rspack/binding-wasm32-wasi': 1.4.11
+      '@rspack/binding-win32-arm64-msvc': 1.4.11
+      '@rspack/binding-win32-ia32-msvc': 1.4.11
+      '@rspack/binding-win32-x64-msvc': 1.4.11
 
   '@rspack/binding@1.4.9':
     optionalDependencies:
@@ -9054,10 +9054,10 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.4.9
       '@rspack/binding-win32-x64-msvc': 1.4.9
 
-  '@rspack/core@1.4.10(@swc/helpers@0.5.17)':
+  '@rspack/core@1.4.11(@swc/helpers@0.5.17)':
     dependencies:
-      '@module-federation/runtime-tools': 0.17.0
-      '@rspack/binding': 1.4.10
+      '@module-federation/runtime-tools': 0.17.1
+      '@rspack/binding': 1.4.11
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
       '@swc/helpers': 0.5.17
@@ -9088,8 +9088,8 @@ snapshots:
       '@mdx-js/loader': 3.1.0(acorn@8.14.1)
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       '@mdx-js/react': 3.1.0(@types/react@19.1.8)(react@19.1.0)
-      '@rsbuild/core': 1.4.11
-      '@rsbuild/plugin-react': 1.3.4(@rsbuild/core@1.4.11)
+      '@rsbuild/core': 1.4.12
+      '@rsbuild/plugin-react': 1.3.4(@rsbuild/core@1.4.12)
       '@rspress/mdx-rs': 0.6.6
       '@rspress/runtime': 2.0.0-beta.22
       '@rspress/shared': 2.0.0-beta.22
@@ -9204,7 +9204,7 @@ snapshots:
 
   '@rspress/shared@2.0.0-beta.22':
     dependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       '@shikijs/rehype': 3.8.1
       gray-matter: 4.0.3
       lodash-es: 4.17.21
@@ -13644,10 +13644,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.11.0(@microsoft/api-extractor@7.52.9(@types/node@22.16.5))(@rsbuild/core@1.4.11)(typescript@5.8.3):
+  rsbuild-plugin-dts@0.11.0(@microsoft/api-extractor@7.52.9(@types/node@22.16.5))(@rsbuild/core@1.4.12)(typescript@5.8.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       magic-string: 0.30.17
       picocolors: 1.1.1
       tinyglobby: 0.2.14
@@ -13656,33 +13656,33 @@ snapshots:
       '@microsoft/api-extractor': 7.52.9(@types/node@22.16.5)
       typescript: 5.8.3
 
-  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.4.11):
+  rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.4.12):
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
 
-  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.4.11):
+  rsbuild-plugin-html-minifier-terser@1.1.1(@rsbuild/core@1.4.12):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
 
-  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.4.11):
+  rsbuild-plugin-open-graph@1.0.2(@rsbuild/core@1.4.12):
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
 
-  rsbuild-plugin-publint@0.3.2(@rsbuild/core@1.4.11):
+  rsbuild-plugin-publint@0.3.2(@rsbuild/core@1.4.12):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.12
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
 
-  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.4.11)(@types/node@22.16.5)(jiti@2.5.1)(sass-embedded@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(vue@3.5.18(typescript@5.8.3))(yaml@2.6.1):
+  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.4.12)(@types/node@22.16.5)(jiti@2.5.1)(sass-embedded@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(vue@3.5.18(typescript@5.8.3))(yaml@2.6.1):
     dependencies:
       unplugin-vue: 6.2.0(@types/node@22.16.5)(jiti@2.5.1)(sass-embedded@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(vue@3.5.18(typescript@5.8.3))(yaml@2.6.1)
     optionalDependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14094,18 +14094,18 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@2.0.2(@rsbuild/core@1.4.11)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3))(typescript@5.8.3):
+  storybook-addon-rslib@2.0.2(@rsbuild/core@1.4.12)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
+      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
 
-  storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3):
+  storybook-builder-rsbuild@2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3):
     dependencies:
-      '@rsbuild/core': 1.4.11
-      '@rsbuild/plugin-type-check': 1.2.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(typescript@5.8.3)
+      '@rsbuild/core': 1.4.12
+      '@rsbuild/plugin-type-check': 1.2.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3)
       '@storybook/addon-docs': 9.0.12(@types/react@19.1.8)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
       '@storybook/core-webpack': 9.0.12(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
       browser-assert: 1.2.1
@@ -14118,7 +14118,7 @@ snapshots:
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.4.11)
+      rsbuild-plugin-html-minifier-terser: 1.1.1(@rsbuild/core@1.4.12)
       sirv: 2.0.4
       storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       ts-dedent: 2.2.0
@@ -14134,10 +14134,10 @@ snapshots:
       - '@types/react'
       - webpack-sources
 
-  storybook-react-rsbuild@2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.44.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3):
+  storybook-react-rsbuild@2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.44.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.44.1)
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       '@storybook/react': 9.0.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.8.3)
       '@types/node': 18.19.110
@@ -14149,7 +14149,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       resolve: 1.22.10
       storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
-      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
+      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.8.3
@@ -14161,12 +14161,12 @@ snapshots:
       - webpack
       - webpack-sources
 
-  storybook-vue3-rsbuild@2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vue@3.5.18(typescript@5.8.3)):
+  storybook-vue3-rsbuild@2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vue@3.5.18(typescript@5.8.3)):
     dependencies:
-      '@rsbuild/core': 1.4.11
+      '@rsbuild/core': 1.4.12
       '@storybook/vue3': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vue@3.5.18(typescript@5.8.3))
       storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
-      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.11)(@rspack/core@1.4.10(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
+      storybook-builder-rsbuild: 2.0.2(@rsbuild/core@1.4.12)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
       vue: 3.5.18(typescript@5.8.3)
       vue-docgen-loader: 1.5.1
     transitivePeerDependencies:
@@ -14285,13 +14285,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  stylus-loader@8.1.1(@rspack/core@1.4.10(@swc/helpers@0.5.17))(stylus@0.64.0):
+  stylus-loader@8.1.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 1.4.10(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
 
   stylus@0.64.0:
     dependencies:
@@ -14486,7 +14486,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.1.3(@rspack/core@1.4.10(@swc/helpers@0.5.17))(typescript@5.8.3):
+  ts-checker-rspack-plugin@1.1.3(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@rspack/lite-tapable': 1.0.1
@@ -14497,7 +14497,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.8.3
     optionalDependencies:
-      '@rspack/core': 1.4.10(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^0.17.1",
     "@playwright/test": "1.54.1",
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rsbuild/plugin-less": "^1.3.0",
     "@rsbuild/plugin-react": "^1.3.4",
     "@rsbuild/plugin-sass": "^1.3.3",

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "rspress preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.4.11",
+    "@rsbuild/core": "~1.4.12",
     "@rsbuild/plugin-sass": "^1.3.3",
     "@rslib/tsconfig": "workspace:*",
     "@rspress/core": "2.0.0-beta.22",


### PR DESCRIPTION
## Summary

This PR brings some import changes:

### export star cause random output
fix PR: https://github.com/web-infra-dev/rspack/pull/11229

close: #882
close: #1007 

### preserve magic comments

support PR: https://github.com/web-infra-dev/rspack/pull/11218

close: https://github.com/web-infra-dev/rslib/discussions/1131

Users can modify minify configurations to set `comments: 'all'` to keep magic comments in output.

see https://rslib.rs/config/rsbuild/output#outputminify

e.g.

```diff
export default defineConfig({
  output: {
    minify: {
      js: true,
      css: false,
      jsOptions: {
        minimizerOptions: {
          mangle: false,
          minify: false,
          compress: {
            defaults: false,
            unused: true,
            dead_code: true,
            toplevel: true,
          },
          format: {
-           comments: 'some',
+           comments: 'all',
            preserve_annotations: true,
          },
        },
      },
    },
  },
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
