### PR TITLE
fix: only force split async chunks when format is esm or cjs

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -513,10 +513,6 @@ export async function createConstantRsbuildConfig(): Promise<EnvironmentConfig> 
       htmlPlugin: false,
       rspack: {
         optimization: {
-          splitChunks: {
-            // Splitted "sync" chunks will make entry modules can't be inlined.
-            chunks: 'async',
-          },
           moduleIds: 'named',
           nodeEnv: false,
         },
@@ -604,6 +600,10 @@ const composeFormatConfig = ({
               concatenateModules: true,
               sideEffects: 'flag',
               avoidEntryIife: true,
+              splitChunks: {
+                // Splitted "sync" chunks will make entry modules can't be inlined.
+                chunks: 'async',
+              },
             },
             output: {
               module: true,
@@ -632,6 +632,12 @@ const composeFormatConfig = ({
                   ...jsParserOptions.cjs,
                   ...jsParserOptions.others,
                 },
+              },
+            },
+            optimization: {
+              splitChunks: {
+                // Splitted "sync" chunks will make entry modules can't be inlined.
+                chunks: 'async',
               },
             },
             output: {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -157,9 +157,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "optimization": {
               "moduleIds": "named",
               "nodeEnv": false,
-              "splitChunks": {
-                "chunks": "async",
-              },
             },
             "resolve": {
               "extensionAlias": {
@@ -208,6 +205,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
               "avoidEntryIife": true,
               "concatenateModules": true,
               "sideEffects": "flag",
+              "splitChunks": {
+                "chunks": "async",
+              },
             },
             "output": {
               "chunkFormat": "module",
@@ -434,9 +434,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "optimization": {
               "moduleIds": "named",
               "nodeEnv": false,
-              "splitChunks": {
-                "chunks": "async",
-              },
             },
             "resolve": {
               "extensionAlias": {
@@ -472,6 +469,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                   "requireResolve": false,
                   "worker": false,
                 },
+              },
+            },
+            "optimization": {
+              "splitChunks": {
+                "chunks": "async",
               },
             },
             "output": {
@@ -668,9 +670,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "optimization": {
               "moduleIds": "named",
               "nodeEnv": false,
-              "splitChunks": {
-                "chunks": "async",
-              },
             },
             "resolve": {
               "extensionAlias": {
@@ -898,9 +897,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "optimization": {
               "moduleIds": "named",
               "nodeEnv": false,
-              "splitChunks": {
-                "chunks": "async",
-              },
             },
             "resolve": {
               "extensionAlias": {
@@ -1085,9 +1081,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "optimization": {
               "moduleIds": "named",
               "nodeEnv": false,
-              "splitChunks": {
-                "chunks": "async",
-              },
             },
             "resolve": {
               "extensionAlias": {


### PR DESCRIPTION
## Summary

only force split async chunks when format is esm or cjs

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
