### PR TITLE
test: use `expect.poll` to avoid flaky watching file changes test cases

### DIFF
--- a/tests/integration/cli/build-watch/build.test.ts
+++ b/tests/integration/cli/build-watch/build.test.ts
@@ -4,8 +4,8 @@ import { after } from 'node:test';
 import { describe, expect, test } from '@rstest/core';
 import fse from 'fs-extra';
 import {
-  awaitFileChanges,
-  awaitFileExists,
+  expectFile,
+  expectFileChanges,
   rslibBinPath,
   runCli,
 } from 'test-helper';
@@ -35,7 +35,7 @@ export default defineConfig({
       cwd: __dirname,
     });
 
-    await awaitFileExists(distEsmIndexFile);
+    await expectFile(distEsmIndexFile);
 
     fse.outputFileSync(
       tempConfigFile,
@@ -54,7 +54,7 @@ export default defineConfig({
   `,
     );
 
-    await awaitFileExists(dist1EsmIndexFile);
+    await expectFile(dist1EsmIndexFile);
 
     process.kill();
   });
@@ -111,12 +111,12 @@ export default defineConfig({
         shell: true,
       },
     );
-    await awaitFileExists(distIndexFile);
+    await expectFile(distIndexFile);
 
     fse.outputFileSync(srcFooFile, `export const foo = 'foo';`);
     fse.outputFileSync(srcFoo2File, `export const foo2 = 'foo2';`);
-    await awaitFileExists(distFooFile);
-    await awaitFileExists(distFoo2File);
+    await expectFile(distFooFile);
+    await expectFile(distFoo2File);
     const content1 = await fse.readFile(distFooFile, 'utf-8');
     expect(content1!).toMatchInlineSnapshot(`
       "const foo = 'foo';
@@ -135,9 +135,8 @@ export default defineConfig({
     fse.removeSync(srcIndexFile);
 
     // change
-    const wait = await awaitFileChanges(distFooFile, 'foo1');
     fse.outputFileSync(srcFooFile, `export const foo = 'foo1';`);
-    await wait();
+    await expectFileChanges(distFooFile, content1, 'foo1');
     const content3 = await fse.readFile(distFooFile, 'utf-8');
     expect(content3!).toMatchInlineSnapshot(`
       "const foo = 'foo1';

--- a/tests/integration/cli/mf/mf.test.ts
+++ b/tests/integration/cli/mf/mf.test.ts
@@ -4,7 +4,7 @@ import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { startMFDevServer } from '@rslib/core';
 import { expect, test } from '@rstest/core';
 import fse from 'fs-extra';
-import { awaitFileExists, runCli, runCliSync } from 'test-helper';
+import { expectFile, runCli, runCliSync } from 'test-helper';
 
 const { existsSync } = fse;
 
@@ -26,7 +26,7 @@ describe('mf-dev', () => {
       },
     });
 
-    await awaitFileExists(distPath);
+    await expectFile(distPath);
 
     const rspackConfigContent = await fse.readFile(rspackConfigFile, 'utf-8');
     expect(rspackConfigContent).toContain(`nodeEnv: 'development'`);
@@ -52,8 +52,8 @@ describe('mf-dev', () => {
       cwd: fixturePath,
     });
 
-    await awaitFileExists(distPath1);
-    await awaitFileExists(distPath2);
+    await expectFile(distPath1);
+    await expectFile(distPath2);
 
     expect(existsSync(distPath1)).toBe(true);
     expect(existsSync(distPath2)).toBe(true);

--- a/tests/integration/plugins/index.test.ts
+++ b/tests/integration/plugins/index.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, test } from '@rstest/core';
-import { awaitFileExists, buildAndGetResults, runCli } from 'test-helper';
+import { buildAndGetResults, expectFile, runCli } from 'test-helper';
 
 import { distIndex } from './basic/rslib.config';
 import { plugin1Path, plugin2Path } from './mf-dev/rslib.config';
@@ -20,8 +20,8 @@ test('should merge plugins correctly', async () => {
     cwd: fixturePath,
   });
 
-  await awaitFileExists(plugin1Path);
-  await awaitFileExists(plugin2Path);
+  await expectFile(plugin1Path);
+  await expectFile(plugin2Path);
 
   const content1 = fs.readFileSync(plugin1Path, 'utf-8');
   const content2 = fs.readFileSync(plugin2Path, 'utf-8');

--- a/tests/integration/server/index.test.ts
+++ b/tests/integration/server/index.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, test } from '@rstest/core';
 import fse from 'fs-extra';
-import { awaitFileExists, buildAndGetResults, runCli } from 'test-helper';
+import { buildAndGetResults, expectFile, runCli } from 'test-helper';
 
 describe('server config', async () => {
   test('basic config', async () => {
@@ -31,7 +31,7 @@ describe('server config', async () => {
       },
     });
 
-    await awaitFileExists(doneFile);
+    await expectFile(doneFile);
 
     const rsbuildConfigContent = await fse.readFile(rsbuildConfigFile, 'utf-8');
     expect(rsbuildConfigContent).toContain('open: true');


### PR DESCRIPTION
## Summary

There exists flaky test cases about watching files changed.

<img width="2250" height="1464" alt="image" src="https://github.com/user-attachments/assets/8164c7d5-858b-47e4-96cc-cb8eba1f08d6" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
