### PR TITLE
feat!: update minimum Node.js version to 18.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "packageManager": "pnpm@10.14.0",
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=18.12.0",
     "pnpm": ">=10.14.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,7 @@
     }
   },
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=18.12.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -42,7 +42,7 @@
     "typescript": "^5.9.2"
   },
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=18.12.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -58,7 +58,7 @@
     }
   },
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=18.12.0"
   },
   "publishConfig": {
     "access": "public",

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -2,7 +2,7 @@
 
 ## Setup environment
 
-Before getting started, you will need to install [Node.js](https://nodejs.org/) >= 18, it is recommended to use the Node.js LTS version.
+Before getting started, you will need to install [Node.js](https://nodejs.org/) >= 18.12.0, it is recommended to use the Node.js LTS version.
 
 Check the current Node.js version with the following command:
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -2,7 +2,7 @@
 
 ## Setup environment
 
-Before getting started, you will need to install [Node.js](https://nodejs.org/) >= 16, it is recommended to use the Node.js LTS version.
+Before getting started, you will need to install [Node.js](https://nodejs.org/) >= 18, it is recommended to use the Node.js LTS version.
 
 Check the current Node.js version with the following command:
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -2,7 +2,7 @@
 
 ## 环境准备
 
-开始之前，需要先安装 [Node.js](https://nodejs.org/) >= 16 版本，推荐使用 Node.js LTS 版本。
+开始之前，需要先安装 [Node.js](https://nodejs.org/) >= 18 版本，推荐使用 Node.js LTS 版本。
 
 通过以下命令检查当前的 Node.js 版本：
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -2,7 +2,7 @@
 
 ## 环境准备
 
-开始之前，需要先安装 [Node.js](https://nodejs.org/) >= 18 版本，推荐使用 Node.js LTS 版本。
+开始之前，需要先安装 [Node.js](https://nodejs.org/) >= 18.12.0 版本，推荐使用 Node.js LTS 版本。
 
 通过以下命令检查当前的 Node.js 版本：
 


### PR DESCRIPTION
## Summary

Rspack and Rsbuild v1.5 will no longer support Node 16, as Node.js reached end-of-life on September 11th, 2023, and many npm packages in the ecosystem have also dropped support for Node 16.

This PR update the engines field in `package.json` to require Node.js >= 18.12.0.

## Related Links

https://github.com/web-infra-dev/rspack/discussions/10867

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
