### PR TITLE
feat: update tsconfig.json and build configs to ES2022

### DIFF
--- a/examples/module-federation/mf-host/tsconfig.json
+++ b/examples/module-federation/mf-host/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/examples/module-federation/mf-remote/tsconfig.json
+++ b/examples/module-federation/mf-remote/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "noEmit": true,

--- a/examples/vue-component-bundle/tsconfig.json
+++ b/examples/vue-component-bundle/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2022"],
     "jsx": "preserve",
-    "target": "ES2020",
     "skipLibCheck": true,
     "jsxImportSource": "vue",
     "useDefineForClassFields": true,

--- a/examples/vue-component-bundleless/tsconfig.json
+++ b/examples/vue-component-bundleless/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2022"],
     "jsx": "preserve",
-    "target": "ES2020",
     "skipLibCheck": true,
     "jsxImportSource": "vue",
     "useDefineForClassFields": true,

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: 'es2022',
+      syntax: ['node 18.12.0'],
       dts: {
         bundle: false,
         distPath: './dist-types',

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,10 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { RsbuildPlugin } from '@rsbuild/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
-import { defineConfig, rspack } from 'rslib';
+import { defineConfig, type rsbuild, rspack } from 'rslib';
 
-const pluginFixDtsTypes: RsbuildPlugin = {
+const pluginFixDtsTypes: rsbuild.RsbuildPlugin = {
   name: 'fix-dts-types',
   setup(api) {
     api.onAfterBuild(() => {
@@ -29,7 +28,7 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: ['node 16'],
+      syntax: 'es2022',
       dts: {
         bundle: false,
         distPath: './dist-types',

--- a/packages/create-rslib/fragments/base/node-dual-ts/tsconfig.json
+++ b/packages/create-rslib/fragments/base/node-dual-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2021"],
+    "lib": ["ES2022"],
     "module": "ESNext",
     "noEmit": true,
     "strict": true,

--- a/packages/create-rslib/fragments/base/node-esm-ts/tsconfig.json
+++ b/packages/create-rslib/fragments/base/node-esm-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2021"],
+    "lib": ["ES2022"],
     "module": "ESNext",
     "noEmit": true,
     "strict": true,

--- a/packages/create-rslib/fragments/base/react-ts/tsconfig.json
+++ b/packages/create-rslib/fragments/base/react-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2021"],
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "strict": true,

--- a/packages/create-rslib/fragments/base/vue-ts/tsconfig.json
+++ b/packages/create-rslib/fragments/base/vue-ts/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2022"],
     "jsx": "preserve",
-    "target": "ES2020",
     "skipLibCheck": true,
     "jsxImportSource": "vue",
     "useDefineForClassFields": true,

--- a/packages/create-rslib/rslib.config.ts
+++ b/packages/create-rslib/rslib.config.ts
@@ -4,7 +4,12 @@ import { defineConfig } from 'rslib';
 const { execSync } = require('node:child_process');
 
 export default defineConfig({
-  lib: [{ format: 'esm', syntax: 'es2022' }],
+  lib: [
+    {
+      format: 'esm',
+      syntax: ['node 18.12.0'],
+    },
+  ],
   plugins: [
     pluginPublint(),
     {

--- a/packages/create-rslib/rslib.config.ts
+++ b/packages/create-rslib/rslib.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'rslib';
 const { execSync } = require('node:child_process');
 
 export default defineConfig({
-  lib: [{ format: 'esm' }],
+  lib: [{ format: 'esm', syntax: 'es2022' }],
   plugins: [
     pluginPublint(),
     {

--- a/packages/create-rslib/template-[node-dual]-[]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[node-dual]-[]-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2021"],
+    "lib": ["ES2022"],
     "module": "ESNext",
     "noEmit": true,
     "strict": true,

--- a/packages/create-rslib/template-[node-dual]-[vitest]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[node-dual]-[vitest]-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2021"],
+    "lib": ["ES2022"],
     "module": "ESNext",
     "noEmit": true,
     "strict": true,

--- a/packages/create-rslib/template-[node-esm]-[]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[node-esm]-[]-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2021"],
+    "lib": ["ES2022"],
     "module": "ESNext",
     "noEmit": true,
     "strict": true,

--- a/packages/create-rslib/template-[node-esm]-[vitest]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[node-esm]-[vitest]-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2021"],
+    "lib": ["ES2022"],
     "module": "ESNext",
     "noEmit": true,
     "strict": true,

--- a/packages/create-rslib/template-[react]-[]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[react]-[]-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2021"],
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "strict": true,

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2021"],
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "strict": true,

--- a/packages/create-rslib/template-[react]-[storybook]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2021"],
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "strict": true,

--- a/packages/create-rslib/template-[react]-[vitest]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[react]-[vitest]-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2021"],
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "strict": true,

--- a/packages/create-rslib/template-[vue]-[]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[vue]-[]-ts/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2022"],
     "jsx": "preserve",
-    "target": "ES2020",
     "skipLibCheck": true,
     "jsxImportSource": "vue",
     "useDefineForClassFields": true,

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2022"],
     "jsx": "preserve",
-    "target": "ES2020",
     "skipLibCheck": true,
     "jsxImportSource": "vue",
     "useDefineForClassFields": true,

--- a/packages/create-rslib/template-[vue]-[storybook]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-ts/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2022"],
     "jsx": "preserve",
-    "target": "ES2020",
     "skipLibCheck": true,
     "jsxImportSource": "vue",
     "useDefineForClassFields": true,

--- a/packages/create-rslib/template-[vue]-[vitest]-ts/tsconfig.json
+++ b/packages/create-rslib/template-[vue]-[vitest]-ts/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": ["DOM", "ES2022"],
     "jsx": "preserve",
-    "target": "ES2020",
     "skipLibCheck": true,
     "jsxImportSource": "vue",
     "useDefineForClassFields": true,

--- a/packages/plugin-dts/rslib.config.ts
+++ b/packages/plugin-dts/rslib.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     {
       format: 'esm',
       bundle: false,
-      syntax: 'es2022',
+      syntax: ['node 18.12.0'],
       dts: {
         bundle: false,
       },

--- a/packages/plugin-dts/rslib.config.ts
+++ b/packages/plugin-dts/rslib.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     {
       format: 'esm',
       bundle: false,
-      syntax: ['node 16'],
+      syntax: 'es2022',
       dts: {
         bundle: false,
       },

--- a/scripts/tsconfig/base.json
+++ b/scripts/tsconfig/base.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     "exactOptionalPropertyTypes": false,
-    "target": "ES2021",
+    "target": "ES2022",
     "lib": ["DOM", "ESNext"],
     "allowJs": false,
     "checkJs": false,
-    "module": "ES2020",
+    "module": "ES2022",
     "strict": true,
     "isolatedModules": true,
     "esModuleInterop": true,

--- a/tests/e2e/react-component/tsconfig.json
+++ b/tests/e2e/react-component/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2022",
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "strict": true,


### PR DESCRIPTION
## Summary

Since Rstack no longer supports Node 16, we can update build configs to lib ES2022.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
