### PR TITLE
fix(css): prevent adding empty css rule

### DIFF
--- a/packages/core/src/css/cssConfig.ts
+++ b/packages/core/src/css/cssConfig.ts
@@ -96,6 +96,7 @@ const pluginLibCss = (
         CHAIN_ID.RULE.LESS,
         CHAIN_ID.RULE.STYLUS,
       ]) {
+        if (!config.module.rules.has(ruleId)) continue;
         const rule = config.module.rule(ruleId);
         if (rule.uses.has(CHAIN_ID.USE.MINI_CSS_EXTRACT)) {
           isUsingCssExtract = true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7519,8 +7519,8 @@ packages:
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
 
-  vue-component-type-helpers@3.0.5:
-    resolution: {integrity: sha512-uoNZaJ+a1/zppa/Vgmi8zIOP2PHXDN2rT8NyF+zQRK6ZG94lNB9prcV0GdLJbY9i9lrD47JOVIH92SaiA7oJ1A==}
+  vue-component-type-helpers@3.0.6:
+    resolution: {integrity: sha512-6CRM8X7EJqWCJOiKPvSLQG+hJPb/Oy2gyJx3pLjUEhY7PuaCthQu3e0zAGI1lqUBobrrk9IT0K8sG2GsCluxoQ==}
 
   vue-docgen-loader@1.5.1:
     resolution: {integrity: sha512-coMmQYsg+fy18SVtBNU7/tztdqEyrneFfwQFLmx8O7jaJ11VZ//9tRWXlwGzJM07cPRwMHDKMlAdWrpuw3U46A==}
@@ -9871,7 +9871,7 @@ snapshots:
       storybook: 9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.17.2)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.6.1))
       type-fest: 2.19.0
       vue: 3.5.18(typescript@5.9.2)
-      vue-component-type-helpers: 3.0.5
+      vue-component-type-helpers: 3.0.6
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.0)':
     dependencies:
@@ -15189,7 +15189,7 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-component-type-helpers@3.0.5: {}
+  vue-component-type-helpers@3.0.6: {}
 
   vue-docgen-loader@1.5.1:
     dependencies:


### PR DESCRIPTION
## Summary

`const rule = config.module.rule(ruleId);` will add an empty rule like below:

```
/* config.module.rule('sass') */
{},
/* config.module.rule('less') */
{},
/* config.module.rule('stylus') */
{},
```

When `@rsbuild/plugin-sass` begin to modify configurations, a unique id will be generated for Sass rules:

```
/* config.module.rule('sass-1') */
{},
```

Other plugins like [rsbuild-plugin-typed-css-modules](https://github.com/rspack-contrib/rsbuild-plugin-typed-css-modules) rely on `CHAIN_ID.RULE.SASS` to match rules to make features work, see https://github.com/web-infra-dev/rsbuild/issues/5909.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
