### PR TITLE
chore(dts): use `color.dim` to print environment name

### DIFF
--- a/packages/plugin-dts/src/apiExtractor.ts
+++ b/packages/plugin-dts/src/apiExtractor.ts
@@ -95,19 +95,19 @@ export async function bundleDts(options: BundleOptions): Promise<void> {
         );
 
         if (!extractorResult.succeeded) {
-          throw new Error(`API Extractor error. ${color.gray(`(${name})`)}`);
+          throw new Error(`API Extractor error. ${color.dim(`(${name})`)}`);
         }
 
         await addBannerAndFooter(untrimmedFilePath, banner, footer);
 
         logger.ready(
-          `declaration files bundled successfully: ${color.cyan(relative(cwd, untrimmedFilePath))} in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+          `declaration files bundled successfully: ${color.cyan(relative(cwd, untrimmedFilePath))} in ${getTimeCost(start)} ${color.dim(`(${name})`)}`,
         );
       }),
     );
   } catch (e) {
     const error = new Error(
-      `${logPrefixApiExtractor} ${e} ${color.gray(`(${name})`)}`,
+      `${logPrefixApiExtractor} ${e} ${color.dim(`(${name})`)}`,
     );
     // do not log the stack trace, it is not helpful for users
     error.stack = '';

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -138,7 +138,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
     },
   } = data;
   if (!isWatch) {
-    logger.start(`generating declaration files... ${color.gray(`(${name})`)}`);
+    logger.start(`generating declaration files... ${color.dim(`(${name})`)}`);
   }
 
   // merge alias and tsconfig paths

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -67,7 +67,7 @@ async function handleDiagnosticsAndProcessFiles(
     }
 
     const error = new Error(
-      `Failed to generate declaration files. ${color.gray(`(${name})`)}`,
+      `Failed to generate declaration files. ${color.dim(`(${name})`)}`,
     );
     // do not log the stack trace, diagnostic messages are enough
     error.stack = '';
@@ -128,7 +128,7 @@ export async function emitDts(
     const message = `${ts.flattenDiagnosticMessageText(
       diagnostic.messageText,
       formatHost.getNewLine(),
-    )} ${color.gray(`(${name})`)}`;
+    )} ${color.dim(`(${name})`)}`;
 
     // 6031: File change detected. Starting incremental compilation...
     // 6032: Starting compilation in watch mode...
@@ -374,7 +374,7 @@ export async function emitDts(
 
       if (errorNumber > 0) {
         const error = new Error(
-          `Failed to generate declaration files. ${color.gray(`(${name})`)}`,
+          `Failed to generate declaration files. ${color.dim(`(${name})`)}`,
         );
         // do not log the stack trace, diagnostic messages are enough
         error.stack = '';
@@ -384,11 +384,11 @@ export async function emitDts(
 
     if (bundle) {
       logger.info(
-        `declaration files prepared in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+        `declaration files prepared in ${getTimeCost(start)} ${color.dim(`(${name})`)}`,
       );
     } else {
       logger.ready(
-        `declaration files generated in ${getTimeCost(start)} ${color.gray(`(${name})`)}`,
+        `declaration files generated in ${getTimeCost(start)} ${color.dim(`(${name})`)}`,
       );
     }
   } else {


### PR DESCRIPTION
## Summary

Use `color.dim` to print environment name.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/5901

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
