### PR TITLE
feat: do not print detailed file size in bundleless mode

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -523,7 +523,7 @@ export function composePrintFileSizeConfig(
         }) => {
           let log = `${color.yellow(assets.length)} files generated in ${color.blue(distPath)} ${color.dim(`(${environmentName})`)}`;
           log += '\n';
-          log += `${color.magenta('Total size')}: ${(totalSize / 1000).toFixed(1)} kB`;
+          log += `${color.magenta('Total size:')} ${(totalSize / 1000).toFixed(1)} kB`;
           if (target === 'web') {
             log += ` ${color.green(`(${(totalGzipSize / 1000).toFixed(1)} kB gzipped)`)}`;
           }


### PR DESCRIPTION
## Summary

In bundleless mode, the default value of `performance.printFileSize` will print all files in a list which may be too long in logs, which may let important information be swallowed up.

### before

<img width="1646" height="1088" alt="image" src="https://github.com/user-attachments/assets/1a5d557a-234b-4328-8b25-751eb8c219c8" />


### after

<img width="1696" height="588" alt="image" src="https://github.com/user-attachments/assets/3e9ad684-ea0c-4d55-8d08-c0d3e2f8fe36" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
