### PR TITLE
fix: should glob dot files in bundleless mode

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1348,7 +1348,11 @@ const composeBundlelessExternalConfig = (
                   // Requests that fall through here cannot be matched by any other externals config ahead.
                   // Treat all these requests as relative import of source code. Node.js won't add the
                   // leading './' to the relative path resolved by `path.relative`. So add manually it here.
-                  if (resolvedRequest[0] !== '.') {
+                  // should include dot files like '.hidden.ts'
+                  if (
+                    !resolvedRequest.startsWith('./') &&
+                    !resolvedRequest.startsWith('../')
+                  ) {
                     resolvedRequest = `./${resolvedRequest}`;
                   }
                   return resolvedRequest;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1209,6 +1209,7 @@ const composeEntryConfig = async (
       const globEntryFiles = await glob(entryFiles, {
         cwd: root,
         absolute: true,
+        dot: true,
       });
 
       // Filter the glob resolved entry files based on the allowed extensions

--- a/tests/integration/bundle-false/basic/src/.hidden-folder/index.ts
+++ b/tests/integration/bundle-false/basic/src/.hidden-folder/index.ts
@@ -1,0 +1,1 @@
+export const hiddenFolder = 'This is a hidden folder';

--- a/tests/integration/bundle-false/basic/src/.hidden.ts
+++ b/tests/integration/bundle-false/basic/src/.hidden.ts
@@ -1,0 +1,1 @@
+export const hidden = 'This is a hidden file';

--- a/tests/integration/bundle-false/basic/src/index.ts
+++ b/tests/integration/bundle-false/basic/src/index.ts
@@ -1,5 +1,8 @@
 import { mainFiles1 } from './mainFiles1';
+
 export { mainFiles1 };
+export * from './.hidden';
+export * from './.hidden-folder';
 export { added } from './dep';
 
 export * from './mainFiles2';

--- a/tests/integration/bundle-false/index.test.ts
+++ b/tests/integration/bundle-false/index.test.ts
@@ -9,6 +9,8 @@ test('basic', async () => {
   // ESM
   expect(files.esm).toMatchInlineSnapshot(`
     [
+      "<ROOT>/tests/integration/bundle-false/basic/dist/esm/.hidden-folder/index.js",
+      "<ROOT>/tests/integration/bundle-false/basic/dist/esm/.hidden.js",
       "<ROOT>/tests/integration/bundle-false/basic/dist/esm/dep.js",
       "<ROOT>/tests/integration/bundle-false/basic/dist/esm/index.js",
       "<ROOT>/tests/integration/bundle-false/basic/dist/esm/mainFiles1/index.js",
@@ -26,6 +28,8 @@ test('basic', async () => {
   expect(await import(esmIndexPath)).toMatchInlineSnapshot(`
     {
       "added": 3,
+      "hidden": "This is a hidden file",
+      "hiddenFolder": "This is a hidden folder",
       "mainFiles1": "mainFiles1",
       "mainFiles2": "mainFiles2",
       "num1": 1,
@@ -51,6 +55,8 @@ test('basic', async () => {
   expect(indexContent).toMatchInlineSnapshot(`
     "import { mainFiles1 } from "./mainFiles1/index.js";
     import { added } from "./dep.js";
+    export * from "./.hidden.js";
+    export * from "./.hidden-folder/index.js";
     export * from "./mainFiles2/index.js";
     export * from "./sum.js";
     export * from "./utils/numbers.js";
@@ -76,6 +82,8 @@ test('basic', async () => {
   // CJS
   expect(files.cjs).toMatchInlineSnapshot(`
     [
+      "<ROOT>/tests/integration/bundle-false/basic/dist/cjs/.hidden-folder/index.cjs",
+      "<ROOT>/tests/integration/bundle-false/basic/dist/cjs/.hidden.cjs",
       "<ROOT>/tests/integration/bundle-false/basic/dist/cjs/dep.cjs",
       "<ROOT>/tests/integration/bundle-false/basic/dist/cjs/index.cjs",
       "<ROOT>/tests/integration/bundle-false/basic/dist/cjs/mainFiles1/index.cjs",
@@ -93,6 +101,8 @@ test('basic', async () => {
   expect((await import(cjsIndexPath)).default).toMatchInlineSnapshot(`
     {
       "added": 3,
+      "hidden": "This is a hidden file",
+      "hiddenFolder": "This is a hidden folder",
       "mainFiles1": "mainFiles1",
       "mainFiles2": "mainFiles2",
       "num1": 1,

--- a/tests/integration/bundle-false/index.test.ts
+++ b/tests/integration/bundle-false/index.test.ts
@@ -21,9 +21,7 @@ test('basic', async () => {
     ]
   `);
 
-  const { path: esmIndexPath } = queryContent(contents.esm, 'index.js', {
-    basename: true,
-  });
+  const { path: esmIndexPath } = queryContent(contents.esm, /esm\/index\.js/);
 
   expect(await import(esmIndexPath)).toMatchInlineSnapshot(`
     {
@@ -43,9 +41,10 @@ test('basic', async () => {
     }
   `);
 
-  const { content: indexContent } = queryContent(contents.esm, 'index.js', {
-    basename: true,
-  });
+  const { content: indexContent } = queryContent(
+    contents.esm,
+    /esm\/index\.js/,
+  );
   const { content: depContent } = queryContent(contents.esm, 'dep.js', {
     basename: true,
   });
@@ -94,9 +93,7 @@ test('basic', async () => {
     ]
   `);
 
-  const { path: cjsIndexPath } = queryContent(contents.cjs, 'index.cjs', {
-    basename: true,
-  });
+  const { path: cjsIndexPath } = queryContent(contents.cjs, /cjs\/index\.cjs/);
 
   expect((await import(cjsIndexPath)).default).toMatchInlineSnapshot(`
     {

--- a/tests/integration/redirect/dts.test.ts
+++ b/tests/integration/redirect/dts.test.ts
@@ -12,6 +12,10 @@ beforeAll(async () => {
 test('redirect.dts.path: true with redirect.dts.extension: false - default', async () => {
   expect(contents.esm0).toMatchInlineSnapshot(`
     {
+      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+    ",
       "<ROOT>/tests/integration/redirect/dts/dist/default/esm/a.b/index.d.ts": "export declare const ab = "a.b";
     ",
       "<ROOT>/tests/integration/redirect/dts/dist/default/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
@@ -36,6 +40,8 @@ test('redirect.dts.path: true with redirect.dts.extension: false - default', asy
     export { Router } from 'express';
     export * from '../../../compile/prebundle-pkg';
     export type { Bar } from './types';
+    export * from './.hidden';
+    export * from './.hidden-folder';
     export * from './a.b';
     export * from './bar.baz';
     export * from './foo';
@@ -67,6 +73,10 @@ test('redirect.dts.path: true with redirect.dts.extension: false - default', asy
 test('redirect.dts.path: false with redirect.dts.extension: false', async () => {
   expect(contents.esm1).toMatchInlineSnapshot(`
     {
+      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+    ",
       "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/a.b/index.d.ts": "export declare const ab = "a.b";
     ",
       "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
@@ -91,6 +101,8 @@ test('redirect.dts.path: false with redirect.dts.extension: false', async () => 
     export { Router } from 'express';
     export * from 'prebundle-pkg';
     export type { Bar } from 'types';
+    export * from './.hidden';
+    export * from './.hidden-folder';
     export * from './a.b';
     export * from './bar.baz';
     export * from './foo';
@@ -122,6 +134,10 @@ test('redirect.dts.path: false with redirect.dts.extension: false', async () => 
 test('redirect.dts.path: true with redirect.dts.extension: true', async () => {
   expect(contents.esm2).toMatchInlineSnapshot(`
     {
+      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+    ",
       "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/a.b/index.d.ts": "export declare const ab = "a.b";
     ",
       "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
@@ -146,6 +162,8 @@ test('redirect.dts.path: true with redirect.dts.extension: true', async () => {
     export { Router } from 'express';
     export * from '../../../compile/prebundle-pkg';
     export type { Bar } from './types.js';
+    export * from './.hidden.js';
+    export * from './.hidden-folder/index.js';
     export * from './a.b/index.js';
     export * from './bar.baz.js';
     export * from './foo/index.js';
@@ -177,6 +195,10 @@ test('redirect.dts.path: true with redirect.dts.extension: true', async () => {
 test('redirect.dts.path: false with dts.redirect.extension: true', async () => {
   expect(contents.esm3).toMatchInlineSnapshot(`
     {
+      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+    ",
       "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/a.b/index.d.ts": "export declare const ab = "a.b";
     ",
       "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
@@ -201,6 +223,8 @@ test('redirect.dts.path: false with dts.redirect.extension: true', async () => {
     export { Router } from 'express';
     export * from 'prebundle-pkg';
     export type { Bar } from 'types';
+    export * from './.hidden.js';
+    export * from './.hidden-folder/index.js';
     export * from './a.b/index.js';
     export * from './bar.baz.js';
     export * from './foo/index.js';
@@ -232,6 +256,14 @@ test('redirect.dts.path: false with dts.redirect.extension: true', async () => {
 test('redirect.dts.extension: true with dts.autoExtension: true', async () => {
   expect(contents.esm4).toMatchInlineSnapshot(`
     {
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden-folder/index.d.mts": "export declare const hiddenFolder = "This is a hidden folder";
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden.d.mts": "export declare const hidden = "This is a hidden file";
+    ",
+      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+    ",
       "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/a.b/index.d.mts": "export declare const ab = "a.b";
     ",
       "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/a.b/index.d.ts": "export declare const ab = "a.b";
@@ -267,6 +299,8 @@ test('redirect.dts.extension: true with dts.autoExtension: true', async () => {
     export { Router } from 'express';
     export * from '../../compile/prebundle-pkg';
     export type { Bar } from './types.mjs';
+    export * from './.hidden.mjs';
+    export * from './.hidden-folder/index.mjs';
     export * from './a.b/index.mjs';
     export * from './bar.baz.mjs';
     export * from './foo/index.mjs';
@@ -285,6 +319,8 @@ test('redirect.dts.extension: true with dts.autoExtension: true', async () => {
     export { Router } from 'express';
     export * from '../../compile/prebundle-pkg';
     export type { Bar } from './types.js';
+    export * from './.hidden.js';
+    export * from './.hidden-folder/index.js';
     export * from './a.b/index.js';
     export * from './bar.baz.js';
     export * from './foo/index.js';

--- a/tests/integration/redirect/dts/src/.hidden-folder/index.ts
+++ b/tests/integration/redirect/dts/src/.hidden-folder/index.ts
@@ -1,0 +1,1 @@
+export const hiddenFolder = 'This is a hidden folder';

--- a/tests/integration/redirect/dts/src/.hidden.ts
+++ b/tests/integration/redirect/dts/src/.hidden.ts
@@ -1,0 +1,1 @@
+export const hidden = 'This is a hidden file';

--- a/tests/integration/redirect/dts/src/index.ts
+++ b/tests/integration/redirect/dts/src/index.ts
@@ -21,6 +21,8 @@ export type { Foo } from '@src/types';
 export { Router } from 'express';
 export * from 'prebundle-pkg';
 export type { Bar } from 'types';
+export * from './.hidden';
+export * from './.hidden-folder';
 export * from './a.b';
 export * from './bar.baz';
 export * from './foo';

--- a/tests/integration/redirect/js.test.ts
+++ b/tests/integration/redirect/js.test.ts
@@ -26,6 +26,8 @@ test('redirect.js default', async () => {
     import { bar } from "./bar/index.js";
     import { foo } from "./foo.js";
     import { baz } from "./baz.js";
+    export * from "./.hidden.js";
+    export * from "./.hidden-folder/index.js";
     const src = lodash.toUpper(lodash_merge(foo) + bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
@@ -53,6 +55,8 @@ test('redirect.js.path false', async () => {
     import { baz } from "~/baz";
     import { bar as external_bar_js_bar } from "./bar.js";
     import { foo as external_foo_js_foo } from "./foo.js";
+    export * from "./.hidden.js";
+    export * from "./.hidden-folder.js";
     const src = lodash.toUpper(lodash_merge(external_foo_js_foo) + external_bar_js_bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
@@ -78,6 +82,8 @@ test('redirect.js.path with user override externals', async () => {
     import { baz } from "./baz.js";
     import { bar as index_js_bar } from "./bar/index.js";
     import { foo as external_foo_js_foo } from "./foo.js";
+    export * from "./.hidden.js";
+    export * from "./.hidden-folder/index.js";
     const src = lodash.toUpper(lodash_merge(external_foo_js_foo) + index_js_bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
@@ -111,6 +117,8 @@ test('redirect.js.path with user override alias', async () => {
     import { baz } from "./baz.js";
     import { bar as index_js_bar } from "./bar/index.js";
     import { foo as external_foo_js_foo } from "./foo.js";
+    export * from "./.hidden.js";
+    export * from "./.hidden-folder/index.js";
     const src = lodash.toUpper(lodash_merge(external_foo_js_foo) + index_js_bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "
@@ -137,6 +145,8 @@ test('redirect.js.extension: false', async () => {
     import { bar } from "./bar/index.ts";
     import { foo } from "./foo.ts";
     import { baz } from "./baz.ts";
+    export * from "./.hidden.ts";
+    export * from "./.hidden-folder/index.ts";
     const src = lodash.toUpper(lodash_merge(foo) + bar + foo + bar + baz + typeof prettier.version);
     export { src as default };
     "

--- a/tests/integration/redirect/js/src/.hidden-folder/index.ts
+++ b/tests/integration/redirect/js/src/.hidden-folder/index.ts
@@ -1,0 +1,1 @@
+export const hiddenFolder = 'This is a hidden folder';

--- a/tests/integration/redirect/js/src/.hidden.ts
+++ b/tests/integration/redirect/js/src/.hidden.ts
@@ -1,0 +1,1 @@
+export const hidden = 'This is a hidden file';

--- a/tests/integration/redirect/js/src/index.ts
+++ b/tests/integration/redirect/js/src/index.ts
@@ -12,6 +12,9 @@ import { baz } from '~/baz';
 import { bar } from './bar';
 import { foo } from './foo';
 
+export * from './.hidden';
+export * from './.hidden-folder';
+
 export default lodash.toUpper(
   merge(foo) + bar + foo2 + bar2 + baz + typeof prettier.version,
 );

--- a/tests/scripts/helper.ts
+++ b/tests/scripts/helper.ts
@@ -20,6 +20,7 @@ export const globContentJSON = async (
 ): Promise<Record<string, string>> => {
   const files = await glob(convertPath(join(path, '**/*')), {
     absolute: true,
+    dot: true,
     ...options,
   });
   const ret: Record<string, string> = {};

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -378,6 +378,9 @@ export function queryContent(
 ): { path: string; content: string } {
   const useBasename = options?.basename ?? false;
   const matched = Object.entries(contents).find(([key]) => {
+    if (key.includes('.hidden')) {
+      return false;
+    }
     const toQueried = useBasename ? basename(key) : key;
     return typeof query === 'string'
       ? toQueried === query

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -378,9 +378,6 @@ export function queryContent(
 ): { path: string; content: string } {
   const useBasename = options?.basename ?? false;
   const matched = Object.entries(contents).find(([key]) => {
-    if (key.includes('.hidden')) {
-      return false;
-    }
     const toQueried = useBasename ? basename(key) : key;
     return typeof query === 'string'
       ? toQueried === query


### PR DESCRIPTION
## Summary

Add an option to prevent glob from ignoring directories starting with a dot.

## Related Links

close #1195

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
