### PR TITLE
chore(dts): enhance error logs for dts mainEntryPointFilePath not found

### DIFF
--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -47,8 +47,8 @@ export type PluginDtsOptions = {
 };
 
 export type DtsEntry = {
-  name?: string;
-  path?: string;
+  name: string;
+  path: string;
 };
 
 export type DtsGenOptions = Omit<PluginDtsOptions, 'bundle'> & {


### PR DESCRIPTION
## Summary

Enhance error logs for dts `mainEntryPointFilePath` not found.

<img width="906" height="618" alt="image" src="https://github.com/user-attachments/assets/8af697c1-7ead-43d3-aa9f-062b293a64bd" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
