### PR TITLE
chore: bump Rslib and enable tsgo in local

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,25 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
+      # Special handling for Node.js 18: use Node.js 20 for tsgo dependency installation
+      - name: Setup Node.js 20 for dependency installation (Node 18 only)
+        if: steps.changes.outputs.changed == 'true' && matrix.node-version == 18
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
         run: pnpm install
+
+      # Switch back to Node.js 18 after dependency installation
+      - name: Switch back to Node.js ${{ matrix.node-version }} (Node 18 only)
+        if: steps.changes.outputs.changed == 'true' && matrix.node-version == 18
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
 
       - name: Type Check
         if: steps.changes.outputs.changed == 'true'
@@ -117,9 +133,25 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
+      # Special handling for Node.js 18: use Node.js 20 for tsgo dependency installation
+      - name: Setup Node.js 20 for dependency installation (Node 18 only)
+        if: steps.changes.outputs.changed == 'true' && matrix.node-version == 18
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
         run: pnpm install && cd ./tests && pnpm playwright install chromium
+
+      # Switch back to Node.js 18 after dependency installation
+      - name: Switch back to Node.js ${{ matrix.node-version }} (Node 18 only)
+        if: steps.changes.outputs.changed == 'true' && matrix.node-version == 18
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
 
       - name: Integration Test (Rstest)
         if: steps.changes.outputs.changed == 'true'

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "biomejs.biome",
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
-    "unifiedjs.vscode-mdx"
+    "unifiedjs.vscode-mdx",
+    "TypeScriptTeam.native-preview"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,5 +63,6 @@
       "fileMatch": ["**/_nav.json"],
       "url": "./website/node_modules/rspress/nav-json-schema.json"
     }
-  ]
+  ],
+  "typescript.experimental.useTsgo": true
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "picocolors": "1.1.1",
     "prebundle": "1.4.2",
     "rsbuild-plugin-publint": "^0.3.3",
-    "rslib": "npm:@rslib/core@0.12.4",
+    "rslib": "npm:@rslib/core@0.13.0",
     "rslog": "^1.2.11",
     "tsconfck": "3.1.6",
     "typescript": "^5.9.2"

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
       syntax: ['node 18.12.0'],
       dts: {
         bundle: false,
-        tsgo: true,
+        tsgo: !process.env.CI,
         distPath: './dist-types',
       },
     },

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       syntax: ['node 18.12.0'],
       dts: {
         bundle: false,
+        // Only use tsgo in local dev for faster build, disable it in CI until it's more stable
         tsgo: !process.env.CI,
         distPath: './dist-types',
       },

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       syntax: ['node 18.12.0'],
       dts: {
         bundle: false,
+        tsgo: true,
         distPath: './dist-types',
       },
     },

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rslib/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "declaration": true,
     "declarationDir": "./dist-types",

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^22.18.1",
     "fs-extra": "^11.3.1",
     "rsbuild-plugin-publint": "^0.3.3",
-    "rslib": "npm:@rslib/core@0.12.4",
+    "rslib": "npm:@rslib/core@0.13.0",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   },

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -42,7 +42,7 @@
     "@rslib/tsconfig": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20250907.1",
     "rsbuild-plugin-publint": "^0.3.3",
-    "rslib": "npm:@rslib/core@0.12.4",
+    "rslib": "npm:@rslib/core@0.13.0",
     "typescript": "^5.9.2"
   },
   "peerDependencies": {

--- a/packages/plugin-dts/rslib.config.ts
+++ b/packages/plugin-dts/rslib.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       syntax: ['node 18.12.0'],
       dts: {
         bundle: false,
-        tsgo: true,
+        tsgo: !process.env.CI,
       },
     },
   ],

--- a/packages/plugin-dts/rslib.config.ts
+++ b/packages/plugin-dts/rslib.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       syntax: ['node 18.12.0'],
       dts: {
         bundle: false,
+        tsgo: true,
       },
     },
   ],

--- a/packages/plugin-dts/rslib.config.ts
+++ b/packages/plugin-dts/rslib.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       syntax: ['node 18.12.0'],
       dts: {
         bundle: false,
+        // Only use tsgo in local dev for faster build, disable it in CI until it's more stable
         tsgo: !process.env.CI,
       },
     },

--- a/packages/plugin-dts/tsconfig.json
+++ b/packages/plugin-dts/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rslib/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "declaration": true,
     "isolatedDeclarations": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,8 +380,8 @@ importers:
         specifier: ^0.3.3
         version: 0.3.3(@rsbuild/core@1.5.4)
       rslib:
-        specifier: npm:@rslib/core@0.12.4
-        version: '@rslib/core@0.12.4(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(typescript@5.9.2)'
+        specifier: npm:@rslib/core@0.13.0
+        version: '@rslib/core@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@typescript/native-preview@7.0.0-dev.20250907.1)(typescript@5.9.2)'
       rslog:
         specifier: ^1.2.11
         version: 1.2.11
@@ -414,8 +414,8 @@ importers:
         specifier: ^0.3.3
         version: 0.3.3(@rsbuild/core@1.5.4)
       rslib:
-        specifier: npm:@rslib/core@0.12.4
-        version: '@rslib/core@0.12.4(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(typescript@5.9.2)'
+        specifier: npm:@rslib/core@0.13.0
+        version: '@rslib/core@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@typescript/native-preview@7.0.0-dev.20250907.1)(typescript@5.9.2)'
       tsx:
         specifier: ^4.20.5
         version: 4.20.5
@@ -457,8 +457,8 @@ importers:
         specifier: ^0.3.3
         version: 0.3.3(@rsbuild/core@1.5.4)
       rslib:
-        specifier: npm:@rslib/core@0.12.4
-        version: '@rslib/core@0.12.4(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(typescript@5.9.2)'
+        specifier: npm:@rslib/core@0.13.0
+        version: '@rslib/core@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@typescript/native-preview@7.0.0-dev.20250907.1)(typescript@5.9.2)'
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -2617,8 +2617,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@0.12.4':
-    resolution: {integrity: sha512-GF+TIacQgtfvKK5r5g08IO795DnorpiHqcERsBua38iB0KsePpOGPAO+/E5YJncZ5regc72y1CByIELEeikgQA==}
+  '@rslib/core@0.13.0':
+    resolution: {integrity: sha512-jRCKUQPBhIXKQT5LVC76pcpAg4H10xU8kjxxLqMW5qKTXka5PlF86zyZ/gSolgkHx+AHaFPYweGZKPxbMaI45A==}
     engines: {node: '>=18.12.0'}
     hasBin: true
     peerDependencies:
@@ -6600,15 +6600,18 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  rsbuild-plugin-dts@0.12.4:
-    resolution: {integrity: sha512-+T8/jVMneNZgHG7Mw4fjuL5lqa5+sDDKKY5cxNLxD9erYpNGIpVlU31MNE94lvjMmhlK4u5hW/g10u72Fl/FVw==}
+  rsbuild-plugin-dts@0.13.0:
+    resolution: {integrity: sha512-6E82mYpQkPNBOU2i+UBEdvrvsrtKU3Yo0llTn89QKmLD6m47qgjzXzryuhpdYg0qW6urvBhFWcq59HY1QIedcw==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
       '@rsbuild/core': 1.x
+      '@typescript/native-preview': 7.x
       typescript: ^5
     peerDependenciesMeta:
       '@microsoft/api-extractor':
+        optional: true
+      '@typescript/native-preview':
         optional: true
       typescript:
         optional: true
@@ -9347,14 +9350,16 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.5.4
 
-  '@rslib/core@0.12.4(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(typescript@5.9.2)':
+  '@rslib/core@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@typescript/native-preview@7.0.0-dev.20250907.1)(typescript@5.9.2)':
     dependencies:
       '@rsbuild/core': 1.5.4
-      rsbuild-plugin-dts: 0.12.4(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@rsbuild/core@1.5.4)(typescript@5.9.2)
+      rsbuild-plugin-dts: 0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@rsbuild/core@1.5.4)(@typescript/native-preview@7.0.0-dev.20250907.1)(typescript@5.9.2)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@microsoft/api-extractor': 7.52.11(@types/node@22.18.1)
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
 
   '@rslint/core@0.1.13':
     optionalDependencies:
@@ -14087,7 +14092,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.12.4(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@rsbuild/core@1.5.4)(typescript@5.9.2):
+  rsbuild-plugin-dts@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@rsbuild/core@1.5.4)(@typescript/native-preview@7.0.0-dev.20250907.1)(typescript@5.9.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.5.4
@@ -14097,6 +14102,7 @@ snapshots:
       tsconfig-paths: 4.2.0
     optionalDependencies:
       '@microsoft/api-extractor': 7.52.11(@types/node@22.18.1)
+      '@typescript/native-preview': 7.0.0-dev.20250907.1
       typescript: 5.9.2
 
   rsbuild-plugin-google-analytics@1.0.4(@rsbuild/core@1.5.4):


### PR DESCRIPTION
## Summary

Use tsgo to generate dts in local.

## Related Links

<!--- Provide links of related issues or pages -->

https://github.com/web-infra-dev/rslib/releases/tag/v0.13.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
