### PR TITLE
fix(dts): tsgo bin path should begin with file protocol in windows

### DIFF
--- a/packages/plugin-dts/src/tsgo.ts
+++ b/packages/plugin-dts/src/tsgo.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import fsP from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { logger } from '@rsbuild/core';
 import color from 'picocolors';
 import type ts from 'typescript';
@@ -29,7 +30,16 @@ const getTsgoBinPath = async (): Promise<string> => {
     './lib/getExePath.js',
   );
 
-  return import(libPath).then((mod) => {
+  // handle Windows paths
+  // On Windows, absolute paths must be valid file:// URLs
+  let fileUrl: string;
+  if (process.platform === 'win32') {
+    fileUrl = pathToFileURL(libPath).href;
+  } else {
+    fileUrl = libPath;
+  }
+
+  return import(fileUrl).then((mod) => {
     const getExePath = mod.default;
     return getExePath();
   });


### PR DESCRIPTION
## Summary

tsgo bin path should begin with file protocol in windows

## Related Links

https://github.com/lynx-family/lynx-stack/actions/runs/17573565390/job/49914064104?pr=1685

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
