### PR TITLE
chore(workflow): remove experimental typescript setting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "biomejs.biome",
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
-    "unifiedjs.vscode-mdx",
-    "TypeScriptTeam.native-preview"
+    "unifiedjs.vscode-mdx"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,6 +63,5 @@
       "fileMatch": ["**/_nav.json"],
       "url": "./website/node_modules/rspress/nav-json-schema.json"
     }
-  ],
-  "typescript.experimental.useTsgo": true
+  ]
 }


### PR DESCRIPTION
## Summary

Since the `TypeScriptTeam.native-preview` extension has not been published to the Open VSX registry, we removed the experimental typescript setting to avoid breaking the editors forked from VS Code.

## Related Links

- https://open-vsx.org/?search=typescript%20native&sortBy=relevance&sortOrder=desc
- #1210 
- https://github.com/web-infra-dev/rsbuild/pull/6102

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
