### PR TITLE
fix: pin @rsbuild/core version to avoid @rspack/core 1.5.5

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.18.4",
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-react": "^1.4.0",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.18.4",
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-react": "^1.4.0",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "rsbuild-plugin-dts": "workspace:*",
     "tinyglobby": "^0.2.15"
   },

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@storybook/addon-docs": "^9.1.5",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@storybook/addon-docs": "^9.1.5",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@storybook/addon-docs": "^9.1.5",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@storybook/addon-docs": "^9.1.5",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
@@ -18,7 +18,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.3.3",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.3.3",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.5",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.5",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -17,7 +17,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.5",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.5",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
@@ -20,7 +20,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.3.3",
     "@storybook/addon-docs": "^9.1.5",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.3.3",
     "@storybook/addon-docs": "^9.1.5",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.5",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.5",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-js/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.5",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.5",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.52.11",
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rslib/tsconfig": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20250909.1",
     "rsbuild-plugin-publint": "^0.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,13 +94,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.18.4
-        version: 0.18.4(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+        version: 0.18.4(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@rsbuild/core':
-        specifier: ~1.5.5
-        version: 1.5.5
+        specifier: 1.5.4
+        version: 1.5.4
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@types/react':
         specifier: ^19.1.12
         version: 19.1.12
@@ -115,16 +115,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.18.4
-        version: 0.18.4(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+        version: 0.18.4(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.18.4
-        version: 0.18.4(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+        version: 0.18.4(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@module-federation/storybook-addon':
         specifier: ^4.0.28
-        version: 4.0.28(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))(webpack-virtual-modules@0.6.2)
+        version: 4.0.28(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))(webpack-virtual-modules@0.6.2)
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -145,10 +145,10 @@ importers:
         version: 9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
       storybook-addon-rslib:
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@1.5.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2)
+        version: 2.1.0(@rsbuild/core@1.5.4)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2)
       storybook-react-rsbuild:
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
+        version: 2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -161,13 +161,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.18.4
-        version: 0.18.4(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+        version: 0.18.4(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@rsbuild/core':
-        specifier: ~1.5.5
-        version: 1.5.5
+        specifier: 1.5.4
+        version: 1.5.4
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@types/react':
         specifier: ^19.1.12
         version: 19.1.12
@@ -182,10 +182,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@1.5.5)(preact@10.27.1)
+        version: 1.5.2(@rsbuild/core@1.5.4)(preact@10.27.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -197,10 +197,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -215,10 +215,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -233,10 +233,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -251,13 +251,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@1.5.5)
+        version: 1.0.6(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-solid':
         specifier: ^1.0.6
-        version: 1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.5.5)(solid-js@1.9.9)
+        version: 1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.5.4)(solid-js@1.9.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -275,7 +275,7 @@ importers:
         version: link:../../packages/core
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.5.5)(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.5.4)(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -314,16 +314,16 @@ importers:
         version: 9.1.5(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(vue@3.5.21(typescript@5.9.2))
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.5.5)(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.5.4)(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
       storybook:
         specifier: ^9.1.5
         version: 9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
       storybook-addon-rslib:
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@1.5.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2)
+        version: 2.1.0(@rsbuild/core@1.5.4)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2)
       storybook-vue3-rsbuild:
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2))
+        version: 2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2))
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -337,8 +337,8 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~1.5.5
-        version: 1.5.5
+        specifier: 1.5.4
+        version: 1.5.4
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
@@ -348,7 +348,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.18.4
-        version: 0.18.4(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+        version: 0.18.4(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -378,7 +378,7 @@ importers:
         version: 1.4.2(typescript@5.9.2)
       rsbuild-plugin-publint:
         specifier: ^0.3.3
-        version: 0.3.3(@rsbuild/core@1.5.5)
+        version: 0.3.3(@rsbuild/core@1.5.4)
       rslib:
         specifier: npm:@rslib/core@0.13.0
         version: '@rslib/core@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@typescript/native-preview@7.0.0-dev.20250909.1)(typescript@5.9.2)'
@@ -412,7 +412,7 @@ importers:
         version: 11.3.1
       rsbuild-plugin-publint:
         specifier: ^0.3.3
-        version: 0.3.3(@rsbuild/core@1.5.5)
+        version: 0.3.3(@rsbuild/core@1.5.4)
       rslib:
         specifier: npm:@rslib/core@0.13.0
         version: '@rslib/core@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@typescript/native-preview@7.0.0-dev.20250909.1)(typescript@5.9.2)'
@@ -445,8 +445,8 @@ importers:
         specifier: ^7.52.11
         version: 7.52.11(@types/node@22.18.1)
       '@rsbuild/core':
-        specifier: ~1.5.5
-        version: 1.5.5
+        specifier: 1.5.4
+        version: 1.5.4
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -455,7 +455,7 @@ importers:
         version: 7.0.0-dev.20250909.1
       rsbuild-plugin-publint:
         specifier: ^0.3.3
-        version: 0.3.3(@rsbuild/core@1.5.5)
+        version: 0.3.3(@rsbuild/core@1.5.4)
       rslib:
         specifier: npm:@rslib/core@0.13.0
         version: '@rslib/core@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@typescript/native-preview@7.0.0-dev.20250909.1)(typescript@5.9.2)'
@@ -479,31 +479,31 @@ importers:
         version: 4.0.1(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.18.4
-        version: 0.18.4(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+        version: 0.18.4(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@playwright/test':
         specifier: 1.55.0
         version: 1.55.0
       '@rsbuild/core':
-        specifier: ~1.5.5
-        version: 1.5.5
+        specifier: 1.5.4
+        version: 1.5.4
       '@rsbuild/plugin-less':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@1.5.5)
+        version: 1.5.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-toml':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.5.5)
+        version: 1.1.1(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.5.5)
+        version: 1.1.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.5.5)
+        version: 1.0.3(@rsbuild/core@1.5.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -568,7 +568,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
 
   tests/integration/asset/json: {}
 
@@ -584,10 +584,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.5.5)(typescript@5.9.2)
+        version: 1.2.2(@rsbuild/core@1.5.4)(typescript@5.9.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -681,10 +681,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.5.5)(typescript@5.9.2)
+        version: 1.2.2(@rsbuild/core@1.5.4)(typescript@5.9.2)
 
   tests/integration/cli/build: {}
 
@@ -943,11 +943,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~1.5.5
-        version: 1.5.5
+        specifier: 1.5.4
+        version: 1.5.4
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.2
-        version: 1.4.2(@rsbuild/core@1.5.5)
+        version: 1.4.2(@rsbuild/core@1.5.4)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -956,11 +956,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ~1.5.5
-        version: 1.5.5
+        specifier: 1.5.4
+        version: 1.5.4
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.2
-        version: 1.4.2(@rsbuild/core@1.5.5)
+        version: 1.4.2(@rsbuild/core@1.5.4)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -978,7 +978,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@1.5.5)
+        version: 1.0.6(@rsbuild/core@1.5.4)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.13.0
         version: 0.13.0(@babel/core@7.28.0)
@@ -1126,13 +1126,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))
+        version: 1.2.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))
+        version: 1.2.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -1189,10 +1189,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@1.5.5)
+        version: 1.5.0(@rsbuild/core@1.5.4)
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.5.5)(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.5.4)(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
       vue:
         specifier: ^3.5.21
         version: 3.5.21(typescript@5.9.2)
@@ -1205,16 +1205,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.18.4
-        version: 0.18.4(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+        version: 0.18.4(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@rsbuild/core':
-        specifier: ~1.5.5
-        version: 1.5.5
+        specifier: 1.5.4
+        version: 1.5.4
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.5)
+        version: 1.4.0(@rsbuild/core@1.5.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1262,10 +1262,10 @@ importers:
         version: 19.1.1(react@19.1.1)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.4
-        version: 1.0.4(@rsbuild/core@1.5.5)
+        version: 1.0.4(@rsbuild/core@1.5.4)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.5.5)
+        version: 1.1.0(@rsbuild/core@1.5.4)
       rspress-plugin-font-open-sans:
         specifier: 1.0.3
         version: 1.0.3(@rspress/core@2.0.0-beta.31(@types/react@19.1.12))
@@ -2532,8 +2532,8 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
-  '@rsbuild/core@1.5.5':
-    resolution: {integrity: sha512-PpX0DuMQIUviY59j05XorGRfuQDoXolEWQhhxxfIJRfw8gl07by+FuNZv93lCv7hptknWvBlqR/fBWKkQZs9DQ==}
+  '@rsbuild/core@1.5.4':
+    resolution: {integrity: sha512-iRzq4hEXawL4MVkPKhfGMJxS45XIfwkweAZXEHeaboq6vxbpg0dLRgkbaIuuFyF9hCwI0y3ant/xVXOqDghJNw==}
     engines: {node: '>=18.12.0'}
     hasBin: true
 
@@ -2669,8 +2669,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.5.3':
-    resolution: {integrity: sha512-8R1uqr5E2CzRZjsA1QLXkD4xwcsiHmLJTIzCNj9QJ4+lCw6XgtPqpHZuk3zNROLayijEKwotGXJFHJIbgv1clA==}
+  '@rspack/binding-darwin-arm64@1.5.2':
+    resolution: {integrity: sha512-aO76T6VQvAFt1LJNRA5aPOJ+szeTLlzC5wubsnxgWWjG53goP+Te35kFjDIDe+9VhKE/XqRId6iNAymaEsN+Uw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2679,8 +2679,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.5.3':
-    resolution: {integrity: sha512-R4sb+scZbaBasyS+TQ6dRvv+f/2ZaZ0nXgY7t/ehcuGRvUz3S7FTJF/Mr/Ocxj5oVfb06thDAm+zaAVg+hsM9A==}
+  '@rspack/binding-darwin-x64@1.5.2':
+    resolution: {integrity: sha512-XNSmUOwdGs2PEdCKTFCC0/vu/7U9nMhAlbHJKlmdt0V4iPvFyaNWxkNdFqzLc05jlJOfgDdwbwRb91y9IcIIFQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -2689,8 +2689,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@1.5.3':
-    resolution: {integrity: sha512-NeDJJRNTLx8wOQT+si90th7cdt04I2F697Mp5w0a3Jf3XHAmsraBMn0phdLGWJoUWrrfVGthjgZDl5lcc1UHEA==}
+  '@rspack/binding-linux-arm64-gnu@1.5.2':
+    resolution: {integrity: sha512-rNxRfgC5khlrhyEP6y93+45uQ4TI7CdtWqh5PKsaR6lPepG1rH4L8VE+etejSdhzXH6wQ76Rw4wzb96Hx+5vuQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -2699,8 +2699,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.5.3':
-    resolution: {integrity: sha512-M9utPq9s7zJkKapUlyfwwYT/rjZ+XM56NHQMUH9MVYgMJIl+66QURgWUXCAbuogxf1XWayUGQaZsgypoOrTG9A==}
+  '@rspack/binding-linux-arm64-musl@1.5.2':
+    resolution: {integrity: sha512-kTFX+KsGgArWC5q+jJWz0K/8rfVqZOn1ojv1xpCCcz/ogWRC/qhDGSOva6Wandh157BiR93Vfoe1gMvgjpLe5g==}
     cpu: [arm64]
     os: [linux]
 
@@ -2709,8 +2709,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.5.3':
-    resolution: {integrity: sha512-AsKqU4pIg0yYg1VvSEU0NspIwCexqXD2AYE0wujAAwBo0hOfbt5dl1JCK7idiZdIQvoFg86HbfGwdHIVcFLI0w==}
+  '@rspack/binding-linux-x64-gnu@1.5.2':
+    resolution: {integrity: sha512-Lh/6WZGq30lDV6RteQQu7Phw0RH2Z1f4kGR+MsplJ6X4JpnziDow+9oxKdu6FvFHWxHByncpveVeInusQPmL7Q==}
     cpu: [x64]
     os: [linux]
 
@@ -2719,8 +2719,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.5.3':
-    resolution: {integrity: sha512-0aHuvDef92pFZaHhk8Mp8RP9TfTzhQ+Pjqrc2ixRS/FeJA+jVB2CSaYlAPP4QrgXdmW7tewSxEw8hYhF9CNv/A==}
+  '@rspack/binding-linux-x64-musl@1.5.2':
+    resolution: {integrity: sha512-CsLC/SIOIFs6CBmusSAF0FECB62+J36alMdwl7j6TgN6nX3UQQapnL1aVWuQaxU6un/1Vpim0V/EZbUYIdJQ4g==}
     cpu: [x64]
     os: [linux]
 
@@ -2728,8 +2728,8 @@ packages:
     resolution: {integrity: sha512-8rVpl6xfaAFJgo1wCd+emksfl+/8nlehrtkmjY9bj79Ou+kp07L9e1B+UU0jfs8e7aLPntQuF68kzLHwYLzWIQ==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@1.5.3':
-    resolution: {integrity: sha512-Y7KN/ZRuWcFdjCzuZE0JsPwTqJAz1aipJsEOI3whBUj9Va2RwbR9r3vbW6OscS0Wm3rTJAfqH0xwx9x3GksnAw==}
+  '@rspack/binding-wasm32-wasi@1.5.2':
+    resolution: {integrity: sha512-cuVbGr1b4q0Z6AtEraI3becZraPMMgZtZPRaIsVLeDXCmxup/maSAR3T6UaGf4Q2SNcFfjw4neGz5UJxPK8uvA==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.5.0':
@@ -2737,8 +2737,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@1.5.3':
-    resolution: {integrity: sha512-I9SqobDwFwcIUNzr+VwvR2lUGqfarOpFDp7mZmA6+qO/V0yJxS0aqBIwNoZB/UFPbUh71OdmFavBzcTYE9vPSg==}
+  '@rspack/binding-win32-arm64-msvc@1.5.2':
+    resolution: {integrity: sha512-4vJQdzRTSuvmvL3vrOPuiA7f9v9frNc2RFWDxqg+GYt0YAjDStssp+lkVbRYyXnTYVJkARSuO6N+BOiI+kLdsQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -2747,8 +2747,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.5.3':
-    resolution: {integrity: sha512-pPSzSycfK03lLNxzwEkrRUfqETB7y0KEEbO0HcGX63EC9Ne4SILJfkkH55G0PO4aT/dfAosAlkf6V64ATgrHGA==}
+  '@rspack/binding-win32-ia32-msvc@1.5.2':
+    resolution: {integrity: sha512-zPbu3lx/NrNxdjZzTIjwD0mILUOpfhuPdUdXIFiOAO8RiWSeQpYOvyI061s/+bNOmr4A+Z0uM0dEoOClfkhUFg==}
     cpu: [ia32]
     os: [win32]
 
@@ -2757,16 +2757,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.5.3':
-    resolution: {integrity: sha512-He/GrFVrCZ4gBrHSxGd7mnwk9A9BDkAeZZEBnfK4n/HfXxU32WX5jiAGacFoJQYFLDOWTAcmxFad37TSs61zXw==}
+  '@rspack/binding-win32-x64-msvc@1.5.2':
+    resolution: {integrity: sha512-duLNUTshX38xhC10/W9tpkPca7rOifP2begZjdb1ikw7C4AI0I7VnBnYt8qPSxGISoclmhOBxU/LuAhS8jMMlg==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@1.5.0':
     resolution: {integrity: sha512-UGXQmwEu2gdO+tnGv2q4rOWJdWioy6dlLXeZOLYAZVh3mrfKJhZWtDEygX9hCdE5thWNRTlEvx30QQchJAszIQ==}
 
-  '@rspack/binding@1.5.3':
-    resolution: {integrity: sha512-bWAKligHxelx3XxOgFmK6k1vR+ANxjBXLXTmgOiZxsJNScHJap3HYViXWJHKj5jvdXEvg9sC8TE7WNctCfa8iQ==}
+  '@rspack/binding@1.5.2':
+    resolution: {integrity: sha512-NKiBcsxmAzFDYRnK2ZHWbTtDFVT5/704eK4OfpgsDXPMkaMnBKijMKNgP5pbe18X4rUlz+8HnGm4+Xllo9EESw==}
 
   '@rspack/core@1.5.0':
     resolution: {integrity: sha512-eEtiKV+CUcAtnt1K+eiHDzmBXQcNM8CfCXOzr0+gHGp4w4Zks2B8RF36sYD03MM2bg8VRXXsf0MicQ8FvRMCOg==}
@@ -2777,8 +2777,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@1.5.3':
-    resolution: {integrity: sha512-EMNXysJyqsfd2aVys5C7GDZKaLEcoN5qgs7ZFhWOWJGKgBqjdKTljyRTd4RRZV4fV6iAko/WrxnAxmzZNk8mjA==}
+  '@rspack/core@1.5.2':
+    resolution: {integrity: sha512-ifjHqLczC81d1xjXPXCzxTFKNOFsEzuuLN44cMnyzQ/GWi4B48fyX7JHndWE7Lxd54cW1O9Ik7AdBN3Gq891EA==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -8792,7 +8792,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.18.4(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))':
+  '@module-federation/enhanced@0.18.4(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.18.4
       '@module-federation/cli': 0.18.4(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
@@ -8802,7 +8802,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.18.4(@module-federation/runtime-tools@0.18.4)
       '@module-federation/managers': 0.18.4
       '@module-federation/manifest': 0.18.4(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
-      '@module-federation/rspack': 0.18.4(@rspack/core@1.5.3(@swc/helpers@0.5.17))(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+      '@module-federation/rspack': 0.18.4(@rspack/core@1.5.2(@swc/helpers@0.5.17))(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@module-federation/runtime-tools': 0.18.4
       '@module-federation/sdk': 0.18.4
       btoa: 1.2.1
@@ -8849,9 +8849,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.15(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))':
+  '@module-federation/node@2.7.15(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))':
     dependencies:
-      '@module-federation/enhanced': 0.18.4(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+      '@module-federation/enhanced': 0.18.4(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@module-federation/runtime': 0.18.4
       '@module-federation/sdk': 0.18.4
       btoa: 1.2.1
@@ -8869,14 +8869,14 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.18.4(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))':
+  '@module-federation/rsbuild-plugin@0.18.4(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))':
     dependencies:
-      '@module-federation/enhanced': 0.18.4(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
-      '@module-federation/node': 2.7.15(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+      '@module-federation/enhanced': 0.18.4(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+      '@module-federation/node': 2.7.15(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@module-federation/sdk': 0.18.4
       fs-extra: 11.3.0
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8890,7 +8890,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.18.4(@rspack/core@1.5.3(@swc/helpers@0.5.17))(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))':
+  '@module-federation/rspack@0.18.4(@rspack/core@1.5.2(@swc/helpers@0.5.17))(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.18.4
       '@module-federation/dts-plugin': 0.18.4(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
@@ -8899,7 +8899,7 @@ snapshots:
       '@module-federation/manifest': 0.18.4(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@module-federation/runtime-tools': 0.18.4
       '@module-federation/sdk': 0.18.4
-      '@rspack/core': 1.5.3(@swc/helpers@0.5.17)
+      '@rspack/core': 1.5.2(@swc/helpers@0.5.17)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.2
@@ -8946,12 +8946,12 @@ snapshots:
 
   '@module-federation/sdk@0.18.4': {}
 
-  '@module-federation/storybook-addon@4.0.28(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@4.0.28(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 0.18.4(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
+      '@module-federation/enhanced': 0.18.4(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))
       '@module-federation/sdk': 0.18.4
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -9204,21 +9204,21 @@ snapshots:
       core-js: 3.45.1
       jiti: 2.5.1
 
-  '@rsbuild/core@1.5.5':
+  '@rsbuild/core@1.5.4':
     dependencies:
-      '@rspack/core': 1.5.3(@swc/helpers@0.5.17)
+      '@rspack/core': 1.5.2(@swc/helpers@0.5.17)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.17
       core-js: 3.45.1
       jiti: 2.5.1
 
-  '@rsbuild/plugin-babel@1.0.6(@rsbuild/core@1.5.5)':
+  '@rsbuild/plugin-babel@1.0.6(@rsbuild/core@1.5.4)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.0)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -9226,13 +9226,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.5.0(@rsbuild/core@1.5.5)':
+  '@rsbuild/plugin-less@1.5.0(@rsbuild/core@1.5.4)':
     dependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
-  '@rsbuild/plugin-node-polyfill@1.4.2(@rsbuild/core@1.5.5)':
+  '@rsbuild/plugin-node-polyfill@1.4.2(@rsbuild/core@1.5.4)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9258,39 +9258,39 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
 
-  '@rsbuild/plugin-preact@1.5.2(@rsbuild/core@1.5.5)(preact@10.27.1)':
+  '@rsbuild/plugin-preact@1.5.2(@rsbuild/core@1.5.4)(preact@10.27.1)':
     dependencies:
       '@prefresh/core': 1.5.5(preact@10.27.1)
       '@prefresh/utils': 1.2.1
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       '@rspack/plugin-preact-refresh': 1.1.2(@prefresh/core@1.5.5(preact@10.27.1))(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh': 9.0.1
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@1.4.0(@rsbuild/core@1.5.5)':
+  '@rsbuild/plugin-react@1.4.0(@rsbuild/core@1.5.4)':
     dependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       '@rspack/plugin-react-refresh': 1.5.0(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.4.0(@rsbuild/core@1.5.5)':
+  '@rsbuild/plugin-sass@1.4.0(@rsbuild/core@1.5.4)':
     dependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.6
       reduce-configs: 1.1.1
       sass-embedded: 1.90.0
 
-  '@rsbuild/plugin-solid@1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.5.5)(solid-js@1.9.9)':
+  '@rsbuild/plugin-solid@1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.5.4)(solid-js@1.9.9)':
     dependencies:
-      '@rsbuild/core': 1.5.5
-      '@rsbuild/plugin-babel': 1.0.6(@rsbuild/core@1.5.5)
+      '@rsbuild/core': 1.5.4
+      '@rsbuild/plugin-babel': 1.0.6(@rsbuild/core@1.5.4)
       babel-preset-solid: 1.9.6(@babel/core@7.28.0)
       solid-refresh: 0.6.3(solid-js@1.9.9)
     transitivePeerDependencies:
@@ -9298,22 +9298,22 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@1.2.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))':
+  '@rsbuild/plugin-stylus@1.2.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))':
     dependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
       stylus: 0.64.0
-      stylus-loader: 8.1.2(@rspack/core@1.5.3(@swc/helpers@0.5.17))(stylus@0.64.0)
+      stylus-loader: 8.1.2(@rspack/core@1.5.2(@swc/helpers@0.5.17))(stylus@0.64.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.2.2(@rsbuild/core@1.5.5)(typescript@5.9.2)':
+  '@rsbuild/plugin-svgr@1.2.2(@rsbuild/core@1.5.4)(typescript@5.9.2)':
     dependencies:
-      '@rsbuild/core': 1.5.5
-      '@rsbuild/plugin-react': 1.4.0(@rsbuild/core@1.5.5)
+      '@rsbuild/core': 1.5.4
+      '@rsbuild/plugin-react': 1.4.0(@rsbuild/core@1.5.4)
       '@svgr/core': 8.1.0(typescript@5.9.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))(typescript@5.9.2)
@@ -9324,36 +9324,36 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-toml@1.1.1(@rsbuild/core@1.5.5)':
+  '@rsbuild/plugin-toml@1.1.1(@rsbuild/core@1.5.4)':
     dependencies:
       toml: 3.0.0
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
 
-  '@rsbuild/plugin-type-check@1.2.4(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(typescript@5.9.2)':
+  '@rsbuild/plugin-type-check@1.2.4(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(typescript@5.9.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.1.5(@rspack/core@1.5.3(@swc/helpers@0.5.17))(typescript@5.9.2)
+      ts-checker-rspack-plugin: 1.1.5(@rspack/core@1.5.2(@swc/helpers@0.5.17))(typescript@5.9.2)
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.1.0(@rsbuild/core@1.5.5)':
+  '@rsbuild/plugin-typed-css-modules@1.1.0(@rsbuild/core@1.5.4)':
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
 
-  '@rsbuild/plugin-yaml@1.0.3(@rsbuild/core@1.5.5)':
+  '@rsbuild/plugin-yaml@1.0.3(@rsbuild/core@1.5.4)':
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
 
   '@rslib/core@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@typescript/native-preview@7.0.0-dev.20250909.1)(typescript@5.9.2)':
     dependencies:
-      '@rsbuild/core': 1.5.5
-      rsbuild-plugin-dts: 0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@rsbuild/core@1.5.5)(@typescript/native-preview@7.0.0-dev.20250909.1)(typescript@5.9.2)
+      '@rsbuild/core': 1.5.4
+      rsbuild-plugin-dts: 0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@rsbuild/core@1.5.4)(@typescript/native-preview@7.0.0-dev.20250909.1)(typescript@5.9.2)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@microsoft/api-extractor': 7.52.11(@types/node@22.18.1)
@@ -9391,37 +9391,37 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.5.0':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.5.3':
+  '@rspack/binding-darwin-arm64@1.5.2':
     optional: true
 
   '@rspack/binding-darwin-x64@1.5.0':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.5.3':
+  '@rspack/binding-darwin-x64@1.5.2':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.5.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.5.3':
+  '@rspack/binding-linux-arm64-gnu@1.5.2':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.5.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.5.3':
+  '@rspack/binding-linux-arm64-musl@1.5.2':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.5.0':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.5.3':
+  '@rspack/binding-linux-x64-gnu@1.5.2':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.5.0':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.5.3':
+  '@rspack/binding-linux-x64-musl@1.5.2':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.5.0':
@@ -9429,7 +9429,7 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.1
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.5.3':
+  '@rspack/binding-wasm32-wasi@1.5.2':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.1
     optional: true
@@ -9437,19 +9437,19 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.5.0':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.5.3':
+  '@rspack/binding-win32-arm64-msvc@1.5.2':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.5.0':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.5.3':
+  '@rspack/binding-win32-ia32-msvc@1.5.2':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.5.0':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.5.3':
+  '@rspack/binding-win32-x64-msvc@1.5.2':
     optional: true
 
   '@rspack/binding@1.5.0':
@@ -9465,18 +9465,18 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.5.0
       '@rspack/binding-win32-x64-msvc': 1.5.0
 
-  '@rspack/binding@1.5.3':
+  '@rspack/binding@1.5.2':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.5.3
-      '@rspack/binding-darwin-x64': 1.5.3
-      '@rspack/binding-linux-arm64-gnu': 1.5.3
-      '@rspack/binding-linux-arm64-musl': 1.5.3
-      '@rspack/binding-linux-x64-gnu': 1.5.3
-      '@rspack/binding-linux-x64-musl': 1.5.3
-      '@rspack/binding-wasm32-wasi': 1.5.3
-      '@rspack/binding-win32-arm64-msvc': 1.5.3
-      '@rspack/binding-win32-ia32-msvc': 1.5.3
-      '@rspack/binding-win32-x64-msvc': 1.5.3
+      '@rspack/binding-darwin-arm64': 1.5.2
+      '@rspack/binding-darwin-x64': 1.5.2
+      '@rspack/binding-linux-arm64-gnu': 1.5.2
+      '@rspack/binding-linux-arm64-musl': 1.5.2
+      '@rspack/binding-linux-x64-gnu': 1.5.2
+      '@rspack/binding-linux-x64-musl': 1.5.2
+      '@rspack/binding-wasm32-wasi': 1.5.2
+      '@rspack/binding-win32-arm64-msvc': 1.5.2
+      '@rspack/binding-win32-ia32-msvc': 1.5.2
+      '@rspack/binding-win32-x64-msvc': 1.5.2
 
   '@rspack/core@1.5.0(@swc/helpers@0.5.17)':
     dependencies:
@@ -9486,10 +9486,10 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.17
 
-  '@rspack/core@1.5.3(@swc/helpers@0.5.17)':
+  '@rspack/core@1.5.2(@swc/helpers@0.5.17)':
     dependencies:
       '@module-federation/runtime-tools': 0.18.0
-      '@rspack/binding': 1.5.3
+      '@rspack/binding': 1.5.2
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
       '@swc/helpers': 0.5.17
@@ -9511,8 +9511,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.1.12)(react@19.1.1)
-      '@rsbuild/core': 1.5.5
-      '@rsbuild/plugin-react': 1.4.0(@rsbuild/core@1.5.5)
+      '@rsbuild/core': 1.5.4
+      '@rsbuild/plugin-react': 1.4.0(@rsbuild/core@1.5.4)
       '@rspress/mdx-rs': 0.6.6
       '@rspress/runtime': 2.0.0-beta.31
       '@rspress/shared': 2.0.0-beta.31
@@ -9638,7 +9638,7 @@ snapshots:
 
   '@rspress/shared@2.0.0-beta.31':
     dependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       '@shikijs/rehype': 3.12.1
       gray-matter: 4.0.3
       lodash-es: 4.17.21
@@ -14092,10 +14092,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@rsbuild/core@1.5.5)(@typescript/native-preview@7.0.0-dev.20250909.1)(typescript@5.9.2):
+  rsbuild-plugin-dts@0.13.0(@microsoft/api-extractor@7.52.11(@types/node@22.18.1))(@rsbuild/core@1.5.4)(@typescript/native-preview@7.0.0-dev.20250909.1)(typescript@5.9.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       magic-string: 0.30.19
       picocolors: 1.1.1
       tinyglobby: 0.2.15
@@ -14105,33 +14105,33 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20250909.1
       typescript: 5.9.2
 
-  rsbuild-plugin-google-analytics@1.0.4(@rsbuild/core@1.5.5):
+  rsbuild-plugin-google-analytics@1.0.4(@rsbuild/core@1.5.4):
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
 
-  rsbuild-plugin-html-minifier-terser@1.1.2(@rsbuild/core@1.5.5):
+  rsbuild-plugin-html-minifier-terser@1.1.2(@rsbuild/core@1.5.4):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
 
-  rsbuild-plugin-open-graph@1.1.0(@rsbuild/core@1.5.5):
+  rsbuild-plugin-open-graph@1.1.0(@rsbuild/core@1.5.4):
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
 
-  rsbuild-plugin-publint@0.3.3(@rsbuild/core@1.5.5):
+  rsbuild-plugin-publint@0.3.3(@rsbuild/core@1.5.4):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.12
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
 
-  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.5.5)(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1):
+  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.5.4)(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1):
     dependencies:
       unplugin-vue: 6.2.0(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
     optionalDependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14560,18 +14560,18 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@2.1.0(@rsbuild/core@1.5.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2):
+  storybook-addon-rslib@2.1.0(@rsbuild/core@1.5.4)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2):
     dependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
+      storybook-builder-rsbuild: 2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
 
-  storybook-builder-rsbuild@2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2):
+  storybook-builder-rsbuild@2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2):
     dependencies:
-      '@rsbuild/core': 1.5.5
-      '@rsbuild/plugin-type-check': 1.2.4(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(typescript@5.9.2)
+      '@rsbuild/core': 1.5.4
+      '@rsbuild/plugin-type-check': 1.2.4(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(typescript@5.9.2)
       '@storybook/addon-docs': 9.1.3(@types/react@19.1.12)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))
       '@storybook/core-webpack': 9.1.3(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))
       browser-assert: 1.2.1
@@ -14583,7 +14583,7 @@ snapshots:
       magic-string: 0.30.19
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.2(@rsbuild/core@1.5.5)
+      rsbuild-plugin-html-minifier-terser: 1.1.2(@rsbuild/core@1.5.4)
       sirv: 2.0.4
       storybook: 9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
       ts-dedent: 2.2.0
@@ -14599,10 +14599,10 @@ snapshots:
       - '@types/react'
       - webpack-sources
 
-  storybook-react-rsbuild@2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2):
+  storybook-react-rsbuild@2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2):
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       '@storybook/react': 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.9.2)
       find-up: 5.0.0
@@ -14613,7 +14613,7 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       resolve: 1.22.10
       storybook: 9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
-      storybook-builder-rsbuild: 2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
+      storybook-builder-rsbuild: 2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.9.2
@@ -14625,12 +14625,12 @@ snapshots:
       - webpack
       - webpack-sources
 
-  storybook-vue3-rsbuild@2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2)):
+  storybook-vue3-rsbuild@2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2)):
     dependencies:
-      '@rsbuild/core': 1.5.5
+      '@rsbuild/core': 1.5.4
       '@storybook/vue3': 9.1.5(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(vue@3.5.21(typescript@5.9.2))
       storybook: 9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
-      storybook-builder-rsbuild: 2.1.0(@rsbuild/core@1.5.5)(@rspack/core@1.5.3(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
+      storybook-builder-rsbuild: 2.1.0(@rsbuild/core@1.5.4)(@rspack/core@1.5.2(@swc/helpers@0.5.17))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
       vue: 3.5.21(typescript@5.9.2)
       vue-docgen-loader: 1.5.1
     transitivePeerDependencies:
@@ -14752,13 +14752,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  stylus-loader@8.1.2(@rspack/core@1.5.3(@swc/helpers@0.5.17))(stylus@0.64.0):
+  stylus-loader@8.1.2(@rspack/core@1.5.2(@swc/helpers@0.5.17))(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 1.5.3(@swc/helpers@0.5.17)
+      '@rspack/core': 1.5.2(@swc/helpers@0.5.17)
 
   stylus@0.64.0:
     dependencies:
@@ -14949,7 +14949,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.1.5(@rspack/core@1.5.3(@swc/helpers@0.5.17))(typescript@5.9.2):
+  ts-checker-rspack-plugin@1.1.5(@rspack/core@1.5.2(@swc/helpers@0.5.17))(typescript@5.9.2):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@rspack/lite-tapable': 1.0.1
@@ -14960,7 +14960,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.9.2
     optionalDependencies:
-      '@rspack/core': 1.5.3(@swc/helpers@0.5.17)
+      '@rspack/core': 1.5.2(@swc/helpers@0.5.17)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-node-polyfill": "^1.4.2"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-node-polyfill": "^1.4.2"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^0.18.4",
     "@playwright/test": "1.55.0",
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-less": "^1.5.0",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rsbuild/plugin-sass": "^1.4.0",

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.18.4",
-    "@rsbuild/core": "~1.5.5",
+    "@rsbuild/core": "1.5.4",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rsbuild/plugin-sass": "^1.4.0",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

use `~` until https://github.com/web-infra-dev/rspack/pull/11630 landed.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
