### PR TITLE
fix: avoid chunk conflicts when multiple libs are present

### DIFF
--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -393,7 +393,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   output: {
     path: '<WORKSPACE>/dist',
     filename: '[name].js',
-    chunkFilename: '[name].js',
+    chunkFilename: '0~[name].js',
     publicPath: 'auto',
     pathinfo: false,
     hashFunction: 'xxhash64',
@@ -1091,7 +1091,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   output: {
     path: '<WORKSPACE>/dist',
     filename: '[name].cjs',
-    chunkFilename: '[name].cjs',
+    chunkFilename: '1~[name].cjs',
     publicPath: 'auto',
     pathinfo: false,
     hashFunction: 'xxhash64',
@@ -1775,7 +1775,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   output: {
     path: '<WORKSPACE>/dist',
     filename: '[name].js',
-    chunkFilename: '[name].js',
+    chunkFilename: '2~[name].js',
     publicPath: '/',
     pathinfo: false,
     hashFunction: 'xxhash64',
@@ -2375,7 +2375,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   output: {
     path: '<WORKSPACE>/dist',
     filename: '[name].js',
-    chunkFilename: '[name].js',
+    chunkFilename: '3~[name].js',
     publicPath: '/',
     pathinfo: false,
     hashFunction: 'xxhash64',
@@ -2918,7 +2918,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   output: {
     path: '<WORKSPACE>/dist',
     filename: '[name].js',
-    chunkFilename: '[name].js',
+    chunkFilename: '4~[name].js',
     publicPath: '/',
     pathinfo: false,
     hashFunction: 'xxhash64',
@@ -3696,6 +3696,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           },
           [Function],
           {
+            "output": {
+              "chunkFilename": "0~[name].js",
+            },
+          },
+          {
             "target": [
               "node",
             ],
@@ -3967,6 +3972,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           },
           [Function],
           {
+            "output": {
+              "chunkFilename": "1~[name].cjs",
+            },
+          },
+          {
             "target": [
               "node",
             ],
@@ -4200,6 +4210,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           },
           [Function],
           {
+            "output": {
+              "chunkFilename": "2~[name].js",
+            },
+          },
+          {
             "target": [
               "node",
             ],
@@ -4432,6 +4447,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           },
           [Function],
           {
+            "output": {
+              "chunkFilename": "3~[name].js",
+            },
+          },
+          {
             "target": [
               "node",
             ],
@@ -4590,6 +4610,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           },
           [Function],
           [Function],
+          {
+            "output": {
+              "chunkFilename": "4~[name].js",
+            },
+          },
           {
             "target": [
               "web",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -966,6 +966,10 @@ importers:
 
   tests/integration/outBase/nested-dir: {}
 
+  tests/integration/output/chunkFileName-multi: {}
+
+  tests/integration/output/chunkFileName-single: {}
+
   tests/integration/plugins/basic: {}
 
   tests/integration/plugins/mf-dev: {}
@@ -7657,8 +7661,8 @@ packages:
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
 
-  vue-component-type-helpers@3.0.6:
-    resolution: {integrity: sha512-6CRM8X7EJqWCJOiKPvSLQG+hJPb/Oy2gyJx3pLjUEhY7PuaCthQu3e0zAGI1lqUBobrrk9IT0K8sG2GsCluxoQ==}
+  vue-component-type-helpers@3.0.7:
+    resolution: {integrity: sha512-TvyUcFXmjZcXUvU+r1MOyn4/vv4iF+tPwg5Ig33l/FJ3myZkxeQpzzQMLMFWcQAjr6Xs7BRwVy/TwbmNZUA/4w==}
 
   vue-docgen-loader@1.5.1:
     resolution: {integrity: sha512-coMmQYsg+fy18SVtBNU7/tztdqEyrneFfwQFLmx8O7jaJ11VZ//9tRWXlwGzJM07cPRwMHDKMlAdWrpuw3U46A==}
@@ -9958,7 +9962,7 @@ snapshots:
       storybook: 9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
       type-fest: 2.19.0
       vue: 3.5.21(typescript@5.9.2)
-      vue-component-type-helpers: 3.0.6
+      vue-component-type-helpers: 3.0.7
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.0)':
     dependencies:
@@ -15259,7 +15263,7 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-component-type-helpers@3.0.6: {}
+  vue-component-type-helpers@3.0.7: {}
 
   vue-docgen-loader@1.5.1:
     dependencies:

--- a/tests/integration/output/chunkFileName-multi/package.json
+++ b/tests/integration/output/chunkFileName-multi/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "minify-output-chunk-file-name-multi-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/output/chunkFileName-multi/rslib1.config.ts
+++ b/tests/integration/output/chunkFileName-multi/rslib1.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          lib1: './src/lib1.js',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          lib2: './src/lib2.js',
+        },
+      },
+    }),
+  ],
+});

--- a/tests/integration/output/chunkFileName-multi/rslib2.config.ts
+++ b/tests/integration/output/chunkFileName-multi/rslib2.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  output: {
+    filename: {
+      js: 'static/js/[name].[contenthash:8].js',
+    },
+  },
+  lib: [
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          lib1: './src/lib1.js',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          lib2: './src/lib2.js',
+        },
+      },
+    }),
+  ],
+});

--- a/tests/integration/output/chunkFileName-multi/rslib3.config.ts
+++ b/tests/integration/output/chunkFileName-multi/rslib3.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          lib1: './src/lib1.js',
+        },
+      },
+      output: {
+        filename: {
+          js: 'static1/js/[name].js',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          lib2: './src/lib2.js',
+        },
+      },
+      output: {
+        filename: {
+          js: 'static2/js/[name].[contenthash:8].js',
+        },
+      },
+    }),
+  ],
+});

--- a/tests/integration/output/chunkFileName-multi/src/lib1.js
+++ b/tests/integration/output/chunkFileName-multi/src/lib1.js
@@ -1,0 +1,4 @@
+export default async function main() {
+  const { foo } = await import('./shared.js');
+  return foo;
+}

--- a/tests/integration/output/chunkFileName-multi/src/lib2.js
+++ b/tests/integration/output/chunkFileName-multi/src/lib2.js
@@ -1,0 +1,4 @@
+export default async function main() {
+  const { bar } = await import('./shared.js');
+  return bar;
+}

--- a/tests/integration/output/chunkFileName-multi/src/shared.js
+++ b/tests/integration/output/chunkFileName-multi/src/shared.js
@@ -1,0 +1,2 @@
+export const foo = 'foo';
+export const bar = 'bar';

--- a/tests/integration/output/chunkFileName-single/package.json
+++ b/tests/integration/output/chunkFileName-single/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "minify-output-chunk-file-name-single-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/output/chunkFileName-single/rslib.config.ts
+++ b/tests/integration/output/chunkFileName-single/rslib.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          lib1: './src/lib1.js',
+        },
+      },
+    }),
+  ],
+});

--- a/tests/integration/output/chunkFileName-single/src/lib1.js
+++ b/tests/integration/output/chunkFileName-single/src/lib1.js
@@ -1,0 +1,4 @@
+export default async function main() {
+  const { foo } = await import('./shared.js');
+  return foo;
+}

--- a/tests/integration/output/chunkFileName-single/src/shared.js
+++ b/tests/integration/output/chunkFileName-single/src/shared.js
@@ -1,0 +1,2 @@
+export const foo = 'foo';
+export const bar = 'bar';

--- a/tests/integration/output/index.test.ts
+++ b/tests/integration/output/index.test.ts
@@ -1,0 +1,93 @@
+import { basename, join } from 'node:path';
+import { describe, expect, test } from '@rstest/core';
+import { buildAndGetResults } from 'test-helper';
+
+describe('output config', () => {
+  describe('chunkFileName', () => {
+    test('should prefix index for multi-compiler builds', async () => {
+      const fixturePath = join(__dirname, 'chunkFileName-multi');
+      const { files, rspackConfig } = await buildAndGetResults({
+        fixturePath,
+        configPath: 'rslib1.config.ts',
+      });
+
+      expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
+      expect(rspackConfig[0]!.output?.chunkFilename).toBe('0~[name].js');
+      expect(rspackConfig[1]!.output?.chunkFilename).toBe('1~[name].js');
+
+      const esm0BaseNames = (files.esm0 ?? []).map((p) => basename(p));
+      const esm1BaseNames = (files.esm1 ?? []).map((p) => basename(p));
+
+      expect(esm0BaseNames.some((n) => /^0~188\.js$/.test(n))).toBeTruthy();
+      expect(esm1BaseNames.some((n) => /^1~188\.js$/.test(n))).toBeTruthy();
+    });
+
+    test('should prefix index for multi-compiler builds (with filename)', async () => {
+      const fixturePath = join(__dirname, 'chunkFileName-multi');
+      const { files, rspackConfig } = await buildAndGetResults({
+        fixturePath,
+        configPath: 'rslib2.config.ts',
+      });
+
+      expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
+      expect(rspackConfig[0]!.output?.chunkFilename).toBe(
+        'static/js/0~[name].[contenthash:8].js',
+      );
+      expect(rspackConfig[1]!.output?.chunkFilename).toBe(
+        'static/js/1~[name].[contenthash:8].js',
+      );
+
+      const esm0BaseNames = (files.esm0 ?? []).map((p) => basename(p));
+      const esm1BaseNames = (files.esm1 ?? []).map((p) => basename(p));
+
+      expect(
+        esm0BaseNames.some((n) => /^0~188\.\w+\.js$/.test(n)),
+      ).toBeTruthy();
+      expect(
+        esm1BaseNames.some((n) => /^1~188\.\w+\.js$/.test(n)),
+      ).toBeTruthy();
+    });
+
+    test('should prefix index for multi-compiler builds (with chunkFilename)', async () => {
+      const fixturePath = join(__dirname, 'chunkFileName-multi');
+      const { files, rspackConfig } = await buildAndGetResults({
+        fixturePath,
+        configPath: 'rslib3.config.ts',
+      });
+
+      expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
+      expect(rspackConfig[0]!.output?.chunkFilename).toBe(
+        'static1/js/0~[name].js',
+      );
+      expect(rspackConfig[1]!.output?.chunkFilename).toBe(
+        'static2/js/1~[name].[contenthash:8].js',
+      );
+
+      expect(
+        files.esm0!.some((n) => /static1\/js\/0~188\.js$/.test(n)),
+      ).toBeTruthy();
+      expect(
+        files.esm0!.some((n) => /static1\/js\/lib1\.js$/.test(n)),
+      ).toBeTruthy();
+      expect(
+        files.esm0!.some((n) => /static2\/js\/1~188\.\w+\.js$/.test(n)),
+      ).toBeTruthy();
+      expect(
+        files.esm0!.some((n) => /static2\/js\/lib2\.\w+\.js$/.test(n)),
+      ).toBeTruthy();
+    });
+
+    test('should not prefix index for single-compiler builds', async () => {
+      const fixturePath = join(__dirname, 'chunkFileName-single');
+      const { files } = await buildAndGetResults({ fixturePath });
+
+      const esmBaseNames = (files.esm ?? []).map((p) => basename(p));
+      expect(esmBaseNames.some((n) => /^\d+~.+\.js$/.test(n))).toBeFalsy();
+      expect(
+        esmBaseNames.some(
+          (n) => /^\d+\.js$/.test(n) || /shared.*\.js$/.test(n),
+        ),
+      ).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

to fix the case added in test cases, multi-compiler don't know other compilers' existence, so it's prone to emit chunk file to same path, whereas the content might not the same. this it's not prone to happen in Rsbuild as the hash is enabled but hash is disabled in Rslib.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
