### PR TITLE
chore(renovate): ignore `jsdom` due to Node.js version limit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,8 @@
     'react-dom-18',
     // Breaking change, see https://github.com/web-infra-dev/rslib/pull/992
     '@ast-grep/napi',
+    // Breaking change, minimum supported version Node.js v20
+    'jsdom',
     // Temporarily ignore, see https://github.com/web-infra-dev/rslib/pull/1226
     'tinyglobby',
   ],


### PR DESCRIPTION
## Summary

Ignore `jsdom` due to Node.js version limit

## Related Links

https://github.com/jsdom/jsdom/blob/HEAD/Changelog.md#2700

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
