### PR TITLE
chore(deps): bump Rsbuild 1.5.9

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.19.1",
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-react": "^1.4.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.19.1",
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-react": "^1.4.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -311,7 +311,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   experiments: {
     lazyBarrel: true,
     inlineEnum: true,
-    inlineConst: true,
+    inlineConst: false,
     typeReexportsPresence: true,
     rspackFuture: {
       bundlerInfo: {
@@ -454,7 +454,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   module: {
     parser: {
       javascript: {
-        inlineConst: true,
+        inlineConst: false,
         exportsPresence: 'error',
         typeReexportsPresence: 'tolerant',
         importMeta: false,
@@ -1009,7 +1009,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   experiments: {
     lazyBarrel: true,
     inlineEnum: true,
-    inlineConst: true,
+    inlineConst: false,
     typeReexportsPresence: true,
     rspackFuture: {
       bundlerInfo: {
@@ -1150,7 +1150,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   module: {
     parser: {
       javascript: {
-        inlineConst: true,
+        inlineConst: false,
         exportsPresence: 'error',
         typeReexportsPresence: 'tolerant',
         importMeta: false,
@@ -1701,7 +1701,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   experiments: {
     lazyBarrel: true,
     inlineEnum: true,
-    inlineConst: true,
+    inlineConst: false,
     typeReexportsPresence: true,
     rspackFuture: {
       bundlerInfo: {
@@ -1831,7 +1831,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   module: {
     parser: {
       javascript: {
-        inlineConst: true,
+        inlineConst: false,
         exportsPresence: 'error',
         typeReexportsPresence: 'tolerant',
         importMeta: false
@@ -2301,7 +2301,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   experiments: {
     lazyBarrel: true,
     inlineEnum: true,
-    inlineConst: true,
+    inlineConst: false,
     typeReexportsPresence: true,
     rspackFuture: {
       bundlerInfo: {
@@ -2433,7 +2433,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   module: {
     parser: {
       javascript: {
-        inlineConst: true,
+        inlineConst: false,
         exportsPresence: 'error',
         typeReexportsPresence: 'tolerant',
         importMeta: false
@@ -2902,7 +2902,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   experiments: {
     lazyBarrel: true,
     inlineEnum: true,
-    inlineConst: true,
+    inlineConst: false,
     typeReexportsPresence: true,
     rspackFuture: {
       bundlerInfo: {
@@ -2971,7 +2971,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   module: {
     parser: {
       javascript: {
-        inlineConst: true,
+        inlineConst: false,
         exportsPresence: 'error',
         typeReexportsPresence: 'tolerant'
       }

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@storybook/addon-docs": "^9.1.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@storybook/addon-docs": "^9.1.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@storybook/addon-docs": "^9.1.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@storybook/addon-docs": "^9.1.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-interactions": "^9.0.0-alpha.10",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
@@ -18,7 +18,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.3.4",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.3.4",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.6",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.6",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -17,7 +17,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.6",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.6",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
@@ -20,7 +20,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.3.4",
     "@storybook/addon-docs": "^9.1.6",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.3.4",
     "@storybook/addon-docs": "^9.1.6",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-js/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.6",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.52.13",
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rslib/tsconfig": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20250915.1",
     "magic-string": "^0.30.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,13 +94,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.19.1
-        version: 0.19.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+        version: 0.19.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@rsbuild/core':
-        specifier: ~1.5.7
-        version: 1.5.7
+        specifier: ~1.5.9
+        version: 1.5.9
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@types/react':
         specifier: ^19.1.13
         version: 19.1.13
@@ -115,16 +115,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.19.1
-        version: 0.19.1(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+        version: 0.19.1(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.19.1
-        version: 0.19.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+        version: 0.19.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@module-federation/storybook-addon':
         specifier: ^4.0.30
-        version: 4.0.30(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))(webpack-virtual-modules@0.6.2)
+        version: 4.0.30(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))(webpack-virtual-modules@0.6.2)
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -145,10 +145,10 @@ importers:
         version: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
       storybook-addon-rslib:
         specifier: ^2.1.1
-        version: 2.1.1(@rsbuild/core@1.5.7)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2)
+        version: 2.1.1(@rsbuild/core@1.5.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2)
       storybook-react-rsbuild:
         specifier: ^2.1.1
-        version: 2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
+        version: 2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -161,13 +161,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.19.1
-        version: 0.19.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+        version: 0.19.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@rsbuild/core':
-        specifier: ~1.5.7
-        version: 1.5.7
+        specifier: ~1.5.9
+        version: 1.5.9
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@types/react':
         specifier: ^19.1.13
         version: 19.1.13
@@ -182,10 +182,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@1.5.7)(preact@10.27.2)
+        version: 1.5.2(@rsbuild/core@1.5.9)(preact@10.27.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -197,10 +197,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -215,10 +215,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -233,10 +233,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -251,13 +251,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@1.5.7)
+        version: 1.0.6(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-solid':
         specifier: ^1.0.6
-        version: 1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.5.7)(solid-js@1.9.9)
+        version: 1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.5.9)(solid-js@1.9.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -275,7 +275,7 @@ importers:
         version: link:../../packages/core
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.5.7)(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.5.9)(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -314,16 +314,16 @@ importers:
         version: 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(vue@3.5.21(typescript@5.9.2))
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.5.7)(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.5.9)(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
       storybook:
         specifier: ^9.1.6
         version: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
       storybook-addon-rslib:
         specifier: ^2.1.1
-        version: 2.1.1(@rsbuild/core@1.5.7)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2)
+        version: 2.1.1(@rsbuild/core@1.5.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2)
       storybook-vue3-rsbuild:
         specifier: ^2.1.1
-        version: 2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2))
+        version: 2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2))
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -337,15 +337,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~1.5.7
-        version: 1.5.7
+        specifier: ~1.5.9
+        version: 1.5.9
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.19.1
-        version: 0.19.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+        version: 0.19.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -375,7 +375,7 @@ importers:
         version: 1.4.2(typescript@5.9.2)
       rsbuild-plugin-publint:
         specifier: ^0.3.3
-        version: 0.3.3(@rsbuild/core@1.5.7)
+        version: 0.3.3(@rsbuild/core@1.5.9)
       rslib:
         specifier: npm:@rslib/core@0.13.2
         version: '@rslib/core@0.13.2(@microsoft/api-extractor@7.52.13(@types/node@22.18.4))(@typescript/native-preview@7.0.0-dev.20250915.1)(typescript@5.9.2)'
@@ -412,7 +412,7 @@ importers:
         version: 11.3.2
       rsbuild-plugin-publint:
         specifier: ^0.3.3
-        version: 0.3.3(@rsbuild/core@1.5.7)
+        version: 0.3.3(@rsbuild/core@1.5.9)
       rslib:
         specifier: npm:@rslib/core@0.13.2
         version: '@rslib/core@0.13.2(@microsoft/api-extractor@7.52.13(@types/node@22.18.4))(@typescript/native-preview@7.0.0-dev.20250915.1)(typescript@5.9.2)'
@@ -433,8 +433,8 @@ importers:
         specifier: ^7.52.13
         version: 7.52.13(@types/node@22.18.4)
       '@rsbuild/core':
-        specifier: ~1.5.7
-        version: 1.5.7
+        specifier: ~1.5.9
+        version: 1.5.9
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -452,7 +452,7 @@ importers:
         version: 1.4.2(typescript@5.9.2)
       rsbuild-plugin-publint:
         specifier: ^0.3.3
-        version: 0.3.3(@rsbuild/core@1.5.7)
+        version: 0.3.3(@rsbuild/core@1.5.9)
       rslib:
         specifier: npm:@rslib/core@0.13.2
         version: '@rslib/core@0.13.2(@microsoft/api-extractor@7.52.13(@types/node@22.18.4))(@typescript/native-preview@7.0.0-dev.20250915.1)(typescript@5.9.2)'
@@ -482,31 +482,31 @@ importers:
         version: 4.0.1(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.19.1
-        version: 0.19.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+        version: 0.19.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@playwright/test':
         specifier: 1.55.0
         version: 1.55.0
       '@rsbuild/core':
-        specifier: ~1.5.7
-        version: 1.5.7
+        specifier: ~1.5.9
+        version: 1.5.9
       '@rsbuild/plugin-less':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@1.5.7)
+        version: 1.5.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-toml':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.5.7)
+        version: 1.1.1(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.5.7)
+        version: 1.1.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.5.7)
+        version: 1.0.3(@rsbuild/core@1.5.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -571,7 +571,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
 
   tests/integration/asset/json: {}
 
@@ -587,10 +587,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.5.7)(typescript@5.9.2)
+        version: 1.2.2(@rsbuild/core@1.5.9)(typescript@5.9.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -684,10 +684,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.5.7)(typescript@5.9.2)
+        version: 1.2.2(@rsbuild/core@1.5.9)(typescript@5.9.2)
 
   tests/integration/cli/build: {}
 
@@ -946,11 +946,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~1.5.7
-        version: 1.5.7
+        specifier: ~1.5.9
+        version: 1.5.9
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.2
-        version: 1.4.2(@rsbuild/core@1.5.7)
+        version: 1.4.2(@rsbuild/core@1.5.9)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -959,11 +959,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ~1.5.7
-        version: 1.5.7
+        specifier: ~1.5.9
+        version: 1.5.9
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.2
-        version: 1.4.2(@rsbuild/core@1.5.7)
+        version: 1.4.2(@rsbuild/core@1.5.9)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -985,7 +985,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@1.5.7)
+        version: 1.0.6(@rsbuild/core@1.5.9)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.13.0
         version: 0.13.0(@babel/core@7.28.0)
@@ -1133,13 +1133,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))
+        version: 1.2.0(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))
+        version: 1.2.0(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -1202,10 +1202,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@1.5.7)
+        version: 1.5.0(@rsbuild/core@1.5.9)
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.5.7)(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.5.9)(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
       vue:
         specifier: ^3.5.21
         version: 3.5.21(typescript@5.9.2)
@@ -1218,16 +1218,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.19.1
-        version: 0.19.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+        version: 0.19.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@rsbuild/core':
-        specifier: ~1.5.7
-        version: 1.5.7
+        specifier: ~1.5.9
+        version: 1.5.9
       '@rsbuild/plugin-react':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.5.7)
+        version: 1.4.0(@rsbuild/core@1.5.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1275,10 +1275,10 @@ importers:
         version: 19.1.1(react@19.1.1)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.4
-        version: 1.0.4(@rsbuild/core@1.5.7)
+        version: 1.0.4(@rsbuild/core@1.5.9)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.5.7)
+        version: 1.1.0(@rsbuild/core@1.5.9)
       rspress-plugin-font-open-sans:
         specifier: 1.0.3
         version: 1.0.3(@rspress/core@2.0.0-beta.32(@types/react@19.1.13))
@@ -1780,14 +1780,14 @@ packages:
       search-insights:
         optional: true
 
-  '@emnapi/core@1.4.5':
-    resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
+  '@emnapi/core@1.5.0':
+    resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
 
-  '@emnapi/runtime@1.4.5':
-    resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
+  '@emnapi/runtime@1.5.0':
+    resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
 
-  '@emnapi/wasi-threads@1.0.4':
-    resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
@@ -2235,8 +2235,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
-  '@napi-rs/wasm-runtime@1.0.1':
-    resolution: {integrity: sha512-KVlQ/jgywZpixGCKMNwxStmmbYEMyokZpCf2YuIChhfJA2uqfAKNEM8INz7zzTo55iEXfBhIIs3VqYyqzDLj8g==}
+  '@napi-rs/wasm-runtime@1.0.5':
+    resolution: {integrity: sha512-TBr9Cf9onSAS2LQ2+QHx6XcC6h9+RIzJgbqG3++9TUZSH204AwEy5jg3BTQ0VATsyoGj4ee49tN/y6rvaOOtcg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2544,8 +2544,8 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
-  '@rsbuild/core@1.5.7':
-    resolution: {integrity: sha512-1/yyJJfZo4hqMsL3WQQmMDYFp0L/znHqjHrYE6NKsiKhkBEwEwSVMk1M5QoRu2EcRL1acW5AJf7WJyKFfPZ//Q==}
+  '@rsbuild/core@1.5.9':
+    resolution: {integrity: sha512-mj0MxorF0uTppKdYS2uFpx7xYBwBP1WnOzwPm9Szd8WZDun7vmrDe8xfc6c5kK9hScHHA7zlfj8IVJFccQmpbA==}
     engines: {node: '>=18.12.0'}
     hasBin: true
 
@@ -2686,8 +2686,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.5.4':
-    resolution: {integrity: sha512-qD+n4D8KOOSoWdngK87iXl6lqbx1J63f6/xZFLPVIstzxIUbNyo9V9tpJYsoT3gYpnLkPVqA+KwQI0ozgYEXvw==}
+  '@rspack/binding-darwin-arm64@1.5.5':
+    resolution: {integrity: sha512-Kg3ywEZHLX+aROfTQ5tMOv+Ud+8b4jk8ruUgsi0W8oBkEkR5xBdhFa9vcf6pzy+gfoLCnEI68U9i8ttm+G0csA==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2701,8 +2701,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.5.4':
-    resolution: {integrity: sha512-g75qkrLLa28kVp7pkWAjUADwr+0GumEF134VWHuL+TAm7VCw4IXRKnZhquE8K5kcqRpLcLX4guRqZzK9OEu/hg==}
+  '@rspack/binding-darwin-x64@1.5.5':
+    resolution: {integrity: sha512-uoGTYnlYW8m47yiDCKvXOehhAOH12wlePJq4sbUbBoHmG07vbDw7fUqnvy2k8319NTVEpMJWGoKyisgI09/uMQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -2716,8 +2716,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@1.5.4':
-    resolution: {integrity: sha512-O3zSTz/dy1EJHd7YS8zzmAG2zxewEZJi7QlYiU+YhFuqjP2ab6ZFWLHkglvrSy4aHyC8fx9OkSjioYtHUcCSdQ==}
+  '@rspack/binding-linux-arm64-gnu@1.5.5':
+    resolution: {integrity: sha512-KgVN3TeUJ3iNwwOX3JGY4arvoLHX94eItJ4TeOSyetRiSJUrQI0evP16i5kIh+n+p7mVnXmfUS944Gl+uNsJmg==}
     cpu: [arm64]
     os: [linux]
 
@@ -2731,8 +2731,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.5.4':
-    resolution: {integrity: sha512-ki84vbRY1gbf1T3BHiKAdi3m0hQFmqiAIYvFuLGA9Vop1R+W2C3Mzh8Q5YL6TnWOP0eiwizuigztz4/07fPf6Q==}
+  '@rspack/binding-linux-arm64-musl@1.5.5':
+    resolution: {integrity: sha512-1gKthlCQinXtWar6Hl9Il6BQ/NgYBH0NVuUsjjf85ejD/cTPQENKyIpGvVa1rSIHSfnG/XujUbruHAeY9mEHCA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2746,8 +2746,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.5.4':
-    resolution: {integrity: sha512-SJVQSgR1JqDEnURI79SRcn/gcdG+yFb2mLUYV/TSPUTxMIlu44p5+fnOY6+6qMtjQhO6J4C2+UyV00U/yjlikA==}
+  '@rspack/binding-linux-x64-gnu@1.5.5':
+    resolution: {integrity: sha512-haPFg4M9GwpSI5g9BQhKUNdzCKDvFexIUkLiAHBjFU9iWQTEcI9VfYPixestOIwzUv7E34rHM+jAsmRGWdgmXw==}
     cpu: [x64]
     os: [linux]
 
@@ -2761,8 +2761,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.5.4':
-    resolution: {integrity: sha512-UL1xw3yLsFH6UD/ubXXbRaDRNl+qI22QgugKYuqmpDGfOcVlv4fGpf3faPwYJasqPjhDWvcoyd8OqI+ftWKWEA==}
+  '@rspack/binding-linux-x64-musl@1.5.5':
+    resolution: {integrity: sha512-oUny56JEkCZvIu4n8/P7IPLPNtJnL89EDhxHINH87XLBY3OOgo8JHELR11Zj9SFWiGNsRcLqi+Q78tWa0ligBQ==}
     cpu: [x64]
     os: [linux]
 
@@ -2774,8 +2774,8 @@ packages:
     resolution: {integrity: sha512-cuVbGr1b4q0Z6AtEraI3becZraPMMgZtZPRaIsVLeDXCmxup/maSAR3T6UaGf4Q2SNcFfjw4neGz5UJxPK8uvA==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@1.5.4':
-    resolution: {integrity: sha512-VPGhik1M87SZQzmX2sRvXrO6KgycSbmJ/bLqVuXHYGjsLkYqw4auKCJrkZcKa1GVsSvpVNC3FlTUk2QxjpmNSA==}
+  '@rspack/binding-wasm32-wasi@1.5.5':
+    resolution: {integrity: sha512-tRgxBgIXaBKBH/0KlwvyqbIMqQrg8jKOyFOEQseEE7Oqs2M9KkJ7Vp5QN11u3NvZ9nz5GbZxmVGBMkdj9Gth1w==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.5.0':
@@ -2788,8 +2788,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@1.5.4':
-    resolution: {integrity: sha512-YxhK8dTv/6ff//C5Djm87TkiePuvGRoxLgsHgwR7C0rnA8lS5gLNwrNY9FjAY1x6WamnGGirFK97rigaeTDn+g==}
+  '@rspack/binding-win32-arm64-msvc@1.5.5':
+    resolution: {integrity: sha512-wGWd2yluoFdQgtkIbny6FoHnzahTk+o9RzrptjeS1u/NV1lKrWzmWhwZojMGOUqPiaukZKaziOEo7gpRn2XbEQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -2803,8 +2803,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.5.4':
-    resolution: {integrity: sha512-SU4EyAo1BI1zV/sSDF2cqoN+Qq6iIHLwtq0RJI5WQ4Yjn/mhhRFxNoerPCJUpPiiCxvG/IrpGzGi90MwFnMtNQ==}
+  '@rspack/binding-win32-ia32-msvc@1.5.5':
+    resolution: {integrity: sha512-Ikml8AQkzjPCG24vTO4pG2bpJ8vp93jVEgo9X9uYjO2vQbIp5QSOmeZOTM7tXCf8AfTfHEF/yAdE/pR/+tXXGQ==}
     cpu: [ia32]
     os: [win32]
 
@@ -2818,8 +2818,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.5.4':
-    resolution: {integrity: sha512-xEgOCnD2FCUcxRgg3X5etq81vvf8rWwvPASfrG234diSduvU6zRiuiyYFMLTMDwQNEzZEFGHp7wIZNCKHudbng==}
+  '@rspack/binding-win32-x64-msvc@1.5.5':
+    resolution: {integrity: sha512-m2059ms0i/GIQGWTlZ5GI6SWpuMFAPMsWlhXLk2LZRIydhi+N/YPkmc33lFRTlDA3QpKDCvowvCvIIA7g6WSlg==}
     cpu: [x64]
     os: [win32]
 
@@ -2829,8 +2829,8 @@ packages:
   '@rspack/binding@1.5.2':
     resolution: {integrity: sha512-NKiBcsxmAzFDYRnK2ZHWbTtDFVT5/704eK4OfpgsDXPMkaMnBKijMKNgP5pbe18X4rUlz+8HnGm4+Xllo9EESw==}
 
-  '@rspack/binding@1.5.4':
-    resolution: {integrity: sha512-HtLF5uxbf77hDarB/Wl26XgaTyWkhMogDPUOC1mLU+YPke1vYem8p8yr+McUkRtbhYoqtFMcVcT3S8jKJPP3+g==}
+  '@rspack/binding@1.5.5':
+    resolution: {integrity: sha512-JkB943uBU0lABnKG/jdO+gg3/eeO9CEQMR/1dL6jSU9GTxaNf3XIVc05RhRC7qoVsiXuhSMMFxWyV0hyHxp2bA==}
 
   '@rspack/core@1.5.0':
     resolution: {integrity: sha512-eEtiKV+CUcAtnt1K+eiHDzmBXQcNM8CfCXOzr0+gHGp4w4Zks2B8RF36sYD03MM2bg8VRXXsf0MicQ8FvRMCOg==}
@@ -2850,8 +2850,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@1.5.4':
-    resolution: {integrity: sha512-s/bVG+KRZjIpPP2f4TOQkJ/D+rql7HAV0MFEWoqoyeNnln/p6I28RYbw5zYF+Qg4J0swR8Qk2pbn7qlIdGusLQ==}
+  '@rspack/core@1.5.5':
+    resolution: {integrity: sha512-AOIuMktK6X/xHAjJ/0QJ2kbSkILXj641GCPE+EOfWO27ODA8fHPArKbyz5AVGVePV3aUfEo2VFcsNzP67VBEPA==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -3386,8 +3386,8 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
-  '@tybys/wasm-util@0.10.0':
-    resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
@@ -8283,16 +8283,16 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@emnapi/core@1.4.5':
+  '@emnapi/core@1.5.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.0.4
+      '@emnapi/wasi-threads': 1.1.0
       tslib: 2.8.1
 
-  '@emnapi/runtime@1.4.5':
+  '@emnapi/runtime@1.5.0':
     dependencies:
       tslib: 2.8.1
 
-  '@emnapi/wasi-threads@1.0.4':
+  '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
 
@@ -8639,7 +8639,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.19.1(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))':
+  '@module-federation/enhanced@0.19.1(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.19.1
       '@module-federation/cli': 0.19.1(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
@@ -8649,7 +8649,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.19.1(@module-federation/runtime-tools@0.19.1)
       '@module-federation/managers': 0.19.1
       '@module-federation/manifest': 0.19.1(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
-      '@module-federation/rspack': 0.19.1(@rspack/core@1.5.4(@swc/helpers@0.5.17))(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+      '@module-federation/rspack': 0.19.1(@rspack/core@1.5.5(@swc/helpers@0.5.17))(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@module-federation/runtime-tools': 0.19.1
       '@module-federation/sdk': 0.19.1
       btoa: 1.2.1
@@ -8696,9 +8696,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.17(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))':
+  '@module-federation/node@2.7.17(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))':
     dependencies:
-      '@module-federation/enhanced': 0.19.1(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+      '@module-federation/enhanced': 0.19.1(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@module-federation/runtime': 0.19.1
       '@module-federation/sdk': 0.19.1
       btoa: 1.2.1
@@ -8716,14 +8716,14 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.19.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))':
+  '@module-federation/rsbuild-plugin@0.19.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))':
     dependencies:
-      '@module-federation/enhanced': 0.19.1(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
-      '@module-federation/node': 2.7.17(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+      '@module-federation/enhanced': 0.19.1(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+      '@module-federation/node': 2.7.17(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@module-federation/sdk': 0.19.1
       fs-extra: 11.3.0
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8737,7 +8737,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.19.1(@rspack/core@1.5.4(@swc/helpers@0.5.17))(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))':
+  '@module-federation/rspack@0.19.1(@rspack/core@1.5.5(@swc/helpers@0.5.17))(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.19.1
       '@module-federation/dts-plugin': 0.19.1(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
@@ -8746,7 +8746,7 @@ snapshots:
       '@module-federation/manifest': 0.19.1(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@module-federation/runtime-tools': 0.19.1
       '@module-federation/sdk': 0.19.1
-      '@rspack/core': 1.5.4(@swc/helpers@0.5.17)
+      '@rspack/core': 1.5.5(@swc/helpers@0.5.17)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.2
@@ -8793,12 +8793,12 @@ snapshots:
 
   '@module-federation/sdk@0.19.1': {}
 
-  '@module-federation/storybook-addon@4.0.30(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@4.0.30(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 0.19.1(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
+      '@module-federation/enhanced': 0.19.1(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vue-tsc@3.0.7(typescript@5.9.2))
       '@module-federation/sdk': 0.19.1
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -8829,15 +8829,15 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
-      '@emnapi/core': 1.4.5
-      '@emnapi/runtime': 1.4.5
+      '@emnapi/core': 1.5.0
+      '@emnapi/runtime': 1.5.0
       '@tybys/wasm-util': 0.9.0
 
-  '@napi-rs/wasm-runtime@1.0.1':
+  '@napi-rs/wasm-runtime@1.0.5':
     dependencies:
-      '@emnapi/core': 1.4.5
-      '@emnapi/runtime': 1.4.5
-      '@tybys/wasm-util': 0.10.0
+      '@emnapi/core': 1.5.0
+      '@emnapi/runtime': 1.5.0
+      '@tybys/wasm-util': 0.10.1
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -9059,21 +9059,21 @@ snapshots:
       core-js: 3.45.1
       jiti: 2.5.1
 
-  '@rsbuild/core@1.5.7':
+  '@rsbuild/core@1.5.9':
     dependencies:
-      '@rspack/core': 1.5.4(@swc/helpers@0.5.17)
+      '@rspack/core': 1.5.5(@swc/helpers@0.5.17)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.17
       core-js: 3.45.1
       jiti: 2.5.1
 
-  '@rsbuild/plugin-babel@1.0.6(@rsbuild/core@1.5.7)':
+  '@rsbuild/plugin-babel@1.0.6(@rsbuild/core@1.5.9)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.0)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -9081,13 +9081,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.5.0(@rsbuild/core@1.5.7)':
+  '@rsbuild/plugin-less@1.5.0(@rsbuild/core@1.5.9)':
     dependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
-  '@rsbuild/plugin-node-polyfill@1.4.2(@rsbuild/core@1.5.7)':
+  '@rsbuild/plugin-node-polyfill@1.4.2(@rsbuild/core@1.5.9)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9113,39 +9113,39 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
 
-  '@rsbuild/plugin-preact@1.5.2(@rsbuild/core@1.5.7)(preact@10.27.2)':
+  '@rsbuild/plugin-preact@1.5.2(@rsbuild/core@1.5.9)(preact@10.27.2)':
     dependencies:
       '@prefresh/core': 1.5.5(preact@10.27.2)
       '@prefresh/utils': 1.2.1
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       '@rspack/plugin-preact-refresh': 1.1.2(@prefresh/core@1.5.5(preact@10.27.2))(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh': 9.0.1
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@1.4.0(@rsbuild/core@1.5.7)':
+  '@rsbuild/plugin-react@1.4.0(@rsbuild/core@1.5.9)':
     dependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       '@rspack/plugin-react-refresh': 1.5.0(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.4.0(@rsbuild/core@1.5.7)':
+  '@rsbuild/plugin-sass@1.4.0(@rsbuild/core@1.5.9)':
     dependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.6
       reduce-configs: 1.1.1
       sass-embedded: 1.90.0
 
-  '@rsbuild/plugin-solid@1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.5.7)(solid-js@1.9.9)':
+  '@rsbuild/plugin-solid@1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.5.9)(solid-js@1.9.9)':
     dependencies:
-      '@rsbuild/core': 1.5.7
-      '@rsbuild/plugin-babel': 1.0.6(@rsbuild/core@1.5.7)
+      '@rsbuild/core': 1.5.9
+      '@rsbuild/plugin-babel': 1.0.6(@rsbuild/core@1.5.9)
       babel-preset-solid: 1.9.6(@babel/core@7.28.0)
       solid-refresh: 0.6.3(solid-js@1.9.9)
     transitivePeerDependencies:
@@ -9153,22 +9153,22 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@1.2.0(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))':
+  '@rsbuild/plugin-stylus@1.2.0(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))':
     dependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
       stylus: 0.64.0
-      stylus-loader: 8.1.2(@rspack/core@1.5.4(@swc/helpers@0.5.17))(stylus@0.64.0)
+      stylus-loader: 8.1.2(@rspack/core@1.5.5(@swc/helpers@0.5.17))(stylus@0.64.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.2.2(@rsbuild/core@1.5.7)(typescript@5.9.2)':
+  '@rsbuild/plugin-svgr@1.2.2(@rsbuild/core@1.5.9)(typescript@5.9.2)':
     dependencies:
-      '@rsbuild/core': 1.5.7
-      '@rsbuild/plugin-react': 1.4.0(@rsbuild/core@1.5.7)
+      '@rsbuild/core': 1.5.9
+      '@rsbuild/plugin-react': 1.4.0(@rsbuild/core@1.5.9)
       '@svgr/core': 8.1.0(typescript@5.9.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))(typescript@5.9.2)
@@ -9179,31 +9179,31 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-toml@1.1.1(@rsbuild/core@1.5.7)':
+  '@rsbuild/plugin-toml@1.1.1(@rsbuild/core@1.5.9)':
     dependencies:
       toml: 3.0.0
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
 
-  '@rsbuild/plugin-type-check@1.2.4(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(typescript@5.9.2)':
+  '@rsbuild/plugin-type-check@1.2.4(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(typescript@5.9.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.1.5(@rspack/core@1.5.4(@swc/helpers@0.5.17))(typescript@5.9.2)
+      ts-checker-rspack-plugin: 1.1.5(@rspack/core@1.5.5(@swc/helpers@0.5.17))(typescript@5.9.2)
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.1.0(@rsbuild/core@1.5.7)':
+  '@rsbuild/plugin-typed-css-modules@1.1.0(@rsbuild/core@1.5.9)':
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
 
-  '@rsbuild/plugin-yaml@1.0.3(@rsbuild/core@1.5.7)':
+  '@rsbuild/plugin-yaml@1.0.3(@rsbuild/core@1.5.9)':
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
 
   '@rslib/core@0.13.2(@microsoft/api-extractor@7.52.13(@types/node@22.18.4))(@typescript/native-preview@7.0.0-dev.20250915.1)(typescript@5.9.2)':
     dependencies:
@@ -9249,7 +9249,7 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.5.2':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.5.4':
+  '@rspack/binding-darwin-arm64@1.5.5':
     optional: true
 
   '@rspack/binding-darwin-x64@1.5.0':
@@ -9258,7 +9258,7 @@ snapshots:
   '@rspack/binding-darwin-x64@1.5.2':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.5.4':
+  '@rspack/binding-darwin-x64@1.5.5':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.5.0':
@@ -9267,7 +9267,7 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.5.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.5.4':
+  '@rspack/binding-linux-arm64-gnu@1.5.5':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.5.0':
@@ -9276,7 +9276,7 @@ snapshots:
   '@rspack/binding-linux-arm64-musl@1.5.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.5.4':
+  '@rspack/binding-linux-arm64-musl@1.5.5':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.5.0':
@@ -9285,7 +9285,7 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.5.2':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.5.4':
+  '@rspack/binding-linux-x64-gnu@1.5.5':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.5.0':
@@ -9294,22 +9294,22 @@ snapshots:
   '@rspack/binding-linux-x64-musl@1.5.2':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.5.4':
+  '@rspack/binding-linux-x64-musl@1.5.5':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.5.0':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.1
+      '@napi-rs/wasm-runtime': 1.0.5
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.5.2':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.1
+      '@napi-rs/wasm-runtime': 1.0.5
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.5.4':
+  '@rspack/binding-wasm32-wasi@1.5.5':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.1
+      '@napi-rs/wasm-runtime': 1.0.5
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.5.0':
@@ -9318,7 +9318,7 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.5.2':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.5.4':
+  '@rspack/binding-win32-arm64-msvc@1.5.5':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.5.0':
@@ -9327,7 +9327,7 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@1.5.2':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.5.4':
+  '@rspack/binding-win32-ia32-msvc@1.5.5':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.5.0':
@@ -9336,7 +9336,7 @@ snapshots:
   '@rspack/binding-win32-x64-msvc@1.5.2':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.5.4':
+  '@rspack/binding-win32-x64-msvc@1.5.5':
     optional: true
 
   '@rspack/binding@1.5.0':
@@ -9365,18 +9365,18 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.5.2
       '@rspack/binding-win32-x64-msvc': 1.5.2
 
-  '@rspack/binding@1.5.4':
+  '@rspack/binding@1.5.5':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.5.4
-      '@rspack/binding-darwin-x64': 1.5.4
-      '@rspack/binding-linux-arm64-gnu': 1.5.4
-      '@rspack/binding-linux-arm64-musl': 1.5.4
-      '@rspack/binding-linux-x64-gnu': 1.5.4
-      '@rspack/binding-linux-x64-musl': 1.5.4
-      '@rspack/binding-wasm32-wasi': 1.5.4
-      '@rspack/binding-win32-arm64-msvc': 1.5.4
-      '@rspack/binding-win32-ia32-msvc': 1.5.4
-      '@rspack/binding-win32-x64-msvc': 1.5.4
+      '@rspack/binding-darwin-arm64': 1.5.5
+      '@rspack/binding-darwin-x64': 1.5.5
+      '@rspack/binding-linux-arm64-gnu': 1.5.5
+      '@rspack/binding-linux-arm64-musl': 1.5.5
+      '@rspack/binding-linux-x64-gnu': 1.5.5
+      '@rspack/binding-linux-x64-musl': 1.5.5
+      '@rspack/binding-wasm32-wasi': 1.5.5
+      '@rspack/binding-win32-arm64-msvc': 1.5.5
+      '@rspack/binding-win32-ia32-msvc': 1.5.5
+      '@rspack/binding-win32-x64-msvc': 1.5.5
 
   '@rspack/core@1.5.0(@swc/helpers@0.5.17)':
     dependencies:
@@ -9394,10 +9394,10 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.17
 
-  '@rspack/core@1.5.4(@swc/helpers@0.5.17)':
+  '@rspack/core@1.5.5(@swc/helpers@0.5.17)':
     dependencies:
       '@module-federation/runtime-tools': 0.18.0
-      '@rspack/binding': 1.5.4
+      '@rspack/binding': 1.5.5
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
       '@swc/helpers': 0.5.17
@@ -9419,8 +9419,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.1.13)(react@19.1.1)
-      '@rsbuild/core': 1.5.7
-      '@rsbuild/plugin-react': 1.4.0(@rsbuild/core@1.5.7)
+      '@rsbuild/core': 1.5.9
+      '@rsbuild/plugin-react': 1.4.0(@rsbuild/core@1.5.9)
       '@rspress/mdx-rs': 0.6.6
       '@rspress/runtime': 2.0.0-beta.32
       '@rspress/shared': 2.0.0-beta.32
@@ -9546,7 +9546,7 @@ snapshots:
 
   '@rspress/shared@2.0.0-beta.32':
     dependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       '@shikijs/rehype': 3.12.2
       gray-matter: 4.0.3
       lodash-es: 4.17.21
@@ -10046,7 +10046,7 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
-  '@tybys/wasm-util@0.10.0':
+  '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -13797,33 +13797,33 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20250915.1
       typescript: 5.9.2
 
-  rsbuild-plugin-google-analytics@1.0.4(@rsbuild/core@1.5.7):
+  rsbuild-plugin-google-analytics@1.0.4(@rsbuild/core@1.5.9):
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
 
-  rsbuild-plugin-html-minifier-terser@1.1.2(@rsbuild/core@1.5.7):
+  rsbuild-plugin-html-minifier-terser@1.1.2(@rsbuild/core@1.5.9):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
 
-  rsbuild-plugin-open-graph@1.1.0(@rsbuild/core@1.5.7):
+  rsbuild-plugin-open-graph@1.1.0(@rsbuild/core@1.5.9):
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
 
-  rsbuild-plugin-publint@0.3.3(@rsbuild/core@1.5.7):
+  rsbuild-plugin-publint@0.3.3(@rsbuild/core@1.5.9):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.12
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
 
-  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.5.7)(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1):
+  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.5.9)(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1):
     dependencies:
       unplugin-vue: 6.2.0(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(vue@3.5.21(typescript@5.9.2))(yaml@2.6.1)
     optionalDependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14198,18 +14198,18 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@2.1.1(@rsbuild/core@1.5.7)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2):
+  storybook-addon-rslib@2.1.1(@rsbuild/core@1.5.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2))(typescript@5.9.2):
     dependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
+      storybook-builder-rsbuild: 2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
 
-  storybook-builder-rsbuild@2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2):
+  storybook-builder-rsbuild@2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2):
     dependencies:
-      '@rsbuild/core': 1.5.7
-      '@rsbuild/plugin-type-check': 1.2.4(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(typescript@5.9.2)
+      '@rsbuild/core': 1.5.9
+      '@rsbuild/plugin-type-check': 1.2.4(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(typescript@5.9.2)
       '@storybook/addon-docs': 9.1.6(@types/react@19.1.13)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))
       '@storybook/core-webpack': 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))
       browser-assert: 1.2.1
@@ -14221,7 +14221,7 @@ snapshots:
       magic-string: 0.30.19
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.2(@rsbuild/core@1.5.7)
+      rsbuild-plugin-html-minifier-terser: 1.1.2(@rsbuild/core@1.5.9)
       sirv: 2.0.4
       storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
       ts-dedent: 2.2.0
@@ -14237,10 +14237,10 @@ snapshots:
       - '@types/react'
       - webpack-sources
 
-  storybook-react-rsbuild@2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2):
+  storybook-react-rsbuild@2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.46.2)
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       '@storybook/react': 9.1.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.9.2)
       find-up: 5.0.0
@@ -14251,7 +14251,7 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       resolve: 1.22.10
       storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
-      storybook-builder-rsbuild: 2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
+      storybook-builder-rsbuild: 2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.9.2
@@ -14263,12 +14263,12 @@ snapshots:
       - webpack
       - webpack-sources
 
-  storybook-vue3-rsbuild@2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2)):
+  storybook-vue3-rsbuild@2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2)):
     dependencies:
-      '@rsbuild/core': 1.5.7
+      '@rsbuild/core': 1.5.9
       '@storybook/vue3': 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(vue@3.5.21(typescript@5.9.2))
       storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1))
-      storybook-builder-rsbuild: 2.1.1(@rsbuild/core@1.5.7)(@rspack/core@1.5.4(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
+      storybook-builder-rsbuild: 2.1.1(@rsbuild/core@1.5.9)(@rspack/core@1.5.5(@swc/helpers@0.5.17))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.4)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.6.1)))(typescript@5.9.2)
       vue: 3.5.21(typescript@5.9.2)
       vue-docgen-loader: 2.0.1
     transitivePeerDependencies:
@@ -14389,13 +14389,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  stylus-loader@8.1.2(@rspack/core@1.5.4(@swc/helpers@0.5.17))(stylus@0.64.0):
+  stylus-loader@8.1.2(@rspack/core@1.5.5(@swc/helpers@0.5.17))(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 1.5.4(@swc/helpers@0.5.17)
+      '@rspack/core': 1.5.5(@swc/helpers@0.5.17)
 
   stylus@0.64.0:
     dependencies:
@@ -14543,7 +14543,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.1.5(@rspack/core@1.5.4(@swc/helpers@0.5.17))(typescript@5.9.2):
+  ts-checker-rspack-plugin@1.1.5(@rspack/core@1.5.5(@swc/helpers@0.5.17))(typescript@5.9.2):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@rspack/lite-tapable': 1.0.1
@@ -14554,7 +14554,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.9.2
     optionalDependencies:
-      '@rspack/core': 1.5.4(@swc/helpers@0.5.17)
+      '@rspack/core': 1.5.5(@swc/helpers@0.5.17)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/integration/auto-extension/index.test.ts
+++ b/tests/integration/auto-extension/index.test.ts
@@ -46,15 +46,15 @@ describe('should respect output.filename.js and output.filenameHash to override 
     // override output.filename.js
     expect(extname(entryFiles.esm0!)).toEqual('.mjs');
     expect(entryFiles.cjs0).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename/index.c8a12fd0.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename/index.df02628a.js"`,
     );
 
     // override output.filenameHash
     expect(entryFiles.esm1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/esm-override-filename-hash/index.b4545719.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/esm-override-filename-hash/index.996a7edd.js"`,
     );
     expect(entryFiles.cjs1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename-hash/index.c8a12fd0.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename-hash/index.df02628a.js"`,
     );
 
     // override different file types with function
@@ -80,16 +80,16 @@ describe('should respect output.filename.js and output.filenameHash to override 
 
     // override output.filename.js
     expect(entryFiles.esm0).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm-override-filename/index.b4545719.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm-override-filename/index.996a7edd.js"`,
     );
     expect(extname(entryFiles.cjs0!)).toEqual('.cjs');
 
     // override output.filenameHash
     expect(entryFiles.esm1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm-override-filename-hash/index.b4545719.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm-override-filename-hash/index.996a7edd.js"`,
     );
     expect(entryFiles.cjs1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/cjs-override-filename-hash/index.c8a12fd0.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/cjs-override-filename-hash/index.df02628a.js"`,
     );
 
     // override different file types with function

--- a/tests/integration/entry/index.test.ts
+++ b/tests/integration/entry/index.test.ts
@@ -67,8 +67,9 @@ test('multiple entry bundle', async () => {
   });
   // cspell:disable
   expect(index).toMatchInlineSnapshot(`
-    "const foo = "fooshared";
-    const src_text = ()=>\`hello \${foo} shared\`;
+    "const shared = 'shared';
+    const foo = 'foo' + shared;
+    const src_text = ()=>\`hello \${foo} \${shared}\`;
     export { src_text as text };
     "
   `);
@@ -79,7 +80,8 @@ test('multiple entry bundle', async () => {
   });
   // cspell:disable
   expect(foo).toMatchInlineSnapshot(`
-    "const foo = "fooshared";
+    "const shared = 'shared';
+    const foo = 'foo' + shared;
     export { foo };
     "
   `);

--- a/tests/integration/extension-alias/__snapshots__/index.test.ts.snap
+++ b/tests/integration/extension-alias/__snapshots__/index.test.ts.snap
@@ -2,20 +2,10 @@
 
 exports[`resolve.extensionAlias should work 1`] = `
 ""use strict";
-var __webpack_require__ = {};
-(()=>{
-    __webpack_require__.r = (exports1)=>{
-        if ('undefined' != typeof Symbol && Symbol.toStringTag) Object.defineProperty(exports1, Symbol.toStringTag, {
-            value: 'Module'
-        });
-        Object.defineProperty(exports1, '__esModule', {
-            value: true
-        });
-    };
-})();
 var __webpack_exports__ = {};
-__webpack_require__.r(__webpack_exports__);
-console.log("foobar");
+const bar = 'bar';
+const foo = 'foo';
+console.log(foo + bar);
 for(var __webpack_i__ in __webpack_exports__)exports[__webpack_i__] = __webpack_exports__[__webpack_i__];
 Object.defineProperty(exports, '__esModule', {
     value: true
@@ -24,6 +14,8 @@ Object.defineProperty(exports, '__esModule', {
 `;
 
 exports[`resolve.extensionAlias should work 2`] = `
-"console.log("foobar");
+"const bar = 'bar';
+const foo = 'foo';
+console.log(foo + bar);
 "
 `;

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -96,7 +96,8 @@ test('user externals', async () => {
     "import node_fs from "node:fs";
     import lodash from "lodash";
     import zip from "lodash/zip";
-    console.log(node_fs, lodash.add, zip, "foo");
+    const foo = 'foo';
+    console.log(node_fs, lodash.add, zip, foo);
     "
   `,
   );

--- a/tests/integration/format/index.test.ts
+++ b/tests/integration/format/index.test.ts
@@ -30,7 +30,8 @@ test('format default to esm', async () => {
   // cspell:disable
   expect(contents.esm0).toMatchInlineSnapshot(`
     {
-      "<ROOT>/tests/integration/format/default/dist/bundle-esm/index.js": "const str = "hellofoo world";
+      "<ROOT>/tests/integration/format/default/dist/bundle-esm/index.js": "const foo = 'foo';
+    const str = 'hello' + foo + ' world';
     export { str };
     ",
     }

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-node-polyfill": "^1.4.2"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-node-polyfill": "^1.4.2"
   }
 }

--- a/tests/integration/resolve/index.test.ts
+++ b/tests/integration/resolve/index.test.ts
@@ -63,7 +63,8 @@ test('resolve with js extensions', async () => {
 
   expect(isSuccess).toBeTruthy();
   expect(entries.esm).toMatchInlineSnapshot(`
-    "console.log(1);
+    "const value = 1;
+    console.log(value);
     "
   `);
 });
@@ -75,7 +76,8 @@ test('resolve with main fields', async () => {
 
   expect(isSuccess).toBeTruthy();
   expect(Object.values(results[0]!)[0]).toMatchInlineSnapshot(`
-    "console.log(1);
+    "const value = 1;
+    console.log(value);
     "
   `);
   expect(Object.values(results[1]!)[0]).toContain('main');

--- a/tests/integration/tsconfig/index.test.ts
+++ b/tests/integration/tsconfig/index.test.ts
@@ -6,8 +6,6 @@ test('tsconfig path', async () => {
   const { isSuccess, entries } = await buildAndGetResults({ fixturePath });
 
   expect(isSuccess).toBe(true);
-  expect(entries.esm).toContain(`console.info("foo");
-`);
-  expect(entries.cjs).toContain(`console.info("foo");
-`);
+  expect(entries.esm).toContain(`const foo = 'foo'`);
+  expect(entries.cjs).toContain(`const foo = 'foo'`);
 });

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^0.19.1",
     "@playwright/test": "1.55.0",
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-less": "^1.5.0",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rsbuild/plugin-sass": "^1.4.0",

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.19.1",
-    "@rsbuild/core": "~1.5.7",
+    "@rsbuild/core": "~1.5.9",
     "@rsbuild/plugin-react": "^1.4.0",
     "@rsbuild/plugin-sass": "^1.4.0",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

Fix the Eco CI by bumping Rsbuild to version 1.5.9, which has inline const optimization temporarily disabled.

## Related Links

- https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/17820487606/job/50661777689
- https://github.com/web-infra-dev/rsbuild/releases/tag/v1.5.9

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
