### PR TITLE
fix(docs): use `rp-not-doc` for rsbuild doc badge

### DIFF
--- a/website/theme/components/RsbuildDocBadge.tsx
+++ b/website/theme/components/RsbuildDocBadge.tsx
@@ -19,7 +19,7 @@ export function RsbuildDocBadge({ path, text, alt }: Props) {
       href={href}
       target="_blank"
       rel="noreferrer"
-      className="rspress-toc-exclude"
+      className="rspress-toc-exclude rp-not-doc"
     >
       <Badge type="info">
         <img


### PR DESCRIPTION
## Summary

### Before
<img width="416" height="164" alt="image" src="https://github.com/user-attachments/assets/b3100eaa-7af4-4c29-8eb4-fb2dd0d8e696" />

### Now
<img width="440" height="132" alt="image" src="https://github.com/user-attachments/assets/9384b1ce-4013-4f8c-9a0a-a2aca91da737" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
