### PR TITLE
test: make test logs clear

### DIFF
--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -288,7 +288,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       setup() {}
     }
   ],
-  logLevel: undefined
+  logLevel: 'silent'
 }"
 `;
 

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -208,6 +208,7 @@ describe('Should compose create Rsbuild config correctly', () => {
           },
         },
       },
+      logLevel: 'silent',
     };
     const composedRsbuildConfig = await composeCreateRsbuildConfig(rslibConfig);
     expect(composedRsbuildConfig).toMatchSnapshot();

--- a/tests/integration/cli/build-watch/build.test.ts
+++ b/tests/integration/cli/build-watch/build.test.ts
@@ -1,7 +1,6 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
-import { after } from 'node:test';
-import { describe, expect, test } from '@rstest/core';
+import { describe, expect, onTestFinished, test } from '@rstest/core';
 import fse from 'fs-extra';
 import {
   expectFile,
@@ -107,7 +106,7 @@ export default defineConfig({
       [rslibBinPath, 'build', '--watch', '-c', tempConfigFile],
       {
         cwd: __dirname,
-        stdio: 'inherit',
+        stdio: 'pipe',
         shell: true,
       },
     );
@@ -144,7 +143,7 @@ export default defineConfig({
       "
     `);
 
-    after(() => {
+    onTestFinished(() => {
       child.kill();
     });
   });

--- a/tests/integration/cli/inspect/inspect.test.ts
+++ b/tests/integration/cli/inspect/inspect.test.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
-import { describe } from 'node:test';
-import { expect, test } from '@rstest/core';
+import { describe, expect, test } from '@rstest/core';
 import fse from 'fs-extra';
 import { globContentJSON, runCliSync } from 'test-helper';
 

--- a/tests/integration/cli/log-level/index.test.ts
+++ b/tests/integration/cli/log-level/index.test.ts
@@ -1,6 +1,5 @@
-import { describe } from 'node:test';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { expect, test } from '@rstest/core';
+import { describe, expect, test } from '@rstest/core';
 import { runCliSync } from 'test-helper';
 
 describe('log level', async () => {

--- a/tests/integration/cli/mf/mf.test.ts
+++ b/tests/integration/cli/mf/mf.test.ts
@@ -1,8 +1,7 @@
 import { join } from 'node:path';
-import { describe } from 'node:test';
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { startMFDevServer } from '@rslib/core';
-import { expect, test } from '@rstest/core';
+import { describe, expect, test } from '@rstest/core';
 import fse from 'fs-extra';
 import { expectFile, runCli, runCliSync } from 'test-helper';
 

--- a/tests/integration/entry/index.test.ts
+++ b/tests/integration/entry/index.test.ts
@@ -165,7 +165,7 @@ test('validate entry and throw errors', async () => {
 test('duplicate entry in bundleless mode', async () => {
   const { logs, restore } = proxyConsole();
   const fixturePath = join(__dirname, 'duplicate');
-  await buildAndGetResults({ fixturePath });
+  await buildAndGetResults({ fixturePath, logLevel: 'info' });
 
   const logStrings = logs.map((log) => stripAnsi(log));
 

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import {
   type InspectConfigResult,
+  type LogLevel,
   mergeRsbuildConfig as mergeConfig,
 } from '@rsbuild/core';
 import type { Format, LibConfig, RslibConfig } from '@rslib/core';
@@ -223,14 +224,16 @@ export async function getResults(
   };
 }
 
-const updateConfigForTest = (rslibConfig: RslibConfig) => {
-  Object.assign(rslibConfig, {
-    performance: {
-      // Do not print file size in tests
-      printFileSize: false,
-    },
-  });
-};
+const updateConfigForTest =
+  (logLevel?: LogLevel) => (rslibConfig: RslibConfig) => {
+    Object.assign(rslibConfig, {
+      performance: {
+        // Do not print file size in tests
+        printFileSize: false,
+      },
+      logLevel,
+    });
+  };
 
 export async function rslibBuild({
   cwd,
@@ -258,6 +261,7 @@ export async function buildAndGetResults(options: {
   configPath?: string;
   type: 'all';
   lib?: string[];
+  logLevel?: LogLevel;
 }): Promise<{
   js: BuildResult;
   dts: BuildResult;
@@ -268,22 +272,25 @@ export async function buildAndGetResults(options: {
   configPath?: string;
   type?: 'js' | 'dts' | 'css';
   lib?: string[];
+  logLevel?: LogLevel;
 }): Promise<BuildResult>;
 export async function buildAndGetResults({
   fixturePath,
   configPath,
   type = 'js',
   lib,
+  logLevel = 'warn',
 }: {
   fixturePath: string;
   configPath?: string;
   type?: 'js' | 'dts' | 'css' | 'all';
   lib?: string[];
+  logLevel?: LogLevel;
 }) {
   const { rsbuildInstance, rslibConfig } = await rslibBuild({
     cwd: fixturePath,
     path: configPath,
-    modifyConfig: updateConfigForTest,
+    modifyConfig: updateConfigForTest(logLevel),
     lib,
   });
   const {


### PR DESCRIPTION
## Summary

Set `logLevel` to `'warn'` when running tests to make test logs clear.

Tests related to log messages should call `proxyConsole` when writing tests.

<img width="1590" height="1512" alt="image" src="https://github.com/user-attachments/assets/3c383912-3d4f-46fd-8e58-02715f5591c9" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
