### PR TITLE
docs(zh): translate bundle example heading

### DIFF
--- a/website/docs/zh/config/lib/bundle.mdx
+++ b/website/docs/zh/config/lib/bundle.mdx
@@ -87,7 +87,7 @@ export default {
 
 :::
 
-## Example
+## 示例
 
 对于以下的源代码文件结构：
 


### PR DESCRIPTION
## Summary
- translate the "Example" section heading in the Chinese lib bundle docs to "示例" to match the localized content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b480888c832d88a5803ccc8ef046