### PR TITLE
docs: distinguish watch mode in configuration files

### DIFF
--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -51,14 +51,33 @@ Options:
 
 ### Environment variables
 
-Rslib supports injecting env variables or expressions into the code during build, which is helpful for distinguishing the running environment or replacing constants.
+Rslib supports injecting environment variables or expressions into the code during the build, which is helpful for distinguishing running environments or replacing constants. You can see more details in [Rsbuild - Environment variables](https://rsbuild.rs/guide/advanced/env-vars).
 
-You can see more details in [Rsbuild - Environment variables](https://rsbuild.rs/guide/advanced/env-vars).
+By default, Rslib sets the `process.env.NODE_ENV` environment variable, which is always `'production'` during the build. If you need to distinguish watch mode to dynamically set different configurations, you can set as follows:
+
+```ts title="rslib.config.ts"
+import { defineConfig } from '@rslib/core';
+
+const isWatch = process.argv.includes('--watch');
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+    },
+  ],
+  source: {
+    alias: {
+      '@request': isWatch ? './src/request.dev.js' : './src/request.prod.js',
+    },
+  },
+});
+```
 
 ::: note
 
-- If [format](/config/lib/format) is `esm` or `cjs`, `process.env.NODE_ENV` will be preserved in the build output.
-- If [format](/config/lib/format) is `mf` or `umd`, `process.env.NODE_ENV` will be replaced to ensure that the output can run in the browser.
+- If [format](/config/lib/format) is `esm` or `cjs`, `process.env.NODE_ENV` in source code will be preserved in the build output.
+- If [format](/config/lib/format) is `mf` or `umd`, `process.env.NODE_ENV` in source code will be replaced to ensure that the output can run in the browser.
 
 :::
 

--- a/website/docs/en/guide/basic/configure-rslib.mdx
+++ b/website/docs/en/guide/basic/configure-rslib.mdx
@@ -168,7 +168,7 @@ When using Node.js's native loader, please note the following limitations:
 
 ## Using environment variables
 
-In the configuration file, you can use Node.js environment variables such as `process.env.NODE_ENV` to dynamically set different configurations:
+In the configuration file, you can use Node.js environment variables to dynamically set different configurations:
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
@@ -181,10 +181,10 @@ export default defineConfig({
   ],
   source: {
     alias: {
-      '@request':
-        process.env.NODE_ENV === 'development'
-          ? './src/request.dev.js'
-          : './src/request.prod.js',
+      '@language':
+        process.env.LANGUAGE === 'en'
+          ? './src/language/en.js'
+          : './src/language/zh.js',
     },
   },
 });

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -51,14 +51,33 @@ Options:
 
 ### 环境变量
 
-Rslib 支持在构建过程中向代码中注入环境变量或表达式，这对于区分运行环境、替换常量值等场景很有帮助。
+Rslib 支持在构建过程中向代码中注入环境变量或表达式，这对于区分运行环境、替换常量值等场景很有帮助。你可以查看 [Rsbuild - 环境变量](https://rsbuild.rs/zh/guide/advanced/env-vars) 了解更多详细信息。
 
-你可以查看 [Rsbuild - 环境变量](https://rsbuild.rs/zh/guide/advanced/env-vars) 了解更多详细信息。
+默认情况下，Rslib 会自动设置 `process.env.NODE_ENV` 环境变量，在 build 时始终为 `'production'`。如果你需要区分 watch 模式来动态写入不同的配置，可以如下：
+
+```ts title="rslib.config.ts"
+import { defineConfig } from '@rslib/core';
+
+const isWatch = process.argv.includes('--watch');
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+    },
+  ],
+  source: {
+    alias: {
+      '@request': isWatch ? './src/request.dev.js' : './src/request.prod.js',
+    },
+  },
+});
+```
 
 ::: note
 
-- 当 [format](/config/lib/format) 设置为 `esm` 或 `cjs` 时，`process.env.NODE_ENV` 会在构建产物中被保留。
-- 当 [format](/config/lib/format) 设置为 `mf` 或 `umd` 时，`process.env.NODE_ENV` 将被替换，以确保构建产物可以在浏览器中运行。
+- 当 [format](/config/lib/format) 设置为 `esm` 或 `cjs` 时，源代码中的 `process.env.NODE_ENV` 会在构建产物中被保留。
+- 当 [format](/config/lib/format) 设置为 `mf` 或 `umd` 时，源代码中的 `process.env.NODE_ENV` 将被替换，以确保构建产物可以在浏览器中运行。
 
 :::
 

--- a/website/docs/zh/guide/basic/configure-rslib.mdx
+++ b/website/docs/zh/guide/basic/configure-rslib.mdx
@@ -168,7 +168,7 @@ Rslib 提供了三种配置文件加载方式：
 
 ## 使用环境变量
 
-在配置文件中，你可以使用 `process.env.NODE_ENV` 等 Node.js 环境变量，来动态写入不同的配置：
+在配置文件中，你可以使用 Node.js 环境变量，来动态写入不同的配置：
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
@@ -181,10 +181,10 @@ export default defineConfig({
   ],
   source: {
     alias: {
-      '@request':
-        process.env.NODE_ENV === 'development'
-          ? './src/request.dev.js'
-          : './src/request.prod.js',
+      '@language':
+        process.env.LANGUAGE === 'en'
+          ? './src/language/en.js'
+          : './src/language/zh.js',
     },
   },
 });


### PR DESCRIPTION
## Summary

This pull request updates the documentation for both English and Chinese guides to clarify and improve instructions for using environment variables in Rslib configuration files. The changes focus on explaining default behaviors, providing practical examples for dynamic configuration, and refining the sample code for aliasing based on environment variables.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
