### PR TITLE
feat(dts): support using `output.distPath` as dts emit path

### DIFF
--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -89,7 +89,7 @@ The output directory of declaration files. The default value follows the priorit
 
 1. The `distPath` value of the plugin options.
 2. The `declarationDir` value in the `tsconfig.json` file.
-3. The [output.distPath.root](https://rsbuild.rs/config/output/dist-path) value of Rsbuild configuration.
+3. The [output.distPath](https://rsbuild.rs/config/output/dist-path) or [output.distPath.root](https://rsbuild.rs/config/output/dist-path) value of Rsbuild configuration.
 
 ```js
 pluginDts({

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -187,7 +187,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
       throw Error(
         `Please set "declarationDir": "${dtsEmitPath}" in ${color.underline(
           tsconfigPath,
-        )} to keep it same as "dts.distPath" or "output.distPath.root" field in lib config.`,
+        )} to keep it same as "dts.distPath" or "output.distPath" field in lib config.`,
       );
     }
   }

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -144,10 +144,15 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
         const { options: rawCompilerOptions } = tsConfigResult;
         const { declarationDir, outDir, composite, incremental } =
           rawCompilerOptions;
+        const distPathRoot =
+          typeof config.output?.distPath === 'string'
+            ? config.output?.distPath
+            : config.output?.distPath.root;
+
         const dtsEmitPath = getDtsEmitPath(
           options.distPath,
           declarationDir,
-          config.output?.distPath?.root,
+          distPathRoot,
         );
 
         // check whether declarationDir or outDir is outside from current project

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -655,14 +655,14 @@ export async function cleanTsBuildInfoFile(
   }
 }
 
-// the priority of dtsEmitPath is dts.distPath > declarationDir > output.distPath.root
+// the priority of dtsEmitPath is dts.distPath > declarationDir > output.distPath > output.distPath.root
 // outDir is not considered since in multiple formats, the dts files may not in the same directory as the js files
 export function getDtsEmitPath(
   pathFromPlugin: string | undefined,
   declarationDir: string | undefined,
-  distPath: string,
+  distPathRoot: string,
 ): string {
-  return pathFromPlugin ?? declarationDir ?? distPath;
+  return pathFromPlugin ?? declarationDir ?? distPathRoot;
 }
 
 export function warnIfOutside(

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -136,7 +136,7 @@ The default value follows the priority below:
 
 1. The `dts.distPath` value in the current lib configuration.
 2. The `declarationDir` value in the `tsconfig.json` file.
-3. The [output.distPath.root](/config/rsbuild/output#outputdistpath) value in the current lib configuration.
+3. The [output.distPath](/config/rsbuild/output#outputdistpath) or [output.distPath.root](/config/rsbuild/output#outputdistpath) value in the current lib configuration.
 
 #### Example
 

--- a/website/docs/en/guide/advanced/dts.mdx
+++ b/website/docs/en/guide/advanced/dts.mdx
@@ -149,7 +149,7 @@ The priority from highest to lowest of final output directory of declaration fil
 
 - The configuration option [dts.distPath](/config/lib/dts#dtsdistpath)
 - The configuration option `declarationDir` in `tsconfig.json`
-- The configuration option [output.distPath.root](/config/rsbuild/output#outputdistpath)
+- The configuration option [output.distPath](/config/rsbuild/output#outputdistpath) or [output.distPath.root](/config/rsbuild/output#outputdistpath)
 
 ## Related configuration of declaration files
 

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -136,7 +136,7 @@ export default {
 
 1. 当前 lib 配置中的 `dts.distPath` 值。
 2. `tsconfig.json` 文件中的 `declarationDir` 值。
-3. 当前 lib 配置中的 [output.distPath.root](/config/rsbuild/output#outputdistpath) 值。
+3. 当前 lib 配置中的 [output.distPath](/config/rsbuild/output#outputdistpath) 值或 [output.distPath.root](/config/rsbuild/output#outputdistpath) 值。
 
 #### 示例
 

--- a/website/docs/zh/guide/advanced/dts.mdx
+++ b/website/docs/zh/guide/advanced/dts.mdx
@@ -152,7 +152,7 @@ API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API) 或 [t
 
 - [dts.distPath](/config/lib/dts#dtsdistpath) 配置项
 - `tsconfig.json` 中的 `declarationDir` 配置项
-- [output.distPath.root](/config/rsbuild/output#outputdistpath) 配置项
+- [output.distPath](/config/rsbuild/output#outputdistpath) 或 [output.distPath.root](/config/rsbuild/output#outputdistpath) 配置项
 
 ## 类型声明文件的相关配置
 


### PR DESCRIPTION
## Summary

Support using shorter string value of `output.distPath` as dts emit path.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/6352

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
