### PR TITLE
chore: use shorter string value for `output.distPath`

### DIFF
--- a/examples/express-plugin/rslib.config.ts
+++ b/examples/express-plugin/rslib.config.ts
@@ -6,18 +6,14 @@ export default defineConfig({
       format: 'esm',
       dts: true,
       output: {
-        distPath: {
-          root: './dist/esm',
-        },
+        distPath: './dist/esm',
       },
     },
     {
       format: 'cjs',
       dts: true,
       output: {
-        distPath: {
-          root: './dist/cjs',
-        },
+        distPath: './dist/cjs',
       },
     },
   ],

--- a/examples/module-federation/mf-react-component/rslib.config.ts
+++ b/examples/module-federation/mf-react-component/rslib.config.ts
@@ -8,26 +8,20 @@ export default defineConfig({
       format: 'esm',
       dts: true,
       output: {
-        distPath: {
-          root: './dist/esm',
-        },
+        distPath: './dist/esm',
       },
     },
     {
       format: 'cjs',
       dts: true,
       output: {
-        distPath: {
-          root: './dist/cjs',
-        },
+        distPath: './dist/cjs',
       },
     },
     {
       format: 'mf',
       output: {
-        distPath: {
-          root: './dist/mf',
-        },
+        distPath: './dist/mf',
         assetPrefix: 'http://localhost:3001/mf',
       },
       dev: {

--- a/examples/preact-component-bundle-false/rslib.config.ts
+++ b/examples/preact-component-bundle-false/rslib.config.ts
@@ -9,9 +9,7 @@ export default defineConfig({
       dts: true,
       format: 'esm',
       output: {
-        distPath: {
-          root: './dist/esm',
-        },
+        distPath: './dist/esm',
       },
     },
     {
@@ -19,9 +17,7 @@ export default defineConfig({
       dts: true,
       format: 'cjs',
       output: {
-        distPath: {
-          root: './dist/cjs',
-        },
+        distPath: './dist/cjs',
       },
     },
   ],

--- a/examples/react-component-bundle-false/rslib.config.ts
+++ b/examples/react-component-bundle-false/rslib.config.ts
@@ -9,9 +9,7 @@ export default defineConfig({
       bundle: false,
       dts: true,
       output: {
-        distPath: {
-          root: './dist/esm',
-        },
+        distPath: './dist/esm',
       },
     },
     {
@@ -19,9 +17,7 @@ export default defineConfig({
       bundle: false,
       dts: true,
       output: {
-        distPath: {
-          root: './dist/cjs',
-        },
+        distPath: './dist/cjs',
       },
     },
   ],

--- a/examples/react-component-bundle/rslib.config.ts
+++ b/examples/react-component-bundle/rslib.config.ts
@@ -8,18 +8,14 @@ export default defineConfig({
       format: 'esm',
       dts: true,
       output: {
-        distPath: {
-          root: './dist/esm',
-        },
+        distPath: './dist/esm',
       },
     },
     {
       format: 'cjs',
       dts: true,
       output: {
-        distPath: {
-          root: './dist/cjs',
-        },
+        distPath: './dist/cjs',
       },
     },
   ],

--- a/examples/react-component-umd/rslib.config.ts
+++ b/examples/react-component-umd/rslib.config.ts
@@ -11,9 +11,7 @@ export default defineConfig({
         externals: {
           react: 'React',
         },
-        distPath: {
-          root: './dist/umd',
-        },
+        distPath: './dist/umd',
       },
     },
   ],

--- a/tests/integration/alias/rslib.config.ts
+++ b/tests/integration/alias/rslib.config.ts
@@ -10,9 +10,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/bundle/esm',
-        },
+        distPath: 'dist/bundle/esm',
       },
     }),
     generateBundleCjsConfig({
@@ -22,9 +20,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/bundle/cjs',
-        },
+        distPath: 'dist/bundle/cjs',
       },
     }),
     generateBundleEsmConfig({
@@ -35,9 +31,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/bundleless/esm',
-        },
+        distPath: 'dist/bundleless/esm',
       },
     }),
     generateBundleCjsConfig({
@@ -48,9 +42,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/bundleless/cjs',
-        },
+        distPath: 'dist/bundleless/cjs',
       },
     }),
   ],

--- a/tests/integration/asset/assets-include/rslib.config.ts
+++ b/tests/integration/asset/assets-include/rslib.config.ts
@@ -10,9 +10,7 @@ export default defineConfig({
         assetsInclude: /\.txt/,
       },
       output: {
-        distPath: {
-          root: './dist/esm/bundle',
-        },
+        distPath: './dist/esm/bundle',
       },
     }),
     // 1. bundleless
@@ -23,9 +21,7 @@ export default defineConfig({
         assetsInclude: /\.txt/,
       },
       output: {
-        distPath: {
-          root: './dist/esm/bundleless',
-        },
+        distPath: './dist/esm/bundleless',
       },
     }),
   ],

--- a/tests/integration/asset/hash/rslib.config.ts
+++ b/tests/integration/asset/hash/rslib.config.ts
@@ -8,9 +8,7 @@ export default defineConfig({
     // esm
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundle',
-        },
+        distPath: './dist/esm/bundle',
         filename: {
           image: '[name].[contenthash:8][ext]',
         },
@@ -19,9 +17,7 @@ export default defineConfig({
     // cjs
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs/bundle',
-        },
+        distPath: './dist/cjs/bundle',
         filename: {
           image: '[name].[contenthash:8][ext]',
         },
@@ -32,9 +28,7 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/esm/bundleless',
-        },
+        distPath: './dist/esm/bundleless',
         filename: {
           image: '[name].[contenthash:8][ext]',
         },
@@ -44,9 +38,7 @@ export default defineConfig({
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/cjs/bundleless',
-        },
+        distPath: './dist/cjs/bundleless',
         filename: {
           image: '[name].[contenthash:8][ext]',
         },

--- a/tests/integration/asset/json/rslib.config.ts
+++ b/tests/integration/asset/json/rslib.config.ts
@@ -9,9 +9,7 @@ export default defineConfig({
     // esm
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundle',
-        },
+        distPath: './dist/esm/bundle',
       },
       source: {
         entry: {
@@ -25,9 +23,7 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/esm/bundleless',
-        },
+        distPath: './dist/esm/bundleless',
       },
       source: {
         entry: {

--- a/tests/integration/asset/limit/rslib.config.ts
+++ b/tests/integration/asset/limit/rslib.config.ts
@@ -7,26 +7,20 @@ export default defineConfig({
     // esm
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundle-default',
-        },
+        distPath: './dist/esm/bundle-default',
       },
     }),
     // cjs
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs/bundle-default',
-        },
+        distPath: './dist/cjs/bundle-default',
       },
     }),
     // 1. bundle inline
     // esm
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundle-inline',
-        },
+        distPath: './dist/esm/bundle-inline',
         dataUriLimit: {
           svg: 4096,
         },
@@ -35,9 +29,7 @@ export default defineConfig({
     // cjs
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs/bundle-inline',
-        },
+        distPath: './dist/cjs/bundle-inline',
         dataUriLimit: {
           svg: 4096,
         },
@@ -48,18 +40,14 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/esm/bundleless-default',
-        },
+        distPath: './dist/esm/bundleless-default',
       },
     }),
     // cjs
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/cjs/bundleless-default',
-        },
+        distPath: './dist/cjs/bundleless-default',
       },
     }),
 
@@ -67,9 +55,7 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/esm/bundleless-inline',
-        },
+        distPath: './dist/esm/bundleless-inline',
         dataUriLimit: {
           svg: 4096,
         },
@@ -78,9 +64,7 @@ export default defineConfig({
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/cjs/bundleless-inline',
-        },
+        distPath: './dist/cjs/bundleless-inline',
         dataUriLimit: {
           svg: 4096,
         },

--- a/tests/integration/asset/public-path/rslib.config.ts
+++ b/tests/integration/asset/public-path/rslib.config.ts
@@ -10,18 +10,14 @@ export default defineConfig({
     }),
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundle',
-        },
+        distPath: './dist/esm/bundle',
         assetPrefix: '/public/path',
       },
     }),
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/esm/bundle-false',
-        },
+        distPath: './dist/esm/bundle-false',
         assetPrefix: '/public/path',
       },
     }),

--- a/tests/integration/asset/source/rslib.config.ts
+++ b/tests/integration/asset/source/rslib.config.ts
@@ -19,9 +19,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm/bundle',
-        },
+        distPath: './dist/esm/bundle',
       },
     }),
     // 1. bundleless
@@ -34,9 +32,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm/bundleless',
-        },
+        distPath: './dist/esm/bundleless',
       },
     }),
   ],

--- a/tests/integration/asset/svgr/rslib.config.ts
+++ b/tests/integration/asset/svgr/rslib.config.ts
@@ -9,9 +9,7 @@ export default defineConfig({
     // esm
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundle-default',
-        },
+        distPath: './dist/esm/bundle-default',
       },
       plugins: [
         pluginSvgr({
@@ -22,9 +20,7 @@ export default defineConfig({
     // cjs
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs/bundle-default',
-        },
+        distPath: './dist/cjs/bundle-default',
       },
       plugins: [
         pluginSvgr({
@@ -42,9 +38,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm/bundleless-mixed',
-        },
+        distPath: './dist/esm/bundleless-mixed',
       },
       plugins: [
         pluginSvgr({
@@ -61,9 +55,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/cjs/bundleless-mixed',
-        },
+        distPath: './dist/cjs/bundleless-mixed',
       },
       plugins: [
         pluginSvgr({
@@ -81,9 +73,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm/bundleless-only-svgr',
-        },
+        distPath: './dist/esm/bundleless-only-svgr',
       },
       plugins: [
         pluginSvgr({
@@ -103,9 +93,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/cjs/bundleless-only-svgr',
-        },
+        distPath: './dist/cjs/bundleless-only-svgr',
       },
       plugins: [
         pluginSvgr({
@@ -126,9 +114,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm/bundleless-css-svg',
-        },
+        distPath: './dist/esm/bundleless-css-svg',
       },
       plugins: [
         pluginSvgr({
@@ -147,9 +133,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/cjs/bundleless-css-svg',
-        },
+        distPath: './dist/cjs/bundleless-css-svg',
       },
       plugins: [
         pluginSvgr({

--- a/tests/integration/auto-extension/type-commonjs/config-override/rslib.config.ts
+++ b/tests/integration/auto-extension/type-commonjs/config-override/rslib.config.ts
@@ -9,9 +9,7 @@ export default defineConfig({
         filename: {
           js: '[name].mjs',
         },
-        distPath: {
-          root: './dist/esm-override-filename',
-        },
+        distPath: './dist/esm-override-filename',
       },
     }),
     generateBundleCjsConfig({
@@ -19,26 +17,20 @@ export default defineConfig({
         filename: {
           js: '[name].[contenthash:8].js',
         },
-        distPath: {
-          root: './dist/cjs-override-filename',
-        },
+        distPath: './dist/cjs-override-filename',
       },
     }),
     generateBundleEsmConfig({
       autoExtension: false,
       output: {
         filenameHash: true,
-        distPath: {
-          root: './dist/esm-override-filename-hash',
-        },
+        distPath: './dist/esm-override-filename-hash',
       },
     }),
     generateBundleCjsConfig({
       output: {
         filenameHash: true,
-        distPath: {
-          root: './dist/cjs-override-filename-hash',
-        },
+        distPath: './dist/cjs-override-filename-hash',
       },
     }),
     generateBundleCjsConfig({
@@ -51,9 +43,7 @@ export default defineConfig({
             return 'bar-[name].js';
           },
         },
-        distPath: {
-          root: './dist/cjs-override-filename-function',
-        },
+        distPath: './dist/cjs-override-filename-function',
       },
       bundle: false,
       source: {

--- a/tests/integration/auto-extension/type-module/config-override/rslib.config.ts
+++ b/tests/integration/auto-extension/type-module/config-override/rslib.config.ts
@@ -8,9 +8,7 @@ export default defineConfig({
         filename: {
           js: '[name].[contenthash:8].js',
         },
-        distPath: {
-          root: './dist/esm-override-filename',
-        },
+        distPath: './dist/esm-override-filename',
       },
     }),
     generateBundleCjsConfig({
@@ -19,26 +17,20 @@ export default defineConfig({
         filename: {
           js: '[name].cjs',
         },
-        distPath: {
-          root: './dist/cjs-override-filename',
-        },
+        distPath: './dist/cjs-override-filename',
       },
     }),
     generateBundleEsmConfig({
       output: {
         filenameHash: true,
-        distPath: {
-          root: './dist/esm-override-filename-hash',
-        },
+        distPath: './dist/esm-override-filename-hash',
       },
     }),
     generateBundleCjsConfig({
       autoExtension: false,
       output: {
         filenameHash: true,
-        distPath: {
-          root: './dist/cjs-override-filename-hash',
-        },
+        distPath: './dist/cjs-override-filename-hash',
       },
     }),
     generateBundleEsmConfig({
@@ -51,9 +43,7 @@ export default defineConfig({
             return 'bar-[name].js';
           },
         },
-        distPath: {
-          root: './dist/esm-override-filename-function',
-        },
+        distPath: './dist/esm-override-filename-function',
       },
       bundle: false,
       source: {

--- a/tests/integration/banner-footer/rslib.config.ts
+++ b/tests/integration/banner-footer/rslib.config.ts
@@ -19,9 +19,7 @@ export default defineConfig({
     // bundle esm
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundle',
-        },
+        distPath: './dist/esm/bundle',
       },
       dts: {
         bundle: true,
@@ -31,9 +29,7 @@ export default defineConfig({
     // bundle cjs
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs/bundle',
-        },
+        distPath: './dist/cjs/bundle',
       },
       dts: {
         bundle: true,
@@ -43,9 +39,7 @@ export default defineConfig({
     // bundleless esm
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundleless',
-        },
+        distPath: './dist/esm/bundleless',
       },
       bundle: false,
       dts: {
@@ -61,9 +55,7 @@ export default defineConfig({
     // bundleless cjs
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs/bundleless',
-        },
+        distPath: './dist/cjs/bundleless',
       },
       bundle: false,
       dts: {
@@ -79,9 +71,7 @@ export default defineConfig({
     // bundle esm with minify enabled
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundle-minify',
-        },
+        distPath: './dist/esm/bundle-minify',
         minify: true,
       },
       dts: {
@@ -92,9 +82,7 @@ export default defineConfig({
     // bundle esm
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm-tsgo/bundle',
-        },
+        distPath: './dist/esm-tsgo/bundle',
       },
       dts: {
         bundle: true,
@@ -105,9 +93,7 @@ export default defineConfig({
     // bundle cjs
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs-tsgo/bundle',
-        },
+        distPath: './dist/cjs-tsgo/bundle',
       },
       dts: {
         bundle: true,
@@ -118,9 +104,7 @@ export default defineConfig({
     // bundleless esm
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm-tsgo/bundleless',
-        },
+        distPath: './dist/esm-tsgo/bundleless',
       },
       bundle: false,
       dts: {
@@ -137,9 +121,7 @@ export default defineConfig({
     // bundleless cjs
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs-tsgo/bundleless',
-        },
+        distPath: './dist/cjs-tsgo/bundleless',
       },
       bundle: false,
       dts: {
@@ -156,9 +138,7 @@ export default defineConfig({
     // bundle esm with minify enabled
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm-tsgo/bundle-minify',
-        },
+        distPath: './dist/esm-tsgo/bundle-minify',
         minify: true,
       },
       dts: {

--- a/tests/integration/bundle-false/js-extension/rslib.config.ts
+++ b/tests/integration/bundle-false/js-extension/rslib.config.ts
@@ -6,25 +6,19 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/basic-esm',
-        },
+        distPath: './dist/basic-esm',
       },
     }),
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/basic-cjs',
-        },
+        distPath: './dist/basic-cjs',
       },
     }),
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/no-auto-extension-esm',
-        },
+        distPath: './dist/no-auto-extension-esm',
         filename: {
           js: '[name].mjs',
         },
@@ -34,9 +28,7 @@ export default defineConfig({
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/no-auto-extension-cjs',
-        },
+        distPath: './dist/no-auto-extension-cjs',
         filename: {
           js: '[name].cjs',
         },

--- a/tests/integration/cli/build-watch/build.test.ts
+++ b/tests/integration/cli/build-watch/build.test.ts
@@ -44,9 +44,7 @@ import { generateBundleEsmConfig } from 'test-helper';
 export default defineConfig({
   lib: [generateBundleEsmConfig({
    output: {
-      distPath: {
-        root: './dist-1/esm',
-      },
+      distPath: './dist-1/esm',
     },
   })],
 });

--- a/tests/integration/cli/build/custom-config/rslib.config.custom.ts
+++ b/tests/integration/cli/build/custom-config/rslib.config.custom.ts
@@ -5,16 +5,12 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/custom',
-        },
+        distPath: './dist/custom',
       },
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/custom',
-        },
+        distPath: './dist/custom',
       },
     }),
   ],

--- a/tests/integration/cli/build/custom-root/rslib.config.ts
+++ b/tests/integration/cli/build/custom-root/rslib.config.ts
@@ -6,16 +6,12 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/root',
-        },
+        distPath: './dist/root',
       },
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/root',
-        },
+        distPath: './dist/root',
       },
     }),
   ],

--- a/tests/integration/cli/build/rslib.config.auto.mts
+++ b/tests/integration/cli/build/rslib.config.auto.mts
@@ -6,9 +6,7 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: distPathJson.distPath,
-        },
+        distPath: distPathJson.distPath,
       },
     }),
   ],

--- a/tests/integration/cli/env/rslib.config.ts
+++ b/tests/integration/cli/env/rslib.config.ts
@@ -5,9 +5,7 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: `dist/${process.env.FOO}`,
-        },
+        distPath: `dist/${process.env.FOO}`,
       },
     }),
   ],

--- a/tests/integration/cli/mf/dev/rslib.config.ts
+++ b/tests/integration/cli/mf/dev/rslib.config.ts
@@ -9,9 +9,7 @@ export default defineConfig({
       },
       {
         output: {
-          distPath: {
-            root: 'dist-mf0',
-          },
+          distPath: 'dist-mf0',
         },
       },
     ),
@@ -21,9 +19,7 @@ export default defineConfig({
       },
       {
         output: {
-          distPath: {
-            root: 'dist-mf1',
-          },
+          distPath: 'dist-mf1',
         },
       },
     ),
@@ -34,9 +30,7 @@ export default defineConfig({
       {
         id: 'mf2',
         output: {
-          distPath: {
-            root: 'dist-mf2',
-          },
+          distPath: 'dist-mf2',
         },
       },
     ),

--- a/tests/integration/decorators/tsconfig/rslib.config.ts
+++ b/tests/integration/decorators/tsconfig/rslib.config.ts
@@ -5,16 +5,12 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/legacy',
-        },
+        distPath: './dist/esm/legacy',
       },
     }),
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/stage3',
-        },
+        distPath: './dist/esm/stage3',
       },
       source: {
         decorators: {

--- a/tests/integration/define/rslib.config.ts
+++ b/tests/integration/define/rslib.config.ts
@@ -10,9 +10,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm/0',
-        },
+        distPath: './dist/esm/0',
       },
     }),
     generateBundleEsmConfig({
@@ -23,9 +21,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm/1',
-        },
+        distPath: './dist/esm/1',
       },
     }),
     generateBundleCjsConfig({
@@ -35,9 +31,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/cjs/0',
-        },
+        distPath: './dist/cjs/0',
       },
     }),
   ],

--- a/tests/integration/directive/react/bundleless/rslib.config.ts
+++ b/tests/integration/directive/react/bundleless/rslib.config.ts
@@ -6,18 +6,14 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/esm',
-        },
+        distPath: './dist/esm',
       },
     }),
     generateBundleCjsConfig({
       bundle: false,
       output: {
         minify: true,
-        distPath: {
-          root: './dist/cjs',
-        },
+        distPath: './dist/cjs',
       },
     }),
   ],

--- a/tests/integration/directive/shebang/rslib.config.ts
+++ b/tests/integration/directive/shebang/rslib.config.ts
@@ -24,9 +24,7 @@ export default defineConfig({
       ...esmShared,
       shims: { esm: { __dirname: true, __filename: true } },
       output: {
-        distPath: {
-          root: './dist/bundle/esm0',
-        },
+        distPath: './dist/bundle/esm0',
       },
     }),
     generateBundleEsmConfig({
@@ -34,18 +32,14 @@ export default defineConfig({
       shims: { esm: { __dirname: true, __filename: true } },
       output: {
         minify: true,
-        distPath: {
-          root: './dist/bundle/esm1',
-        },
+        distPath: './dist/bundle/esm1',
       },
     }),
     generateBundleEsmConfig({
       ...esmSharedBundleFalse,
       shims: { esm: { __dirname: true, __filename: true } },
       output: {
-        distPath: {
-          root: './dist/bundle-false/esm0',
-        },
+        distPath: './dist/bundle-false/esm0',
       },
     }),
     generateBundleEsmConfig({
@@ -53,9 +47,7 @@ export default defineConfig({
       shims: { esm: { __dirname: true, __filename: true } },
       output: {
         minify: true,
-        distPath: {
-          root: './dist/bundle-false/esm1',
-        },
+        distPath: './dist/bundle-false/esm1',
       },
     }),
   ],

--- a/tests/integration/dts-tsgo/bundle/bundled-packages/rslib.config.ts
+++ b/tests/integration/dts-tsgo/bundle/bundled-packages/rslib.config.ts
@@ -9,9 +9,7 @@ export default defineConfig({
         tsgo: true,
       },
       output: {
-        distPath: {
-          root: './dist/esm/default',
-        },
+        distPath: './dist/esm/default',
       },
     }),
     generateBundleEsmConfig({
@@ -22,9 +20,7 @@ export default defineConfig({
         tsgo: true,
       },
       output: {
-        distPath: {
-          root: './dist/esm/override-empty-array',
-        },
+        distPath: './dist/esm/override-empty-array',
       },
     }),
     generateBundleEsmConfig({
@@ -43,9 +39,7 @@ export default defineConfig({
         tsgo: true,
       },
       output: {
-        distPath: {
-          root: './dist/esm/override-array-string',
-        },
+        distPath: './dist/esm/override-array-string',
       },
     }),
   ],

--- a/tests/integration/dts/bundle/bundled-packages/rslib.config.ts
+++ b/tests/integration/dts/bundle/bundled-packages/rslib.config.ts
@@ -8,9 +8,7 @@ export default defineConfig({
         bundle: true,
       },
       output: {
-        distPath: {
-          root: './dist/esm/default',
-        },
+        distPath: './dist/esm/default',
       },
     }),
     generateBundleEsmConfig({
@@ -20,9 +18,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm/override-empty-array',
-        },
+        distPath: './dist/esm/override-empty-array',
       },
     }),
     generateBundleEsmConfig({
@@ -40,9 +36,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm/override-array-string',
-        },
+        distPath: './dist/esm/override-array-string',
       },
     }),
   ],

--- a/tests/integration/entry/default/rslib.config.ts
+++ b/tests/integration/entry/default/rslib.config.ts
@@ -5,31 +5,23 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: 'dist/esm-bundle',
-        },
+        distPath: 'dist/esm-bundle',
       },
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: 'dist/cjs-bundle',
-        },
+        distPath: 'dist/cjs-bundle',
       },
     }),
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: 'dist/esm-bundle-false',
-        },
+        distPath: 'dist/esm-bundle-false',
       },
       bundle: false,
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: 'dist/cjs-bundle-false',
-        },
+        distPath: 'dist/cjs-bundle-false',
       },
       bundle: false,
     }),

--- a/tests/integration/external-helpers/config-override/rslib.config.ts
+++ b/tests/integration/external-helpers/config-override/rslib.config.ts
@@ -14,9 +14,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/1',
-        },
+        distPath: './dist/1',
       },
     }),
     generateBundleEsmConfig({
@@ -29,9 +27,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/2',
-        },
+        distPath: './dist/2',
       },
     }),
   ],

--- a/tests/integration/external-helpers/true/rslib.config.ts
+++ b/tests/integration/external-helpers/true/rslib.config.ts
@@ -7,9 +7,7 @@ export default defineConfig({
       syntax: 'es5',
       externalHelpers: true,
       output: {
-        distPath: {
-          root: './dist/1',
-        },
+        distPath: './dist/1',
       },
     }),
     generateBundleEsmConfig({
@@ -17,9 +15,7 @@ export default defineConfig({
       externalHelpers: true,
       autoExternal: false,
       output: {
-        distPath: {
-          root: './dist/2',
-        },
+        distPath: './dist/2',
       },
     }),
   ],

--- a/tests/integration/externals/user-externals/rslib.config.ts
+++ b/tests/integration/externals/user-externals/rslib.config.ts
@@ -10,18 +10,14 @@ export default defineConfig({
     generateBundleEsmConfig({
       output: {
         externals: baseExternals,
-        distPath: {
-          root: 'dist/bundle',
-        },
+        distPath: 'dist/bundle',
       },
     }),
     generateBundleEsmConfig({
       bundle: false,
       output: {
         externals: { ...baseExternals, './foo': './foo2' },
-        distPath: {
-          root: 'dist/bundle-false',
-        },
+        distPath: 'dist/bundle-false',
       },
     }),
   ],

--- a/tests/integration/format/cjs-static-export/rslib.config.ts
+++ b/tests/integration/format/cjs-static-export/rslib.config.ts
@@ -5,9 +5,7 @@ export default defineConfig({
   lib: [
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs',
-        },
+        distPath: './dist/cjs',
         filename: {
           js: '[name].cjs',
         },

--- a/tests/integration/format/default/rslib.config.ts
+++ b/tests/integration/format/default/rslib.config.ts
@@ -6,35 +6,27 @@ export default defineConfig({
     // ESM
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/bundle-esm',
-        },
+        distPath: './dist/bundle-esm',
       },
     }),
     // CJS
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/bundle-cjs',
-        },
+        distPath: './dist/bundle-cjs',
       },
     }),
     // ESM bundleless
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/bundleless-esm',
-        },
+        distPath: './dist/bundleless-esm',
       },
     }),
     // CJS bundleless
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/bundleless-cjs',
-        },
+        distPath: './dist/bundleless-cjs',
       },
     }),
   ],

--- a/tests/integration/format/import-meta-url/rslib.config.ts
+++ b/tests/integration/format/import-meta-url/rslib.config.ts
@@ -5,9 +5,7 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm',
-        },
+        distPath: './dist/esm',
       },
     }),
   ],

--- a/tests/integration/json/rslib.config.ts
+++ b/tests/integration/json/rslib.config.ts
@@ -6,9 +6,7 @@ export default defineConfig({
     // bundle default
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/bundle-default',
-        },
+        distPath: './dist/bundle-default',
       },
     }),
     // bundleless default
@@ -20,9 +18,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/bundleless-default',
-        },
+        distPath: './dist/bundleless-default',
       },
     }),
     // bundleless preserve JSON
@@ -36,9 +32,7 @@ export default defineConfig({
       output: {
         copy: [{ from: './**/*.json', context: './src' }],
         externals: [/.*\.json$/],
-        distPath: {
-          root: './dist/bundleless-preserve-json',
-        },
+        distPath: './dist/bundleless-preserve-json',
       },
     }),
   ],

--- a/tests/integration/node-polyfill/bundle-false/rslib.config.ts
+++ b/tests/integration/node-polyfill/bundle-false/rslib.config.ts
@@ -22,9 +22,7 @@ export default defineConfig({
           },
           {} as Record<string, string>,
         ),
-        distPath: {
-          root: './dist/esm/bundleless',
-        },
+        distPath: './dist/esm/bundleless',
       },
     }),
   ],

--- a/tests/integration/node-polyfill/bundle/rslib.config.ts
+++ b/tests/integration/node-polyfill/bundle/rslib.config.ts
@@ -7,17 +7,13 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: true,
       output: {
-        distPath: {
-          root: './dist/esm/bundle',
-        },
+        distPath: './dist/esm/bundle',
       },
     }),
     generateBundleCjsConfig({
       bundle: true,
       output: {
-        distPath: {
-          root: './dist/cjs/bundle',
-        },
+        distPath: './dist/cjs/bundle',
       },
     }),
   ],

--- a/tests/integration/outBase/custom-entry/rslib.config.ts
+++ b/tests/integration/outBase/custom-entry/rslib.config.ts
@@ -13,9 +13,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm0',
-        },
+        distPath: './dist/esm0',
       },
     }),
     // configured with relative outBase
@@ -28,9 +26,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm1',
-        },
+        distPath: './dist/esm1',
       },
     }),
     // configured with absolute outBase
@@ -43,9 +39,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/esm2',
-        },
+        distPath: './dist/esm2',
       },
     }),
   ],

--- a/tests/integration/outBase/nested-dir/rslib.config.ts
+++ b/tests/integration/outBase/nested-dir/rslib.config.ts
@@ -8,9 +8,7 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: './dist/esm0',
-        },
+        distPath: './dist/esm0',
       },
     }),
     // configured with relative outBase
@@ -18,9 +16,7 @@ export default defineConfig({
       bundle: false,
       outBase: './src',
       output: {
-        distPath: {
-          root: './dist/esm1',
-        },
+        distPath: './dist/esm1',
       },
     }),
     // configured with absolute outBase
@@ -28,9 +24,7 @@ export default defineConfig({
       bundle: false,
       outBase: path.resolve(__dirname, 'src'),
       output: {
-        distPath: {
-          root: './dist/esm2',
-        },
+        distPath: './dist/esm2',
       },
     }),
   ],

--- a/tests/integration/parser-javascript/api-plugin/rslib.config.ts
+++ b/tests/integration/parser-javascript/api-plugin/rslib.config.ts
@@ -6,17 +6,13 @@ export default defineConfig({
     // ESM
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/bundle-esm',
-        },
+        distPath: './dist/bundle-esm',
       },
     }),
     // CJS
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/bundle-cjs',
-        },
+        distPath: './dist/bundle-cjs',
       },
     }),
   ],

--- a/tests/integration/polyfill/rslib.config.ts
+++ b/tests/integration/polyfill/rslib.config.ts
@@ -22,9 +22,7 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: 'dist/esm0',
-        },
+        distPath: 'dist/esm0',
       },
       plugins: [
         polyfillPlugin({
@@ -34,9 +32,7 @@ export default defineConfig({
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: 'dist/cjs0',
-        },
+        distPath: 'dist/cjs0',
       },
       plugins: [
         polyfillPlugin({
@@ -46,9 +42,7 @@ export default defineConfig({
     }),
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: 'dist/esm1',
-        },
+        distPath: 'dist/esm1',
       },
       plugins: [
         polyfillPlugin({

--- a/tests/integration/preserve-jsx/default/rslib.config.ts
+++ b/tests/integration/preserve-jsx/default/rslib.config.ts
@@ -10,17 +10,13 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/esm0',
-        },
+        distPath: 'dist/esm0',
       },
     }),
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/esm1',
-        },
+        distPath: 'dist/esm1',
         filename: {
           js: '[name].jsx',
         },

--- a/tests/integration/redirect/asset/rslib.config.ts
+++ b/tests/integration/redirect/asset/rslib.config.ts
@@ -7,17 +7,13 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/default/esm',
-        },
+        distPath: 'dist/default/esm',
       },
     }),
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/default/cjs',
-        },
+        distPath: 'dist/default/cjs',
       },
     }),
     // 1. redirect.asset.extension: false
@@ -29,9 +25,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/asset-extension-false/esm',
-        },
+        distPath: 'dist/asset-extension-false/esm',
       },
     }),
     generateBundleCjsConfig({
@@ -42,9 +36,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/asset-extension-false/cjs',
-        },
+        distPath: 'dist/asset-extension-false/cjs',
       },
     }),
     // 2. redirect.asset.path: false
@@ -56,9 +48,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/asset-path-false/esm',
-        },
+        distPath: 'dist/asset-path-false/esm',
       },
     }),
     generateBundleCjsConfig({
@@ -69,9 +59,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/asset-path-false/cjs',
-        },
+        distPath: 'dist/asset-path-false/cjs',
       },
     }),
     // 3. redirect.asset.extension: false + redirect.asset.path: false
@@ -84,9 +72,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/asset-false/esm',
-        },
+        distPath: 'dist/asset-false/esm',
       },
     }),
     generateBundleCjsConfig({
@@ -98,9 +84,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/asset-false/cjs',
-        },
+        distPath: 'dist/asset-false/cjs',
       },
     }),
   ],

--- a/tests/integration/redirect/dts-tsgo/rslib.config.ts
+++ b/tests/integration/redirect/dts-tsgo/rslib.config.ts
@@ -9,9 +9,7 @@ export default defineConfig({
         tsgo: true,
       },
       output: {
-        distPath: {
-          root: './dist/default/esm',
-        },
+        distPath: './dist/default/esm',
       },
     }),
     // 1 - path: false extension: false
@@ -20,9 +18,7 @@ export default defineConfig({
         tsgo: true,
       },
       output: {
-        distPath: {
-          root: './dist/path-false/esm',
-        },
+        distPath: './dist/path-false/esm',
       },
       redirect: {
         dts: {
@@ -36,9 +32,7 @@ export default defineConfig({
         tsgo: true,
       },
       output: {
-        distPath: {
-          root: './dist/extension-true/esm',
-        },
+        distPath: './dist/extension-true/esm',
       },
       redirect: {
         dts: {
@@ -52,9 +46,7 @@ export default defineConfig({
         tsgo: true,
       },
       output: {
-        distPath: {
-          root: './dist/path-false-extension-true/esm',
-        },
+        distPath: './dist/path-false-extension-true/esm',
       },
       redirect: {
         dts: {
@@ -70,9 +62,7 @@ export default defineConfig({
         tsgo: true,
       },
       output: {
-        distPath: {
-          root: './dist/auto-extension-true/esm',
-        },
+        distPath: './dist/auto-extension-true/esm',
       },
       redirect: {
         dts: {
@@ -87,9 +77,7 @@ export default defineConfig({
         tsgo: true,
       },
       output: {
-        distPath: {
-          root: './dist/auto-extension-true/cjs',
-        },
+        distPath: './dist/auto-extension-true/cjs',
       },
       redirect: {
         dts: {

--- a/tests/integration/redirect/dts/rslib.config.ts
+++ b/tests/integration/redirect/dts/rslib.config.ts
@@ -7,18 +7,14 @@ export default defineConfig({
     generateBundleEsmConfig({
       dts: true,
       output: {
-        distPath: {
-          root: './dist/default/esm',
-        },
+        distPath: './dist/default/esm',
       },
     }),
     // 1 - path: false extension: false
     generateBundleEsmConfig({
       dts: true,
       output: {
-        distPath: {
-          root: './dist/path-false/esm',
-        },
+        distPath: './dist/path-false/esm',
       },
       redirect: {
         dts: {
@@ -30,9 +26,7 @@ export default defineConfig({
     generateBundleEsmConfig({
       dts: true,
       output: {
-        distPath: {
-          root: './dist/extension-true/esm',
-        },
+        distPath: './dist/extension-true/esm',
       },
       redirect: {
         dts: {
@@ -44,9 +38,7 @@ export default defineConfig({
     generateBundleEsmConfig({
       dts: true,
       output: {
-        distPath: {
-          root: './dist/path-false-extension-true/esm',
-        },
+        distPath: './dist/path-false-extension-true/esm',
       },
       redirect: {
         dts: {
@@ -61,9 +53,7 @@ export default defineConfig({
         autoExtension: true,
       },
       output: {
-        distPath: {
-          root: './dist/auto-extension-true',
-        },
+        distPath: './dist/auto-extension-true',
       },
       redirect: {
         dts: {
@@ -77,9 +67,7 @@ export default defineConfig({
         autoExtension: true,
       },
       output: {
-        distPath: {
-          root: './dist/auto-extension-true',
-        },
+        distPath: './dist/auto-extension-true',
       },
       redirect: {
         dts: {

--- a/tests/integration/redirect/js-not-resolve/rslib.config.ts
+++ b/tests/integration/redirect/js-not-resolve/rslib.config.ts
@@ -7,18 +7,14 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/default/esm',
-        },
+        distPath: 'dist/default/esm',
       },
     }),
     // 1 js.path: false
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/js-path-false/esm',
-        },
+        distPath: 'dist/js-path-false/esm',
       },
       redirect: {
         js: {
@@ -30,9 +26,7 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/js-extension-false/esm',
-        },
+        distPath: 'dist/js-extension-false/esm',
       },
       redirect: {
         js: {

--- a/tests/integration/redirect/js/rslib.config.ts
+++ b/tests/integration/redirect/js/rslib.config.ts
@@ -7,26 +7,20 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/default/esm',
-        },
+        distPath: 'dist/default/esm',
       },
     }),
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/default/cjs',
-        },
+        distPath: 'dist/default/cjs',
       },
     }),
     // 1 js.path: false
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/js-path-false/esm',
-        },
+        distPath: 'dist/js-path-false/esm',
       },
       redirect: {
         js: {
@@ -37,9 +31,7 @@ export default defineConfig({
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/js-path-false/cjs',
-        },
+        distPath: 'dist/js-path-false/cjs',
       },
       redirect: {
         js: {
@@ -51,9 +43,7 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/js-path-externals-override/esm',
-        },
+        distPath: 'dist/js-path-externals-override/esm',
         externals: {
           '@/foo': './others/foo.js',
           '@/bar': './others/bar/index.js',
@@ -63,9 +53,7 @@ export default defineConfig({
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/js-path-externals-override/cjs',
-        },
+        distPath: 'dist/js-path-externals-override/cjs',
         externals: {
           '@/foo': './others/foo.cjs',
           '@/bar': './others/bar/index.cjs',
@@ -83,9 +71,7 @@ export default defineConfig({
         aliasStrategy: 'prefer-alias',
       },
       output: {
-        distPath: {
-          root: 'dist/js-path-alias-override/esm',
-        },
+        distPath: 'dist/js-path-alias-override/esm',
       },
     }),
     generateBundleCjsConfig({
@@ -98,18 +84,14 @@ export default defineConfig({
         aliasStrategy: 'prefer-alias',
       },
       output: {
-        distPath: {
-          root: 'dist/js-path-alias-override/cjs',
-        },
+        distPath: 'dist/js-path-alias-override/cjs',
       },
     }),
     // 4 js.extension: false
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/js-extension-false/esm',
-        },
+        distPath: 'dist/js-extension-false/esm',
       },
       redirect: {
         js: {
@@ -120,9 +102,7 @@ export default defineConfig({
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/js-extension-false/cjs',
-        },
+        distPath: 'dist/js-extension-false/cjs',
       },
       redirect: {
         js: {

--- a/tests/integration/redirect/style/rslib.config.ts
+++ b/tests/integration/redirect/style/rslib.config.ts
@@ -11,17 +11,13 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/default/esm',
-        },
+        distPath: 'dist/default/esm',
       },
     }),
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: 'dist/default/cjs',
-        },
+        distPath: 'dist/default/cjs',
       },
     }),
 
@@ -34,9 +30,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/style-path-false/esm',
-        },
+        distPath: 'dist/style-path-false/esm',
       },
     }),
     generateBundleCjsConfig({
@@ -47,9 +41,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: 'dist/style-path-false/cjs',
-        },
+        distPath: 'dist/style-path-false/cjs',
       },
     }),
     // 2. style.extension: false
@@ -67,9 +59,7 @@ export default defineConfig({
       },
       output: {
         copy: [{ from: './**/*.less', context: './src' }],
-        distPath: {
-          root: 'dist/style-extension-false/esm',
-        },
+        distPath: 'dist/style-extension-false/esm',
       },
     }),
     generateBundleCjsConfig({
@@ -86,9 +76,7 @@ export default defineConfig({
       },
       output: {
         copy: [{ from: './**/*.less', context: './src' }],
-        distPath: {
-          root: 'dist/style-extension-false/cjs',
-        },
+        distPath: 'dist/style-extension-false/cjs',
       },
     }),
 
@@ -109,9 +97,7 @@ export default defineConfig({
       },
       output: {
         copy: [{ from: './**/*.less', context: './src' }],
-        distPath: {
-          root: 'dist/style-path-extension-false/esm',
-        },
+        distPath: 'dist/style-path-extension-false/esm',
       },
     }),
     generateBundleCjsConfig({
@@ -128,9 +114,7 @@ export default defineConfig({
       },
       output: {
         copy: [{ from: './**/*.less', context: './src' }],
-        distPath: {
-          root: 'dist/style-path-extension-false/cjs',
-        },
+        distPath: 'dist/style-path-extension-false/cjs',
       },
     }),
   ],

--- a/tests/integration/resolve/with-condition-exports/rslib.config.ts
+++ b/tests/integration/resolve/with-condition-exports/rslib.config.ts
@@ -5,16 +5,12 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/node',
-        },
+        distPath: './dist/node',
       },
     }),
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/browser',
-        },
+        distPath: './dist/browser',
         target: 'web',
       },
     }),

--- a/tests/integration/resolve/with-main-fields/rslib.config.ts
+++ b/tests/integration/resolve/with-main-fields/rslib.config.ts
@@ -19,9 +19,7 @@ export default defineConfig({
     }),
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/node',
-        },
+        distPath: './dist/node',
       },
       source: {
         entry: {
@@ -31,9 +29,7 @@ export default defineConfig({
     }),
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/browser',
-        },
+        distPath: './dist/browser',
         target: 'web',
       },
       source: {

--- a/tests/integration/shims/esm/rslib.config.ts
+++ b/tests/integration/shims/esm/rslib.config.ts
@@ -11,9 +11,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/enabled/esm0',
-        },
+        distPath: './dist/enabled/esm0',
       },
     }),
     generateBundleEsmConfig({
@@ -25,9 +23,7 @@ export default defineConfig({
         },
       },
       output: {
-        distPath: {
-          root: './dist/enabled/esm1',
-        },
+        distPath: './dist/enabled/esm1',
       },
     }),
     generateBundleEsmConfig({
@@ -40,9 +36,7 @@ export default defineConfig({
       },
       output: {
         copy: [{ from: './src/ok.cjs' }],
-        distPath: {
-          root: './dist/enabled/esm2',
-        },
+        distPath: './dist/enabled/esm2',
       },
     }),
   ],

--- a/tests/integration/style/less/bundle-false/rslib.config.ts
+++ b/tests/integration/style/less/bundle-false/rslib.config.ts
@@ -8,17 +8,13 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: resolve(__dirname, 'dist/esm'),
-        },
+        distPath: resolve(__dirname, 'dist/esm'),
       },
     }),
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: resolve(__dirname, 'dist/cjs'),
-        },
+        distPath: resolve(__dirname, 'dist/cjs'),
       },
     }),
   ],

--- a/tests/integration/style/less/bundle-import/rslib.config.ts
+++ b/tests/integration/style/less/bundle-import/rslib.config.ts
@@ -7,16 +7,12 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: resolve(__dirname, 'dist/esm'),
-        },
+        distPath: resolve(__dirname, 'dist/esm'),
       },
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: resolve(__dirname, 'dist/cjs'),
-        },
+        distPath: resolve(__dirname, 'dist/cjs'),
       },
     }),
   ],

--- a/tests/integration/style/less/bundle/rslib.config.ts
+++ b/tests/integration/style/less/bundle/rslib.config.ts
@@ -7,16 +7,12 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: resolve(__dirname, 'dist/esm'),
-        },
+        distPath: resolve(__dirname, 'dist/esm'),
       },
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: resolve(__dirname, 'dist/cjs'),
-        },
+        distPath: resolve(__dirname, 'dist/cjs'),
       },
     }),
   ],

--- a/tests/integration/style/sass/bundle-false/rslib.config.ts
+++ b/tests/integration/style/sass/bundle-false/rslib.config.ts
@@ -8,17 +8,13 @@ export default defineConfig({
     generateBundleEsmConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: resolve(__dirname, 'dist/esm'),
-        },
+        distPath: resolve(__dirname, 'dist/esm'),
       },
     }),
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        distPath: {
-          root: resolve(__dirname, 'dist/cjs'),
-        },
+        distPath: resolve(__dirname, 'dist/cjs'),
       },
     }),
   ],

--- a/tests/integration/syntax/config/rslib.config.ts
+++ b/tests/integration/syntax/config/rslib.config.ts
@@ -6,25 +6,25 @@ export default defineConfig({
     generateBundleEsmConfig({
       syntax: 'es2015',
       output: {
-        distPath: { root: 'dist/esm/0' },
+        distPath: 'dist/esm/0',
       },
     }),
     generateBundleEsmConfig({
       syntax: ['es2022'],
       output: {
-        distPath: { root: 'dist/esm/1' },
+        distPath: 'dist/esm/1',
       },
     }),
     generateBundleCjsConfig({
       syntax: ['node 20'],
       output: {
-        distPath: { root: 'dist/cjs/0' },
+        distPath: 'dist/cjs/0',
       },
     }),
     generateBundleCjsConfig({
       syntax: ['node 20', 'es5'],
       output: {
-        distPath: { root: 'dist/cjs/1' },
+        distPath: 'dist/cjs/1',
       },
     }),
   ],

--- a/tests/integration/transform-import/arco-design/rslib.config.ts
+++ b/tests/integration/transform-import/arco-design/rslib.config.ts
@@ -5,31 +5,23 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundle',
-        },
+        distPath: './dist/esm/bundle',
       },
     }),
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundleless',
-        },
+        distPath: './dist/esm/bundleless',
       },
       bundle: false,
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs/bundle',
-        },
+        distPath: './dist/cjs/bundle',
       },
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs/bundleless',
-        },
+        distPath: './dist/cjs/bundleless',
       },
       bundle: false,
     }),

--- a/tests/integration/transform-import/lodash/rslib.config.ts
+++ b/tests/integration/transform-import/lodash/rslib.config.ts
@@ -5,31 +5,23 @@ export default defineConfig({
   lib: [
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundle',
-        },
+        distPath: './dist/esm/bundle',
       },
     }),
     generateBundleEsmConfig({
       output: {
-        distPath: {
-          root: './dist/esm/bundleless',
-        },
+        distPath: './dist/esm/bundleless',
       },
       bundle: false,
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs/bundle',
-        },
+        distPath: './dist/cjs/bundle',
       },
     }),
     generateBundleCjsConfig({
       output: {
-        distPath: {
-          root: './dist/cjs/bundleless',
-        },
+        distPath: './dist/cjs/bundleless',
       },
       bundle: false,
     }),

--- a/tests/integration/umd-library-name/rslib.config.ts
+++ b/tests/integration/umd-library-name/rslib.config.ts
@@ -6,17 +6,13 @@ export default defineConfig({
     generateBundleUmdConfig({
       umdName: 'MyLibrary',
       output: {
-        distPath: {
-          root: './dist/string',
-        },
+        distPath: './dist/string',
       },
     }),
     generateBundleUmdConfig({
       umdName: ['MyLibrary', 'Utils'],
       output: {
-        distPath: {
-          root: './dist/array',
-        },
+        distPath: './dist/array',
       },
     }),
   ],

--- a/tests/integration/vue/rslib.config.ts
+++ b/tests/integration/vue/rslib.config.ts
@@ -12,9 +12,7 @@ export default defineConfig({
       bundle: false,
       output: {
         target: 'web',
-        distPath: {
-          root: 'dist/bundleless',
-        },
+        distPath: 'dist/bundleless',
       },
     }),
     // bundle, ESM
@@ -22,9 +20,7 @@ export default defineConfig({
       plugins: [pluginUnpluginVue()],
       output: {
         target: 'web',
-        distPath: {
-          root: 'dist/bundle',
-        },
+        distPath: 'dist/bundle',
       },
     }),
   ],

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -41,9 +41,7 @@ export function getCwdByExample(exampleName: string) {
 export function generateBundleEsmConfig(config: LibConfig = {}): LibConfig {
   const esmBasicConfig: LibConfig = {
     output: {
-      distPath: {
-        root: './dist/esm',
-      },
+      distPath: './dist/esm',
     },
   };
 
@@ -54,9 +52,7 @@ export function generateBundleCjsConfig(config: LibConfig = {}): LibConfig {
   const cjsBasicConfig: LibConfig = {
     format: 'cjs',
     output: {
-      distPath: {
-        root: './dist/cjs',
-      },
+      distPath: './dist/cjs',
     },
   };
 
@@ -70,9 +66,7 @@ export function generateBundleMFConfig(
   const mfBasicConfig: LibConfig = {
     format: 'mf',
     output: {
-      distPath: {
-        root: './dist/mf',
-      },
+      distPath: './dist/mf',
     },
     plugins: [pluginModuleFederation(options, {})],
   };
@@ -84,9 +78,7 @@ export function generateBundleUmdConfig(config: LibConfig = {}): LibConfig {
   const umdBasicConfig: LibConfig = {
     format: 'umd',
     output: {
-      distPath: {
-        root: './dist/umd',
-      },
+      distPath: './dist/umd',
     },
   };
 
@@ -97,9 +89,7 @@ export function generateBundleIifeConfig(config: LibConfig = {}): LibConfig {
   const iifeBasicConfig: LibConfig = {
     format: 'iife',
     output: {
-      distPath: {
-        root: './dist/iife',
-      },
+      distPath: './dist/iife',
     },
   };
 

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -37,13 +37,11 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     // ... other format
-    // [!code highlight:37]
+    // [!code highlight:33]
     {
       format: 'mf',
       output: {
-        distPath: {
-          root: './dist/mf',
-        },
+        distPath: './dist/mf',
         // for production, add online assetPrefix here
         assetPrefix: 'http://localhost:3001/mf',
       },

--- a/website/docs/en/guide/basic/output-format.mdx
+++ b/website/docs/en/guide/basic/output-format.mdx
@@ -109,9 +109,7 @@ export default defineConfig({
         externals: {
           react: 'React',
         },
-        distPath: {
-          root: './dist/umd',
-        },
+        distPath: './dist/umd',
       },
     },
   ],

--- a/website/docs/en/guide/solution/nodejs.mdx
+++ b/website/docs/en/guide/solution/nodejs.mdx
@@ -33,17 +33,13 @@ export default defineConfig({
     {
       format: 'esm',
       output: {
-        distPath: {
-          root: './dist/esm',
-        },
+        distPath: './dist/esm',
       },
     },
     {
       format: 'cjs',
       output: {
-        distPath: {
-          root: './dist/cjs',
-        },
+        distPath: './dist/cjs',
       },
     },
   ],

--- a/website/docs/zh/guide/advanced/module-federation.mdx
+++ b/website/docs/zh/guide/advanced/module-federation.mdx
@@ -37,13 +37,11 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     // ... 其他 format
-    // [!code highlight:37]
+    // [!code highlight:33]
     {
       format: 'mf',
       output: {
-        distPath: {
-          root: './dist/mf',
-        },
+        distPath: './dist/mf',
         // production 时, 在这里使用线上 assetPrefix
         assetPrefix: 'http://localhost:3001/mf',
       },

--- a/website/docs/zh/guide/basic/output-format.mdx
+++ b/website/docs/zh/guide/basic/output-format.mdx
@@ -104,9 +104,7 @@ export default defineConfig({
         externals: {
           react: 'React',
         },
-        distPath: {
-          root: './dist/umd',
-        },
+        distPath: './dist/umd',
       },
     },
   ],

--- a/website/docs/zh/guide/solution/nodejs.mdx
+++ b/website/docs/zh/guide/solution/nodejs.mdx
@@ -33,17 +33,13 @@ export default defineConfig({
     {
       format: 'esm',
       output: {
-        distPath: {
-          root: './dist/esm',
-        },
+        distPath: './dist/esm',
       },
     },
     {
       format: 'cjs',
       output: {
-        distPath: {
-          root: './dist/cjs',
-        },
+        distPath: './dist/cjs',
       },
     },
   ],


### PR DESCRIPTION
## Summary

Use shorter string value for `output.distPath`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
