### PR TITLE
chore: disable lazyCompilation to make mf e2e case stable

### DIFF
--- a/examples/module-federation/mf-host/rsbuild.config.ts
+++ b/examples/module-federation/mf-host/rsbuild.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
+  dev: {
+    lazyCompilation: false,
+  },
   plugins: [
     pluginReact(),
     pluginModuleFederation(


### PR DESCRIPTION
## Summary

disbale lazyCompilation to make mf e2e case stable

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
