### PR TITLE
fix: cjs `import.meta.url` shims in async chunks

### DIFF
--- a/packages/core/src/plugins/EntryChunkPlugin.ts
+++ b/packages/core/src/plugins/EntryChunkPlugin.ts
@@ -109,10 +109,10 @@ class EntryChunkPlugin {
         const isJs = JS_EXTENSIONS_PATTERN.test(filename);
         if (!isJs) return;
 
+        this.shimsInjectedAssets.add(filename);
+
         const name = chunk.name;
         if (!name) return;
-
-        this.shimsInjectedAssets.add(filename);
 
         const shebangEntry = this.shebangEntries[name];
         if (shebangEntry) {

--- a/tests/integration/shims/cjs/rslib.config.ts
+++ b/tests/integration/shims/cjs/rslib.config.ts
@@ -6,12 +6,18 @@ export default defineConfig({
     generateBundleEsmConfig(),
     generateBundleCjsConfig({
       shims: {
-        cjs: { 'import.meta.url': true },
+        cjs: {
+          'import.meta.url': true,
+        },
       },
     }),
   ],
   output: {
-    copy: [{ from: 'src/ok.cjs' }],
+    copy: [
+      {
+        from: 'src/ok.cjs',
+      },
+    ],
   },
   source: {
     entry: {

--- a/tests/integration/shims/cjs/src/dynamic.ts
+++ b/tests/integration/shims/cjs/src/dynamic.ts
@@ -1,0 +1,3 @@
+const dynamic = import.meta.url;
+
+export { dynamic };

--- a/tests/integration/shims/cjs/src/index.ts
+++ b/tests/integration/shims/cjs/src/index.ts
@@ -4,6 +4,11 @@ const importMetaUrl = import.meta.url;
 const require = createRequire(import.meta.url);
 const requiredModule = require('./ok.cjs');
 
+const dynamicImportMetaUrl = async () => {
+  const { dynamic } = await import('./dynamic');
+  return dynamic;
+};
+
 // https://github.com/web-infra-dev/rslib/issues/425
 import { fileURLToPath } from 'url';
 
@@ -13,4 +18,4 @@ console.log(__filename);
 // https://github.com/web-infra-dev/rslib/pull/399
 export const module = null;
 
-export { importMetaUrl, requiredModule, __filename };
+export { importMetaUrl, requiredModule, dynamicImportMetaUrl, __filename };


### PR DESCRIPTION
## Summary

`import.meta.url` shims should work correctly in async chunks since `chunk.name` may be undefined if no magic comments set.

## Related Links

close: https://github.com/web-infra-dev/rslib/issues/1277

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
