### PR TITLE
chore: bump Rsbuild 1.6.0-beta.1 and remove special `output.distPath` merge logic

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.21.1",
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-react": "^1.4.1",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.21.1",
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-react": "^1.4.1",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1905,16 +1905,6 @@ export async function composeCreateRsbuildConfig(
     userConfig.output ??= {};
     delete userConfig.output.externals;
 
-    // Convert output.distPath to an object to ensure it merges correctly with the built-in constant config
-    if (
-      userConfig.output.distPath &&
-      typeof userConfig.output.distPath === 'string'
-    ) {
-      userConfig.output.distPath = {
-        root: userConfig.output.distPath,
-      };
-    }
-
     const config: RsbuildConfigWithLibInfo = {
       format: libConfig.format ?? 'esm',
       // The merge order represents the priority of the configuration

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -2,33 +2,6 @@
 
 exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config in each format > inspected Rsbuild configs 1`] = `
 "{
-  dev: {
-    hmr: true,
-    liveReload: true,
-    browserLogs: true,
-    watchFiles: [
-      {
-        paths: [
-          '<WORKSPACE>/tsconfig.json'
-        ],
-        type: 'reload-server'
-      }
-    ],
-    assetPrefix: '/',
-    writeToDisk: false,
-    cliShortcuts: false,
-    client: {
-      path: '/rsbuild-hmr',
-      port: '',
-      host: '',
-      overlay: true,
-      reconnect: 100
-    },
-    lazyCompilation: {
-      imports: true,
-      entries: false
-    }
-  },
   server: {
     port: 3000,
     host: '0.0.0.0',
@@ -86,6 +59,57 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     },
     tsconfigPath: '<WORKSPACE>/tsconfig.json'
   },
+  tools: {
+    cssExtract: {
+      loaderOptions: {},
+      pluginOptions: {
+        ignoreOrder: true
+      }
+    }
+  },
+  security: {
+    nonce: '',
+    sri: {
+      enable: false
+    }
+  },
+  performance: {
+    profile: false,
+    printFileSize: true,
+    removeConsole: false,
+    removeMomentLocale: false,
+    chunkSplit: {
+      strategy: 'split-by-experience'
+    }
+  },
+  mode: 'production',
+  dev: {
+    hmr: true,
+    liveReload: true,
+    browserLogs: true,
+    watchFiles: [
+      {
+        paths: [
+          '<WORKSPACE>/tsconfig.json'
+        ],
+        type: 'reload-server'
+      }
+    ],
+    assetPrefix: '/',
+    writeToDisk: false,
+    cliShortcuts: false,
+    client: {
+      path: '/rsbuild-hmr',
+      port: '',
+      host: '',
+      overlay: true,
+      reconnect: 100
+    },
+    lazyCompilation: {
+      imports: true,
+      entries: false
+    }
+  },
   output: {
     target: 'web',
     cleanDistPath: 'auto',
@@ -132,30 +156,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     },
     emitAssets: true
   },
-  tools: {
-    cssExtract: {
-      loaderOptions: {},
-      pluginOptions: {
-        ignoreOrder: true
-      }
-    }
-  },
-  security: {
-    nonce: '',
-    sri: {
-      enable: false
-    }
-  },
-  performance: {
-    profile: false,
-    printFileSize: true,
-    removeConsole: false,
-    removeMomentLocale: false,
-    chunkSplit: {
-      strategy: 'split-by-experience'
-    }
-  },
-  mode: 'production',
   root: '<WORKSPACE>',
   plugins: [
     {
@@ -318,7 +318,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    lazyBarrel: true,
     inlineEnum: true,
     inlineConst: true,
     typeReexportsPresence: true,
@@ -1021,7 +1020,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    lazyBarrel: true,
     inlineEnum: true,
     inlineConst: true,
     typeReexportsPresence: true,
@@ -1718,7 +1716,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    lazyBarrel: true,
     inlineEnum: true,
     inlineConst: true,
     typeReexportsPresence: true,
@@ -2320,7 +2317,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    lazyBarrel: true,
     inlineEnum: true,
     inlineConst: true,
     typeReexportsPresence: true,
@@ -2923,7 +2919,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    lazyBarrel: true,
     inlineEnum: true,
     inlineConst: true,
     typeReexportsPresence: true,
@@ -3481,6 +3476,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
 [
   {
     "config": {
+      "dev": undefined,
       "output": {
         "assetPrefix": "auto",
         "dataUriLimit": 0,
@@ -3767,6 +3763,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   {
     "config": {
+      "dev": undefined,
       "output": {
         "assetPrefix": "auto",
         "dataUriLimit": 0,
@@ -4050,6 +4047,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   {
     "config": {
+      "dev": undefined,
       "output": {
         "distPath": {
           "css": "./",
@@ -4294,6 +4292,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   {
     "config": {
+      "dev": undefined,
       "output": {
         "distPath": {
           "css": "./",

--- a/packages/create-rslib/fragments/tools/storybook-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@storybook/addon-docs": "^9.1.13",
     "@storybook/addon-onboarding": "^9.1.13",
     "@storybook/react": "^9.1.13",

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@storybook/addon-docs": "^9.1.13",
     "@storybook/addon-onboarding": "^9.1.13",
     "@storybook/react": "^9.1.13",

--- a/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@storybook/addon-docs": "^9.1.13",
     "@storybook/addon-onboarding": "^9.1.13",
     "@storybook/vue3": "^9.1.13",

--- a/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
+++ b/packages/create-rslib/fragments/tools/storybook-vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@storybook/addon-docs": "^9.1.13",
     "@storybook/addon-onboarding": "^9.1.13",
     "@storybook/vue3": "^9.1.13",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
@@ -18,7 +18,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-react": "^1.4.1",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.5.4",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-react": "^1.4.1",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.5.4",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-react": "^1.4.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.13",

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-react": "^1.4.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.13",

--- a/packages/create-rslib/template-[react]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-js/package.json
@@ -17,7 +17,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-react": "^1.4.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.13",

--- a/packages/create-rslib/template-[react]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-react": "^1.4.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.13",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
@@ -20,7 +20,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.5.4",
     "@storybook/addon-docs": "^9.1.13",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rslib/core": "workspace:*",
     "@rstest/core": "^0.5.4",
     "@storybook/addon-docs": "^9.1.13",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-js/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.13",
     "@storybook/addon-onboarding": "^9.1.13",

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.13",
     "@storybook/addon-onboarding": "^9.1.13",

--- a/packages/create-rslib/template-[vue]-[storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-js/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.13",
     "@storybook/addon-onboarding": "^9.1.13",

--- a/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[storybook]-ts/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^9.1.13",
     "@storybook/addon-onboarding": "^9.1.13",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.53.1",
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rslib/tsconfig": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20251021.1",
     "magic-string": "^0.30.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,13 +94,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.21.1
-        version: 0.21.1(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+        version: 0.21.1(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@rsbuild/core':
-        specifier: 1.6.0-beta.0
-        version: 1.6.0-beta.0
+        specifier: 1.6.0-beta.1
+        version: 1.6.0-beta.1
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@types/react':
         specifier: ^19.2.2
         version: 19.2.2
@@ -115,16 +115,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.21.1
-        version: 0.21.1(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+        version: 0.21.1(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.21.1
-        version: 0.21.1(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+        version: 0.21.1(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@module-federation/storybook-addon':
         specifier: ^4.0.33
-        version: 4.0.33(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(webpack-virtual-modules@0.6.2)
+        version: 4.0.33(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(webpack-virtual-modules@0.6.2)
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -145,10 +145,10 @@ importers:
         version: 9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1))
       storybook-addon-rslib:
         specifier: ^2.1.2
-        version: 2.1.2(@rsbuild/core@1.6.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3))(typescript@5.9.3)
+        version: 2.1.2(@rsbuild/core@1.6.0-beta.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3))(typescript@5.9.3)
       storybook-react-rsbuild:
         specifier: ^2.1.2
-        version: 2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.46.2)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
+        version: 2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.46.2)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -161,13 +161,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.21.1
-        version: 0.21.1(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+        version: 0.21.1(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@rsbuild/core':
-        specifier: 1.6.0-beta.0
-        version: 1.6.0-beta.0
+        specifier: 1.6.0-beta.1
+        version: 1.6.0-beta.1
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@types/react':
         specifier: ^19.2.2
         version: 19.2.2
@@ -182,10 +182,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@1.6.0-beta.0)(preact@10.27.2)
+        version: 1.5.2(@rsbuild/core@1.6.0-beta.1)(preact@10.27.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.0(@rsbuild/core@1.6.0-beta.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -197,10 +197,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.0(@rsbuild/core@1.6.0-beta.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -215,10 +215,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.0(@rsbuild/core@1.6.0-beta.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -233,10 +233,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.0(@rsbuild/core@1.6.0-beta.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -251,13 +251,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@1.6.0-beta.0)
+        version: 1.0.6(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.0(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-solid':
         specifier: ^1.0.6
-        version: 1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.6.0-beta.0)(solid-js@1.9.9)
+        version: 1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.6.0-beta.1)(solid-js@1.9.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -302,16 +302,16 @@ importers:
         version: 9.1.13(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(vue@3.5.22(typescript@5.9.3))
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.6.0-beta.0)(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(vue@3.5.22(typescript@5.9.3))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.6.0-beta.1)(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(vue@3.5.22(typescript@5.9.3))(yaml@2.6.1)
       storybook:
         specifier: ^9.1.13
         version: 9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1))
       storybook-addon-rslib:
         specifier: ^2.1.2
-        version: 2.1.2(@rsbuild/core@1.6.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3))(typescript@5.9.3)
+        version: 2.1.2(@rsbuild/core@1.6.0-beta.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3))(typescript@5.9.3)
       storybook-vue3-rsbuild:
         specifier: ^2.1.2
-        version: 2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))
+        version: 2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -325,15 +325,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: 1.6.0-beta.0
-        version: 1.6.0-beta.0
+        specifier: 1.6.0-beta.1
+        version: 1.6.0-beta.1
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.21.1
-        version: 0.21.1(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+        version: 0.21.1(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -363,7 +363,7 @@ importers:
         version: 1.4.2(typescript@5.9.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.3
-        version: 0.3.3(@rsbuild/core@1.6.0-beta.0)
+        version: 0.3.3(@rsbuild/core@1.6.0-beta.1)
       rslib:
         specifier: npm:@rslib/core@0.16.0
         version: '@rslib/core@0.16.0(@microsoft/api-extractor@7.53.1(@types/node@22.18.12))(@typescript/native-preview@7.0.0-dev.20251021.1)(typescript@5.9.3)'
@@ -421,8 +421,8 @@ importers:
         specifier: ^7.53.1
         version: 7.53.1(@types/node@22.18.12)
       '@rsbuild/core':
-        specifier: 1.6.0-beta.0
-        version: 1.6.0-beta.0
+        specifier: 1.6.0-beta.1
+        version: 1.6.0-beta.1
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -440,7 +440,7 @@ importers:
         version: 1.4.2(typescript@5.9.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.3
-        version: 0.3.3(@rsbuild/core@1.6.0-beta.0)
+        version: 0.3.3(@rsbuild/core@1.6.0-beta.1)
       rslib:
         specifier: npm:@rslib/core@0.16.0
         version: '@rslib/core@0.16.0(@microsoft/api-extractor@7.53.1(@types/node@22.18.12))(@typescript/native-preview@7.0.0-dev.20251021.1)(typescript@5.9.3)'
@@ -470,31 +470,31 @@ importers:
         version: 4.0.1(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.21.1
-        version: 0.21.1(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+        version: 0.21.1(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@playwright/test':
         specifier: 1.56.1
         version: 1.56.1
       '@rsbuild/core':
-        specifier: 1.6.0-beta.0
-        version: 1.6.0-beta.0
+        specifier: 1.6.0-beta.1
+        version: 1.6.0-beta.1
       '@rsbuild/plugin-less':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@1.6.0-beta.0)
+        version: 1.5.0(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.0(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-toml':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.1.1(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.1.1
-        version: 1.1.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.1.1(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.3
-        version: 1.0.3(@rsbuild/core@1.6.0-beta.0)
+        version: 1.0.3(@rsbuild/core@1.6.0-beta.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -556,7 +556,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
 
   tests/integration/asset/json: {}
 
@@ -572,10 +572,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.6.0-beta.0)(typescript@5.9.3)
+        version: 1.2.2(@rsbuild/core@1.6.0-beta.1)(typescript@5.9.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -669,10 +669,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@1.6.0-beta.0)(typescript@5.9.3)
+        version: 1.2.2(@rsbuild/core@1.6.0-beta.1)(typescript@5.9.3)
 
   tests/integration/cli/build: {}
 
@@ -935,11 +935,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: 1.6.0-beta.0
-        version: 1.6.0-beta.0
+        specifier: 1.6.0-beta.1
+        version: 1.6.0-beta.1
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.2
-        version: 1.4.2(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.2(@rsbuild/core@1.6.0-beta.1)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -948,11 +948,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: 1.6.0-beta.0
-        version: 1.6.0-beta.0
+        specifier: 1.6.0-beta.1
+        version: 1.6.0-beta.1
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.2
-        version: 1.4.2(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.2(@rsbuild/core@1.6.0-beta.1)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -986,7 +986,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@1.6.0-beta.0)
+        version: 1.0.6(@rsbuild/core@1.6.0-beta.1)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.13.0
         version: 0.13.0(@babel/core@7.28.0)
@@ -999,7 +999,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1138,13 +1138,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))
+        version: 1.2.0(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.2.0
-        version: 1.2.0(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))
+        version: 1.2.0(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -1207,10 +1207,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@1.6.0-beta.0)
+        version: 1.5.0(@rsbuild/core@1.6.0-beta.1)
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@1.6.0-beta.0)(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(vue@3.5.22(typescript@5.9.3))(yaml@2.6.1)
+        version: 0.1.0(@rsbuild/core@1.6.0-beta.1)(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(vue@3.5.22(typescript@5.9.3))(yaml@2.6.1)
       vue:
         specifier: ^3.5.22
         version: 3.5.22(typescript@5.9.3)
@@ -1223,16 +1223,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.21.1
-        version: 0.21.1(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+        version: 0.21.1(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@rsbuild/core':
-        specifier: 1.6.0-beta.0
-        version: 1.6.0-beta.0
+        specifier: 1.6.0-beta.1
+        version: 1.6.0-beta.1
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
-        version: 1.4.1(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.4.0
-        version: 1.4.0(@rsbuild/core@1.6.0-beta.0)
+        version: 1.4.0(@rsbuild/core@1.6.0-beta.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1280,10 +1280,10 @@ importers:
         version: 19.2.0(react@19.2.0)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.4
-        version: 1.0.4(@rsbuild/core@1.6.0-beta.0)
+        version: 1.0.4(@rsbuild/core@1.6.0-beta.1)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.0
-        version: 1.1.0(@rsbuild/core@1.6.0-beta.0)
+        version: 1.1.0(@rsbuild/core@1.6.0-beta.1)
       rspress-plugin-font-open-sans:
         specifier: 1.0.3
         version: 1.0.3(@rspress/core@2.0.0-beta.34(@types/react@19.2.2))
@@ -2591,6 +2591,11 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
+  '@rsbuild/core@1.6.0-beta.1':
+    resolution: {integrity: sha512-UjQnvXDW9m/hS4DP66ubGIMVjK2PzYx8tzgiinrO0kjNCr9i8KWuJSJGUWyczFMpSsXxp20LnuTxtx7kiGiYdA==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
   '@rsbuild/plugin-babel@1.0.6':
     resolution: {integrity: sha512-tWnqG938MedKJx7U4F1lHb156VDtNzj7mSsi2ZoxZVBnECQE01/V6QTN1XKw7nWunGyGoETb+nQBGc+fkVZjvw==}
     peerDependencies:
@@ -2733,6 +2738,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@1.6.0-beta.1':
+    resolution: {integrity: sha512-RXQ97iVXgvQAb/cq265z/txdHOOJ6fQQRBfnn0IfMNk7gT4W2rvsLrOqQpwtMKxYV4N/mfWnycfAVa0OOf22Gg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.5.0':
     resolution: {integrity: sha512-poGuQsGKCMQqSswgrz8X+frqMVTdmtzUDyvi/p9BLwW+2DwWgmywU8jwE+BYtjfWp1tErBSTlLxmEPQTdcIQgQ==}
     cpu: [x64]
@@ -2745,6 +2755,11 @@ packages:
 
   '@rspack/binding-darwin-x64@1.6.0-beta.0':
     resolution: {integrity: sha512-4rHw6IHpWO04C22lEQK34vk6H+CtBkVQK9pEoA4gr+zMX8H+Bfl8liVQgeaAgwRqD7ipDo3jXGLaakVGktDexw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.6.0-beta.1':
+    resolution: {integrity: sha512-Ulb7Jyyvuf28BwPXZKSbglaSK/19b32ItWT+pgswhbFsnfhzAQQd7Jo7TUEvHNHAdVDiES8VFlrnOhOSnwEOLg==}
     cpu: [x64]
     os: [darwin]
 
@@ -2763,6 +2778,11 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@1.6.0-beta.1':
+    resolution: {integrity: sha512-UyUoh5RXHTWCktqPVnqoc5rwlWyLkWqGu6ga+iyJHDxdxlrHFfwJnTSnCd4y8cRadf7CrmjHElxE61GU3WCYhw==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-musl@1.5.0':
     resolution: {integrity: sha512-bH7UwkbACDYT37YnN9kkhaF9niFFK9ndcdNvYFFr1oUT4W9Ie3V9b41EXijqp3pyh0mDSeeLPFY0aEx1t3e7Pw==}
     cpu: [arm64]
@@ -2775,6 +2795,11 @@ packages:
 
   '@rspack/binding-linux-arm64-musl@1.6.0-beta.0':
     resolution: {integrity: sha512-nxkqLF8vz62NR65wxxMpdRDXce6q36R3BHvibyXlElSbSPSPL0n7gsOW2yMeCB5q812DRkzm2c9RNkpQ8nfXwQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.6.0-beta.1':
+    resolution: {integrity: sha512-JAXVKHQieN4Ruvs7MstvsPUtRBSAROqJ0abCh4rXdV+FzncKp/ZkdfjQploDhBWtWfU8rPvIjaxeZcPfHMI5/A==}
     cpu: [arm64]
     os: [linux]
 
@@ -2793,6 +2818,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@1.6.0-beta.1':
+    resolution: {integrity: sha512-LqAos71CJS5/V4knX9T7T68oGz0XPRZ2IJmI3jEByRlNcyZdxYeQ7Dw09JO9Y5Xj0T+0cudOeL2MxHcD3gTF/w==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@1.5.0':
     resolution: {integrity: sha512-mv65jYvcyYPkPZJ9kjSvTAcH0o7C5jfICWCQcMmN1tCGD3b8gmf9GqSZ8e+W/JkuvrJ05qTo/PvEq9nhu+pNIg==}
     cpu: [x64]
@@ -2808,6 +2838,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-musl@1.6.0-beta.1':
+    resolution: {integrity: sha512-E4dRMzIHYaoYkgmDTFLrgnGtdspbAuVbLfaPF9AWW5YkQn52obGAgbbNb1wi1JJ5f29nTBoLauYCucEO5IGFvA==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-wasm32-wasi@1.5.0':
     resolution: {integrity: sha512-8rVpl6xfaAFJgo1wCd+emksfl+/8nlehrtkmjY9bj79Ou+kp07L9e1B+UU0jfs8e7aLPntQuF68kzLHwYLzWIQ==}
     cpu: [wasm32]
@@ -2818,6 +2853,10 @@ packages:
 
   '@rspack/binding-wasm32-wasi@1.6.0-beta.0':
     resolution: {integrity: sha512-0sSaIM39lSNthIvZsDA7WDnwdP4/4rRH4QyN4/DLUOCdci5xUSUSz/MsRXA+smI41qu4sh9yU/jRT8pq9bSWAQ==}
+    cpu: [wasm32]
+
+  '@rspack/binding-wasm32-wasi@1.6.0-beta.1':
+    resolution: {integrity: sha512-PaKEjXOkYprSFlgdgVm/P3pv2E8nAQx9WSGgPmMVIAtxo3Cyz0wwFf0f1Bp9wCw0KkIWgi+9lz8oXNkgKZilug==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.5.0':
@@ -2832,6 +2871,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@1.6.0-beta.0':
     resolution: {integrity: sha512-QqtnwHhpst37I3eQtx1FqpWCQCkigg2M73QUDvjhCE+opb1X46XK+kZOyt5qO0fKRdOgtxTcTVLLzRUWuT4t4A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@1.6.0-beta.1':
+    resolution: {integrity: sha512-HWz9Qxrjf3TKLCwiFPJaqw+STvEsBvFYZvBXZ8umIZXqtdfgQP5d91V8JRG4Gg1J6xnGC/KhZexxBuR/y64aBA==}
     cpu: [arm64]
     os: [win32]
 
@@ -2850,6 +2894,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@1.6.0-beta.1':
+    resolution: {integrity: sha512-alAZHRuyPzCH3rJpEC9EBE60EZPnQjzltZ6HN8lsCidACMFTzaLBvuzZyYQah+Zm58O22ok2Eon4BpP1Coizgg==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@1.5.0':
     resolution: {integrity: sha512-V4fcPVYWJgDkIkSsFwmUdwC9lkL8+1dzDOwyTWe6KW2MYHF2D148WPHNyVVE6gum12TShpbIsh0j4NiiMhkMtw==}
     cpu: [x64]
@@ -2865,6 +2914,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@1.6.0-beta.1':
+    resolution: {integrity: sha512-/WBzhed0Cu0o9XQ9caGgWwzyNnnPKlENlExa2aGbRCbB14/+CwfhCyETyKlc/ID+dtlV/eHKTC9cckUNI8NpTQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@1.5.0':
     resolution: {integrity: sha512-UGXQmwEu2gdO+tnGv2q4rOWJdWioy6dlLXeZOLYAZVh3mrfKJhZWtDEygX9hCdE5thWNRTlEvx30QQchJAszIQ==}
 
@@ -2873,6 +2927,9 @@ packages:
 
   '@rspack/binding@1.6.0-beta.0':
     resolution: {integrity: sha512-8CoJCSkWhhgAcmymvkvXb6fHV1zfRnx68mW/tFD/pN2BzwLrAqzvq9PUhJw0MLq4Dg+RIYG6xjzDDp3fkt574Q==}
+
+  '@rspack/binding@1.6.0-beta.1':
+    resolution: {integrity: sha512-r3L60ekkDLM5qoRjCMrqsgwU9SQ5e8oA/Omltu/FEEUspIVHawPvAqNZvAXnGB+FoNxM8YgdRRh12PAwXJww0A==}
 
   '@rspack/core@1.5.0':
     resolution: {integrity: sha512-eEtiKV+CUcAtnt1K+eiHDzmBXQcNM8CfCXOzr0+gHGp4w4Zks2B8RF36sYD03MM2bg8VRXXsf0MicQ8FvRMCOg==}
@@ -2894,6 +2951,15 @@ packages:
 
   '@rspack/core@1.6.0-beta.0':
     resolution: {integrity: sha512-wrGg90zjX5/cf2hKh2La0q3++twOBnk6z2WkWWcd1Jz5F9OcbHWyn+9yGHJI921A0AziC0pv7P1MmucmG3e7fA==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@1.6.0-beta.1':
+    resolution: {integrity: sha512-2ff8XWonPPHyQ6mEWogMspg+Sul3lXZUfNQVrbYSjfNpi8CeDV0/ZtRbHHbAXiy6pz5fvBFL6X+i/ATckjTYBw==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -8599,7 +8665,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.21.1(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))':
+  '@module-federation/enhanced@0.21.1(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.21.1
       '@module-federation/cli': 0.21.1(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
@@ -8609,7 +8675,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.21.1(@module-federation/runtime-tools@0.21.1)
       '@module-federation/managers': 0.21.1
       '@module-federation/manifest': 0.21.1(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
-      '@module-federation/rspack': 0.21.1(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+      '@module-federation/rspack': 0.21.1(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@module-federation/runtime-tools': 0.21.1
       '@module-federation/sdk': 0.21.1
       btoa: 1.2.1
@@ -8658,9 +8724,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.20(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))':
+  '@module-federation/node@2.7.20(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))':
     dependencies:
-      '@module-federation/enhanced': 0.21.1(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+      '@module-federation/enhanced': 0.21.1(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@module-federation/runtime': 0.21.1
       '@module-federation/sdk': 0.21.1
       btoa: 1.2.1
@@ -8678,14 +8744,14 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.21.1(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))':
+  '@module-federation/rsbuild-plugin@0.21.1(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))':
     dependencies:
-      '@module-federation/enhanced': 0.21.1(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
-      '@module-federation/node': 2.7.20(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+      '@module-federation/enhanced': 0.21.1(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+      '@module-federation/node': 2.7.20(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@module-federation/sdk': 0.21.1
       fs-extra: 11.3.0
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8699,7 +8765,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.21.1(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))':
+  '@module-federation/rspack@0.21.1(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.21.1
       '@module-federation/dts-plugin': 0.21.1(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
@@ -8708,7 +8774,7 @@ snapshots:
       '@module-federation/manifest': 0.21.1(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@module-federation/runtime-tools': 0.21.1
       '@module-federation/sdk': 0.21.1
-      '@rspack/core': 1.6.0-beta.0(@swc/helpers@0.5.17)
+      '@rspack/core': 1.6.0-beta.1(@swc/helpers@0.5.17)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.3
@@ -8773,12 +8839,12 @@ snapshots:
 
   '@module-federation/sdk@0.21.1': {}
 
-  '@module-federation/storybook-addon@4.0.33(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@4.0.33(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 0.21.1(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
+      '@module-federation/enhanced': 0.21.1(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(vue-tsc@3.1.1(typescript@5.9.3))
       '@module-federation/sdk': 0.21.1
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -9054,13 +9120,21 @@ snapshots:
       core-js: 3.46.0
       jiti: 2.6.1
 
-  '@rsbuild/plugin-babel@1.0.6(@rsbuild/core@1.6.0-beta.0)':
+  '@rsbuild/core@1.6.0-beta.1':
+    dependencies:
+      '@rspack/core': 1.6.0-beta.1(@swc/helpers@0.5.17)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.17
+      core-js: 3.46.0
+      jiti: 2.6.1
+
+  '@rsbuild/plugin-babel@1.0.6(@rsbuild/core@1.6.0-beta.1)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.0)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -9068,13 +9142,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.5.0(@rsbuild/core@1.6.0-beta.0)':
+  '@rsbuild/plugin-less@1.5.0(@rsbuild/core@1.6.0-beta.1)':
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
-  '@rsbuild/plugin-node-polyfill@1.4.2(@rsbuild/core@1.6.0-beta.0)':
+  '@rsbuild/plugin-node-polyfill@1.4.2(@rsbuild/core@1.6.0-beta.1)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9100,13 +9174,13 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
 
-  '@rsbuild/plugin-preact@1.5.2(@rsbuild/core@1.6.0-beta.0)(preact@10.27.2)':
+  '@rsbuild/plugin-preact@1.5.2(@rsbuild/core@1.6.0-beta.1)(preact@10.27.2)':
     dependencies:
       '@prefresh/core': 1.5.5(preact@10.27.2)
       '@prefresh/utils': 1.2.1
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       '@rspack/plugin-preact-refresh': 1.1.2(@prefresh/core@1.5.5(preact@10.27.2))(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh': 9.0.1
     transitivePeerDependencies:
@@ -9120,27 +9194,27 @@ snapshots:
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-react@1.4.1(@rsbuild/core@1.6.0-beta.0)':
+  '@rsbuild/plugin-react@1.4.1(@rsbuild/core@1.6.0-beta.1)':
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       '@rspack/plugin-react-refresh': 1.5.1(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.4.0(@rsbuild/core@1.6.0-beta.0)':
+  '@rsbuild/plugin-sass@1.4.0(@rsbuild/core@1.6.0-beta.1)':
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.6
       reduce-configs: 1.1.1
       sass-embedded: 1.90.0
 
-  '@rsbuild/plugin-solid@1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.6.0-beta.0)(solid-js@1.9.9)':
+  '@rsbuild/plugin-solid@1.0.6(@babel/core@7.28.0)(@rsbuild/core@1.6.0-beta.1)(solid-js@1.9.9)':
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
-      '@rsbuild/plugin-babel': 1.0.6(@rsbuild/core@1.6.0-beta.0)
+      '@rsbuild/core': 1.6.0-beta.1
+      '@rsbuild/plugin-babel': 1.0.6(@rsbuild/core@1.6.0-beta.1)
       babel-preset-solid: 1.9.6(@babel/core@7.28.0)
       solid-refresh: 0.6.3(solid-js@1.9.9)
     transitivePeerDependencies:
@@ -9148,9 +9222,9 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@1.2.0(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))':
+  '@rsbuild/plugin-stylus@1.2.0(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))':
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
       stylus: 0.64.0
@@ -9160,10 +9234,10 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.2.2(@rsbuild/core@1.6.0-beta.0)(typescript@5.9.3)':
+  '@rsbuild/plugin-svgr@1.2.2(@rsbuild/core@1.6.0-beta.1)(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
-      '@rsbuild/plugin-react': 1.4.1(@rsbuild/core@1.6.0-beta.0)
+      '@rsbuild/core': 1.6.0-beta.1
+      '@rsbuild/plugin-react': 1.4.1(@rsbuild/core@1.6.0-beta.1)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
@@ -9174,43 +9248,43 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-toml@1.1.1(@rsbuild/core@1.6.0-beta.0)':
+  '@rsbuild/plugin-toml@1.1.1(@rsbuild/core@1.6.0-beta.1)':
     dependencies:
       toml: 3.0.0
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
 
-  '@rsbuild/plugin-type-check@1.2.4(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(typescript@5.9.3)':
+  '@rsbuild/plugin-type-check@1.2.4(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(typescript@5.9.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
       ts-checker-rspack-plugin: 1.1.5(@rspack/core@1.5.8(@swc/helpers@0.5.17))(typescript@5.9.3)
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-type-check@1.2.4(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(typescript@5.9.3)':
+  '@rsbuild/plugin-type-check@1.2.4(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(typescript@5.9.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.1.5(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(typescript@5.9.3)
+      ts-checker-rspack-plugin: 1.1.5(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(typescript@5.9.3)
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.1.1(@rsbuild/core@1.6.0-beta.0)':
+  '@rsbuild/plugin-typed-css-modules@1.1.1(@rsbuild/core@1.6.0-beta.1)':
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
 
-  '@rsbuild/plugin-yaml@1.0.3(@rsbuild/core@1.6.0-beta.0)':
+  '@rsbuild/plugin-yaml@1.0.3(@rsbuild/core@1.6.0-beta.1)':
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
 
   '@rslib/core@0.16.0(@microsoft/api-extractor@7.53.1(@types/node@22.18.12))(@typescript/native-preview@7.0.0-dev.20251021.1)(typescript@5.9.3)':
     dependencies:
@@ -9258,6 +9332,9 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.6.0-beta.0':
     optional: true
 
+  '@rspack/binding-darwin-arm64@1.6.0-beta.1':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.5.0':
     optional: true
 
@@ -9265,6 +9342,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-darwin-x64@1.6.0-beta.0':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.6.0-beta.1':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.5.0':
@@ -9276,6 +9356,9 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.6.0-beta.0':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@1.6.0-beta.1':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.5.0':
     optional: true
 
@@ -9283,6 +9366,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.6.0-beta.0':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.6.0-beta.1':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.5.0':
@@ -9294,6 +9380,9 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.6.0-beta.0':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@1.6.0-beta.1':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.5.0':
     optional: true
 
@@ -9301,6 +9390,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.6.0-beta.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.6.0-beta.1':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.5.0':
@@ -9318,6 +9410,11 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
+  '@rspack/binding-wasm32-wasi@1.6.0-beta.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@1.5.0':
     optional: true
 
@@ -9325,6 +9422,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.6.0-beta.0':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@1.6.0-beta.1':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.5.0':
@@ -9336,6 +9436,9 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@1.6.0-beta.0':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@1.6.0-beta.1':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.5.0':
     optional: true
 
@@ -9343,6 +9446,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.6.0-beta.0':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.6.0-beta.1':
     optional: true
 
   '@rspack/binding@1.5.0':
@@ -9384,6 +9490,19 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.6.0-beta.0
       '@rspack/binding-win32-x64-msvc': 1.6.0-beta.0
 
+  '@rspack/binding@1.6.0-beta.1':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.6.0-beta.1
+      '@rspack/binding-darwin-x64': 1.6.0-beta.1
+      '@rspack/binding-linux-arm64-gnu': 1.6.0-beta.1
+      '@rspack/binding-linux-arm64-musl': 1.6.0-beta.1
+      '@rspack/binding-linux-x64-gnu': 1.6.0-beta.1
+      '@rspack/binding-linux-x64-musl': 1.6.0-beta.1
+      '@rspack/binding-wasm32-wasi': 1.6.0-beta.1
+      '@rspack/binding-win32-arm64-msvc': 1.6.0-beta.1
+      '@rspack/binding-win32-ia32-msvc': 1.6.0-beta.1
+      '@rspack/binding-win32-x64-msvc': 1.6.0-beta.1
+
   '@rspack/core@1.5.0(@swc/helpers@0.5.17)':
     dependencies:
       '@module-federation/runtime-tools': 0.18.0
@@ -9404,6 +9523,14 @@ snapshots:
     dependencies:
       '@module-federation/runtime-tools': 0.20.0
       '@rspack/binding': 1.6.0-beta.0
+      '@rspack/lite-tapable': 1.0.1
+    optionalDependencies:
+      '@swc/helpers': 0.5.17
+
+  '@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.21.1
+      '@rspack/binding': 1.6.0-beta.1
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
       '@swc/helpers': 0.5.17
@@ -13660,20 +13787,20 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20251021.1
       typescript: 5.9.3
 
-  rsbuild-plugin-google-analytics@1.0.4(@rsbuild/core@1.6.0-beta.0):
+  rsbuild-plugin-google-analytics@1.0.4(@rsbuild/core@1.6.0-beta.1):
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
 
-  rsbuild-plugin-html-minifier-terser@1.1.2(@rsbuild/core@1.6.0-beta.0):
+  rsbuild-plugin-html-minifier-terser@1.1.2(@rsbuild/core@1.6.0-beta.1):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
 
-  rsbuild-plugin-open-graph@1.1.0(@rsbuild/core@1.6.0-beta.0):
+  rsbuild-plugin-open-graph@1.1.0(@rsbuild/core@1.6.0-beta.1):
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
 
   rsbuild-plugin-publint@0.3.3(@rsbuild/core@1.5.17):
     dependencies:
@@ -13682,12 +13809,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.5.17
 
-  rsbuild-plugin-publint@0.3.3(@rsbuild/core@1.6.0-beta.0):
+  rsbuild-plugin-publint@0.3.3(@rsbuild/core@1.6.0-beta.1):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.12
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
 
   rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.5.17)(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(vue@3.5.22(typescript@5.9.3))(yaml@2.6.1):
     dependencies:
@@ -13709,11 +13836,11 @@ snapshots:
       - vue
       - yaml
 
-  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.6.0-beta.0)(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(vue@3.5.22(typescript@5.9.3))(yaml@2.6.1):
+  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@1.6.0-beta.1)(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(vue@3.5.22(typescript@5.9.3))(yaml@2.6.1):
     dependencies:
       unplugin-vue: 6.2.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(vue@3.5.22(typescript@5.9.3))(yaml@2.6.1)
     optionalDependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14086,26 +14213,26 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook-addon-rslib@2.1.2(@rsbuild/core@1.6.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3))(typescript@5.9.3):
+  storybook-addon-rslib@2.1.2(@rsbuild/core@1.6.0-beta.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
+      storybook-builder-rsbuild: 2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  storybook-addon-rslib@2.1.2(@rsbuild/core@1.6.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3))(typescript@5.9.3):
+  storybook-addon-rslib@2.1.2(@rsbuild/core@1.6.0-beta.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
+      storybook-builder-rsbuild: 2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3):
+  storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3):
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
-      '@rsbuild/plugin-type-check': 1.2.4(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(typescript@5.9.3)
+      '@rsbuild/core': 1.6.0-beta.1
+      '@rsbuild/plugin-type-check': 1.2.4(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(typescript@5.9.3)
       '@storybook/addon-docs': 9.1.13(@types/react@19.2.2)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))
       '@storybook/core-webpack': 9.1.8(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))
       browser-assert: 1.2.1
@@ -14117,7 +14244,7 @@ snapshots:
       magic-string: 0.30.19
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.2(@rsbuild/core@1.6.0-beta.0)
+      rsbuild-plugin-html-minifier-terser: 1.1.2(@rsbuild/core@1.6.0-beta.1)
       sirv: 2.0.4
       storybook: 9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1))
       ts-dedent: 2.2.0
@@ -14132,10 +14259,10 @@ snapshots:
       - '@rspack/core'
       - '@types/react'
 
-  storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3):
+  storybook-builder-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3):
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
-      '@rsbuild/plugin-type-check': 1.2.4(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(typescript@5.9.3)
+      '@rsbuild/core': 1.6.0-beta.1
+      '@rsbuild/plugin-type-check': 1.2.4(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(typescript@5.9.3)
       '@storybook/addon-docs': 9.1.13(@types/react@19.2.2)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))
       '@storybook/core-webpack': 9.1.8(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))
       browser-assert: 1.2.1
@@ -14147,7 +14274,7 @@ snapshots:
       magic-string: 0.30.19
       path-browserify: 1.0.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.2(@rsbuild/core@1.6.0-beta.0)
+      rsbuild-plugin-html-minifier-terser: 1.1.2(@rsbuild/core@1.6.0-beta.1)
       sirv: 2.0.4
       storybook: 9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1))
       ts-dedent: 2.2.0
@@ -14162,10 +14289,10 @@ snapshots:
       - '@rspack/core'
       - '@types/react'
 
-  storybook-react-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.46.2)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3):
+  storybook-react-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.46.2)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.46.2)
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       '@storybook/react': 9.1.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.9.3)
       find-up: 5.0.0
@@ -14176,7 +14303,7 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.10
       storybook: 9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1))
-      storybook-builder-rsbuild: 2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
+      storybook-builder-rsbuild: 2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -14187,12 +14314,12 @@ snapshots:
       - supports-color
       - webpack
 
-  storybook-vue3-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3)):
+  storybook-vue3-rsbuild@2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3)):
     dependencies:
-      '@rsbuild/core': 1.6.0-beta.0
+      '@rsbuild/core': 1.6.0-beta.1
       '@storybook/vue3': 9.1.13(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(vue@3.5.22(typescript@5.9.3))
       storybook: 9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1))
-      storybook-builder-rsbuild: 2.1.2(@rsbuild/core@1.6.0-beta.0)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
+      storybook-builder-rsbuild: 2.1.2(@rsbuild/core@1.6.0-beta.1)(@rspack/core@1.5.8(@swc/helpers@0.5.17))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.13(prettier@3.6.2)(vite@6.3.5(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.6)(yaml@2.6.1)))(typescript@5.9.3)
       vue: 3.5.22(typescript@5.9.3)
       vue-docgen-loader: 2.0.1
     transitivePeerDependencies:
@@ -14474,7 +14601,7 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.5.8(@swc/helpers@0.5.17)
 
-  ts-checker-rspack-plugin@1.1.5(@rspack/core@1.6.0-beta.0(@swc/helpers@0.5.17))(typescript@5.9.3):
+  ts-checker-rspack-plugin@1.1.5(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@rspack/lite-tapable': 1.0.1
@@ -14485,7 +14612,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.9.3
     optionalDependencies:
-      '@rspack/core': 1.6.0-beta.0(@swc/helpers@0.5.17)
+      '@rspack/core': 1.6.0-beta.1(@swc/helpers@0.5.17)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-node-polyfill": "^1.4.2"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-node-polyfill": "^1.4.2"
   }
 }

--- a/tests/integration/preserve-jsx/__snapshots__/index.test.ts.snap
+++ b/tests/integration/preserve-jsx/__snapshots__/index.test.ts.snap
@@ -36,7 +36,7 @@ function __webpack_require__(moduleId) {
             getProto([]),
             getProto(getProto)
         ];
-        for(var current = 2 & mode && value; 'object' == typeof current && !~leafPrototypes.indexOf(current); current = getProto(current))Object.getOwnPropertyNames(current).forEach((key)=>{
+        for(var current = 2 & mode && value; ('object' == typeof current || 'function' == typeof current) && !~leafPrototypes.indexOf(current); current = getProto(current))Object.getOwnPropertyNames(current).forEach((key)=>{
             def[key] = ()=>value[key];
         });
         def['default'] = ()=>value;

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^0.21.1",
     "@playwright/test": "1.56.1",
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-less": "^1.5.0",
     "@rsbuild/plugin-react": "^1.4.1",
     "@rsbuild/plugin-sass": "^1.4.0",

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.21.1",
-    "@rsbuild/core": "1.6.0-beta.0",
+    "@rsbuild/core": "1.6.0-beta.1",
     "@rsbuild/plugin-react": "^1.4.1",
     "@rsbuild/plugin-sass": "^1.4.0",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

- Bump Rsbuild to [v1.6.0-beta.1](https://github.com/web-infra-dev/rsbuild/releases/tag/v1.6.0-beta.1)
- Remove special `output.distPath` merge logic introduced in https://github.com/web-infra-dev/rslib/pull/1270 since Rsbuild ensure to merge correctly in https://github.com/web-infra-dev/rsbuild/pull/6369

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
