### PR TITLE
chore(build): avoid using `require` in configuration file

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { pluginPublint } from 'rsbuild-plugin-publint';
 import { defineConfig, type rsbuild, rspack } from 'rslib';
+import packageJson from './package.json' with { type: 'json' };
 
 const pluginFixDtsTypes: rsbuild.RsbuildPlugin = {
   name: 'fix-dts-types',
@@ -45,7 +46,7 @@ export default defineConfig({
       entryModuleLoader: './src/plugins/entryModuleLoader.ts',
     },
     define: {
-      RSLIB_VERSION: JSON.stringify(require('./package.json').version),
+      RSLIB_VERSION: JSON.stringify(packageJson.version),
     },
   },
   // externalize pre-bundled dependencies


### PR DESCRIPTION
## Summary

Instead of using `require` to load version from `package.json`, now imports `package.json` as a JSON module.

Fix the config loading error in debug mode:

<img width="2098" height="480" alt="image" src="https://github.com/user-attachments/assets/44f6bb28-29d9-4a15-ae82-8d8aa3642fd3" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
