### PR TITLE
feat: warn used dep in devDependencies under bundeless mode

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,6 +894,15 @@ importers:
 
   tests/integration/externals/browser: {}
 
+  tests/integration/externals/dev-dependency-warning:
+    devDependencies:
+      left-pad:
+        specifier: 1.0.0
+        version: 1.0.0
+      normalize.css:
+        specifier: 8.0.1
+        version: 8.0.1
+
   tests/integration/externals/module-import-warn: {}
 
   tests/integration/externals/node: {}
@@ -5286,6 +5295,10 @@ packages:
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
+  left-pad@1.0.0:
+    resolution: {integrity: sha512-Xvly4CWfzT+7TGZRB2Qd7ub2dmJDomZCNf3BuT3XXfrNerQHtta82NNhbvToU4Qiz7IHrg21YB3UpL/6npCtmg==}
+    deprecated: use String.prototype.padStart()
+
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
     engines: {node: '>= 12.0.0'}
@@ -5807,6 +5820,9 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  normalize.css@8.0.1:
+    resolution: {integrity: sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -12114,6 +12130,8 @@ snapshots:
 
   leac@0.6.0: {}
 
+  left-pad@1.0.0: {}
+
   lightningcss-android-arm64@1.30.2:
     optional: true
 
@@ -12844,6 +12862,8 @@ snapshots:
       sorted-array-functions: 1.3.0
 
   normalize-path@3.0.0: {}
+
+  normalize.css@8.0.1: {}
 
   npm-run-path@4.0.1:
     dependencies:

--- a/tests/integration/externals/dev-dependency-warning/package.json
+++ b/tests/integration/externals/dev-dependency-warning/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bundleless-dev-dependency-warning",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "left-pad": "1.0.0",
+    "normalize.css": "8.0.1"
+  }
+}

--- a/tests/integration/externals/dev-dependency-warning/rslib.config.ts
+++ b/tests/integration/externals/dev-dependency-warning/rslib.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      source: {
+        entry: {
+          index: 'src/index.ts',
+        },
+      },
+      output: {
+        distPath: 'dist',
+      },
+    }),
+  ],
+});

--- a/tests/integration/externals/dev-dependency-warning/src/index.ts
+++ b/tests/integration/externals/dev-dependency-warning/src/index.ts
@@ -1,0 +1,6 @@
+import leftPad from 'left-pad';
+import leftPadLib from 'left-pad/lib';
+import 'normalize.css';
+
+export const primary = leftPad('foo', 5, ' ');
+export const secondary = leftPadLib;

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -112,3 +112,24 @@ test('user externals', async () => {
     "
   `);
 });
+
+test('warn when bundleless external depends on devDependencies', async () => {
+  const fixturePath = join(__dirname, 'dev-dependency-warning');
+  const { logs, restore } = proxyConsole();
+
+  await buildAndGetResults({ fixturePath });
+
+  restore();
+  const warnLogs = logs.map((log) => stripAnsi(String(log)));
+  console.log(warnLogs);
+  const jsMatchingLog = warnLogs.filter(
+    (log) =>
+      log.includes('The externalized request "left-pad/lib" from index.ts is declared in "devDependencies" in package.json. Bundleless mode does not include devDependencies in the output, consider moving it to "dependencies" or "peerDependencies".')
+  );
+  expect(jsMatchingLog.length).toBe(1);
+  const cssMatchingLog = warnLogs.filter(
+    (log) =>
+      log.includes('The externalized request "normalize.css" from index.ts is declared in "devDependencies" in package.json. Bundleless mode does not include devDependencies in the output, consider moving it to "dependencies" or "peerDependencies".')
+  );
+  expect(cssMatchingLog.length).toBe(1);
+});


### PR DESCRIPTION
## Summary

warn user when they're using some package but not declared in `dependencies` or `devDependencies` in bundleless mode, since nothing will be bundled then.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
