### PR TITLE
ci: add ecosystem CI

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -1,0 +1,33 @@
+name: Ecosystem CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch of the Ecosystem CI run'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  ecosystem_ci:
+    name: Run Ecosystem CI
+    runs-on: ubuntu-latest
+    if: github.repository == 'web-infra-dev/rslib'
+    steps:
+      - name: Trigger Ecosystem CI
+        uses: rspack-contrib/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_RSLIB_ECO_CI_GITHUB_TOKEN }}
+        with:
+          github-token: ${{ secrets.REPO_RSLIB_ECO_CI_GITHUB_TOKEN }}
+          ecosystem-owner: web-infra-dev
+          ecosystem-repo: rslib
+          workflow-file: rslib-ecosystem-ci-selected.yml
+          client-payload: '{"ref":"${{ github.event.inputs.branch }}","repo":"web-infra-dev/rslib","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'
+          result-heading: Rslib Ecosystem CI
+          branch: ${{ github.event.inputs.branch }}


### PR DESCRIPTION
## Summary

using unified ecosystem CI, since dispatch workflows requires merging to default branch first. this workflow is not likely to work after merge, still WIP.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
