### PR TITLE
ci: add per commit notify

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -67,5 +67,5 @@ jobs:
           ecosystem-owner: web-infra-dev
           ecosystem-repo: rslib
           workflow-file: rslib-ecosystem-ci-selected.yml
-          client-payload: '{"commitSHA":"${{ github.sha }}","updateComment":true,"repo":"web-infra-dev/rsbuild","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'
+          client-payload: '{"commitSHA":"${{ github.sha }}","updateComment":true,"repo":"web-infra-dev/rslib","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'
           result-heading: Rslib Ecosystem CI


### PR DESCRIPTION
## Summary

add per commit CI, currently only notify on a test branch intead of main.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
