### PR TITLE
fix(create-rslib): compatible with Storybook 10

### DIFF
--- a/packages/create-rslib/fragments/tools/storybook-react-js/.storybook/main.js
+++ b/packages/create-rslib/fragments/tools/storybook-react-js/.storybook/main.js
@@ -1,4 +1,7 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
 
 /**
  * This function is used to resolve the absolute path of a package.

--- a/packages/create-rslib/fragments/tools/storybook-react-ts/.storybook/main.ts
+++ b/packages/create-rslib/fragments/tools/storybook-react-ts/.storybook/main.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
 import type { StorybookConfig } from 'storybook-react-rsbuild';
 
 /**

--- a/packages/create-rslib/fragments/tools/storybook-vue-js/.storybook/main.js
+++ b/packages/create-rslib/fragments/tools/storybook-vue-js/.storybook/main.js
@@ -1,5 +1,7 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 
+const require = createRequire(import.meta.url);
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.

--- a/packages/create-rslib/fragments/tools/storybook-vue-ts/.storybook/main.ts
+++ b/packages/create-rslib/fragments/tools/storybook-vue-ts/.storybook/main.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
 import type { StorybookConfig } from 'storybook-vue3-rsbuild';
 
 /**

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-js/.storybook/main.js
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-js/.storybook/main.js
@@ -1,4 +1,7 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
 
 /**
  * This function is used to resolve the absolute path of a package.

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-ts/.storybook/main.ts
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-ts/.storybook/main.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
 import type { StorybookConfig } from 'storybook-react-rsbuild';
 
 /**

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-js/.storybook/main.js
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-js/.storybook/main.js
@@ -1,4 +1,7 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
 
 /**
  * This function is used to resolve the absolute path of a package.

--- a/packages/create-rslib/template-[react]-[storybook,vitest]-ts/.storybook/main.ts
+++ b/packages/create-rslib/template-[react]-[storybook,vitest]-ts/.storybook/main.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
 import type { StorybookConfig } from 'storybook-react-rsbuild';
 
 /**

--- a/packages/create-rslib/template-[react]-[storybook]-js/.storybook/main.js
+++ b/packages/create-rslib/template-[react]-[storybook]-js/.storybook/main.js
@@ -1,4 +1,7 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
 
 /**
  * This function is used to resolve the absolute path of a package.

--- a/packages/create-rslib/template-[react]-[storybook]-ts/.storybook/main.ts
+++ b/packages/create-rslib/template-[react]-[storybook]-ts/.storybook/main.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
 import type { StorybookConfig } from 'storybook-react-rsbuild';
 
 /**

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-js/.storybook/main.js
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-js/.storybook/main.js
@@ -1,5 +1,7 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 
+const require = createRequire(import.meta.url);
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/.storybook/main.ts
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/.storybook/main.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
 import type { StorybookConfig } from 'storybook-vue3-rsbuild';
 
 /**

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-js/.storybook/main.js
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-js/.storybook/main.js
@@ -1,5 +1,7 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 
+const require = createRequire(import.meta.url);
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.

--- a/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/.storybook/main.ts
+++ b/packages/create-rslib/template-[vue]-[storybook,vitest]-ts/.storybook/main.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
 import type { StorybookConfig } from 'storybook-vue3-rsbuild';
 
 /**

--- a/packages/create-rslib/template-[vue]-[storybook]-js/.storybook/main.js
+++ b/packages/create-rslib/template-[vue]-[storybook]-js/.storybook/main.js
@@ -1,5 +1,7 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 
+const require = createRequire(import.meta.url);
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.

--- a/packages/create-rslib/template-[vue]-[storybook]-ts/.storybook/main.ts
+++ b/packages/create-rslib/template-[vue]-[storybook]-ts/.storybook/main.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
 import type { StorybookConfig } from 'storybook-vue3-rsbuild';
 
 /**


### PR DESCRIPTION
## Summary

due to the breaking change of https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#from-version-9x-to-1000. use pure ESM syntax in Storybook config files.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
