### PR TITLE
chore: rename rsbuildConfig to config

### DIFF
--- a/packages/core/src/cli/build.ts
+++ b/packages/core/src/cli/build.ts
@@ -12,7 +12,7 @@ export async function build(
   const { environments } = await composeRsbuildEnvironments(config);
   const rsbuildInstance = await createRsbuild({
     callerName: 'rslib',
-    rsbuildConfig: {
+    config: {
       mode: 'production',
       root: config.root,
       plugins: config.plugins,

--- a/packages/core/src/cli/inspect.ts
+++ b/packages/core/src/cli/inspect.ts
@@ -11,7 +11,7 @@ export async function inspect(
   const { environments } = await composeRsbuildEnvironments(config);
   const rsbuildInstance = await createRsbuild({
     callerName: 'rslib',
-    rsbuildConfig: {
+    config: {
       mode: 'production',
       root: config.root,
       plugins: config.plugins,

--- a/packages/core/src/cli/mf.ts
+++ b/packages/core/src/cli/mf.ts
@@ -48,7 +48,7 @@ async function initMFRsbuild(
 
   const rsbuildInstance = await createRsbuild({
     callerName: 'rslib',
-    rsbuildConfig: {
+    config: {
       mode: 'development',
       root: config.root,
       plugins: config.plugins,

--- a/tests/scripts/rsbuild.ts
+++ b/tests/scripts/rsbuild.ts
@@ -87,15 +87,15 @@ const updateConfigForTest = async (
 
 const createRsbuild = async (
   rsbuildOptions: CreateRsbuildOptions & {
-    rsbuildConfig?: RsbuildConfig;
+    config?: RsbuildConfig;
   },
   plugins: RsbuildPlugins = [],
 ) => {
   const { createRsbuild: createRsbuildInner } = await import('@rsbuild/core');
 
-  rsbuildOptions.rsbuildConfig ||= {};
-  rsbuildOptions.rsbuildConfig.plugins = [
-    ...(rsbuildOptions.rsbuildConfig.plugins || []),
+  rsbuildOptions.config ||= {};
+  rsbuildOptions.config.plugins = [
+    ...(rsbuildOptions.config.plugins || []),
     ...(plugins || []),
   ];
 
@@ -109,7 +109,7 @@ export async function dev({
   ...options
 }: CreateRsbuildOptions & {
   plugins?: RsbuildPlugins;
-  rsbuildConfig?: RsbuildConfig;
+  config?: RsbuildConfig;
   /**
    * Playwright Page instance.
    * This method will automatically goto the page.
@@ -119,10 +119,7 @@ export async function dev({
   process.env.NODE_ENV = 'development';
 
   options.callerName = 'rslib';
-  options.rsbuildConfig = await updateConfigForTest(
-    options.rsbuildConfig || {},
-    options.cwd,
-  );
+  options.config = await updateConfigForTest(options.config || {}, options.cwd);
 
   const rsbuild = await createRsbuild(options, plugins);
   const result = await rsbuild.startDevServer();


### PR DESCRIPTION
## Summary

Simplify the configuration parameter name of `createRsbuild`, see https://github.com/web-infra-dev/rsbuild/pull/6245

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
