### PR TITLE
feat: runtime chunk name default to `rslib-runtime`

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -664,7 +664,11 @@ const composeFormatConfig = ({
               // experimentalEsmOutput don't need concatenateModules
               concatenateModules: !experimentalEsmOutput,
               sideEffects: experimentalEsmOutput ? true : 'flag',
-              runtimeChunk: experimentalEsmOutput ? 'single' : undefined,
+              runtimeChunk: experimentalEsmOutput
+                ? {
+                    name: 'rslib-runtime',
+                  }
+                : undefined,
               avoidEntryIife: true,
               splitChunks: {
                 // Splitted "sync" chunks will make entry modules can't be inlined.

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -658,7 +658,9 @@ exports[`Should compose create Rsbuild config correctly > Enable experiment.adva
     nodeEnv: false,
     concatenateModules: false,
     sideEffects: true,
-    runtimeChunk: 'single',
+    runtimeChunk: {
+      name: 'rslib-runtime'
+    },
     avoidEntryIife: true
   },
   plugins: [

--- a/tests/integration/resolve/index.test.ts
+++ b/tests/integration/resolve/index.test.ts
@@ -21,7 +21,7 @@ test('resolve false', async () => {
   expect(isSuccess).toBeTruthy();
   if (process.env.ADVANCED_ESM) {
     expect(entries.esm).toMatchInlineSnapshot(`
-      "import { __webpack_require__ } from "./runtime.js";
+      "import { __webpack_require__ } from "./rslib-runtime.js";
       __webpack_require__.add({
           "?b5d4": function() {}
       });

--- a/tests/integration/style/css-modules-named/index.test.ts
+++ b/tests/integration/style/css-modules-named/index.test.ts
@@ -20,7 +20,7 @@ test('should extract css-modules named export successfully in bundle', async () 
   `);
   if (process.env.ADVANCED_ESM) {
     expect(js.entries.esm).toMatchInlineSnapshot(`
-      "import "./runtime.js";
+      "import "./rslib-runtime.js";
       var _1 = "content-wrapper-iNtwbA";
       const src_button = _1;
       export { src_button as button };

--- a/tests/integration/vue/index.test.ts
+++ b/tests/integration/vue/index.test.ts
@@ -14,7 +14,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
     if (process.env.ADVANCED_ESM) {
       expect(js.contents.esm1).toMatchInlineSnapshot(`
         {
-          "<ROOT>/tests/integration/vue/dist/bundle/index.js": "import "./runtime.js";
+          "<ROOT>/tests/integration/vue/dist/bundle/index.js": "import "./rslib-runtime.js";
         import { createElementBlock, openBlock, ref, toDisplayString } from "vue";
         const _00_2Fplugin_vue_2Fexport_helper = (sfc, props)=>{
             const target = sfc.__vccOpts || sfc;
@@ -87,7 +87,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
         ]);
         export { Button, Card };
         ",
-          "<ROOT>/tests/integration/vue/dist/bundle/runtime.js": "var __webpack_modules__ = {};
+          "<ROOT>/tests/integration/vue/dist/bundle/rslib-runtime.js": "var __webpack_modules__ = {};
         var __webpack_module_cache__ = {};
         function __webpack_require__(moduleId) {
             var cachedModule = __webpack_module_cache__[moduleId];


### PR DESCRIPTION
## Summary

Runtime chunk name default to `rslib-runtime` in advanced esm to avoid name conflict.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
