### PR TITLE
fix: use native plugin to handle hashbang and react directives

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -414,6 +414,7 @@ export function composeMinifyConfig(config: LibConfig): EnvironmentConfig {
             // MF assets are loaded over the network, which means they will not be compressed by the project. Therefore, minifying them is necessary.
             minify: format === 'mf',
             compress: {
+              directives: false,
               defaults: false,
               unused: true,
               dead_code: true,
@@ -1831,6 +1832,7 @@ async function composeLibRsbuildConfig(
   const assetConfig = composeAssetConfig(bundle, format);
 
   const entryChunkConfig = composeEntryChunkConfig({
+    useLoader: advancedEsm !== true,
     enabledImportMetaUrlShim: enabledShims.cjs['import.meta.url'],
     contextToWatch: outBase,
   });

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -10,10 +10,6 @@ export const DEFAULT_CONFIG_EXTENSIONS = [
 ] as const;
 
 export const SWC_HELPERS = '@swc/helpers';
-export const SHEBANG_PREFIX = '#!';
-export const SHEBANG_REGEX: RegExp = /#!.*[\s\n\r]*$/;
-export const REACT_DIRECTIVE_REGEX: RegExp =
-  /^['"]use (client|server)['"](;?)[\s\n\r]*$/;
 
 const DTS_EXTENSIONS: string[] = ['d.ts', 'd.mts', 'd.cts'];
 

--- a/packages/core/src/plugins/entryModuleLoader.ts
+++ b/packages/core/src/plugins/entryModuleLoader.ts
@@ -1,30 +1,8 @@
 import type { Rspack } from '@rsbuild/core';
-import { REACT_DIRECTIVE_REGEX, SHEBANG_REGEX } from '../constant';
 
-function splitFromFirstLine(text: string): [string, string] {
-  const match = text.match(/(\r\n|\n)/);
-  if (!match) {
-    return [text, ''];
-  }
-
-  return [text.slice(0, match.index), text.slice(match.index)];
-}
-
+// Empty loader, only to make doppelganger of entry module.
 const loader: Rspack.LoaderDefinition = function loader(source) {
-  let result = source;
-
-  const [firstLine1, rest] = splitFromFirstLine(result);
-
-  if (SHEBANG_REGEX.test(firstLine1)) {
-    result = rest;
-  }
-
-  const [firstLine2, rest2] = splitFromFirstLine(result);
-  if (REACT_DIRECTIVE_REGEX.test(firstLine2)) {
-    result = rest2;
-  }
-
-  return result;
+  return source;
 };
 
 export default loader;

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -634,17 +634,6 @@ exports[`Should compose create Rsbuild config correctly > Enable experiment.adva
             }
           }
         ]
-      },
-      /* config.module.rule('Rslib:js-entry-loader') */
-      {
-        test: /\\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/,
-        issuer: /^$/,
-        use: [
-          /* config.module.rule('Rslib:js-entry-loader').use('rsbuild:lib-entry-module') */
-          {
-            loader: '<WORKSPACE>/dist/entryModuleLoader.js'
-          }
-        ]
       }
     ]
   },
@@ -666,6 +655,7 @@ exports[`Should compose create Rsbuild config correctly > Enable experiment.adva
             mangle: false,
             minify: false,
             compress: {
+              directives: false,
               defaults: false,
               unused: true,
               dead_code: true,
@@ -717,11 +707,7 @@ exports[`Should compose create Rsbuild config correctly > Enable experiment.adva
       options: undefined
     },
     {
-      reactDirectives: {},
       shimsInjectedAssets: new Set([]),
-      shebangChmod: 493,
-      shebangEntries: {},
-      shebangInjectedAssets: new Set([]),
       enabledImportMetaUrlShim: false,
       contextToWatch: null
     }
@@ -1727,6 +1713,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             mangle: false,
             minify: false,
             compress: {
+              directives: false,
               defaults: false,
               unused: true,
               dead_code: true,
@@ -1773,11 +1760,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       ]
     },
     {
-      reactDirectives: {},
       shimsInjectedAssets: new Set([]),
-      shebangChmod: 493,
-      shebangEntries: {},
-      shebangInjectedAssets: new Set([]),
       enabledImportMetaUrlShim: false,
       contextToWatch: null
     }
@@ -2474,6 +2457,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             mangle: false,
             minify: false,
             compress: {
+              directives: false,
               defaults: false,
               unused: true,
               dead_code: true,
@@ -2517,11 +2501,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       ]
     },
     {
-      reactDirectives: {},
       shimsInjectedAssets: new Set([]),
-      shebangChmod: 493,
-      shebangEntries: {},
-      shebangInjectedAssets: new Set([]),
       enabledImportMetaUrlShim: true,
       contextToWatch: null
     }
@@ -3124,6 +3104,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             mangle: false,
             minify: false,
             compress: {
+              directives: false,
               defaults: false,
               unused: true,
               dead_code: true,
@@ -3166,11 +3147,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       ]
     },
     {
-      reactDirectives: {},
       shimsInjectedAssets: new Set([]),
-      shebangChmod: 493,
-      shebangEntries: {},
-      shebangInjectedAssets: new Set([]),
       enabledImportMetaUrlShim: false,
       contextToWatch: null
     }
@@ -3772,6 +3749,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             mangle: false,
             minify: false,
             compress: {
+              directives: false,
               defaults: false,
               unused: true,
               dead_code: true,
@@ -3814,11 +3792,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       ]
     },
     {
-      reactDirectives: {},
       shimsInjectedAssets: new Set([]),
-      shebangChmod: 493,
-      shebangEntries: {},
-      shebangInjectedAssets: new Set([]),
       enabledImportMetaUrlShim: false,
       contextToWatch: null
     }
@@ -4371,6 +4345,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             mangle: false,
             minify: true,
             compress: {
+              directives: false,
               defaults: false,
               unused: true,
               dead_code: true,
@@ -4411,11 +4386,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       }
     ),
     {
-      reactDirectives: {},
       shimsInjectedAssets: new Set([]),
-      shebangChmod: 493,
-      shebangEntries: {},
-      shebangInjectedAssets: new Set([]),
       enabledImportMetaUrlShim: false,
       contextToWatch: null
     }
@@ -4524,6 +4495,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "compress": {
               "dead_code": true,
               "defaults": false,
+              "directives": false,
               "toplevel": true,
               "unused": true,
             },
@@ -4697,10 +4669,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             EntryChunkPlugin {
               "contextToWatch": null,
               "enabledImportMetaUrlShim": false,
-              "reactDirectives": {},
-              "shebangChmod": 493,
-              "shebangEntries": {},
-              "shebangInjectedAssets": Set {},
               "shimsInjectedAssets": Set {},
             },
           ],
@@ -4817,6 +4785,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "compress": {
               "dead_code": true,
               "defaults": false,
+              "directives": false,
               "toplevel": true,
               "unused": true,
             },
@@ -4987,10 +4956,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             EntryChunkPlugin {
               "contextToWatch": null,
               "enabledImportMetaUrlShim": true,
-              "reactDirectives": {},
-              "shebangChmod": 493,
-              "shebangEntries": {},
-              "shebangInjectedAssets": Set {},
               "shimsInjectedAssets": Set {},
             },
           ],
@@ -5097,6 +5062,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "compress": {
               "dead_code": true,
               "defaults": false,
+              "directives": false,
               "toplevel": true,
               "unused": true,
             },
@@ -5238,10 +5204,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             EntryChunkPlugin {
               "contextToWatch": null,
               "enabledImportMetaUrlShim": false,
-              "reactDirectives": {},
-              "shebangChmod": 493,
-              "shebangEntries": {},
-              "shebangInjectedAssets": Set {},
               "shimsInjectedAssets": Set {},
             },
           ],
@@ -5348,6 +5310,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "compress": {
               "dead_code": true,
               "defaults": false,
+              "directives": false,
               "toplevel": true,
               "unused": true,
             },
@@ -5491,10 +5454,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             EntryChunkPlugin {
               "contextToWatch": null,
               "enabledImportMetaUrlShim": false,
-              "reactDirectives": {},
-              "shebangChmod": 493,
-              "shebangEntries": {},
-              "shebangInjectedAssets": Set {},
               "shimsInjectedAssets": Set {},
             },
           ],
@@ -5543,6 +5502,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "compress": {
               "dead_code": true,
               "defaults": false,
+              "directives": false,
               "toplevel": false,
               "unused": true,
             },
@@ -5653,10 +5613,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             EntryChunkPlugin {
               "contextToWatch": null,
               "enabledImportMetaUrlShim": false,
-              "reactDirectives": {},
-              "shebangChmod": 493,
-              "shebangEntries": {},
-              "shebangInjectedAssets": Set {},
               "shimsInjectedAssets": Set {},
             },
           ],

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -484,6 +484,7 @@ describe('minify', () => {
             "compress": {
               "dead_code": true,
               "defaults": false,
+              "directives": false,
               "toplevel": true,
               "unused": true,
             },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2895,8 +2895,8 @@ packages:
       '@prefresh/core': ^1.5.0
       '@prefresh/utils': ^1.2.0
 
-  '@rspack/plugin-react-refresh@1.5.2':
-    resolution: {integrity: sha512-uTbN6P01LPdQOnl5YNwHkN4hDsb9Sb5nIetQb55mPyFiJnu9MQetmBUm+tmh8JJg0QPv4Ew7tXgi4hjpHFY3Rw==}
+  '@rspack/plugin-react-refresh@1.5.3':
+    resolution: {integrity: sha512-VOnQMf3YOHkTqJ0+BJbrYga4tQAWNwoAnkgwRauXB4HOyCc5wLfBs9DcOFla/2usnRT3Sq6CMVhXmdPobwAoTA==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
       webpack-hot-middleware: 2.x
@@ -9108,7 +9108,7 @@ snapshots:
   '@rsbuild/plugin-react@1.4.2(@rsbuild/core@1.6.7)':
     dependencies:
       '@rsbuild/core': 1.6.7
-      '@rspack/plugin-react-refresh': 1.5.2(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 1.5.3(react-refresh@0.18.0)
       react-refresh: 0.18.0
     transitivePeerDependencies:
       - webpack-hot-middleware
@@ -9337,7 +9337,7 @@ snapshots:
       '@prefresh/core': 1.5.8(preact@10.27.2)
       '@prefresh/utils': 1.2.1
 
-  '@rspack/plugin-react-refresh@1.5.2(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@1.5.3(react-refresh@0.18.0)':
     dependencies:
       error-stack-parser: 2.1.4
       html-entities: 2.6.0

--- a/tests/integration/directive/index.test.ts
+++ b/tests/integration/directive/index.test.ts
@@ -59,7 +59,7 @@ describe('shebang', async () => {
       expect(foo!.includes('#!')).toBe(false);
     });
 
-    test.todo('shebang commented by JS parser should be striped', async () => {
+    test('shebang commented by JS parser should be striped', async () => {
       const { content: index } = queryContent(contents.esm3!, 'index.js', {
         basename: true,
       });
@@ -98,24 +98,24 @@ describe('react', async () => {
       const { content: foo } = queryContent(contents.esm!, 'foo.js', {
         basename: true,
       });
-      expect(onlyStartsWith(foo!, `'use client';`)).toBe(true);
+      expect(onlyStartsWith(foo!, `"use client";`)).toBe(true);
 
       const { content: bar } = queryContent(contents.esm!, 'bar.js', {
         basename: true,
       });
-      expect(onlyStartsWith(bar!, `'use server';`)).toBe(true);
+      expect(onlyStartsWith(bar!, `"use server";`)).toBe(true);
     });
 
     test('React directive at the beginning even if minified', async () => {
       const { content: foo } = queryContent(contents.cjs!, 'foo.cjs', {
         basename: true,
       });
-      expect(onlyStartsWith(foo!, `'use client';`)).toBe(true);
+      expect(onlyStartsWith(foo!, `"use strict";"use client";`)).toBe(true);
 
       const { content: bar } = queryContent(contents.cjs!, 'bar.cjs', {
         basename: true,
       });
-      expect(onlyStartsWith(bar!, `'use server';`)).toBe(true);
+      expect(onlyStartsWith(bar!, `"use strict";"use server";`)).toBe(true);
     });
   });
 });

--- a/tests/integration/directive/react/bundleless/rslib.config.ts
+++ b/tests/integration/directive/react/bundleless/rslib.config.ts
@@ -12,7 +12,16 @@ export default defineConfig({
     generateBundleCjsConfig({
       bundle: false,
       output: {
-        minify: true,
+        minify: {
+          jsOptions: {
+            minimizerOptions: {
+              compress: {
+                // `directives` option is required to keep `"use strict"` in the output files.
+                directives: false,
+              },
+            },
+          },
+        },
         distPath: './dist/cjs',
       },
     }),

--- a/tests/integration/entry/index.test.ts
+++ b/tests/integration/entry/index.test.ts
@@ -56,6 +56,7 @@ test('multiple entry bundle', async () => {
           "<ROOT>/tests/integration/entry/multiple/dist/cjs/shared.cjs",
         ],
         "esm": [
+          "<ROOT>/tests/integration/entry/multiple/dist/esm/447.js",
           "<ROOT>/tests/integration/entry/multiple/dist/esm/994.js",
           "<ROOT>/tests/integration/entry/multiple/dist/esm/foo.js",
           "<ROOT>/tests/integration/entry/multiple/dist/esm/index.js",
@@ -86,8 +87,8 @@ test('multiple entry bundle', async () => {
   // cspell:disable
   if (process.env.ADVANCED_ESM) {
     expect(index).toMatchInlineSnapshot(`
-      "import { shared } from "./994.js";
-      const foo = shared('foo');
+      "import { foo } from "./447.js";
+      import { shared } from "./994.js";
       const src_text = ()=>\`\${foo} \${shared('index')}\`;
       export { src_text as text };
       "
@@ -109,9 +110,7 @@ test('multiple entry bundle', async () => {
   // cspell:disable
   if (process.env.ADVANCED_ESM) {
     expect(foo).toMatchInlineSnapshot(`
-      "import { shared } from "./994.js";
-      const foo = shared('foo');
-      export { foo };
+      "export { foo } from "./447.js";
       "
     `);
   } else {
@@ -127,11 +126,19 @@ test('multiple entry bundle', async () => {
   const { content: shared } = queryContent(contents.esm, 'shared.js', {
     basename: true,
   });
-  expect(shared).toMatchInlineSnapshot(`
-    "const shared = (str)=>'shared-' + str;
-    export { shared };
-    "
-  `);
+
+  if (process.env.ADVANCED_ESM) {
+    expect(shared).toMatchInlineSnapshot(`
+        "export { shared } from "./994.js";
+        "
+        `);
+  } else {
+    expect(shared).toMatchInlineSnapshot(`
+        "const shared = (str)=>'shared-' + str;
+        export { shared };
+        "
+      `);
+  }
 });
 
 test('glob entry bundleless', async () => {

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -127,7 +127,7 @@ describe('CJS shims', () => {
     const dynamicUrl = await dynamicImportMetaUrl();
     const { content: dynamicContent } = queryContent(
       contents.cjs!,
-      /cjs\/1~368\.cjs/,
+      /1~\d+\.cjs/,
     );
 
     expect(importMetaUrl).toBe(fileUrl);

--- a/website/docs/en/config/rsbuild/output.mdx
+++ b/website/docs/en/config/rsbuild/output.mdx
@@ -149,6 +149,7 @@ export default defineConfig({
           minify: false,
           compress: {
             defaults: false,
+            directives: false,
             unused: true,
             dead_code: true,
             toplevel: true,
@@ -189,6 +190,7 @@ export default defineConfig({
           minify: true,
           compress: {
             defaults: false,
+            directives: false,
             unused: true,
             dead_code: true,
             // Avoid remoteEntry's global variable being tree-shaken

--- a/website/docs/zh/config/rsbuild/output.mdx
+++ b/website/docs/zh/config/rsbuild/output.mdx
@@ -145,6 +145,7 @@ export default defineConfig({
           minify: false,
           compress: {
             defaults: false,
+            directives: false,
             unused: true,
             dead_code: true,
             toplevel: true,
@@ -185,6 +186,7 @@ export default defineConfig({
           minify: true,
           compress: {
             defaults: false,
+            directives: false,
             unused: true,
             dead_code: true,
             // 避免 remoteEntry 的全局变量被 tree-shaking


### PR DESCRIPTION
## Summary

fix https://github.com/web-infra-dev/rslib/issues/316.

## in this PR:

depends on depends on https://github.com/web-infra-dev/rspack/pull/12168, the native Rslib plugin has handled hashbang and react directives.

### with `advancedEsm`

no entry dedicated loader anymore, `advancedEsm` can handle "the issue of a module acting as both an entry module and a non-entry module is that the module graph can affect each other".

### without `advancedEsm`

still using a dedicated loader, but only an empty loader to make the doppelganger. the loader will not handle hashbang and react directives anymore (already handled in native plugin).

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
