### PR TITLE
fix(dts): gracefully shutdown when panic

### DIFF
--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -286,6 +286,11 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
   }
 }
 
+// Gracefully shutdown on disconnect when panic
+process.on('disconnect', () => {
+  process.exit();
+});
+
 process.on('message', async (data: DtsGenOptions) => {
   if (!data.cwd) {
     return;


### PR DESCRIPTION
## Summary

Gracefully shutdown when main process panic.

### Before

<img width="2654" height="642" alt="image" src="https://github.com/user-attachments/assets/c5f3dd59-b9a2-4996-8bda-017bf9240bd0" />

### Now

<img width="2638" height="170" alt="image" src="https://github.com/user-attachments/assets/5e3d4b75-a5c3-410a-a2e8-e4c4d1a66831" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
