### PR TITLE
fix: should only make entry doppelganger in non-advanced ESM

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1832,7 +1832,7 @@ async function composeLibRsbuildConfig(
   const assetConfig = composeAssetConfig(bundle, format);
 
   const entryChunkConfig = composeEntryChunkConfig({
-    useLoader: advancedEsm !== true,
+    useLoader: advancedEsm !== true && (format === 'esm' || format === 'iife'),
     enabledImportMetaUrlShim: enabledShims.cjs['import.meta.url'],
     contextToWatch: outBase,
   });

--- a/packages/core/src/plugins/EntryChunkPlugin.ts
+++ b/packages/core/src/plugins/EntryChunkPlugin.ts
@@ -72,13 +72,17 @@ class EntryChunkPlugin {
           compilation.updateAsset(name, (old) => {
             const oldSource = old.source().toString();
             const replaceSource = new rspack.sources.ReplaceSource(old);
-            if (
-              oldSource.startsWith('use strict;') ||
-              oldSource.startsWith('"use strict";')
+
+            if (oldSource.startsWith('#!')) {
+              const firstLineEnd = oldSource.indexOf('\n');
+              replaceSource.insert(firstLineEnd + 1, IMPORT_META_URL_SHIM);
+            } else if (
+              oldSource.startsWith("'use strict'") ||
+              oldSource.startsWith('"use strict"')
             ) {
               replaceSource.replace(
                 0,
-                11, // 'use strict;'.length,
+                11,
                 `"use strict";\n${IMPORT_META_URL_SHIM}`,
               );
             } else {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -2425,17 +2425,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             }
           }
         ]
-      },
-      /* config.module.rule('Rslib:js-entry-loader') */
-      {
-        test: /\\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/,
-        issuer: /^$/,
-        use: [
-          /* config.module.rule('Rslib:js-entry-loader').use('rsbuild:lib-entry-module') */
-          {
-            loader: '<WORKSPACE>/dist/entryModuleLoader.js'
-          }
-        ]
       }
     ]
   },
@@ -3070,17 +3059,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
               id: 'rsbuild-transform-0',
               getEnvironment: ()=>environmentContext
             }
-          }
-        ]
-      },
-      /* config.module.rule('Rslib:js-entry-loader') */
-      {
-        test: /\\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/,
-        issuer: /^$/,
-        use: [
-          /* config.module.rule('Rslib:js-entry-loader').use('rsbuild:lib-entry-module') */
-          {
-            loader: '<WORKSPACE>/dist/entryModuleLoader.js'
           }
         ]
       }
@@ -4312,17 +4290,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         generator: {
           filename: 'static/wasm/[contenthash:8].module.wasm'
         }
-      },
-      /* config.module.rule('Rslib:js-entry-loader') */
-      {
-        test: /\\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/,
-        issuer: /^$/,
-        use: [
-          /* config.module.rule('Rslib:js-entry-loader').use('rsbuild:lib-entry-module') */
-          {
-            loader: '<WORKSPACE>/dist/entryModuleLoader.js'
-          }
-        ]
       }
     ]
   },
@@ -4834,10 +4801,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         ],
         "setup": [Function],
       },
-      {
-        "name": "rsbuild:lib-entry-chunk",
-        "setup": [Function],
-      },
     ],
     "resolve": {
       "alias": {
@@ -5094,10 +5057,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       },
       {
         "name": "rsbuild:fix-js-module-type",
-        "setup": [Function],
-      },
-      {
-        "name": "rsbuild:lib-entry-chunk",
         "setup": [Function],
       },
     ],
@@ -5539,10 +5498,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       },
       {
         "name": "rsbuild:fix-js-module-type",
-        "setup": [Function],
-      },
-      {
-        "name": "rsbuild:lib-entry-chunk",
         "setup": [Function],
       },
       {

--- a/tests/integration/directive/shebang/rslib.config.ts
+++ b/tests/integration/directive/shebang/rslib.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@rslib/core';
-import { generateBundleEsmConfig } from 'test-helper';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
 
 const esmShared = {
   source: {
@@ -20,6 +20,11 @@ const esmSharedBundleFalse = {
 
 export default defineConfig({
   lib: [
+    generateBundleCjsConfig({
+      output: {
+        distPath: './dist/bundle/cjs0',
+      },
+    }),
     generateBundleEsmConfig({
       ...esmShared,
       shims: { esm: { __dirname: true, __filename: true } },

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -74,8 +74,8 @@ describe('minify config (mf)', () => {
     const { mfExposeEntry } = await buildAndGetResults({ fixturePath });
     // biome-ignore format: snapshot
     expect(mfExposeEntry).toMatchInlineSnapshot(`
-      "/*! For license information please see __federation_expose_default_export.fd95b46e.js.LICENSE.txt */
-      "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["525"],{807:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{Button:()=>Button,foo:()=>foo});var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__=__webpack_require__(491);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("button",{})}}]);"
+      "/*! For license information please see __federation_expose_default_export.8ba7966f.js.LICENSE.txt */
+      "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([["525"],{510:function(__unused_webpack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{Button:()=>Button,foo:()=>foo});var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__=__webpack_require__(491);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_0__.jsx)("button",{})}}]);"
     `);
   });
 
@@ -86,7 +86,7 @@ describe('minify config (mf)', () => {
     expect(mfExposeEntry).toMatchInlineSnapshot(`
       ""use strict";
       (globalThis["disable_minify"] = globalThis["disable_minify"] || []).push([["525"], {
-      807: (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+      510: (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
       __webpack_require__.r(__webpack_exports__);
       __webpack_require__.d(__webpack_exports__, {
         Button: () => (Button),


### PR DESCRIPTION
## Summary

only non-advancedEsm `modern-module` need this, as others formats doesn't rely on it.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
