### PR TITLE
fix: clean declaration maps before the build starts

### DIFF
--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -159,7 +159,7 @@ export const pluginDts = (options: PluginDtsOptions = {}): RsbuildPlugin => ({
         warnIfOutside(cwd, declarationDir, 'declarationDir');
         warnIfOutside(cwd, outDir, 'outDir');
 
-        // clean dts files
+        // clean dts files and maps
         if (config.output.cleanDistPath !== false) {
           await cleanDtsFiles(dtsEmitPath);
         }

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -612,7 +612,14 @@ export const globDtsFiles = async (
 };
 
 export async function cleanDtsFiles(dir: string): Promise<void> {
-  const patterns = ['/**/*.d.ts', '/**/*.d.cts', '/**/*.d.mts'];
+  const patterns = [
+    '/**/*.d.ts',
+    '/**/*.d.cts',
+    '/**/*.d.mts',
+    '/**/*.d.ts.map',
+    '/**/*.d.cts.map',
+    '/**/*.d.mts.map',
+  ];
   const allFiles = await globDtsFiles(dir, patterns);
 
   await Promise.all(

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -465,14 +465,24 @@ export async function createTempFiles(
   const tempDirEsm = join(fixturePath, 'dist-types', 'esm');
   const tempFileCjs = join(tempDirCjs, 'tempFile.d.ts');
   const tempFileEsm = join(tempDirEsm, 'tempFile.d.ts');
+  const tempFileMapCjs = join(tempDirCjs, 'tempFile.d.ts.map');
+  const tempFileMapEsm = join(tempDirEsm, 'tempFile.d.ts.map');
 
   await fs.promises.mkdir(tempDirCjs, { recursive: true });
   await fs.promises.mkdir(tempDirEsm, { recursive: true });
 
   await fs.promises.writeFile(tempFileCjs, 'console.log("temp file for cjs");');
   await fs.promises.writeFile(tempFileEsm, 'console.log("temp file for esm");');
+  await fs.promises.writeFile(
+    tempFileMapCjs,
+    'console.log("temp map file for cjs");',
+  );
+  await fs.promises.writeFile(
+    tempFileMapEsm,
+    'console.log("temp map file for esm");',
+  );
 
-  checkFile.push(tempFileCjs, tempFileEsm);
+  checkFile.push(tempFileCjs, tempFileEsm, tempFileMapCjs, tempFileMapEsm);
 
   if (bundle) {
     const tempDirRslib = join(fixturePath, '.rslib', 'declarations', 'cjs');


### PR DESCRIPTION
## Summary

clean declaration maps before the build starts

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
