### PR TITLE
feat: default exclude `@types/react` from dts bundle

### DIFF
--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -20,6 +20,8 @@ import {
 const isObject = (obj: unknown): obj is Record<string, any> =>
   Object.prototype.toString.call(obj) === '[object Object]';
 
+export const DEFAULT_EXCLUDED_PACKAGES: string[] = ['@types/react'];
+
 // use !externals
 export const calcBundledPackages = (options: {
   cwd: string;
@@ -110,7 +112,11 @@ export const calcBundledPackages = (options: {
       !externals.some((e) => (typeof e === 'string' ? d === e : e.test(d))),
   );
 
-  return Array.from(new Set(bundledPackages));
+  const filteredBundledPackages = Array.from(new Set(bundledPackages)).filter(
+    (pkg) => !DEFAULT_EXCLUDED_PACKAGES.includes(pkg),
+  );
+
+  return filteredBundledPackages;
 };
 
 export async function generateDts(data: DtsGenOptions): Promise<void> {

--- a/packages/plugin-dts/tests/external.test.ts
+++ b/packages/plugin-dts/tests/external.test.ts
@@ -1,7 +1,15 @@
 import fs from 'node:fs';
 import { logger } from '@rsbuild/core';
 import { describe, expect, it, rs } from '@rstest/core';
-import { calcBundledPackages } from '../src/dts';
+import { calcBundledPackages, DEFAULT_EXCLUDED_PACKAGES } from '../src/dts';
+
+const defaultExcludePackages = DEFAULT_EXCLUDED_PACKAGES.reduce(
+  (acc: Record<string, string>, cur: string) => {
+    acc[cur] = '1.0.0';
+    return acc;
+  },
+  {},
+);
 
 const commonPkgJson = {
   dependencies: {
@@ -13,6 +21,7 @@ const commonPkgJson = {
   devDependencies: {
     baz: '1.0.0',
     bar: '1.0.0',
+    ...defaultExcludePackages,
   },
 };
 
@@ -65,6 +74,7 @@ describe('should calcBundledPackages correctly', () => {
           baz: '1.0.0',
           bar: '1.0.0',
           react: '1.0.0',
+          ...defaultExcludePackages,
         },
       }),
     );

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -199,11 +199,9 @@ export default {
 
 ### How to additionally exclude specified dependencies when `dts.bundle` is `true`?
 
-Rslib uses [rsbuild-plugin-dts](https://github.com/web-infra-dev/rslib/blob/main/packages/plugin-dts/README.md) to generate declaration files, which supports configuration via [output.externals](/config/rsbuild/output#outputtarget) for excluding certain dependencies from bundled declaration files.
+Rslib uses [rsbuild-plugin-dts](https://github.com/web-infra-dev/rslib/blob/main/packages/plugin-dts/README.md) to generate declaration files, which supports configuration via [output.externals](/config/rsbuild/output#outputexternals) for excluding certain dependencies from bundled declaration files.
 
-For example, a typical React component library often does not declare `@types/react` in `peerDependencies` but only in `devDependencies`. Following the [autoExternal](/config/lib/auto-external) logic for dependency handling, Rslib will attempt to bundle `@types/react` into the declaration output files during the build. However, in practice, a component library should not bundle `@types/react`.
-
-In this scenario, you can configure [output.externals](/config/rsbuild/output#outputtarget) to exclude `@types/react`.
+For example, if `@types/foo` is only declared in `devDependencies`, according to the dependency handling logic of [autoExternal](/config/lib/auto-external), Rslib will try to bundle `@types/foo` into the declaration output files during the build. In this case, you can exclude `@types/foo` by configuring [output.externals](/config/rsbuild/output#outputexternals).
 
 ```ts title="rslib.config.ts"
 export default {
@@ -211,10 +209,12 @@ export default {
     // ...
   ],
   output: {
-    externals: ['@types/react'],
+    externals: ['@types/foo'],
   },
 };
 ```
+
+In addition, if you only want to specify a few dependencies to be bundled into the declaration output files, you can configure [dts.bundle.bundledPackages](/config/lib/dts#dtsbundlebundledpackages) to achieve this. All other dependencies not in this configuration will be excluded.
 
 ## Rsbuild plugin
 

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -199,11 +199,9 @@ export default {
 
 ### 如何在 `dts.bundle` 为 `true` 时额外排除指定的依赖？
 
-Rslib 通过 [rsbuild-plugin-dts](https://github.com/web-infra-dev/rslib/blob/main/packages/plugin-dts/README.md) 完成对类型声明文件的生成，该插件支持通过 [output.externals](/config/rsbuild/output#outputtarget) 进行配置，用于从打包后的类型声明文件中排除指定的依赖。
+Rslib 通过 [rsbuild-plugin-dts](https://github.com/web-infra-dev/rslib/blob/main/packages/plugin-dts/README.md) 生成类型声明文件，该插件支持通过 [output.externals](/config/rsbuild/output#outputexternals) 配置，从打包后的类型声明文件中排除指定的依赖。
 
-举个例子：常见的 React 组件库通常不会将 `@types/react` 声明在 `peerDependencies` 中，而是仅声明在 `devDependencies`，按照 [autoExternal](/config/lib/auto-external) 处理依赖的逻辑，在打包时 Rslib 会尝试将 `@types/react` 一同打包进类型声明文件产物中，但在实践中组件库并不应该打包 `@types/react`。
-
-此时可以通过配置 [output.externals](/config/rsbuild/output#outputtarget) 来排除 `@types/react`。
+举个例子，若 `@types/foo` 仅声明在 `devDependencies` 中，按照 [autoExternal](/config/lib/auto-external) 处理依赖的逻辑，在打包时 Rslib 会尝试将 `@types/foo` 一同打包进类型声明文件产物中，此时可以通过配置 [output.externals](/config/rsbuild/output#outputexternals) 来排除 `@types/foo`。
 
 ```ts title="rslib.config.ts"
 export default {
@@ -211,10 +209,12 @@ export default {
     // ...
   ],
   output: {
-    externals: ['@types/react'],
+    externals: ['@types/foo'],
   },
 };
 ```
+
+此外，如果只想指定某几个依赖项打包进类型声明文件产物中，可以通过配置 [dts.bundle.bundledPackages](/config/lib/dts#dtsbundlebundledpackages) 来实现，不在该配置中的所有其他依赖项都会被排除。
 
 ## Rsbuild 插件
 


### PR DESCRIPTION
## Summary

- Api extractor can not bundle `@types/react`.

<img width="1626" height="150" alt="image" src="https://github.com/user-attachments/assets/1441ebee-80c9-4c84-a4a0-cc6967e74f25" />

- A typical React component library often does not declare `@types/react` in `peerDependencies` but only in `devDependencies`. Following the autoExternal logic for dependency handling, Rslib will attempt to bundle `@types/react` into the declaration output files during the build. However, in practice, a component library should not bundle `@types/react`.

In this PR, default exclude `@types/react` from dts bundle.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
