### PR TITLE
test: use rstest es module outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@biomejs/biome": "^2.3.8",
     "@changesets/cli": "^2.29.8",
     "@rslint/core": "^0.1.14",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^24.10.1",
     "check-dependency-version-consistency": "^5.0.1",

--- a/packages/core/__mocks__/fs/promises.js
+++ b/packages/core/__mocks__/fs/promises.js
@@ -1,2 +1,5 @@
-import { promises } from 'memfs';
+import memfs from 'memfs';
+
+const { promises } = memfs;
+
 export default promises;

--- a/packages/create-rslib/fragments/tools/rstest-node-js/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-node-js/package.json
@@ -3,6 +3,6 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rstest/core": "^0.7.0"
+    "@rstest/core": "^0.7.1"
   }
 }

--- a/packages/create-rslib/fragments/tools/rstest-node-ts/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-node-ts/package.json
@@ -3,6 +3,6 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rstest/core": "^0.7.0"
+    "@rstest/core": "^0.7.1"
   }
 }

--- a/packages/create-rslib/fragments/tools/rstest-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-react-js/package.json
@@ -3,7 +3,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "jsdom": "^26.1.0"

--- a/packages/create-rslib/fragments/tools/rstest-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-react-ts/package.json
@@ -3,7 +3,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "jsdom": "^26.1.0"

--- a/packages/create-rslib/fragments/tools/rstest-vue-js/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-vue-js/package.json
@@ -3,7 +3,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.6",

--- a/packages/create-rslib/fragments/tools/rstest-vue-ts/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-vue-ts/package.json
@@ -3,7 +3,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.6",

--- a/packages/create-rslib/template-[node-dual]-[rstest]-js/package.json
+++ b/packages/create-rslib/template-[node-dual]-[rstest]-js/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0"
+    "@rstest/core": "^0.7.1"
   }
 }

--- a/packages/create-rslib/template-[node-dual]-[rstest]-ts/package.json
+++ b/packages/create-rslib/template-[node-dual]-[rstest]-ts/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@types/node": "^24.10.1",
     "typescript": "^5.9.3"
   }

--- a/packages/create-rslib/template-[node-esm]-[rstest]-js/package.json
+++ b/packages/create-rslib/template-[node-esm]-[rstest]-js/package.json
@@ -17,6 +17,6 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0"
+    "@rstest/core": "^0.7.1"
   }
 }

--- a/packages/create-rslib/template-[node-esm]-[rstest]-ts/package.json
+++ b/packages/create-rslib/template-[node-esm]-[rstest]-ts/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@types/node": "^24.10.1",
     "typescript": "^5.9.3"
   }

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
@@ -21,7 +21,7 @@
     "@rsbuild/core": "~1.6.13",
     "@rsbuild/plugin-react": "^1.4.2",
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@storybook/addon-docs": "^10.1.4",
     "@storybook/addon-onboarding": "^10.1.4",
     "@storybook/react": "^10.1.4",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
@@ -23,7 +23,7 @@
     "@rsbuild/core": "~1.6.13",
     "@rsbuild/plugin-react": "^1.4.2",
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@storybook/addon-docs": "^10.1.4",
     "@storybook/addon-onboarding": "^10.1.4",
     "@storybook/react": "^10.1.4",

--- a/packages/create-rslib/template-[react]-[rstest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[rstest]-js/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@rsbuild/plugin-react": "^1.4.2",
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "jsdom": "^26.1.0",

--- a/packages/create-rslib/template-[react]-[rstest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[rstest]-ts/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@rsbuild/plugin-react": "^1.4.2",
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.2.7",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@rsbuild/core": "~1.6.13",
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@storybook/addon-docs": "^10.1.4",
     "@storybook/addon-onboarding": "^10.1.4",
     "@storybook/vue3": "^10.1.4",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@rsbuild/core": "~1.6.13",
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@storybook/addon-docs": "^10.1.4",
     "@storybook/addon-onboarding": "^10.1.4",
     "@storybook/vue3": "^10.1.4",

--- a/packages/create-rslib/template-[vue]-[rstest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest]-js/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.6",

--- a/packages/create-rslib/template-[vue]-[rstest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest]-ts/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
-    "@rstest/core": "^0.7.0",
+    "@rstest/core": "^0.7.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.1.14
         version: 0.1.14
       '@rstest/core':
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.7.1
+        version: 0.7.1
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -3105,8 +3105,8 @@ packages:
   '@rstack-dev/doc-ui@1.12.0':
     resolution: {integrity: sha512-YYnJ/8oCUuNMLxBXVFydmEfNOmELR7/Ee8Xcwh4Vt+sGhddf7GFFWFHD9c3fVy/IjdLL+rEIAj1i5nGQxsjwOA==}
 
-  '@rstest/core@0.7.0':
-    resolution: {integrity: sha512-imqWtaulpq71uSPfTh6l7iIbunQmIjs6yVitGgtlejJXzcunKJS8m3oeVXoIa2a5OMlG6a7tYfVNYNVh7otlYw==}
+  '@rstest/core@0.7.1':
+    resolution: {integrity: sha512-laAkO1HsxYvxl1VBzFKSrRdP3STMJRe58W4IjPSIMloZnXU70wvjdGP9FtxGKEBg7uAUtishDzJ7cXfJCVVaFA==}
     engines: {node: '>=18.12.0'}
     hasBin: true
     peerDependencies:
@@ -9755,7 +9755,7 @@ snapshots:
       - react
       - react-dom
 
-  '@rstest/core@0.7.0':
+  '@rstest/core@0.7.1':
     dependencies:
       '@rsbuild/core': 1.6.12-canary-20251204065915
       '@types/chai': 5.2.3

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -7,6 +7,9 @@ export const shared: RstestConfig = {
   testTimeout: 60_000,
   hookTimeout: 50_000,
   restoreMocks: true,
+  output: {
+    module: true,
+  },
 };
 
 export default defineConfig({

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -117,7 +117,7 @@ describe('CJS shims', () => {
     const req = createRequire(entryFiles.cjs);
     const context = vm.createContext({
       require: req,
-      exports,
+      exports: {},
       module: { require: req },
       __filename: entryFiles.cjs,
     });


### PR DESCRIPTION
## Summary

Outputs and executes test code in ES module format by default. 

https://rstest.rs/config/build/output#outputmodule

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
