### PR TITLE
fix(plugin-dts): follow `lib.dts.abortOnError` when generating dts

### DIFF
--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -122,6 +122,7 @@ export const calcBundledPackages = (options: {
 export async function generateDts(data: DtsGenOptions): Promise<void> {
   const {
     bundle,
+    abortOnError,
     dtsEntry,
     dtsEmitPath,
     tsconfigPath,
@@ -269,6 +270,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
       tsConfigResult,
       declarationDir,
       dtsExtension,
+      abortOnError,
       redirect,
       rootDir,
       paths,
@@ -282,7 +284,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
   );
 
   if (tsgo) {
-    if (!hasError) {
+    if (!hasError || !abortOnError) {
       await bundleDtsIfNeeded();
     }
   } else {

--- a/packages/plugin-dts/src/tsgo.ts
+++ b/packages/plugin-dts/src/tsgo.ts
@@ -74,6 +74,7 @@ const generateTsgoArgs = (
 };
 
 async function handleDiagnosticsAndProcessFiles(
+  abortOnError: boolean | undefined,
   isWatch: boolean,
   hasErrors: boolean,
   tsConfigResult: ts.ParsedCommandLine,
@@ -124,7 +125,7 @@ async function handleDiagnosticsAndProcessFiles(
     footer,
   );
 
-  if (hasErrors && !isWatch) {
+  if (hasErrors && !isWatch && abortOnError) {
     const error = new Error(
       `Failed to generate declaration files. ${color.dim(`(${name})`)}`,
     );
@@ -143,6 +144,7 @@ export async function emitDtsTsgo(
 ): Promise<boolean> {
   const start = Date.now();
   const {
+    abortOnError,
     configPath,
     tsConfigResult,
     declarationDir,
@@ -203,6 +205,7 @@ export async function emitDtsTsgo(
         }
 
         await handleDiagnosticsAndProcessFiles(
+          abortOnError,
           isWatch,
           hasErrors,
           tsConfigResult,


### PR DESCRIPTION
## Summary

- pass `abortOnError` through dts pipeline (tsc/tsgo) instead of always failing when type-check has error
- allow bundling to proceed when `abortOnError` is `false` despite diagnostics

## Related Links

N/A

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated (not required).
