### PR TITLE
fix: should throw error when custom config file not found

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -110,7 +110,9 @@ const resolveConfigPath = (
     if (fs.existsSync(customConfigPath)) {
       return customConfigPath;
     }
-    logger.warn(`Cannot find config file: ${color.dim(customConfigPath)}\n`);
+    throw new Error(
+      `${color.dim('[rslib:loadConfig]')} Cannot find config file: ${color.dim(customConfigPath)}`,
+    );
   }
 
   const configFilePath = findConfig(join(root, DEFAULT_CONFIG_NAME));

--- a/tests/integration/cli/build/build.test.ts
+++ b/tests/integration/cli/build/build.test.ts
@@ -104,6 +104,16 @@ describe('build command', async () => {
     `);
   });
 
+  test('--config 404 config file', () => {
+    expect(() => {
+      runCliSync('build --config ./custom-not-found.config.js', {
+        cwd: __dirname,
+        // only capture stderr output
+        stdio: ['ignore', 'ignore', 'pipe'],
+      });
+    }).toThrowError(/Cannot find config file: .*custom-not-found.config.js/);
+  });
+
   test('should use Node.js native loader to load config', async () => {
     // Skip Node.js <= 22.18
     if (!process.features.typescript) {


### PR DESCRIPTION
## Summary

fix: should throw error when custom config file not found. 

expect throw `config not found` error, but fallback to default config.


## Related Links

https://github.com/web-infra-dev/rsbuild/pull/6828

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
