### PR TITLE
feat(CLI): add `--no-env` cli options

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -78,7 +78,8 @@ const applyCommonOptions = (cli: CAC) => {
         type: [String],
         default: [],
       },
-    );
+    )
+    .option('--no-env', 'Disable loading of `.env` files');
 };
 
 export function runCli(): void {

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -35,6 +35,7 @@ Rslib CLI provides several common flags that can be used with all commands:
 | `-h, --help`               | Display help for command                                                                                                                                    |
 | `--lib <id>`               | Specify the library to run commands (repeatable, e.g. `--lib esm --lib cjs`), see [lib.id](/config/lib/id) to learn how to get or set the ID of the library |
 | `--log-level <level>`      | Set the log level (`info` \| `warn` \| `error` \| `silent`), see [logLevel](/config/rsbuild/log-level)                                                      |
+| `--no-env`                 | Disable loading of `.env` files                                                                                                                             |
 | `-r, --root <root>`        | Specify the project root directory, can be an absolute path or a path relative to cwd                                                                       |
 
 ## rslib build

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -35,6 +35,7 @@ Rslib CLI 提供了一些公共选项，可以用于所有命令：
 | `-h, --help`               | 显示命令帮助                                                                                                              |
 | `--lib <id>`               | 指定运行命令的库（可重复，例如：`--lib esm --lib cjs`），查看 [lib.id](/config/lib/id) 了解如何获取或设置库的 ID          |
 | `--log-level <level>`      | 指定日志级别（`info` \| `warn` \| `error` \| `silent`），详见 [logLevel](/config/rsbuild/log-level)                       |
+| `--no-env`                 | 禁用 `.env` 文件的加载                                                                                                    |
 | `-r, --root <root>`        | 指定项目根目录，可以是绝对路径或者相对于 cwd 的路径                                                                       |
 
 ## rslib build


### PR DESCRIPTION
## Summary

Add `--no-env` cli options to control disable loading of `.env` files.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
