### PR TITLE
fix(CLI): simplify build error logs

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -10,6 +10,8 @@ import { inspect } from './inspect';
 import { startMFDevServer } from './mf';
 import { watchFilesForRestart } from './restart';
 
+export const RSPACK_BUILD_ERROR = 'Rspack build failed.';
+
 export type CommonOptions = {
   root?: string;
   config?: string;
@@ -162,7 +164,11 @@ export function runCli(): void {
 
         await cliBuild();
       } catch (err) {
-        logger.error('Failed to build.');
+        const isRspackError =
+          err instanceof Error && err.message === RSPACK_BUILD_ERROR;
+        if (!isRspackError) {
+          logger.error('Failed to build.');
+        }
         if (err instanceof AggregateError) {
           for (const error of err.errors) {
             logger.error(error);


### PR DESCRIPTION
## Summary

Simplify build error logs

**before**
<img width="516" height="108" alt="image" src="https://github.com/user-attachments/assets/199693cf-f288-4257-9deb-7e29e9bbc96c" />

**now**
<img width="584" height="92" alt="image" src="https://github.com/user-attachments/assets/3ed7c02c-9d79-42f1-9fac-dfee9304f16c" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
