### PR TITLE
feat(create-rslib): use `happy-dom` instead of `jsdom`

### DIFF
--- a/packages/create-rslib/fragments/tools/rstest-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-react-js/package.json
@@ -6,6 +6,6 @@
     "@rstest/core": "^0.7.6",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
-    "jsdom": "^26.1.0"
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/create-rslib/fragments/tools/rstest-react-js/rstest.config.js
+++ b/packages/create-rslib/fragments/tools/rstest-react-js/rstest.config.js
@@ -2,7 +2,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.js'],
   plugins: [pluginReact()],
 });

--- a/packages/create-rslib/fragments/tools/rstest-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-react-ts/package.json
@@ -6,6 +6,6 @@
     "@rstest/core": "^0.7.6",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
-    "jsdom": "^26.1.0"
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/create-rslib/fragments/tools/rstest-react-ts/rstest.config.ts
+++ b/packages/create-rslib/fragments/tools/rstest-react-ts/rstest.config.ts
@@ -2,7 +2,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.ts'],
   plugins: [pluginReact()],
 });

--- a/packages/create-rslib/fragments/tools/rstest-vue-js/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-vue-js/package.json
@@ -7,6 +7,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.6",
-    "jsdom": "^26.1.0"
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/create-rslib/fragments/tools/rstest-vue-js/rstest.config.js
+++ b/packages/create-rslib/fragments/tools/rstest-vue-js/rstest.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from '@rstest/core';
 import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.js'],
   plugins: [pluginUnpluginVue()],
 });

--- a/packages/create-rslib/fragments/tools/rstest-vue-ts/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-vue-ts/package.json
@@ -7,6 +7,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.6",
-    "jsdom": "^26.1.0"
+    "happy-dom": "^20.0.11"
   }
 }

--- a/packages/create-rslib/fragments/tools/rstest-vue-ts/rstest.config.ts
+++ b/packages/create-rslib/fragments/tools/rstest-vue-ts/rstest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@rstest/core';
 import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.ts'],
   plugins: [pluginUnpluginVue()],
 });

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
@@ -27,7 +27,7 @@
     "@storybook/react": "^10.1.10",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
-    "jsdom": "^26.1.0",
+    "happy-dom": "^20.0.11",
     "react": "^19.2.3",
     "storybook": "^10.1.10",
     "storybook-addon-rslib": "^3.2.0",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-js/rstest.config.js
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-js/rstest.config.js
@@ -2,7 +2,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.js'],
   plugins: [pluginReact()],
 });

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
@@ -30,7 +30,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@types/react": "^19.2.7",
-    "jsdom": "^26.1.0",
+    "happy-dom": "^20.0.11",
     "react": "^19.2.3",
     "storybook": "^10.1.10",
     "storybook-addon-rslib": "^3.2.0",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-ts/rstest.config.ts
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-ts/rstest.config.ts
@@ -2,7 +2,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.ts'],
   plugins: [pluginReact()],
 });

--- a/packages/create-rslib/template-[react]-[rstest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[rstest]-js/package.json
@@ -21,7 +21,7 @@
     "@rstest/core": "^0.7.6",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
-    "jsdom": "^26.1.0",
+    "happy-dom": "^20.0.11",
     "react": "^19.2.3"
   },
   "peerDependencies": {

--- a/packages/create-rslib/template-[react]-[rstest]-js/rstest.config.js
+++ b/packages/create-rslib/template-[react]-[rstest]-js/rstest.config.js
@@ -2,7 +2,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.js'],
   plugins: [pluginReact()],
 });

--- a/packages/create-rslib/template-[react]-[rstest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[rstest]-ts/package.json
@@ -24,7 +24,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@types/react": "^19.2.7",
-    "jsdom": "^26.1.0",
+    "happy-dom": "^20.0.11",
     "react": "^19.2.3",
     "typescript": "^5.9.3"
   },

--- a/packages/create-rslib/template-[react]-[rstest]-ts/rstest.config.ts
+++ b/packages/create-rslib/template-[react]-[rstest]-ts/rstest.config.ts
@@ -2,7 +2,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.ts'],
   plugins: [pluginReact()],
 });

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
@@ -29,7 +29,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.6",
-    "jsdom": "^26.1.0",
+    "happy-dom": "^20.0.11",
     "rsbuild-plugin-unplugin-vue": "^0.1.0",
     "storybook": "^10.1.10",
     "storybook-addon-rslib": "^3.2.0",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-js/rstest.config.js
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-js/rstest.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from '@rstest/core';
 import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.js'],
   plugins: [pluginUnpluginVue()],
 });

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
@@ -29,7 +29,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.6",
-    "jsdom": "^26.1.0",
+    "happy-dom": "^20.0.11",
     "rsbuild-plugin-unplugin-vue": "^0.1.0",
     "storybook": "^10.1.10",
     "storybook-addon-rslib": "^3.2.0",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/rstest.config.ts
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/rstest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@rstest/core';
 import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.ts'],
   plugins: [pluginUnpluginVue()],
 });

--- a/packages/create-rslib/template-[vue]-[rstest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest]-js/package.json
@@ -23,7 +23,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.6",
-    "jsdom": "^26.1.0",
+    "happy-dom": "^20.0.11",
     "rsbuild-plugin-unplugin-vue": "^0.1.0",
     "vue": "^3.5.26"
   },

--- a/packages/create-rslib/template-[vue]-[rstest]-js/rstest.config.js
+++ b/packages/create-rslib/template-[vue]-[rstest]-js/rstest.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from '@rstest/core';
 import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.js'],
   plugins: [pluginUnpluginVue()],
 });

--- a/packages/create-rslib/template-[vue]-[rstest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest]-ts/package.json
@@ -23,7 +23,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.6",
-    "jsdom": "^26.1.0",
+    "happy-dom": "^20.0.11",
     "rsbuild-plugin-unplugin-vue": "^0.1.0",
     "typescript": "^5.9.3",
     "vue": "^3.5.26",

--- a/packages/create-rslib/template-[vue]-[rstest]-ts/rstest.config.ts
+++ b/packages/create-rslib/template-[vue]-[rstest]-ts/rstest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@rstest/core';
 import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'jsdom',
+  testEnvironment: 'happy-dom',
   setupFiles: ['./rstest.setup.ts'],
   plugins: [pluginUnpluginVue()],
 });


### PR DESCRIPTION
## Summary

Use `happy-dom` instead of `jsdom` as default testEnvironment in Rstest template.

`happy-dom` is considered faster than jsdom, but it lacks some APIs.

https://github.com/capricorn86/happy-dom/wiki/

```bash
hyperfine 'pnpm test --testEnvironment jsdom' 'pnpm test --testEnvironment happy-dom'

Benchmark 1: pnpm test --testEnvironment jsdom
  Time (mean ± σ):     899.7 ms ± 118.5 ms    [User: 830.1 ms, System: 295.0 ms]
  Range (min … max):   835.9 ms … 1231.8 ms    10 runs
  
Benchmark 2: pnpm test --testEnvironment happy-dom
  Time (mean ± σ):     757.9 ms ±  17.2 ms    [User: 754.3 ms, System: 276.4 ms]
  Range (min … max):   745.9 ms … 802.8 ms    10 runs
 
Summary
  pnpm test --testEnvironment happy-dom ran
    1.19 ± 0.16 times faster than pnpm test --testEnvironment jsdom
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
