### PR TITLE
feat(create-rslib): use `@rstest/adapter-rslib`

### DIFF
--- a/packages/create-rslib/fragments/tools/rstest-node-js/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-node-js/package.json
@@ -3,6 +3,7 @@
     "test": "rstest"
   },
   "devDependencies": {
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7"
   }
 }

--- a/packages/create-rslib/fragments/tools/rstest-node-js/rstest.config.js
+++ b/packages/create-rslib/fragments/tools/rstest-node-js/rstest.config.js
@@ -1,3 +1,6 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({});
+export default defineConfig({
+  extends: withRslibConfig(),
+});

--- a/packages/create-rslib/fragments/tools/rstest-node-ts/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-node-ts/package.json
@@ -3,6 +3,7 @@
     "test": "rstest"
   },
   "devDependencies": {
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7"
   }
 }

--- a/packages/create-rslib/fragments/tools/rstest-node-ts/rstest.config.ts
+++ b/packages/create-rslib/fragments/tools/rstest-node-ts/rstest.config.ts
@@ -1,3 +1,6 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({});
+export default defineConfig({
+  extends: withRslibConfig(),
+});

--- a/packages/create-rslib/fragments/tools/rstest-react-js/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-react-js/package.json
@@ -3,6 +3,7 @@
     "test": "rstest"
   },
   "devDependencies": {
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",

--- a/packages/create-rslib/fragments/tools/rstest-react-js/rstest.config.js
+++ b/packages/create-rslib/fragments/tools/rstest-react-js/rstest.config.js
@@ -1,8 +1,7 @@
-import { pluginReact } from '@rsbuild/plugin-react';
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.js'],
-  plugins: [pluginReact()],
 });

--- a/packages/create-rslib/fragments/tools/rstest-react-ts/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-react-ts/package.json
@@ -3,6 +3,7 @@
     "test": "rstest"
   },
   "devDependencies": {
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",

--- a/packages/create-rslib/fragments/tools/rstest-react-ts/rstest.config.ts
+++ b/packages/create-rslib/fragments/tools/rstest-react-ts/rstest.config.ts
@@ -1,8 +1,7 @@
-import { pluginReact } from '@rsbuild/plugin-react';
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.ts'],
-  plugins: [pluginReact()],
 });

--- a/packages/create-rslib/fragments/tools/rstest-vue-js/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-vue-js/package.json
@@ -3,6 +3,7 @@
     "test": "rstest"
   },
   "devDependencies": {
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",

--- a/packages/create-rslib/fragments/tools/rstest-vue-js/rstest.config.js
+++ b/packages/create-rslib/fragments/tools/rstest-vue-js/rstest.config.js
@@ -1,8 +1,7 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
-import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.js'],
-  plugins: [pluginUnpluginVue()],
 });

--- a/packages/create-rslib/fragments/tools/rstest-vue-ts/package.json
+++ b/packages/create-rslib/fragments/tools/rstest-vue-ts/package.json
@@ -3,6 +3,7 @@
     "test": "rstest"
   },
   "devDependencies": {
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",

--- a/packages/create-rslib/fragments/tools/rstest-vue-ts/rstest.config.ts
+++ b/packages/create-rslib/fragments/tools/rstest-vue-ts/rstest.config.ts
@@ -1,8 +1,7 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
-import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.ts'],
-  plugins: [pluginUnpluginVue()],
 });

--- a/packages/create-rslib/template-[node-dual]-[rstest]-js/package.json
+++ b/packages/create-rslib/template-[node-dual]-[rstest]-js/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7"
   }
 }

--- a/packages/create-rslib/template-[node-dual]-[rstest]-js/rstest.config.js
+++ b/packages/create-rslib/template-[node-dual]-[rstest]-js/rstest.config.js
@@ -1,3 +1,6 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({});
+export default defineConfig({
+  extends: withRslibConfig(),
+});

--- a/packages/create-rslib/template-[node-dual]-[rstest]-ts/package.json
+++ b/packages/create-rslib/template-[node-dual]-[rstest]-ts/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@types/node": "^24.10.4",
     "typescript": "^5.9.3"

--- a/packages/create-rslib/template-[node-dual]-[rstest]-ts/rstest.config.ts
+++ b/packages/create-rslib/template-[node-dual]-[rstest]-ts/rstest.config.ts
@@ -1,3 +1,6 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({});
+export default defineConfig({
+  extends: withRslibConfig(),
+});

--- a/packages/create-rslib/template-[node-esm]-[rstest]-js/package.json
+++ b/packages/create-rslib/template-[node-esm]-[rstest]-js/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7"
   }
 }

--- a/packages/create-rslib/template-[node-esm]-[rstest]-js/rstest.config.js
+++ b/packages/create-rslib/template-[node-esm]-[rstest]-js/rstest.config.js
@@ -1,3 +1,6 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({});
+export default defineConfig({
+  extends: withRslibConfig(),
+});

--- a/packages/create-rslib/template-[node-esm]-[rstest]-ts/package.json
+++ b/packages/create-rslib/template-[node-esm]-[rstest]-ts/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@types/node": "^24.10.4",
     "typescript": "^5.9.3"

--- a/packages/create-rslib/template-[node-esm]-[rstest]-ts/rstest.config.ts
+++ b/packages/create-rslib/template-[node-esm]-[rstest]-ts/rstest.config.ts
@@ -1,3 +1,6 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
-export default defineConfig({});
+export default defineConfig({
+  extends: withRslibConfig(),
+});

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-js/package.json
@@ -21,6 +21,7 @@
     "@rsbuild/core": "~1.7.0-beta.2",
     "@rsbuild/plugin-react": "^1.4.2",
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@storybook/addon-docs": "^10.1.10",
     "@storybook/addon-onboarding": "^10.1.10",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-js/rstest.config.js
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-js/rstest.config.js
@@ -1,8 +1,7 @@
-import { pluginReact } from '@rsbuild/plugin-react';
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.js'],
-  plugins: [pluginReact()],
 });

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-ts/package.json
@@ -23,6 +23,7 @@
     "@rsbuild/core": "~1.7.0-beta.2",
     "@rsbuild/plugin-react": "^1.4.2",
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@storybook/addon-docs": "^10.1.10",
     "@storybook/addon-onboarding": "^10.1.10",

--- a/packages/create-rslib/template-[react]-[rstest,storybook]-ts/rstest.config.ts
+++ b/packages/create-rslib/template-[react]-[rstest,storybook]-ts/rstest.config.ts
@@ -1,8 +1,7 @@
-import { pluginReact } from '@rsbuild/plugin-react';
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.ts'],
-  plugins: [pluginReact()],
 });

--- a/packages/create-rslib/template-[react]-[rstest]-js/package.json
+++ b/packages/create-rslib/template-[react]-[rstest]-js/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@rsbuild/plugin-react": "^1.4.2",
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",

--- a/packages/create-rslib/template-[react]-[rstest]-js/rstest.config.js
+++ b/packages/create-rslib/template-[react]-[rstest]-js/rstest.config.js
@@ -1,8 +1,7 @@
-import { pluginReact } from '@rsbuild/plugin-react';
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.js'],
-  plugins: [pluginReact()],
 });

--- a/packages/create-rslib/template-[react]-[rstest]-ts/package.json
+++ b/packages/create-rslib/template-[react]-[rstest]-ts/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@rsbuild/plugin-react": "^1.4.2",
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",

--- a/packages/create-rslib/template-[react]-[rstest]-ts/rstest.config.ts
+++ b/packages/create-rslib/template-[react]-[rstest]-ts/rstest.config.ts
@@ -1,8 +1,7 @@
-import { pluginReact } from '@rsbuild/plugin-react';
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.ts'],
-  plugins: [pluginReact()],
 });

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-js/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@rsbuild/core": "~1.7.0-beta.2",
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@storybook/addon-docs": "^10.1.10",
     "@storybook/addon-onboarding": "^10.1.10",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-js/rstest.config.js
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-js/rstest.config.js
@@ -1,8 +1,7 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
-import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.js'],
-  plugins: [pluginUnpluginVue()],
 });

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@rsbuild/core": "~1.7.0-beta.2",
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@storybook/addon-docs": "^10.1.10",
     "@storybook/addon-onboarding": "^10.1.10",

--- a/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/rstest.config.ts
+++ b/packages/create-rslib/template-[vue]-[rstest,storybook]-ts/rstest.config.ts
@@ -1,8 +1,7 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
-import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.ts'],
-  plugins: [pluginUnpluginVue()],
 });

--- a/packages/create-rslib/template-[vue]-[rstest]-js/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest]-js/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",

--- a/packages/create-rslib/template-[vue]-[rstest]-js/rstest.config.js
+++ b/packages/create-rslib/template-[vue]-[rstest]-js/rstest.config.js
@@ -1,8 +1,7 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
-import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.js'],
-  plugins: [pluginUnpluginVue()],
 });

--- a/packages/create-rslib/template-[vue]-[rstest]-ts/package.json
+++ b/packages/create-rslib/template-[vue]-[rstest]-ts/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.1.0",
     "@rstest/core": "^0.7.7",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",

--- a/packages/create-rslib/template-[vue]-[rstest]-ts/rstest.config.ts
+++ b/packages/create-rslib/template-[vue]-[rstest]-ts/rstest.config.ts
@@ -1,8 +1,7 @@
+import { withRslibConfig } from '@rstest/adapter-rslib';
 import { defineConfig } from '@rstest/core';
-import { pluginUnpluginVue } from 'rsbuild-plugin-unplugin-vue';
 
 export default defineConfig({
-  testEnvironment: 'happy-dom',
+  extends: withRslibConfig(),
   setupFiles: ['./rstest.setup.ts'],
-  plugins: [pluginUnpluginVue()],
 });


### PR DESCRIPTION
## Summary

use `@rstest/adapter-rslib` in rstest template to reuse rslib's configuration in rstest.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
