### PR TITLE
docs: refine third-party dependencies guide

### DIFF
--- a/website/docs/en/guide/advanced/third-party-deps.mdx
+++ b/website/docs/en/guide/advanced/third-party-deps.mdx
@@ -25,32 +25,32 @@ If you need to package some dependencies, it is recommended to move them from `"
 
 ### Example
 
-If the project has a dependency on `react`.
+If the project depends on `foo`.
 
 ```json title="package.json"
 {
   "dependencies": {
-    "react": "^18"
+    "foo": "^1.0.0"
   },
   // or
   "peerDependencies": {
-    "react": "^18"
+    "foo": "^1.0.0"
   }
 }
 ```
 
-When a `react` dependency is used in the source code:
+When the `foo` dependency is used in the source code:
 
 ```tsx title="src/index.ts"
-import React from 'react';
-console.info(React);
+import foo from 'foo';
+console.info(foo);
 ```
 
-The `react` code will not be bundled into the output:
+The `foo` package will not be bundled into the output:
 
 ```js title="dist/index.js"
-import external_react_default from 'react';
-console.info(external_react_default);
+import foo from 'foo';
+console.info(foo);
 ```
 
 If you want to modify the default processing, you can use the following API:

--- a/website/docs/zh/guide/advanced/third-party-deps.mdx
+++ b/website/docs/zh/guide/advanced/third-party-deps.mdx
@@ -25,32 +25,32 @@
 
 ### 示例
 
-如果项目依赖了 `react`。
+如果项目依赖了 `foo`。
 
 ```json title="package.json"
 {
   "dependencies": {
-    "react": "^18"
+    "foo": "^1.0.0"
   },
   // 或
   "peerDependencies": {
-    "react": "^18"
+    "foo": "^1.0.0"
   }
 }
 ```
 
-当在源代码中使用 `react` 依赖时：
+当在源代码中使用 `foo` 依赖时：
 
 ```tsx title="src/index.ts"
-import React from 'react';
-console.info(React);
+import foo from 'foo';
+console.info(foo);
 ```
 
-此时产物中不会包含 `react` 的代码:
+此时产物中不会包含 `foo` 的代码:
 
 ```js title="dist/index.js"
-import external_react_default from 'react';
-console.info(external_react_default);
+import foo from 'foo';
+console.info(foo);
 ```
 
 如果想要修改默认的处理方式，可以通过下面的 API 进行修改:


### PR DESCRIPTION
## Summary

Refine the documentation for "Third-Party Dependencies" (`third-party-deps.mdx`):

1. **Replace Example:** Swapped the `react` example with a generic `foo` package. Using React could imply this behavior is specific to React or framework components, whereas `foo` clarifies that it applies to any dependency.
2. **Improve Translation:** Rewrote the English version to be more idiomatic and clear.

## Related Links

https://github.com/web-infra-dev/rslib/issues/1418

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).