### PR TITLE
docs: update links from rspack-contrib to rstackjs

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.repository == 'web-infra-dev/rslib' && github.event_name == 'workflow_dispatch'
     steps:
       - name: Trigger Ecosystem CI
-        uses: rspack-contrib/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@main
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@main
         with:
           github-token: ${{ secrets.REPO_RSLIB_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev
@@ -59,7 +59,7 @@ jobs:
     if: github.repository == 'web-infra-dev/rslib' && github.event_name != 'workflow_dispatch' && needs.changes.outputs.changed == 'true'
     steps:
       - name: Trigger Ecosystem CI
-        uses: rspack-contrib/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@main
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@main
         with:
           github-token: ${{ secrets.REPO_RSLIB_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To get started with Rslib, see the [Quick start](https://rslib.rs/guide/start/qu
 
 ## 🦀 Rstack
 
-Rstack is a unified JavaScript toolchain built around Rspack, with high performance and consistent architecture.
+Rstack is a unified JavaScript toolchain centered on Rspack, with high performance and consistent architecture.
 
 | Name                                                  | Description              | Version                                                                                                                                                                          |
 | ----------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -61,11 +61,11 @@ Rstack is a unified JavaScript toolchain built around Rspack, with high performa
 
 ## 🔗 Links
 
-- [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack): A curated list of awesome things related to Rstack.
-- [rstack-examples](https://github.com/rspack-contrib/rstack-examples): Examples for Rstack.
-- [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): Storybook builder powered by Rsbuild.
-- [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template): Use this template to create your own Rsbuild plugin.
-- [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources): Design resources for Rstack.
+- [awesome-rstack](https://github.com/rstackjs/awesome-rstack): A curated list of awesome things related to Rstack.
+- [rstack-examples](https://github.com/rstackjs/rstack-examples): Examples for Rstack.
+- [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild): Storybook builder powered by Rsbuild.
+- [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template): Use this template to create your own Rsbuild plugin.
+- [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources): Design resources for Rstack.
 
 ## 🤝 Contribution
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,7 +47,7 @@ Rslib 基于 Rsbuild 实现，并完全复用 Rsbuild 的能力和生态系统�
 
 ## 🦀 Rstack
 
-Rstack 是一个围绕 Rspack 打造的 JavaScript 统一工具链，具有优秀的性能和一致的架构。
+Rstack 是一个以 Rspack 为核心的 JavaScript 统一工具链，具有优秀的性能和一致的架构。
 
 | 名称                                                  | 描述           | 版本                                                                                                                                                                             |
 | ----------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -61,11 +61,11 @@ Rstack 是一个围绕 Rspack 打造的 JavaScript 统一工具链，具有优�
 
 ## 🔗 链接
 
-- [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack): 与 Rstack 相关的精彩内容列表。
-- [rstack-examples](https://github.com/rspack-contrib/rstack-examples): Rstack 的示例项目。
-- [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): 基于 Rsbuild 构建的 Storybook。
-- [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template): 使用此模板创建你的 Rsbuild 插件。
-- [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources): Rstack 的设计资源。
+- [awesome-rstack](https://github.com/rstackjs/awesome-rstack): 与 Rstack 相关的精彩内容列表。
+- [rstack-examples](https://github.com/rstackjs/rstack-examples): Rstack 的示例项目。
+- [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild): 基于 Rsbuild 构建的 Storybook。
+- [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template): 使用此模板创建你的 Rsbuild 插件。
+- [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources): Rstack 的设计资源。
 
 ## 🤝 参与贡献
 

--- a/packages/core/src/utils/syntax.ts
+++ b/packages/core/src/utils/syntax.ts
@@ -41,7 +41,7 @@ const RSPACK_TARGET_UNLISTED_MODERN_ECMA_VERSIONS: EcmaScriptVersion[] = [
 
 /**
  * The esX to browserslist mapping is transformed from
- * https://github.com/rspack-contrib/browserslist-to-es-version
+ * https://github.com/rstackjs/browserslist-to-es-version
  */
 export const ESX_TO_BROWSERSLIST: Record<
   FixedEcmaVersions,

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -111,6 +111,7 @@ rslog
 rspack
 rspress
 rstack
+rstackjs
 Rstest
 selfsign
 selfsigned

--- a/website/README.md
+++ b/website/README.md
@@ -12,6 +12,6 @@ The same as Rspack: [Writing style guide](https://github.com/web-infra-dev/rspac
 
 ### Image assets
 
-For images you use in the document, it's better to upload them to the [rspack-contrib/rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) repository, so the size of the current repository doesn't get too big.
+For images you use in the document, it's better to upload them to the [rstackjs/rstack-design-resources](https://github.com/rstackjs/rstack-design-resources) repository, so the size of the current repository doesn't get too big.
 
 After you upload the images there, they will be automatically deployed under the <https://assets.rspack.rs/>.

--- a/website/docs/en/blog/introducing-rslib.mdx
+++ b/website/docs/en/blog/introducing-rslib.mdx
@@ -135,9 +135,9 @@ Beyond common JavaScript library development solutions, based on Rspack and the 
   Based on the Rspack and Rsbuild ecosystem, Rslib can reuse a series of ecosystem features, including but not limited to:
   - Use [Storybook](https://storybook.rsbuild.rs/guide/integrations/rslib.html) to directly read Rslib's configuration files for UI component library development debugging.
   - Use [Rsdoctor](https://rsdoctor.rs/) for build performance and output analysis.
-  - Use [Node.js polyfill](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill) plugin to develop cross-runtime libraries.
-  - Use [ESLint plugin](https://github.com/rspack-contrib/rsbuild-plugin-eslint) for ESLint validation during development.
-  - Use [publint plugin](https://github.com/rspack-contrib/rsbuild-plugin-publint) to check if the library's package.json is configured correctly.
+  - Use [Node.js polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill) plugin to develop cross-runtime libraries.
+  - Use [ESLint plugin](https://github.com/rstackjs/rsbuild-plugin-eslint) for ESLint validation during development.
+  - Use [publint plugin](https://github.com/rstackjs/rsbuild-plugin-publint) to check if the library's package.json is configured correctly.
 
   <img
     src="https://assets.rspack.rs/others/assets/rslib/publint-screenshot.png"

--- a/website/docs/en/config/rsbuild/plugins.mdx
+++ b/website/docs/en/config/rsbuild/plugins.mdx
@@ -41,11 +41,11 @@ Plugins available for React:
 
 Plugins available for Vue:
 
-- [Vue Plugin](https://github.com/rspack-contrib/rsbuild-plugin-unplugin-vue): Based on [unplugin-vue](https://github.com/unplugin/unplugin-vue), provides support for Vue 3 SFC (Single File Components).
+- [Vue Plugin](https://github.com/rstackjs/rsbuild-plugin-unplugin-vue): Based on [unplugin-vue](https://github.com/unplugin/unplugin-vue), provides support for Vue 3 SFC (Single File Components).
 - [Vue Plugin](https://rsbuild.rs/plugins/list/plugin-vue): Based on [vue-loader](https://github.com/vuejs/vue-loader), provides support for Vue 3 SFC (Single File Components) (Recommend using the implementation based on [unplugin-vue](https://github.com/unplugin/unplugin-vue), as vue-loader is no longer maintained).
-- [Vue JSX Plugin](https://github.com/rspack-contrib/rsbuild-plugin-vue-jsx): Provides support for Vue 3 JSX / TSX syntax.
-- [Vue2 Plugin](https://github.com/rspack-contrib/rsbuild-plugin-vue2): Provides support for Vue 2 SFC (Single File Components).
-- [Vue2 JSX Plugin](https://github.com/rspack-contrib/rsbuild-plugin-vue2-jsx): Provides support for Vue 2 JSX / TSX syntax.
+- [Vue JSX Plugin](https://github.com/rstackjs/rsbuild-plugin-vue-jsx): Provides support for Vue 3 JSX / TSX syntax.
+- [Vue2 Plugin](https://github.com/rstackjs/rsbuild-plugin-vue2): Provides support for Vue 2 SFC (Single File Components).
+- [Vue2 JSX Plugin](https://github.com/rstackjs/rsbuild-plugin-vue2-jsx): Provides support for Vue 2 JSX / TSX syntax.
 
 ### For Preact
 
@@ -73,21 +73,21 @@ The following are common framework-agnostic plugins:
 - [Sass Plugin](https://rsbuild.rs/plugins/list/plugin-sass): Use Sass as the CSS preprocessor.
 - [Less Plugin](https://rsbuild.rs/plugins/list/plugin-less): Use Less as the CSS preprocessor.
 - [Stylus Plugin](https://rsbuild.rs/plugins/list/plugin-stylus): Use Stylus as the CSS preprocessor.
-- [ESLint Plugin](https://github.com/rspack-contrib/rsbuild-plugin-eslint): Run ESLint checks during the compilation.
-- [Type Check Plugin](https://github.com/rspack-contrib/rsbuild-plugin-type-check): Run TypeScript type checker on a separate process.
-- [publint Plugin](https://github.com/rspack-contrib/rsbuild-plugin-publint): Run `publint` to lint npm packages after the build.
-- [Image Compress Plugin](https://github.com/rspack-contrib/rsbuild-plugin-image-compress): Compress the image assets.
-- [MDX Plugin](https://github.com/rspack-contrib/rsbuild-plugin-mdx): Provide support for MDX.
-- [Node Polyfill Plugin](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill): Used to inject polyfills of Node core modules in the browser side.
-- [Source Build Plugin](https://github.com/rspack-contrib/rsbuild-plugin-source-build): This plugin is designed for the monorepo scenario. It supports referencing source code from other subdirectories and performs build and hot update.
-- [Check Syntax Plugin](https://github.com/rspack-contrib/rsbuild-plugin-check-syntax): Check the syntax compatibility of output files and determine if there are any advanced syntaxes that could cause compatibility issues.
-- [CSS Minimizer Plugin](https://github.com/rspack-contrib/rsbuild-plugin-css-minimizer): Used to customize CSS minimizer, switch to [cssnano](https://github.com/cssnano/cssnano) or other tools for CSS compression.
-- [Typed CSS Modules Plugin](https://github.com/rspack-contrib/rsbuild-plugin-typed-css-modules): Generate TypeScript declaration file for CSS Modules.
-- [Pug Plugin](https://github.com/rspack-contrib/rsbuild-plugin-pug): Provides support for the Pug template engine.
-- [Rem Plugin](https://github.com/rspack-contrib/rsbuild-plugin-rem): Implements the rem adaptive layout for mobile pages.
-- [UMD Plugin](https://github.com/rspack-contrib/rsbuild-plugin-umd): Generate outputs in UMD format.
-- [YAML Plugin](https://github.com/rspack-contrib/rsbuild-plugin-yaml): Import YAML files and convert them into JavaScript objects.
-- [TOML Plugin](https://github.com/rspack-contrib/rsbuild-plugin-toml): Import TOML files and convert them into JavaScript objects.
+- [ESLint Plugin](https://github.com/rstackjs/rsbuild-plugin-eslint): Run ESLint checks during the compilation.
+- [Type Check Plugin](https://github.com/rstackjs/rsbuild-plugin-type-check): Run TypeScript type checker on a separate process.
+- [publint Plugin](https://github.com/rstackjs/rsbuild-plugin-publint): Run `publint` to lint npm packages after the build.
+- [Image Compress Plugin](https://github.com/rstackjs/rsbuild-plugin-image-compress): Compress the image assets.
+- [MDX Plugin](https://github.com/rstackjs/rsbuild-plugin-mdx): Provide support for MDX.
+- [Node Polyfill Plugin](https://github.com/rstackjs/rsbuild-plugin-node-polyfill): Used to inject polyfills of Node core modules in the browser side.
+- [Source Build Plugin](https://github.com/rstackjs/rsbuild-plugin-source-build): This plugin is designed for the monorepo scenario. It supports referencing source code from other subdirectories and performs build and hot update.
+- [Check Syntax Plugin](https://github.com/rstackjs/rsbuild-plugin-check-syntax): Check the syntax compatibility of output files and determine if there are any advanced syntaxes that could cause compatibility issues.
+- [CSS Minimizer Plugin](https://github.com/rstackjs/rsbuild-plugin-css-minimizer): Used to customize CSS minimizer, switch to [cssnano](https://github.com/cssnano/cssnano) or other tools for CSS compression.
+- [Typed CSS Modules Plugin](https://github.com/rstackjs/rsbuild-plugin-typed-css-modules): Generate TypeScript declaration file for CSS Modules.
+- [Pug Plugin](https://github.com/rstackjs/rsbuild-plugin-pug): Provides support for the Pug template engine.
+- [Rem Plugin](https://github.com/rstackjs/rsbuild-plugin-rem): Implements the rem adaptive layout for mobile pages.
+- [UMD Plugin](https://github.com/rstackjs/rsbuild-plugin-umd): Generate outputs in UMD format.
+- [YAML Plugin](https://github.com/rstackjs/rsbuild-plugin-yaml): Import YAML files and convert them into JavaScript objects.
+- [TOML Plugin](https://github.com/rstackjs/rsbuild-plugin-toml): Import TOML files and convert them into JavaScript objects.
 
 :::tip
 You can find the source code of all official plugins in [web-infra-dev/rsbuild](https://github.com/web-infra-dev/rsbuild) and [rspack-contrib](https://github.com/rspack-contrib).
@@ -95,6 +95,6 @@ You can find the source code of all official plugins in [web-infra-dev/rsbuild](
 
 ## Community plugins
 
-You can check out the Rsbuild plugins provided by the community at [awesome-rspack - Rsbuild Plugins](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rsbuild-plugins).
+You can check out the Rsbuild plugins provided by the community at [awesome-rstack - Rsbuild Plugins](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#rsbuild-plugins).
 
 You can also discover more Rsbuild plugins on npm by searching for the keyword [rsbuild-plugin](https://www.npmjs.com/search?q=rsbuild-plugin&ranking=popularity).

--- a/website/docs/en/config/rsbuild/tools.mdx
+++ b/website/docs/en/config/rsbuild/tools.mdx
@@ -6,7 +6,7 @@ Options for low-level tools.
 
 ## tools.bundlerChain <RsbuildDocBadge path="/config/tools/bundler-chain" text="tools.bundlerChain" />
 
-[rspack-chain](https://github.com/rspack-contrib/rspack-chain) is a utility library for configuring Rspack. By using `rspack-chain`, you can more easily modify and extend Rspack configurations.
+[rspack-chain](https://github.com/rstackjs/rspack-chain) is a utility library for configuring Rspack. By using `rspack-chain`, you can more easily modify and extend Rspack configurations.
 
 {/* ## tools.cssExtract <RsbuildDocBadge path="/config/tools/css-extract" text="tools.cssExtract" /> */}
 
@@ -18,7 +18,7 @@ Rsbuild uses [css-loader](https://github.com/webpack-contrib/css-loader) by defa
 
 {/* ## tools.htmlPlugin <RsbuildDocBadge path="/config/tools/html-plugin" text="tools.htmlPlugin" /> */}
 
-{/* The configs of [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin) can be modified through `tools.htmlPlugin`. */}
+{/* The configs of [html-rspack-plugin](https://github.com/rstackjs/html-rspack-plugin) can be modified through `tools.htmlPlugin`. */}
 
 ## tools.lightningcssLoader <RsbuildDocBadge path="/config/tools/lightningcss-loader" text="tools.lightningcssLoader" />
 

--- a/website/docs/en/guide/advanced/json-files.mdx
+++ b/website/docs/en/guide/advanced/json-files.mdx
@@ -119,7 +119,7 @@ In bundleless mode, when importing JSON files through import attributes, you nee
 
 [YAML](https://yaml.org/) is a data serialization language commonly used for writing configuration files.
 
-By adding the [@rsbuild/plugin-yaml](https://github.com/rspack-contrib/rsbuild-plugin-yaml) plugin, you can import `.yaml` or `.yml` files in JavaScript and they will be automatically converted to JavaScript objects.
+By adding the [@rsbuild/plugin-yaml](https://github.com/rstackjs/rsbuild-plugin-yaml) plugin, you can import `.yaml` or `.yml` files in JavaScript and they will be automatically converted to JavaScript objects.
 
 import { PackageManagerTabs } from '@theme';
 
@@ -165,7 +165,7 @@ foo:
 
 [TOML](https://toml.io/) is a semantically explicit, easy-to-read configuration file format.
 
-By adding the [@rsbuild/plugin-toml](https://github.com/rspack-contrib/rsbuild-plugin-toml) plugin, you can import `.toml` files in JavaScript and it will be automatically converted to JavaScript objects.
+By adding the [@rsbuild/plugin-toml](https://github.com/rstackjs/rsbuild-plugin-toml) plugin, you can import `.toml` files in JavaScript and it will be automatically converted to JavaScript objects.
 
 <PackageManagerTabs command="add @rsbuild/plugin-toml -D" />
 

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -353,7 +353,7 @@ export default defineConfig({
 
 ## Examples
 
-You can refer to the example projects in [Rslib Module Federation Example](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib/module-federation).
+You can refer to the example projects in [Rslib Module Federation Example](https://github.com/rstackjs/rstack-examples/tree/main/rslib/module-federation).
 
 - `mf-host`: Rsbuild App Consumer
 - `mf-react-component`: Rslib Module, which is both a producer and a consumer, provides the module to the `mf-host` as a producer, and consumes the `mf-remote`

--- a/website/docs/en/guide/advanced/output-compatibility.mdx
+++ b/website/docs/en/guide/advanced/output-compatibility.mdx
@@ -75,11 +75,11 @@ Check out [babel-plugin-polyfill-corejs3](https://www.npmjs.com/package/babel-pl
 Normally, we don't need to use Node libs on the browser side. However, it is possible to use some Node libs when the code will run on both the Node side and the browser side, and Node Polyfill provides browser versions of polyfills for these Node libs.
 :::
 
-By using [@rsbuild/plugin-node-polyfill](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill), Node core libs polyfills are automatically injected into the browser-side, allowing you to use these modules on the browser side with confidence.
+By using [@rsbuild/plugin-node-polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill), Node core libs polyfills are automatically injected into the browser-side, allowing you to use these modules on the browser side with confidence.
 
 #### Set up
 
-Rslib uses [@rsbuild/plugin-node-polyfill](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill) to provide the Node Polyfill feature.
+Rslib uses [@rsbuild/plugin-node-polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill) to provide the Node Polyfill feature.
 
 <PackageManagerTabs command="add @rsbuild/plugin-node-polyfill -D" />
 
@@ -99,9 +99,9 @@ export default defineConfig({
 
 - For projects with `bundle` enabled, the Node Polyfill will be injected and included in the output.
 - For projects with `bundle` disabled, polyfills are not injected into the output by default. To avoid inlining the polyfill in every module, the modules are externalized and need to be added to dependencies manually, follow these steps:
-  1. Configure `output.external` with `resolvedPolyfillToModules`, which you can import from [@rsbuild/plugin-node-polyfill](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill). This will externalize the polyfill modules to the installed polyfill dependencies.
+  1. Configure `output.external` with `resolvedPolyfillToModules`, which you can import from [@rsbuild/plugin-node-polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill). This will externalize the polyfill modules to the installed polyfill dependencies.
   2. Install used polyfill modules as dependencies.
 
   With the above steps, every usage of the polyfill module will be replaced by the corresponding module in the `externals` field. Checkout the <SourceCode href="https://github.com/web-infra-dev/rslib/blob/main/tests/integration/node-polyfill/bundle-false/rslib.config.ts" /> of the example for more details.
 
-Check out the documentation of [@rsbuild/plugin-node-polyfill](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill), all the configurations are applicable for Rslib.
+Check out the documentation of [@rsbuild/plugin-node-polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill), all the configurations are applicable for Rslib.

--- a/website/docs/en/guide/advanced/storybook.mdx
+++ b/website/docs/en/guide/advanced/storybook.mdx
@@ -4,17 +4,17 @@ import { PackageManagerTabs, Tab, Tabs } from '@theme';
 
 [Storybook](https://storybook.js.org/) is a powerful tool for developing UI components in isolation for React, Vue, and other frameworks. It enables you to build and test components independently, which can accelerate both development and testing.
 
-[storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild) is the Rsbuild powered Storybook builder, and provided the framework integration for React, Vue3 and vanilla JavaScript. The coherent Rsbuild system could make Storybook use an unified configuration with Rslib.
+[storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild) is the Rsbuild powered Storybook builder, and provided the framework integration for React, Vue3 and vanilla JavaScript. The coherent Rsbuild system could make Storybook use an unified configuration with Rslib.
 
 :::info Storybook Rsbuild version map
 
 The table below shows how Storybook Rsbuild matches Storybook versions. If you are on Storybook v9 or earlier, follow the [official migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#from-version-9x-to-1000) to upgrade to the latest release.
 
-| Storybook                              | Storybook Rsbuild                                                                        |
-| -------------------------------------- | ---------------------------------------------------------------------------------------- |
-| [v10](https://storybook.js.org/docs/)  | [^3.0.0](https://storybook.rsbuild.rs)                                                   |
-| [v9](https://storybook.js.org/docs/9/) | [^2.0.0](https://storybook-v2.rsbuild.rs)                                                |
-| [v8](https://storybook.js.org/docs/8/) | [^1.0.0](https://github.com/rspack-contrib/storybook-rsbuild/tree/v1/website/docs/guide) |
+| Storybook                              | Storybook Rsbuild                                                                  |
+| -------------------------------------- | ---------------------------------------------------------------------------------- |
+| [v10](https://storybook.js.org/docs/)  | [^3.0.0](https://storybook.rsbuild.rs)                                             |
+| [v9](https://storybook.js.org/docs/9/) | [^2.0.0](https://storybook-v2.rsbuild.rs)                                          |
+| [v8](https://storybook.js.org/docs/8/) | [^1.0.0](https://github.com/rstackjs/storybook-rsbuild/tree/v1/website/docs/guide) |
 
 :::
 
@@ -115,5 +115,5 @@ Check out more details in the [Storybook Rsbuild documentation](https://storyboo
 
 ## Example
 
-- [React component library + Rslib + Storybook](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib/react-storybook)
-- [Vue component library + Rslib + Storybook](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib/vue-storybook)
+- [React component library + Rslib + Storybook](https://github.com/rstackjs/rstack-examples/tree/main/rslib/react-storybook)
+- [Vue component library + Rslib + Storybook](https://github.com/rstackjs/rstack-examples/tree/main/rslib/vue-storybook)

--- a/website/docs/en/guide/solution/index.mdx
+++ b/website/docs/en/guide/solution/index.mdx
@@ -8,7 +8,7 @@ When developing a library that runs in the browser, you can package it in both [
 
 When publishing to npm, you can choose not to [minify](/config/rsbuild/output#outputminify) your code or to minify it while providing a [sourcemap](/config/rsbuild/output#outputsourcemap) to enhance the debugging experience for users of your library. For styling, you can use CSS, or CSS pre-processors like Sass, Less, or Stylus, or apply PostCSS for CSS post-processing. Tools like Tailwind CSS can also help in building your styles. Using CSS Modules to create CSS modules is another option.
 
-In terms of resource management, Rslib handles static assets used in your code, such as SVG and PNG files. You can also build a component library of [React](/guide/solution/react), [Preact](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib/preact), or other frameworks, and use [Storybook](/guide/advanced/storybook) for UI component development and testing.
+In terms of resource management, Rslib handles static assets used in your code, such as SVG and PNG files. You can also build a component library of [React](/guide/solution/react), [Preact](https://github.com/rstackjs/rstack-examples/tree/main/rslib/preact), or other frameworks, and use [Storybook](/guide/advanced/storybook) for UI component development and testing.
 
 Refer to the solutions in this chapter to learn how to use Rslib to develop browser libraries for different frameworks.
 

--- a/website/docs/en/guide/solution/nodejs.mdx
+++ b/website/docs/en/guide/solution/nodejs.mdx
@@ -1,6 +1,6 @@
 # Node.js
 
-In this document, you will learn how to build a Node.js library using Rslib. You can check out Node.js related example projects in [Examples](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib).
+In this document, you will learn how to build a Node.js library using Rslib. You can check out Node.js related example projects in [Examples](https://github.com/rstackjs/rstack-examples/tree/main/rslib).
 
 ## Create Node.js project
 

--- a/website/docs/en/guide/solution/react.mdx
+++ b/website/docs/en/guide/solution/react.mdx
@@ -1,6 +1,6 @@
 # React
 
-In this document, you will learn how to build a React component library with Rslib. You can check out React related example projects in [Examples](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib).
+In this document, you will learn how to build a React component library with Rslib. You can check out React related example projects in [Examples](https://github.com/rstackjs/rstack-examples/tree/main/rslib).
 
 ## Create React project
 

--- a/website/docs/en/guide/solution/vue.mdx
+++ b/website/docs/en/guide/solution/vue.mdx
@@ -1,6 +1,6 @@
 # Vue
 
-In this document, you will learn how to build a Vue component library using Rslib. You can check out Vue related example projects in [Examples](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib).
+In this document, you will learn how to build a Vue component library using Rslib. You can check out Vue related example projects in [Examples](https://github.com/rstackjs/rstack-examples/tree/main/rslib).
 
 ::: note
 
@@ -31,7 +31,7 @@ Then select `Vue` when prompted to "Select template".
 
 For developing Vue components, you need to set the [target](/config/rsbuild/output#outputtarget) to `"web"` in `rslib.config.ts`. This is crucial because Rslib sets `target` to `"node"` by default, which is different from Rsbuild's default target value.
 
-To compile Vue (.vue single-file components), you need to register the [rsbuild-plugin-unplugin-vue](https://github.com/rspack-contrib/rsbuild-plugin-unplugin-vue) plugin based on [unplugin-vue](https://github.com/unplugin/unplugin-vue). This plugin will automatically add the necessary configurations for Vue build.
+To compile Vue (.vue single-file components), you need to register the [rsbuild-plugin-unplugin-vue](https://github.com/rstackjs/rsbuild-plugin-unplugin-vue) plugin based on [unplugin-vue](https://github.com/unplugin/unplugin-vue). This plugin will automatically add the necessary configurations for Vue build.
 
 For example, register in `rslib.config.ts`:
 
@@ -52,7 +52,7 @@ export default defineConfig({
 ```
 
 ::: note
-Currently, the [rsbuild-plugin-unplugin-vue](https://github.com/rspack-contrib/rsbuild-plugin-unplugin-vue) plugin does not support packaging Vue SFC [scoped CSS](https://vuejs.org/api/sfc-css-features#scoped-css) styles. You can choose styling solutions like Less or Sass.
+Currently, the [rsbuild-plugin-unplugin-vue](https://github.com/rstackjs/rsbuild-plugin-unplugin-vue) plugin does not support packaging Vue SFC [scoped CSS](https://vuejs.org/api/sfc-css-features#scoped-css) styles. You can choose styling solutions like Less or Sass.
 :::
 
-For more configuration options, please refer to the [rsbuild-plugin-unplugin-vue](https://github.com/rspack-contrib/rsbuild-plugin-unplugin-vue) plugin documentation.
+For more configuration options, please refer to the [rsbuild-plugin-unplugin-vue](https://github.com/rstackjs/rsbuild-plugin-unplugin-vue) plugin documentation.

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -38,7 +38,7 @@ The following diagram illustrates the relationship between Rslib and other tools
 
 ## 🦀 Rstack
 
-Rstack is a unified JavaScript toolchain built around Rspack, with high performance and consistent architecture.
+Rstack is a unified JavaScript toolchain centered on Rspack, with high performance and consistent architecture.
 
 | Name                                                  | Description              | Version                                                                                                                                                                          |
 | ----------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -52,11 +52,11 @@ Rstack is a unified JavaScript toolchain built around Rspack, with high performa
 
 ## 🔗 Links
 
-- [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack): A curated list of awesome things related to Rstack.
-- [rstack-examples](https://github.com/rspack-contrib/rstack-examples): Examples for Rstack.
-- [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): Storybook builder powered by Rsbuild.
-- [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template): Use this template to create your own Rsbuild plugin.
-- [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources): Design resources for Rstack.
+- [awesome-rstack](https://github.com/rstackjs/awesome-rstack): A curated list of awesome things related to Rstack.
+- [rstack-examples](https://github.com/rstackjs/rstack-examples): Examples for Rstack.
+- [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild): Storybook builder powered by Rsbuild.
+- [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template): Use this template to create your own Rsbuild plugin.
+- [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources): Design resources for Rstack.
 
 ## 🧑‍💻 Community
 

--- a/website/docs/zh/blog/introducing-rslib.mdx
+++ b/website/docs/zh/blog/introducing-rslib.mdx
@@ -135,9 +135,9 @@ Rslib 提供了一套全面的库构建解决方案，涵盖了目前大部分�
   基于 Rspack 和 Rsbuild 生态，Rslib 能复用一系列生态能力，包括但不限于：
   - 使用 [Storybook](https://storybook.rsbuild.rs/guide/integrations/rslib.html) 直接读取 Rslib 的配置文件进行 UI 组件库开发调试。
   - 使用 [Rsdoctor](https://rsdoctor.rs/) 进行构建性能及产物分析。
-  - 使用 [Node.js polyfill](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill) 插件开发跨运行时的库。
-  - 使用 [ESLint 插件](https://github.com/rspack-contrib/rsbuild-plugin-eslint) 在开发时进行 ESLint 校验。
-  - 使用 [publint 插件](https://github.com/rspack-contrib/rsbuild-plugin-publint) 检查开发的库的 package.json 是否配置正确。
+  - 使用 [Node.js polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill) 插件开发跨运行时的库。
+  - 使用 [ESLint 插件](https://github.com/rstackjs/rsbuild-plugin-eslint) 在开发时进行 ESLint 校验。
+  - 使用 [publint 插件](https://github.com/rstackjs/rsbuild-plugin-publint) 检查开发的库的 package.json 是否配置正确。
 
   <img
     src="https://assets.rspack.rs/others/assets/rslib/publint-screenshot.png"

--- a/website/docs/zh/config/rsbuild/plugins.mdx
+++ b/website/docs/zh/config/rsbuild/plugins.mdx
@@ -35,17 +35,17 @@ export default defineConfig({
 
 - [React 插件](https://rsbuild.rs/zh/plugins/list/plugin-react)：提供对 React 的支持。
 - [SVGR 插件](https://rsbuild.rs/zh/plugins/list/plugin-svgr)：支持将 SVG 图片转换为一个 React 组件使用。
-- [Styled Components 插件](https://github.com/rspack-contrib/rsbuild-plugin-styled-components)：提供对 styled-components 的编译时支持。
+- [Styled Components 插件](https://github.com/rstackjs/rsbuild-plugin-styled-components)：提供对 styled-components 的编译时支持。
 
 ### Vue
 
 适用于 Vue 的插件有：
 
-- [Vue 插件](https://github.com/rspack-contrib/rsbuild-plugin-unplugin-vue)：基于 [unplugin-vue](https://github.com/unplugin/unplugin-vue) 实现的为 Vue 3 SFC（单文件组件）提供支持的插件。
+- [Vue 插件](https://github.com/rstackjs/rsbuild-plugin-unplugin-vue)：基于 [unplugin-vue](https://github.com/unplugin/unplugin-vue) 实现的为 Vue 3 SFC（单文件组件）提供支持的插件。
 - [Vue 插件](https://rsbuild.rs/zh/plugins/list/plugin-vue)：基于 [vue-loader](https://github.com/vuejs/vue-loader) 实现的为 Vue 3 SFC（单文件组件）提供支持的插件（推荐使用基于 [unplugin-vue](https://github.com/unplugin/unplugin-vue) 的实现，vue-loader 已不再维护）。
-- [Vue JSX 插件](https://github.com/rspack-contrib/rsbuild-plugin-vue-jsx)：提供对 Vue 3 JSX / TSX 语法的支持。
-- [Vue 2 插件](https://github.com/rspack-contrib/rsbuild-plugin-vue2)：提供对 Vue 2 SFC（单文件组件）的支持。
-- [Vue 2 JSX 插件](https://github.com/rspack-contrib/rsbuild-plugin-vue2-jsx)：提供对 Vue 2 JSX / TSX 语法的支持。
+- [Vue JSX 插件](https://github.com/rstackjs/rsbuild-plugin-vue-jsx)：提供对 Vue 3 JSX / TSX 语法的支持。
+- [Vue 2 插件](https://github.com/rstackjs/rsbuild-plugin-vue2)：提供对 Vue 2 SFC（单文件组件）的支持。
+- [Vue 2 JSX 插件](https://github.com/rstackjs/rsbuild-plugin-vue2-jsx)：提供对 Vue 2 JSX / TSX 语法的支持。
 
 ### Preact
 
@@ -73,21 +73,21 @@ export default defineConfig({
 - [Sass 插件](https://rsbuild.rs/zh/plugins/list/plugin-sass)：使用 Sass 作为 CSS 预处理器。
 - [Less 插件](https://rsbuild.rs/zh/plugins/list/plugin-less)：使用 Less 作为 CSS 预处理器。
 - [Stylus 插件](https://rsbuild.rs/zh/plugins/list/plugin-stylus)：使用 Stylus 作为 CSS 预处理器。
-- [ESLint 插件](https://github.com/rspack-contrib/rsbuild-plugin-eslint)：用于在编译过程中运行 ESLint 检查。
-- [publint 插件](https://github.com/rspack-contrib/rsbuild-plugin-publint)：在构建后运行 `publint` 来检查 npm 包。
-- [Type Check 插件](https://github.com/rspack-contrib/rsbuild-plugin-type-check)：用于在单独的进程中运行 TypeScript 类型检查。
-- [Image Compress 插件](https://github.com/rspack-contrib/rsbuild-plugin-image-compress)：压缩图片资源。
-- [MDX 插件](https://github.com/rspack-contrib/rsbuild-plugin-mdx)：提供 MDX 支持。
-- [Node Polyfill 插件](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill)：用于注入 Node 核心模块在浏览器端的 polyfills。
-- [Source Build 插件](https://github.com/rspack-contrib/rsbuild-plugin-source-build)：用于 monorepo 场景，支持引用其他子目录的源代码，并完成构建和热更新。
-- [Check Syntax 插件](https://github.com/rspack-contrib/rsbuild-plugin-check-syntax)：检查构建产物的语法兼容性，判断是否存在导致兼容性问题的高级语法。
-- [CSS Minimizer 插件](https://github.com/rspack-contrib/rsbuild-plugin-css-minimizer)：用于自定义 CSS 压缩工具，切换到 [cssnano](https://github.com/cssnano/cssnano) 或其他工具进行 CSS 压缩。
-- [Typed CSS Modules 插件](https://github.com/rspack-contrib/rsbuild-plugin-typed-css-modules)：用于为 CSS Modules 文件生成类型声明。
-- [Pug 插件](https://github.com/rspack-contrib/rsbuild-plugin-pug)：提供对 Pug 模板引擎的支持。
-- [Rem 插件](https://github.com/rspack-contrib/rsbuild-plugin-rem)：用于实现移动端页面的 rem 自适应布局。
-- [UMD 插件](https://github.com/rspack-contrib/rsbuild-plugin-umd)：用于构建 UMD 格式的产物。
-- [YAML 插件](https://github.com/rspack-contrib/rsbuild-plugin-yaml)：引用 YAML 文件，并将其转换为 JavaScript 对象。
-- [TOML 插件](https://github.com/rspack-contrib/rsbuild-plugin-toml)：引用 TOML 文件，并将其转换为 JavaScript 对象。
+- [ESLint 插件](https://github.com/rstackjs/rsbuild-plugin-eslint)：用于在编译过程中运行 ESLint 检查。
+- [publint 插件](https://github.com/rstackjs/rsbuild-plugin-publint)：在构建后运行 `publint` 来检查 npm 包。
+- [Type Check 插件](https://github.com/rstackjs/rsbuild-plugin-type-check)：用于在单独的进程中运行 TypeScript 类型检查。
+- [Image Compress 插件](https://github.com/rstackjs/rsbuild-plugin-image-compress)：压缩图片资源。
+- [MDX 插件](https://github.com/rstackjs/rsbuild-plugin-mdx)：提供 MDX 支持。
+- [Node Polyfill 插件](https://github.com/rstackjs/rsbuild-plugin-node-polyfill)：用于注入 Node 核心模块在浏览器端的 polyfills。
+- [Source Build 插件](https://github.com/rstackjs/rsbuild-plugin-source-build)：用于 monorepo 场景，支持引用其他子目录的源代码，并完成构建和热更新。
+- [Check Syntax 插件](https://github.com/rstackjs/rsbuild-plugin-check-syntax)：检查构建产物的语法兼容性，判断是否存在导致兼容性问题的高级语法。
+- [CSS Minimizer 插件](https://github.com/rstackjs/rsbuild-plugin-css-minimizer)：用于自定义 CSS 压缩工具，切换到 [cssnano](https://github.com/cssnano/cssnano) 或其他工具进行 CSS 压缩。
+- [Typed CSS Modules 插件](https://github.com/rstackjs/rsbuild-plugin-typed-css-modules)：用于为 CSS Modules 文件生成类型声明。
+- [Pug 插件](https://github.com/rstackjs/rsbuild-plugin-pug)：提供对 Pug 模板引擎的支持。
+- [Rem 插件](https://github.com/rstackjs/rsbuild-plugin-rem)：用于实现移动端页面的 rem 自适应布局。
+- [UMD 插件](https://github.com/rstackjs/rsbuild-plugin-umd)：用于构建 UMD 格式的产物。
+- [YAML 插件](https://github.com/rstackjs/rsbuild-plugin-yaml)：引用 YAML 文件，并将其转换为 JavaScript 对象。
+- [TOML 插件](https://github.com/rstackjs/rsbuild-plugin-toml)：引用 TOML 文件，并将其转换为 JavaScript 对象。
 
 :::tip
 你可以在 [web-infra-dev/rsbuild](https://github.com/web-infra-dev/rsbuild) 和 [rspack-contrib](https://github.com/rspack-contrib) 中找到这些插件的源代码。
@@ -95,6 +95,6 @@ export default defineConfig({
 
 ## 社区插件
 
-你可以在 [awesome-rspack - Rsbuild Plugins](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rsbuild-plugins) 中查看社区提供的 Rsbuild 插件。
+你可以在 [awesome-rstack - Rsbuild Plugins](https://github.com/rstackjs/awesome-rstack?tab=readme-ov-file#rsbuild-plugins) 中查看社区提供的 Rsbuild 插件。
 
 也可以在 npm 上搜索 [rsbuild-plugin](https://www.npmjs.com/search?q=rsbuild-plugin&ranking=popularity) 关键词来发现更多 Rsbuild 插件。

--- a/website/docs/zh/config/rsbuild/tools.mdx
+++ b/website/docs/zh/config/rsbuild/tools.mdx
@@ -6,7 +6,7 @@ import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
 
 ## tools.bundlerChain <RsbuildDocBadge path="/config/tools/bundler-chain" text="tools.bundlerChain" />
 
-[rspack-chain](https://github.com/rspack-contrib/rspack-chain) 是一个用于配置 Rspack 的工具库，通过 `tools.bundlerChain` 可以调用 `rspack-chain` 以修改默认的 Rspack 配置。
+[rspack-chain](https://github.com/rstackjs/rspack-chain) 是一个用于配置 Rspack 的工具库，通过 `tools.bundlerChain` 可以调用 `rspack-chain` 以修改默认的 Rspack 配置。
 
 ## tools.cssLoader <RsbuildDocBadge path="/config/tools/css-loader" text="tools.cssLoader" />
 

--- a/website/docs/zh/guide/advanced/json-files.mdx
+++ b/website/docs/zh/guide/advanced/json-files.mdx
@@ -116,7 +116,7 @@ import json from './example.json' with { type: 'json' };
 
 [YAML](https://yaml.org/) 是一种数据序列化语言，通常用于编写配置文件。
 
-通过添加 [@rsbuild/plugin-yaml](https://github.com/rspack-contrib/rsbuild-plugin-yaml) 插件，你可以在 JavaScript 中引用 `.yaml` 或 `.yml` 文件，它们会被自动转换为 JavaScript 对象。
+通过添加 [@rsbuild/plugin-yaml](https://github.com/rstackjs/rsbuild-plugin-yaml) 插件，你可以在 JavaScript 中引用 `.yaml` 或 `.yml` 文件，它们会被自动转换为 JavaScript 对象。
 
 import { PackageManagerTabs } from '@theme';
 
@@ -162,7 +162,7 @@ foo:
 
 [TOML](https://toml.io/cn/) 是一种语义明显、易于阅读的配置文件格式。
 
-通过添加 [@rsbuild/plugin-toml](https://github.com/rspack-contrib/rsbuild-plugin-toml) 插件，你可以在 JavaScript 中引用 `.toml` 文件，它们会被自动转换为 JavaScript 对象。
+通过添加 [@rsbuild/plugin-toml](https://github.com/rstackjs/rsbuild-plugin-toml) 插件，你可以在 JavaScript 中引用 `.toml` 文件，它们会被自动转换为 JavaScript 对象。
 
 <PackageManagerTabs command="add @rsbuild/plugin-toml -D" />
 

--- a/website/docs/zh/guide/advanced/module-federation.mdx
+++ b/website/docs/zh/guide/advanced/module-federation.mdx
@@ -351,7 +351,7 @@ export default defineConfig({
 
 ## 示例
 
-你可以在 [Rslib 模块联邦示例](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib/module-federation) 中查看相关项目。
+你可以在 [Rslib 模块联邦示例](https://github.com/rstackjs/rstack-examples/tree/main/rslib/module-federation) 中查看相关项目。
 
 - `mf-host`: Rsbuild App 消费者
 - `mf-react-component`: Rslib Module, 同时是消费者和生产者, 作为生产者向 `mf-host` 提供模块， 并消费 `mf-remote`

--- a/website/docs/zh/guide/advanced/output-compatibility.mdx
+++ b/website/docs/zh/guide/advanced/output-compatibility.mdx
@@ -75,11 +75,11 @@ export default defineConfig({
 通常，我们不需要在浏览器侧使用 Node 库。然而，在某些情况下，代码将在 Node 侧和浏览器侧运行，Node Polyfill 提供了这些 Node 库的浏览器版本 polyfill。
 :::
 
-通过使用 [@rsbuild/plugin-node-polyfill](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill)，Node 核心库的 polyfill 会自动注入到浏览器侧，允许你在浏览器侧使用这些模块。
+通过使用 [@rsbuild/plugin-node-polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill)，Node 核心库的 polyfill 会自动注入到浏览器侧，允许你在浏览器侧使用这些模块。
 
 #### 设置
 
-Rslib 使用 [@rsbuild/plugin-node-polyfill](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill) 提供 Node Polyfill 功能。
+Rslib 使用 [@rsbuild/plugin-node-polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill) 提供 Node Polyfill 功能。
 
 <PackageManagerTabs command="add @rsbuild/plugin-node-polyfill -D" />
 
@@ -99,9 +99,9 @@ export default defineConfig({
 
 - 对于启用了 `bundle` 的项目，Node Polyfill 将被注入并包含在输出中。
 - 对于未启用 `bundle` 的项目，默认情况下不会注入 polyfill。为了避免在每个模块中内联 polyfill，模块需要被 external，并手动添加到依赖中，请按照以下步骤操作：
-  1. 配置 `output.external` 和 `resolvedPolyfillToModules`，你可以从 [@rsbuild/plugin-node-polyfill](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill) 导入。这将 polyfill 模块 external 到已安装的 polyfill 依赖中。
+  1. 配置 `output.external` 和 `resolvedPolyfillToModules`，你可以从 [@rsbuild/plugin-node-polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill) 导入。这将 polyfill 模块 external 到已安装的 polyfill 依赖中。
   2. 安装使用的 polyfill 模块作为依赖。
 
   通过以上步骤，每个 polyfill 模块的使用将被替换为 `externals` 字段中的相应模块。更多详细信息，请查看 <SourceCode href="https://github.com/web-infra-dev/rslib/blob/main/tests/integration/node-polyfill/bundle-false/rslib.config.ts" /> 的示例。
 
-更多详细信息，请查看 [@rsbuild/plugin-node-polyfill](https://github.com/rspack-contrib/rsbuild-plugin-node-polyfill) 文档，所有配置均适用于 Rslib。
+更多详细信息，请查看 [@rsbuild/plugin-node-polyfill](https://github.com/rstackjs/rsbuild-plugin-node-polyfill) 文档，所有配置均适用于 Rslib。

--- a/website/docs/zh/guide/advanced/storybook.mdx
+++ b/website/docs/zh/guide/advanced/storybook.mdx
@@ -4,17 +4,17 @@ import { PackageManagerTabs, Tab, Tabs } from '@theme';
 
 [Storybook](https://storybook.js.org/) 是一个为 React、Vue 等框架独立开发 UI 组件的强大的工具，它能够独立构建和测试组件，从而提升开发和测试效率。
 
-[storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild) 是 Rsbuild 支持的 Storybook 构建器，并集成了 React、Vue 3 框架和原生 JavaScript。统一使用 Rsbuild 构建系统可以使 Storybook 与 Rslib 使用统一的构建配置。
+[storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild) 是 Rsbuild 支持的 Storybook 构建器，并集成了 React、Vue 3 框架和原生 JavaScript。统一使用 Rsbuild 构建系统可以使 Storybook 与 Rslib 使用统一的构建配置。
 
 :::info Storybook Rsbuild 版本对应表
 
 下表展示了 Storybook Rsbuild 与 Storybook 版本的对应关系。如果你正在使用 Storybook v9 或更早版本，请参考 [官方迁移指南](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#from-version-9x-to-1000) 迁移到最新版。
 
-| Storybook                              | Storybook Rsbuild                                                                        |
-| -------------------------------------- | ---------------------------------------------------------------------------------------- |
-| [v10](https://storybook.js.org/docs/)  | [^3.0.0](https://storybook.rsbuild.rs)                                                   |
-| [v9](https://storybook.js.org/docs/9/) | [^2.0.0](https://storybook-v2.rsbuild.rs)                                                |
-| [v8](https://storybook.js.org/docs/8/) | [^1.0.0](https://github.com/rspack-contrib/storybook-rsbuild/tree/v1/website/docs/guide) |
+| Storybook                              | Storybook Rsbuild                                                                  |
+| -------------------------------------- | ---------------------------------------------------------------------------------- |
+| [v10](https://storybook.js.org/docs/)  | [^3.0.0](https://storybook.rsbuild.rs)                                             |
+| [v9](https://storybook.js.org/docs/9/) | [^2.0.0](https://storybook-v2.rsbuild.rs)                                          |
+| [v8](https://storybook.js.org/docs/8/) | [^1.0.0](https://github.com/rstackjs/storybook-rsbuild/tree/v1/website/docs/guide) |
 
 :::
 
@@ -115,5 +115,5 @@ npx storybook build // 构建静态文件
 
 ## 示例
 
-- [React 组件库 + Rslib + Storybook](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib/react-storybook)
-- [Vue 组件库 + Rslib + Storybook](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib/vue-storybook)
+- [React 组件库 + Rslib + Storybook](https://github.com/rstackjs/rstack-examples/tree/main/rslib/react-storybook)
+- [Vue 组件库 + Rslib + Storybook](https://github.com/rstackjs/rstack-examples/tree/main/rslib/vue-storybook)

--- a/website/docs/zh/guide/solution/index.mdx
+++ b/website/docs/zh/guide/solution/index.mdx
@@ -8,7 +8,7 @@
 
 发布到 npm 时，你可以选择不压缩代码或[压缩代码](/config/rsbuild/output#outputminify)，同时提供[sourcemap](/config/rsbuild/output#outputsourcema) 以增强库使用者的调试体验。样式上，可以使用 CSS 或 CSS 预处理器，如 Sass、Less 或 Stylus 等，或使用 PostCSS 用于 CSS 后处理。 Tailwind CSS 等工具也可以帮助你构建样式，也可以使用 CSS Modules。
 
-在资源处理方面，Rslib 处理代码中使用的静态资源，例如 SVG 和 PNG 文件。你还可以构建[React](/guide/solution/react)、[Preact](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib/preact) 或其他框架，使用 [Storybook](/guide/advanced/storybook) 进行 UI 组件开发和测试。
+在资源处理方面，Rslib 处理代码中使用的静态资源，例如 SVG 和 PNG 文件。你还可以构建[React](/guide/solution/react)、[Preact](https://github.com/rstackjs/rstack-examples/tree/main/rslib/preact) 或其他框架，使用 [Storybook](/guide/advanced/storybook) 进行 UI 组件开发和测试。
 
 参考本章的解决方案，了解如何使用 Rslib 开发一个在浏览器中使用的库，给多种框架使用。
 

--- a/website/docs/zh/guide/solution/nodejs.mdx
+++ b/website/docs/zh/guide/solution/nodejs.mdx
@@ -1,6 +1,6 @@
 # Node.js
 
-在本文档中，你将学习如何使用 Rslib 构建 Node.js 库，你可在 [示例](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib) 中查看 Node.js 相关演示项目。
+在本文档中，你将学习如何使用 Rslib 构建 Node.js 库，你可在 [示例](https://github.com/rstackjs/rstack-examples/tree/main/rslib) 中查看 Node.js 相关演示项目。
 
 ## 创建 Node.js 项目
 

--- a/website/docs/zh/guide/solution/react.mdx
+++ b/website/docs/zh/guide/solution/react.mdx
@@ -1,6 +1,6 @@
 # React
 
-在本文档中，你将学习如何使用 Rslib 构建 React 组件库，你可在 [示例](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib) 中查看 React 相关演示项目。
+在本文档中，你将学习如何使用 Rslib 构建 React 组件库，你可在 [示例](https://github.com/rstackjs/rstack-examples/tree/main/rslib) 中查看 React 相关演示项目。
 
 ## 创建 React 项目
 

--- a/website/docs/zh/guide/solution/vue.mdx
+++ b/website/docs/zh/guide/solution/vue.mdx
@@ -1,6 +1,6 @@
 # Vue
 
-在本文档中，你将学习如何使用 Rslib 构建 Vue 组件库，你可在 [示例](https://github.com/rspack-contrib/rstack-examples/tree/main/rslib) 中查看 Vue 相关演示项目。
+在本文档中，你将学习如何使用 Rslib 构建 Vue 组件库，你可在 [示例](https://github.com/rstackjs/rstack-examples/tree/main/rslib) 中查看 Vue 相关演示项目。
 
 ::: note
 
@@ -31,7 +31,7 @@ import { PackageManagerTabs } from '@theme';
 
 开发 Vue 组件，需要在 `rslib.config.ts` 中设置 [target](/config/rsbuild/output#outputtarget) 为 `"web"`。 这一点至关重要，因为 Rslib 默认将 `target` 设置为 `"node"`，这与 Rsbuild 的 target 默认值不同。
 
-要编译 Vue（.vue 单文件组件），你需要注册基于 [unplugin-vue](https://github.com/unplugin/unplugin-vue) 实现的 [rsbuild-plugin-unplugin-vue](https://github.com/rspack-contrib/rsbuild-plugin-unplugin-vue) 插件。该插件将自动添加 Vue 构建所需的配置。
+要编译 Vue（.vue 单文件组件），你需要注册基于 [unplugin-vue](https://github.com/unplugin/unplugin-vue) 实现的 [rsbuild-plugin-unplugin-vue](https://github.com/rstackjs/rsbuild-plugin-unplugin-vue) 插件。该插件将自动添加 Vue 构建所需的配置。
 
 例如，在 `rslib.config.ts` 中注册:
 
@@ -52,7 +52,7 @@ export default defineConfig({
 ```
 
 ::: note
-目前 [rsbuild-plugin-unplugin-vue](https://github.com/rspack-contrib/rsbuild-plugin-unplugin-vue) 插件还不支持打包 Vue SFC [scoped CSS](https://vuejs.org/api/sfc-css-features#scoped-css) 样式，你可以选择 Less、Sass 等样式解决方案
+目前 [rsbuild-plugin-unplugin-vue](https://github.com/rstackjs/rsbuild-plugin-unplugin-vue) 插件还不支持打包 Vue SFC [scoped CSS](https://vuejs.org/api/sfc-css-features#scoped-css) 样式，你可以选择 Less、Sass 等样式解决方案
 :::
 
-更多配置可以参考 [rsbuild-plugin-unplugin-vue](https://github.com/rspack-contrib/rsbuild-plugin-unplugin-vue) 插件文档。
+更多配置可以参考 [rsbuild-plugin-unplugin-vue](https://github.com/rstackjs/rsbuild-plugin-unplugin-vue) 插件文档。

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -40,7 +40,7 @@ Rslib 基于 Rsbuild 实现，并完全复用 Rsbuild 的能力和生态系统�
 
 ## 🦀 Rstack
 
-Rstack 是一个围绕 Rspack 打造的 JavaScript 统一工具链，具有优秀的性能和一致的架构。
+Rstack 是一个以 Rspack 为核心的 JavaScript 统一工具链，具有优秀的性能和一致的架构。
 
 | 名称                                                  | 描述           | 版本                                                                                                                                                                             |
 | ----------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -54,11 +54,11 @@ Rstack 是一个围绕 Rspack 打造的 JavaScript 统一工具链，具有优�
 
 ## 🔗 链接
 
-- [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack): 与 Rstack 相关的精彩内容列表。
-- [rstack-examples](https://github.com/rspack-contrib/rstack-examples): Rstack 的示例项目。
-- [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): 基于 Rsbuild 构建的 Storybook。
-- [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template): 使用此模板创建你的 Rsbuild 插件。
-- [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources): Rstack 的设计资源。
+- [awesome-rstack](https://github.com/rstackjs/awesome-rstack): 与 Rstack 相关的精彩内容列表。
+- [rstack-examples](https://github.com/rstackjs/rstack-examples): Rstack 的示例项目。
+- [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild): 基于 Rsbuild 构建的 Storybook。
+- [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template): 使用此模板创建你的 Rsbuild 插件。
+- [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources): Rstack 的设计资源。
 
 ## 🧑‍💻 社区
 


### PR DESCRIPTION
## Summary

We have renamed the GitHub organization from `rspack-contrib` to `rstackjs` (https://github.com/rstackjs).

This change better reflects the Rstack brand and its growing ecosystem, while also providing a shorter organization name.

Existing links will continue to redirect correctly.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
