### PR TITLE
docs: update rstack org link

### DIFF
--- a/website/docs/en/config/rsbuild/plugins.mdx
+++ b/website/docs/en/config/rsbuild/plugins.mdx
@@ -90,7 +90,7 @@ The following are common framework-agnostic plugins:
 - [TOML Plugin](https://github.com/rstackjs/rsbuild-plugin-toml): Import TOML files and convert them into JavaScript objects.
 
 :::tip
-You can find the source code of all official plugins in [web-infra-dev/rsbuild](https://github.com/web-infra-dev/rsbuild) and [rspack-contrib](https://github.com/rspack-contrib).
+You can find the source code of all official plugins in [web-infra-dev/rsbuild](https://github.com/web-infra-dev/rsbuild) and [rstackjs](https://github.com/rstackjs).
 :::
 
 ## Community plugins

--- a/website/docs/zh/config/rsbuild/plugins.mdx
+++ b/website/docs/zh/config/rsbuild/plugins.mdx
@@ -90,7 +90,7 @@ export default defineConfig({
 - [TOML 插件](https://github.com/rstackjs/rsbuild-plugin-toml)：引用 TOML 文件，并将其转换为 JavaScript 对象。
 
 :::tip
-你可以在 [web-infra-dev/rsbuild](https://github.com/web-infra-dev/rsbuild) 和 [rspack-contrib](https://github.com/rspack-contrib) 中找到这些插件的源代码。
+你可以在 [web-infra-dev/rsbuild](https://github.com/web-infra-dev/rsbuild) 和 [rstackjs](https://github.com/rstackjs) 中找到这些插件的源代码。
 :::
 
 ## 社区插件


### PR DESCRIPTION
## Summary

Updated the tip to reference [rstackjs](https://github.com/rstackjs) instead of `rspack-contrib` for official plugin source code.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1423

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
