### PR TITLE
chore: remove pnpm dedupe check from CI and lint-staged

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,8 +41,3 @@ jobs:
 
       - name: Check Dependency Version
         run: pnpm run check-dependency-version
-
-      - name: Check pnpm Dedupe
-        # Skip on release branches since the new version isn't published yet
-        if: ${{ !startsWith(github.head_ref, 'release') }}
-        run: pnpm dedupe --check

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "package.json": [
       "pnpm run check-dependency-version",
       "prettier --write"
-    ],
-    "pnpm-lock.yaml": "pnpm dedupe --check"
+    ]
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",


### PR DESCRIPTION
## Summary

Removes the `pnpm dedupe --check` step from the CI workflow (`lint.yml`) and `lint-staged` configuration in `package.json` to disable unexpected deduplication checks.

https://github.com/web-infra-dev/rslib/actions/runs/20615576433/job/59207588462

pnpm dedupe will be executed when renovate bump deps now.

## Related Links

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
