### PR TITLE
refactor(core): use named import from node:module for require shim

### DIFF
--- a/packages/core/src/plugins/shims.ts
+++ b/packages/core/src/plugins/shims.ts
@@ -17,8 +17,8 @@ export const pluginCjsImportMetaUrlShim = (): RsbuildPlugin => ({
 });
 
 const requireShim = `// Rslib ESM shims
-import __rslib_shim_module__ from 'module';
-const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(import.meta.url);
+import { createRequire } from "node:module";
+const require = /*#__PURE__*/ createRequire(import.meta.url);
 `;
 
 export const pluginEsmRequireShim = (): RsbuildPlugin => ({

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -51,8 +51,8 @@ describe('ESM shims', async () => {
 
   test('require', async () => {
     expect(entries.esm2).toMatchInlineSnapshot(`
-      "import __rslib_shim_module__ from 'module';
-      const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(import.meta.url);
+      "import { createRequire } from "node:module";
+      const require = /*#__PURE__*/ createRequire(import.meta.url);
       const randomFile = require(process.env.RANDOM_FILE);
       export { randomFile };
       "

--- a/website/docs/en/config/lib/shims.mdx
+++ b/website/docs/en/config/lib/shims.mdx
@@ -168,10 +168,8 @@ Options:
   the ESM output will be transformed to:
 
   ```js
-  import __rslib_shim_module__ from 'module';
-  const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(
-    import.meta.url,
-  );
+  import { createRequire } from 'node:module';
+  const require = /*#__PURE__*/ createRequire(import.meta.url);
   // dynamic require
   require(SOME_VALUE_IN_RUNTIME);
   // require.resolve

--- a/website/docs/zh/config/lib/shims.mdx
+++ b/website/docs/zh/config/lib/shims.mdx
@@ -168,10 +168,8 @@ const defaultShims = {
   ESM 产物将被转换为：
 
   ```js
-  import __rslib_shim_module__ from 'module';
-  const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(
-    import.meta.url,
-  );
+  import { createRequire } from 'node:module';
+  const require = /*#__PURE__*/ createRequire(import.meta.url);
   // dynamic require
   require(SOME_VALUE_IN_RUNTIME);
   // require.resolve


### PR DESCRIPTION
## Summary

This PR updates the implementation of `requireShim` to use a named import from `node:module` instead of the default import. This aligns with modern Node.js practices and ensures better compatibility.

Specifically, it changes:
```ts
// Before
import __rslib_shim_module__ from 'module';
const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(import.meta.url);

// After
import { createRequire } from "node:module";
const require = /*#__PURE__*/ createRequire(import.meta.url);
```

I have also updated the relevant integration tests (`tests/integration/shims/index.test.ts`) and documentation (`website/docs/en/config/lib/shims.mdx`, `website/docs/zh/config/lib/shims.mdx`) to reflect this change.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).