### PR TITLE
fix(core): use default import from node:module to avoid naming conflict

### DIFF
--- a/packages/core/src/plugins/shims.ts
+++ b/packages/core/src/plugins/shims.ts
@@ -17,8 +17,8 @@ export const pluginCjsImportMetaUrlShim = (): RsbuildPlugin => ({
 });
 
 const requireShim = `// Rslib ESM shims
-import { createRequire } from "node:module";
-const require = /*#__PURE__*/ createRequire(import.meta.url);
+import __rslib_shim_module__ from "node:module";
+const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(import.meta.url);
 `;
 
 export const pluginEsmRequireShim = (): RsbuildPlugin => ({

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -51,8 +51,8 @@ describe('ESM shims', async () => {
 
   test('require', async () => {
     expect(entries.esm2).toMatchInlineSnapshot(`
-      "import { createRequire } from "node:module";
-      const require = /*#__PURE__*/ createRequire(import.meta.url);
+      "import __rslib_shim_module__ from "node:module";
+      const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(import.meta.url);
       const randomFile = require(process.env.RANDOM_FILE);
       export { randomFile };
       "

--- a/website/docs/en/config/lib/shims.mdx
+++ b/website/docs/en/config/lib/shims.mdx
@@ -168,8 +168,10 @@ Options:
   the ESM output will be transformed to:
 
   ```js
-  import { createRequire } from 'node:module';
-  const require = /*#__PURE__*/ createRequire(import.meta.url);
+  import __rslib_shim_module__ from 'node:module';
+  const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(
+    import.meta.url,
+  );
   // dynamic require
   require(SOME_VALUE_IN_RUNTIME);
   // require.resolve

--- a/website/docs/zh/config/lib/shims.mdx
+++ b/website/docs/zh/config/lib/shims.mdx
@@ -168,8 +168,10 @@ const defaultShims = {
   ESM 产物将被转换为：
 
   ```js
-  import { createRequire } from 'node:module';
-  const require = /*#__PURE__*/ createRequire(import.meta.url);
+  import __rslib_shim_module__ from 'node:module';
+  const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(
+    import.meta.url,
+  );
   // dynamic require
   require(SOME_VALUE_IN_RUNTIME);
   // require.resolve


### PR DESCRIPTION
## Summary

This PR updates `requireShim` to use the default import from `node:module` instead of a named import.

In the previous PR (#1431), we switched to `import { createRequire } from "node:module"`. However, if the user's code also defines a variable named `createRequire`, this shim injection could cause a naming conflict.

see https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/20743602225/job/59555591523

This PR resolves the issue by using a namespaced default import:

```ts
// Before (potential conflict)
import { createRequire } from "node:module";
const require = /*#__PURE__*/ createRequire(import.meta.url);

// After (safe)
import __rslib_shim_module__ from "node:module";
const require = /*#__PURE__*/ __rslib_shim_module__.createRequire(import.meta.url);
```

## Related Links

- #1431

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).