### PR TITLE
fix(dts): unify logger in dts plugin

### DIFF
--- a/packages/plugin-dts/src/tsgo.ts
+++ b/packages/plugin-dts/src/tsgo.ts
@@ -183,7 +183,7 @@ export async function emitDtsTsgo(
       for (const line of lines) {
         if (line.trim()) {
           // Reset color for each line to avoid color bleed
-          console.log(color.reset(`${logPrefixTsgo} ${line}`));
+          logger.log(color.reset(`${logPrefixTsgo} ${line}`));
         }
       }
     });


### PR DESCRIPTION
## Summary
Updated `packages/plugin-dts/src/tsgo.ts` to use `logger.log` instead of `console.log`. This ensures that the log level configuration is respected and consistent with the rest of the application.

## Related Links
N/A

## Checklist
- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).