### PR TITLE
docs: remove custom llms button

### DIFF
--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,7 +1,4 @@
-import {
-  getCustomMDXComponent as BaseGetCustomMDXComponent,
-  Layout as BaseLayout,
-} from '@rspress/core/theme-original';
+import { Layout as BaseLayout } from '@rspress/core/theme-original';
 import {
   Search as PluginAlgoliaSearch,
   ZH_LOCALES,
@@ -10,31 +7,6 @@ import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
 import { HomeLayout } from './pages';
 import './index.scss';
 import { useLang } from '@rspress/core/runtime';
-import {
-  LlmsContainer,
-  LlmsCopyButton,
-  LlmsViewOptions,
-} from '@rspress/plugin-llms/runtime';
-
-export function getCustomMDXComponent() {
-  const { h1: H1, ...mdxComponents } = BaseGetCustomMDXComponent();
-
-  const MyH1 = ({ ...props }) => {
-    return (
-      <>
-        <H1 {...props} />
-        <LlmsContainer>
-          <LlmsCopyButton />
-          <LlmsViewOptions />
-        </LlmsContainer>
-      </>
-    );
-  };
-  return {
-    ...mdxComponents,
-    h1: MyH1,
-  };
-}
 
 const Layout = () => {
   return <BaseLayout beforeNavTitle={<NavIcon />} />;


### PR DESCRIPTION
## Summary

Since Rspress make LLMS built-in in https://github.com/web-infra-dev/rspress/pull/3026, so in this PR we remove the custom theme component.

## Related Links

https://github.com/web-infra-dev/rslib/pull/1146

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
