### PR TITLE
fix(create-rslib): improve template argument parsing and defaults

### DIFF
--- a/packages/create-rslib/src/index.ts
+++ b/packages/create-rslib/src/index.ts
@@ -38,9 +38,14 @@ export function parseTemplateName(template: string): string {
   const lastPart = pair[pair.length - 1];
   // Check if the last part is a valid language suffix
   if (lastPart === 'ts' || lastPart === 'js') {
-    const language = lastPart;
     const rest = pair.slice(0, pair.length - 1).join('-');
-    return `${rest}-${language}`;
+    // Handle edge case where input is just "ts" or "js"
+    if (!rest) {
+      throw new Error(
+        `Invalid template name: "${template}". Template name cannot be just a language suffix.`,
+      );
+    }
+    return `${rest}-${lastPart}`;
   }
   // No language suffix provided, default to 'ts'
   return `${template}-ts`;

--- a/packages/create-rslib/test/index.test.ts
+++ b/packages/create-rslib/test/index.test.ts
@@ -111,6 +111,15 @@ describe('parseTemplateName', () => {
     expect(parseTemplateName('node-dual')).toBe('node-dual-ts');
     expect(parseTemplateName('node-esm')).toBe('node-esm-ts');
   });
+
+  test('should throw error when input is just a language suffix', () => {
+    expect(() => parseTemplateName('ts')).toThrow(
+      'Invalid template name: "ts". Template name cannot be just a language suffix.',
+    );
+    expect(() => parseTemplateName('js')).toThrow(
+      'Invalid template name: "js". Template name cannot be just a language suffix.',
+    );
+  });
 });
 
 describe('node-dual', () => {


### PR DESCRIPTION
## Summary

This PR improves the parsing of the `--template` argument in `create-rslib`.

- Extracted `parseTemplateName` logic to handle template names more robustly.
- When a language suffix (`-ts` or `-js`) is omitted, it now correctly defaults to `-ts` (appending it to the template name) instead of treating the last part of the template name as the language.
- Added unit tests for `parseTemplateName`.
- Removed `order: 'pre'` from `rspress` template config.

## Related Links

N/A

## Checklist

- [x] Tests updated.
- [ ] Documentation updated (or not required).