### PR TITLE
docs: add Rsdoctor guide

### DIFF
--- a/website/docs/en/guide/advanced/_meta.json
+++ b/website/docs/en/guide/advanced/_meta.json
@@ -8,5 +8,6 @@
   "module-federation",
   "rspress",
   "storybook",
-  "rstest"
+  "rstest",
+  "rsdoctor"
 ]

--- a/website/docs/en/guide/advanced/rsdoctor.mdx
+++ b/website/docs/en/guide/advanced/rsdoctor.mdx
@@ -1,0 +1,67 @@
+import { PackageManagerTabs } from '@theme';
+
+# Use Rsdoctor
+
+[Rsdoctor](https://rsdoctor.rs/) is a build analyzer tailored for the Rspack ecosystem.
+
+Rsdoctor aims to be a one-stop, intelligent build analyzer that makes the build process transparent, predictable, and optimizable through visualization and smart analysis, helping teams pinpoint bottlenecks, improve performance, and raise engineering quality.
+
+Use Rsdoctor to debug build outputs or the build process.
+
+## Quick start
+
+In an Rslib project, enable Rsdoctor as follows:
+
+1. Install the Rsdoctor plugin:
+
+<PackageManagerTabs command="add @rsdoctor/rspack-plugin -D" />
+
+2. Set the `RSDOCTOR=true` environment variable before running the CLI command:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build:rsdoctor": "RSDOCTOR=true rslib build"
+  }
+}
+```
+
+Because Windows does not support this syntax, you can use [cross-env](https://npmjs.com/package/cross-env) to set environment variables across different systems:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build:rsdoctor": "cross-env RSDOCTOR=true rslib build"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.0"
+  }
+}
+```
+
+After running these scripts, Rslib automatically registers the Rsdoctor plugin and opens the build analysis page when the build finishes. See the [Rsdoctor documentation](https://rsdoctor.rs/) for all features.
+
+## Options
+
+To configure the [options](https://rsdoctor.rs/config/options/options) exposed by the Rsdoctor plugin, manually register the plugin:
+
+```ts title="rslib.config.ts"
+import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    // ...lib configuration
+  ],
+  tools: {
+    rspack: {
+      plugins: [
+        process.env.RSDOCTOR === 'true' &&
+          new RsdoctorRspackPlugin({
+            // plugin options
+          }),
+      ],
+    },
+  },
+});
+```

--- a/website/docs/en/guide/advanced/rspress.mdx
+++ b/website/docs/en/guide/advanced/rspress.mdx
@@ -1,7 +1,7 @@
 import { PackageManagerTabs } from '@theme';
 import { Steps } from '@rspress/core/theme';
 
-# Using Rspress
+# Use Rspress
 
 [Rspress](https://rspress.rs/) is a Rspack-based static site generator, ideal for building demos and API docs for component libraries. With [plugin-preview](https://rspress.rs/plugin/plugin-preview) and [plugin-api-docgen](https://rspress.rs/plugin/api-docgen), you can reuse Rslib sources and typings to preview components and view APIs in one site.
 

--- a/website/docs/en/guide/advanced/rstest.mdx
+++ b/website/docs/en/guide/advanced/rstest.mdx
@@ -1,6 +1,6 @@
 import { PackageManagerTabs } from '@theme';
 
-# Using Rstest
+# Use Rstest
 
 [Rstest](https://rstest.rs) is a test framework based on Rspack that provides comprehensive, first-class support for the Rspack ecosystem, you can use the same set of configurations for both development and testing.
 

--- a/website/docs/zh/guide/advanced/_meta.json
+++ b/website/docs/zh/guide/advanced/_meta.json
@@ -8,5 +8,6 @@
   "module-federation",
   "rspress",
   "storybook",
-  "rstest"
+  "rstest",
+  "rsdoctor"
 ]

--- a/website/docs/zh/guide/advanced/rsdoctor.mdx
+++ b/website/docs/zh/guide/advanced/rsdoctor.mdx
@@ -1,0 +1,67 @@
+import { PackageManagerTabs } from '@theme';
+
+# 使用 Rsdoctor
+
+[Rsdoctor](https://rsdoctor.rs/) 是一款为 Rspack 生态量身打造的构建分析工具。
+
+Rsdoctor 致力于成为一站式、智能化的构建分析工具，通过可视化与智能分析，使整个构建流程变得透明、可预测和可优化，从而帮助开发团队精准定位瓶颈、优化性能并提升工程质量。
+
+当你需要调试构建产物或构建过程时，可以借助 Rsdoctor 来提升排查问题的效率。
+
+## 快速上手
+
+在基于 Rslib 的项目中，你可以通过以下步骤开启 Rsdoctor 分析：
+
+1. 安装 Rsdoctor 插件：
+
+<PackageManagerTabs command="add @rsdoctor/rspack-plugin -D" />
+
+2. 在 CLI 命令前添加 `RSDOCTOR=true` 环境变量：
+
+```json title="package.json"
+{
+  "scripts": {
+    "build:rsdoctor": "RSDOCTOR=true rslib build"
+  }
+}
+```
+
+由于 Windows 不支持上述用法，你也可以使用 [cross-env](https://npmjs.com/package/cross-env) 来设置环境变量，这可以确保在不同的操作系统中都能正常使用：
+
+```json title="package.json"
+{
+  "scripts": {
+    "build:rsdoctor": "cross-env RSDOCTOR=true rslib build"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.0"
+  }
+}
+```
+
+在项目内执行上述命令后，Rslib 会自动注册 Rsdoctor 的插件，并在构建完成后打开本次构建的分析页面，请参考 [Rsdoctor 文档](https://rsdoctor.rs/) 来了解完整功能。
+
+## 配置项
+
+如果你需要配置 Rsdoctor 插件提供的 [选项](https://rsdoctor.rs/zh/config/options/options)，请手动注册 Rsdoctor 插件：
+
+```ts title="rslib.config.ts"
+import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    // ...lib 配置
+  ],
+  tools: {
+    rspack: {
+      plugins: [
+        process.env.RSDOCTOR === 'true' &&
+          new RsdoctorRspackPlugin({
+            // 插件选项
+          }),
+      ],
+    },
+  },
+});
+```


### PR DESCRIPTION
## Description

This PR adds the Rsdoctor guide for both English and Chinese documentation.
It also updates the titles in `rspress.mdx` and `rstest.mdx` to be consistent ("Use X" instead of "Using X").

## Changes

- Add `rsdoctor.mdx` in `docs/en/guide/advanced/` and `docs/zh/guide/advanced/`
- Update `_meta.json` to include `rsdoctor`
- Rename "Using Rspress" to "Use Rspress"
- Rename "Using Rstest" to "Use Rstest"