### PR TITLE
docs: fix Rspress plugin URLs to official-plugins path

### DIFF
--- a/website/docs/en/guide/advanced/rspress.mdx
+++ b/website/docs/en/guide/advanced/rspress.mdx
@@ -3,7 +3,7 @@ import { Steps } from '@rspress/core/theme';
 
 # Use Rspress
 
-[Rspress](https://rspress.rs/) is a Rspack-based static site generator, ideal for building demos and API docs for component libraries. With [plugin-preview](https://rspress.rs/plugin/plugin-preview) and [plugin-api-docgen](https://rspress.rs/plugin/api-docgen), you can reuse Rslib sources and typings to preview components and view APIs in one site.
+[Rspress](https://rspress.rs/) is a Rspack-based static site generator, ideal for building demos and API docs for component libraries. With [plugin-preview](https://rspress.rs/plugin/official-plugins/preview) and [plugin-api-docgen](https://rspress.rs/plugin/official-plugins/api-docgen), you can reuse Rslib sources and typings to preview components and view APIs in one site.
 
 ## New project
 
@@ -65,7 +65,7 @@ If you are using Rslib to build a component library, follow these steps to add R
 
 ### Create `rspress.config.ts`
 
-Add preview-related plugins like [plugin-preview](https://rspress.rs/plugin/plugin-preview) and [plugin-api-docgen](https://rspress.rs/plugin/api-docgen).
+Add preview-related plugins like [plugin-preview](https://rspress.rs/plugin/official-plugins/preview) and [plugin-api-docgen](https://rspress.rs/plugin/official-plugins/api-docgen).
 
 ```ts title="rspress.config.ts"
 import * as path from 'node:path';
@@ -115,7 +115,7 @@ Set `paths` in `tsconfig.json` to point to your package, or declare your package
 
 :::tip
 
-In [plugin-preview](https://rspress.rs/plugin/plugin-preview), we recommend importing component outputs by package name rather than relative paths. This keeps the preview environment consistent with how users consume the library.
+In [plugin-preview](https://rspress.rs/plugin/official-plugins/preview), we recommend importing component outputs by package name rather than relative paths. This keeps the preview environment consistent with how users consume the library.
 
 If your project uses the `exports` field, we recommend `"workspace:*"` instead:
 
@@ -168,5 +168,5 @@ export default () => <Button backgroundColor="red" label="Red" />;
 
 - [Rspress docs & plugins](https://rspress.rs/)
 - [`rsbuild-plugin-workspace-dev`](https://www.npmjs.com/package/rsbuild-plugin-workspace-dev)
-- [`@rspress/plugin-api-docgen`](https://rspress.rs/plugin/api-docgen)
-- [`@rspress/plugin-preview`](https://rspress.rs/plugin/plugin-preview)
+- [`@rspress/plugin-api-docgen`](https://rspress.rs/plugin/official-plugins/api-docgen)
+- [`@rspress/plugin-preview`](https://rspress.rs/plugin/official-plugins/preview)

--- a/website/docs/zh/guide/advanced/rspress.mdx
+++ b/website/docs/zh/guide/advanced/rspress.mdx
@@ -3,7 +3,7 @@ import { Steps } from '@rspress/core/theme';
 
 # 使用 Rspress
 
-[Rspress](https://rspress.rs/) 是基于 Rspack 的静态站点生成器，适合为组件库项目提供预览和搭建 API 文档。借助 [plugin-preview](https://rspress.rs/plugin/plugin-preview) 和 [plugin-api-docgen](https://rspress.rs/plugin/api-docgen)。
+[Rspress](https://rspress.rs/) 是基于 Rspack 的静态站点生成器，适合为组件库项目提供预览和搭建 API 文档。借助 [plugin-preview](https://rspress.rs/zh/plugin/official-plugins/preview) 和 [plugin-api-docgen](https://rspress.rs/zh/plugin/official-plugins/api-docgen)。
 
 ## 新项目
 
@@ -65,7 +65,7 @@ import { Steps } from '@rspress/core/theme';
 
 ### 创建 `rspress.config.ts`
 
-增加 Rspress 组件库预览相关的 plugin，比如 [plugin-preview](https://rspress.rs/plugin/plugin-preview) 和 [plugin-api-docgen](https://rspress.rs/plugin/api-docgen)。
+增加 Rspress 组件库预览相关的 plugin，比如 [plugin-preview](https://rspress.rs/zh/plugin/official-plugins/preview) 和 [plugin-api-docgen](https://rspress.rs/zh/plugin/official-plugins/api-docgen)。
 
 ```ts title="rspress.config.ts"
 import * as path from 'node:path';
@@ -115,7 +115,7 @@ export default defineConfig({
 
 :::tip
 
-在 [plugin-preview](https://rspress.rs/plugin/plugin-preview) 中，我们更推荐使用包名导入组件的产物，而不是相对路径导入源码。这样可以确保预览环境和用户使用环境一致。
+在 [plugin-preview](https://rspress.rs/zh/plugin/official-plugins/preview) 中，我们更推荐使用包名导入组件的产物，而不是相对路径导入源码。这样可以确保预览环境和用户使用环境一致。
 
 如果你的项目中使用 `exports` 字段，我们更推荐使用 `"workspace:*"` ：
 
@@ -168,5 +168,5 @@ export default () => <Button backgroundColor="red" label="Red" />;
 
 - [Rspress 文档与插件](https://rspress.rs/)
 - [`rsbuild-plugin-workspace-dev`](https://www.npmjs.com/package/rsbuild-plugin-workspace-dev)
-- [`@rspress/plugin-api-docgen`](https://rspress.rs/plugin/api-docgen)
-- [`@rspress/plugin-preview`](https://rspress.rs/plugin/plugin-preview)
+- [`@rspress/plugin-api-docgen`](https://rspress.rs/zh/plugin/official-plugins/api-docgen)
+- [`@rspress/plugin-preview`](https://rspress.rs/zh/plugin/official-plugins/preview)


### PR DESCRIPTION
## Summary
- Update Rspress plugin documentation URLs to use the `/official-plugins/` path structure
- Sync English documentation with the Chinese version

## Test plan
- [ ] Verify documentation links are accessible