### PR TITLE
chore(deps): update @typescript/native-preview

### DIFF
--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -38,7 +38,7 @@
     "@microsoft/api-extractor": "^7.56.0",
     "@rsbuild/core": "~1.7.3",
     "@rslib/tsconfig": "workspace:*",
-    "@typescript/native-preview": "7.0.0-dev.20260201.1",
+    "@typescript/native-preview": "7.0.0-dev.20260210.1",
     "magic-string": "^0.30.21",
     "picocolors": "1.1.1",
     "prebundle": "1.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 0.2.0
       '@rstest/adapter-rslib':
         specifier: ^0.2.0
-        version: 0.2.0(@rslib/core@0.19.4(@microsoft/api-extractor@7.56.0(@types/node@24.10.9))(typescript@5.9.3))(@rstest/core@0.8.1)(typescript@5.9.3)
+        version: 0.2.0(@rslib/core@0.19.5(@microsoft/api-extractor@7.56.0(@types/node@24.10.9))(typescript@5.9.3))(@rstest/core@0.8.1)(typescript@5.9.3)
       '@rstest/core':
         specifier: ^0.8.1
         version: 0.8.1
@@ -384,7 +384,7 @@ importers:
         version: 0.3.4(@rsbuild/core@1.7.3)
       rslib:
         specifier: npm:@rslib/core@0.19.4
-        version: '@rslib/core@0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@typescript/native-preview@7.0.0-dev.20260201.1)(typescript@5.9.3)'
+        version: '@rslib/core@0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@typescript/native-preview@7.0.0-dev.20260210.1)(typescript@5.9.3)'
       rslog:
         specifier: ^1.3.2
         version: 1.3.2
@@ -445,8 +445,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/tsconfig
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260201.1
-        version: 7.0.0-dev.20260201.1
+        specifier: 7.0.0-dev.20260210.1
+        version: 7.0.0-dev.20260210.1
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
@@ -461,7 +461,7 @@ importers:
         version: 0.3.4(@rsbuild/core@1.7.3)
       rslib:
         specifier: npm:@rslib/core@0.19.4
-        version: '@rslib/core@0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@typescript/native-preview@7.0.0-dev.20260201.1)(typescript@5.9.3)'
+        version: '@rslib/core@0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@typescript/native-preview@7.0.0-dev.20260210.1)(typescript@5.9.3)'
       tinyglobby:
         specifier: 0.2.14
         version: 0.2.14
@@ -2872,6 +2872,19 @@ packages:
       typescript:
         optional: true
 
+  '@rslib/core@0.19.5':
+    resolution: {integrity: sha512-ptpO0ZQcWTIjHq4QT9K5YTnlI792EOUlUMwXhbhEoDmiKN5q7FhQSRrCGmoWBe0Mv9s+r3bmZ7YzjmcB6Oxbuw==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      typescript: ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      typescript:
+        optional: true
+
   '@rslint/core@0.2.0':
     resolution: {integrity: sha512-g9EXVfr5Y5ZDAMSzRA8YOPGrhsUCF1YvVb8XrX9Ft6vX6PPi3RiL+zbDoaOYPx4V0tdHrXs68S8jsasJvld17Q==}
     hasBin: true
@@ -3597,43 +3610,43 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260201.1':
-    resolution: {integrity: sha512-gWQiigYMGYEMT8DZELK04KJWHtNKuWxsrvjMZIYC5leEYegxU9KfVX4uCs/zMvnCBmucccAKidq04RRoi77gqg==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260210.1':
+    resolution: {integrity: sha512-taEYpsrCbdcyHkqNMBiVcqKR7ZHMC1jwTBM9kn3eUgOjXn68ASRrmyzYBdrujluBJMO7rl+Gm5QRT68onYt53A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260201.1':
-    resolution: {integrity: sha512-3bofmAfBzBqZruBJP1DDsAIMuOvTpKRaHMfl1lQ1YQwJwmKIhsMOWn241vtxFZcaqCPOXobQHUFCmCXPCT3heA==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260210.1':
+    resolution: {integrity: sha512-TSgIk2osa3UpivKybsyglBx7KBL+vTNayagmpzYvxBXbPvBnbgGOgzE/5iHkzFJYVUFxqmuj1gopmDT9X/obaQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260201.1':
-    resolution: {integrity: sha512-DBzCiGSbvO37XM0Idxy5PQEP1LJ2f2kKod7tDxFwiChay7y0M0G2MchPVIWJ22OYVFuQFkE1UcXVQ8XgRytdLw==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260210.1':
+    resolution: {integrity: sha512-aSdY/1Uh+4hOpQT1jHvM16cNqXv6lihe3oZmGTV6DmgkeH9soGXRumbu+oA73E3w0Hm6PjD/aIzbvK53yjvN1Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260201.1':
-    resolution: {integrity: sha512-D0cPUILpdhwdnTb44HqUbphsglpu6R1w6EFXpqOu8PXlfaCjrtdlnuLdKFkLro0mfVnxuC0yaT2XVzE3+2UPaQ==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260210.1':
+    resolution: {integrity: sha512-2matUA2ZU/1Zdv/pWLsdNwdzkOxBPeLa1581wgnaANrzZD3IJm4eCMfidRFTh9fVPN/eMsthYOeSnuVJa/mPmg==}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260201.1':
-    resolution: {integrity: sha512-6LcmGJ0BRr0cPJw5kMC/rP4jG1PUBr/VNlwYcfpLSmyxU/OB4zhiHLPehCZZ0jD6D9BW2ninud32rUpK3N0xCQ==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260210.1':
+    resolution: {integrity: sha512-7C5mhiOFzWB+hdoCuog9roQuNFFHALw1jz0zrA9ikH18DOgnnGJpGLuekQJdXG1yQSdrALZROXLidTmVxFYSgg==}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260201.1':
-    resolution: {integrity: sha512-6YltsvcfK7ke3TZnXl55HonVULuSwbYjy8NqyhKY0DZmstIo8l4Gai9XqCQ/DBFWZO+B6PsFs2cuEVR9VTNT8g==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260210.1':
+    resolution: {integrity: sha512-n8/tI1rOrqy+kFqrNc4xBYaVc1eGn5SYS9HHDZOPZ8E2b3Oq7RAPSZdNi+YYwMcOx3MFon0Iu6mZ1N6lqer9Dw==}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260201.1':
-    resolution: {integrity: sha512-fNT3ua4cw17c/vzU5PmaeeaAARPNyZv7ULLe9mMuAYvyOwit9GA6bqCal/c7psgH7jCVyCRCy3FNGY240io9/w==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260210.1':
+    resolution: {integrity: sha512-wC/Aoxf/5/m/7alzb7RxLivGuYwZw3/Iq7RO73egG70LL2RLUuP306MDg1sj2TyeAe+S3zZX3rU1L6qMOW439A==}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260201.1':
-    resolution: {integrity: sha512-UNr61SrdLWNsl+hedT3gJY8xbpdJtkS/cphjmS1xUXnVu9apYv/uMlVw02CTlSxsMoVsVGQ7CLXRABUODTjDVQ==}
+  '@typescript/native-preview@7.0.0-dev.20260210.1':
+    resolution: {integrity: sha512-vy52DLNMYVTizp02/Uu8TrHQrt3BU0b7foE7qqxPAZF63zXpwvGg1g4EAgFtu7ZDJlYrAlUqSdZg6INb/3iY6w==}
     hasBin: true
 
   '@typescript/vfs@1.6.2':
@@ -6691,6 +6704,22 @@ packages:
       typescript:
         optional: true
 
+  rsbuild-plugin-dts@0.19.5:
+    resolution: {integrity: sha512-gyW8F88ZyjcmwpJZp2q9MOiCQ5wR4GUIKIOR9guUeJrngx4FUOKt0FI6+/bCXxm1LvsRshgGl6Kc/ZV2syxErw==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      '@rsbuild/core': 1.x
+      '@typescript/native-preview': 7.x
+      typescript: ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+
   rsbuild-plugin-google-analytics@1.0.5:
     resolution: {integrity: sha512-1qSMjmH3HBNMIyrRjBFHQKmTdL86VNc42HjL3z25z4k4n+N7+cl9UvpD5ou3G6YAn1jNJ2GS2pia+PKNyaTzmg==}
     peerDependencies:
@@ -9581,12 +9610,22 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript/native-preview'
 
-  '@rslib/core@0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@typescript/native-preview@7.0.0-dev.20260201.1)(typescript@5.9.3)':
+  '@rslib/core@0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@typescript/native-preview@7.0.0-dev.20260210.1)(typescript@5.9.3)':
     dependencies:
       '@rsbuild/core': 1.7.3
-      rsbuild-plugin-dts: 0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260201.1)(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260210.1)(typescript@5.9.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.56.0(@types/node@25.2.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+
+  '@rslib/core@0.19.5(@microsoft/api-extractor@7.56.0(@types/node@24.10.9))(typescript@5.9.3)':
+    dependencies:
+      '@rsbuild/core': 1.7.3
+      rsbuild-plugin-dts: 0.19.5(@microsoft/api-extractor@7.56.0(@types/node@24.10.9))(@rsbuild/core@1.7.3)(typescript@5.9.3)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.56.0(@types/node@24.10.9)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@typescript/native-preview'
@@ -9853,9 +9892,9 @@ snapshots:
       - react
       - react-dom
 
-  '@rstest/adapter-rslib@0.2.0(@rslib/core@0.19.4(@microsoft/api-extractor@7.56.0(@types/node@24.10.9))(typescript@5.9.3))(@rstest/core@0.8.1)(typescript@5.9.3)':
+  '@rstest/adapter-rslib@0.2.0(@rslib/core@0.19.5(@microsoft/api-extractor@7.56.0(@types/node@24.10.9))(typescript@5.9.3))(@rstest/core@0.8.1)(typescript@5.9.3)':
     dependencies:
-      '@rslib/core': 0.19.4(@microsoft/api-extractor@7.56.0(@types/node@24.10.9))(typescript@5.9.3)
+      '@rslib/core': 0.19.5(@microsoft/api-extractor@7.56.0(@types/node@24.10.9))(typescript@5.9.3)
       '@rstest/core': 0.8.1
     optionalDependencies:
       typescript: 5.9.3
@@ -10440,36 +10479,36 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260201.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260210.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260201.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260210.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260201.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260210.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260201.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260210.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260201.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260210.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260201.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260210.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260201.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260210.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260201.1':
+  '@typescript/native-preview@7.0.0-dev.20260210.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260201.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260201.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260201.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260201.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260201.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260201.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260201.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260210.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260210.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260210.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260210.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260210.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260210.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260210.1
 
   '@typescript/vfs@1.6.2(typescript@5.9.3)':
     dependencies:
@@ -14159,13 +14198,21 @@ snapshots:
       '@microsoft/api-extractor': 7.56.0(@types/node@24.10.9)
       typescript: 5.9.3
 
-  rsbuild-plugin-dts@0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260201.1)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260210.1)(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.7.3
     optionalDependencies:
       '@microsoft/api-extractor': 7.56.0(@types/node@25.2.0)
-      '@typescript/native-preview': 7.0.0-dev.20260201.1
+      '@typescript/native-preview': 7.0.0-dev.20260210.1
+      typescript: 5.9.3
+
+  rsbuild-plugin-dts@0.19.5(@microsoft/api-extractor@7.56.0(@types/node@24.10.9))(@rsbuild/core@1.7.3)(typescript@5.9.3):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 1.7.3
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.56.0(@types/node@24.10.9)
       typescript: 5.9.3
 
   rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@1.7.3):

--- a/tests/integration/redirect/dts-tsgo/src/index.ts
+++ b/tests/integration/redirect/dts-tsgo/src/index.ts
@@ -4,7 +4,7 @@ import type { Baz } from 'self-entry';
 import type { LoggerOptions } from './types';
 import { defaultOptions } from './types.js';
 
-import sources = require('@src/logger');
+type sources = typeof import('@src/logger');
 
 export {
   sources,

--- a/tests/integration/redirect/dtsTsgo.test.ts
+++ b/tests/integration/redirect/dtsTsgo.test.ts
@@ -40,7 +40,7 @@ describe.skipIf(process.version.startsWith('v18'))(
         import type { Baz } from './';
         import type { LoggerOptions } from './types';
         import { defaultOptions } from './types.js';
-        import sources = require('./logger');
+        type sources = typeof import('./logger');
         export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
         export * from './foo';
         export * from './logger';
@@ -104,7 +104,7 @@ describe.skipIf(process.version.startsWith('v18'))(
         import type { Baz } from 'self-entry';
         import type { LoggerOptions } from './types';
         import { defaultOptions } from './types.js';
-        import sources = require('@src/logger');
+        type sources = typeof import('@src/logger');
         export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
         export * from '@src/foo';
         export * from '@src/logger';
@@ -168,7 +168,7 @@ describe.skipIf(process.version.startsWith('v18'))(
         import type { Baz } from './index.js';
         import type { LoggerOptions } from './types.js';
         import { defaultOptions } from './types.js';
-        import sources = require('./logger.js');
+        type sources = typeof import('./logger.js');
         export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
         export * from './foo/index.js';
         export * from './logger.js';
@@ -232,7 +232,7 @@ describe.skipIf(process.version.startsWith('v18'))(
         import type { Baz } from 'self-entry';
         import type { LoggerOptions } from './types.js';
         import { defaultOptions } from './types.js';
-        import sources = require('@src/logger');
+        type sources = typeof import('@src/logger');
         export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
         export * from '@src/foo';
         export * from '@src/logger';
@@ -296,7 +296,7 @@ describe.skipIf(process.version.startsWith('v18'))(
         import type { Baz } from './index.mjs';
         import type { LoggerOptions } from './types.mjs';
         import { defaultOptions } from './types.mjs';
-        import sources = require('./logger.mjs');
+        type sources = typeof import('./logger.mjs');
         export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
         export * from './foo/index.mjs';
         export * from './logger.mjs';
@@ -357,7 +357,7 @@ describe.skipIf(process.version.startsWith('v18'))(
         import type { Baz } from './index.js';
         import type { LoggerOptions } from './types.js';
         import { defaultOptions } from './types.js';
-        import sources = require('./logger.js');
+        type sources = typeof import('./logger.js');
         export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
         export * from './foo/index.js';
         export * from './logger.js';


### PR DESCRIPTION
## Summary
Update `@typescript/native-preview` to `7.0.0-dev.20260210.1` and fix related integration tests to align with ts 6.0 defaults.

## Related Links

https://github.com/microsoft/TypeScript/issues/63085

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).