### PR TITLE
docs: update output format guide

### DIFF
--- a/website/docs/en/guide/basic/output-format.mdx
+++ b/website/docs/en/guide/basic/output-format.mdx
@@ -17,17 +17,13 @@ Library authors need to carefully consider which module formats to support. Let'
 
 - **CommonJS**: <CJS />
 
-### What is the dilemma of ESM / CJS
+::: tip
 
-> The following references are from [Node Modules at War: Why CommonJS and ES Modules Can't Get Along](https://redfin.engineering/node-modules-at-war-why-commonjs-and-es-modules-cant-get-along-9617135eeca1).
+Read the [Node.js Package Configuration Guide](https://nodejs.github.io/package-examples/) to learn more about ESM and CJS, including file structure, `package.json` configuration, module interoperability, and best practices.
 
-1. You can't `require()` ESM scripts; you can only import ESM scripts, like this: `import {foo} from 'foo'`
-2. CJS scripts can't use static `import` statements like the one above.
-3. ESM scripts can `import` CJS scripts, but only by using the **default import** syntax `import _ from 'lodash'`, not the **named import** syntax `import {shuffle} from 'lodash'`, which is a hassle if the CJS script uses named exports. (Except, sometimes, unpredictibly, Node can figure out what you meant!)
-4. ESM scripts can `require()` CJS scripts, even with named exports, but it's typically not worth the trouble, because it requires even more boilerplate, and, worst of all, bundlers like Webpack and Rollup don't/won't know how to work with ESM scripts that use `require()`.
-5. CJS is the default; you have to opt-in to ESM mode. You can opt-in to ESM mode by renaming your script from `.js` to `.mjs`. Alternately, you can set `"type": "module"` in `package.json`, and then you can opt-out of ESM by renaming scripts from `.js` to `.cjs`. (You can even tweak just an individual subdirectory by putting a one-line `{"type": "module"}` `package.json` file in there.)
+:::
 
-### When to support which format?
+### Choose module formats
 
 For different shapes of libraries, the choice of module format may vary. Here are two common scenarios:
 

--- a/website/docs/zh/guide/basic/output-format.mdx
+++ b/website/docs/zh/guide/basic/output-format.mdx
@@ -17,17 +17,13 @@ Rslib 支持多种 JavaScript 文件的输出格式：[ESM](#esm--cjs)、[CJS](#
 
 - **CommonJS**: <CJS />
 
-### ESM 和 CJS 的困境
+::: tip
 
-> 以下参考自 [Node 模块之战：为什么 CommonJS 和 ES Modules 无法共存](https://redfin.engineering/node-modules-at-war-why-commonjs-and-es-modules-cant-get-along-9617135eeca1)。
+阅读 [Node.js 包配置指南](https://nodejs.github.io/package-examples/) 了解更多 ESM 和 CJS 的相关信息，包括文件结构组织、`package.json` 配置、模块互操作性以及最佳实践。
 
-1. 你不能 `require()` ESM 脚本；你只能导入 ESM 脚本，像这样：`import {foo} from 'foo'`
-2. CJS 脚本不能使用静态 `import` 语句，如上所示。
-3. ESM 脚本可以 `import` CJS 脚本，但只能使用**默认导入**语法 `import _ from 'lodash'`，而不能使用**命名导入**语法 `import {shuffle} from 'lodash'`，如果 CJS 脚本使用命名导出，这会很麻烦。（不过，有时 Node 会不可预料 地猜出你的意思！）
-4. ESM 脚本可以 `require()` CJS 脚本，即使是命名导出，但通常不值得这样做，因为这需要更多的模板代码，而且最糟糕的是，像 webpack 和 Rollup 这样的打包工具不知道/不会处理使用 `require()` 的 ESM 脚本。
-5. CJS 是默认的；你需要选择加入 ESM 模式。你可以通过将脚本从 `.js` 重命名为 `.mjs` 来选择性开启 ESM 模式。或者，你可以在 `package.json` 中设置 `"type": "module"`，然后通过将脚本从 `.js` 重命名为 `.cjs` 来选择性关闭 ESM。（你甚至可以通过在单个子目录中放置一行 `{"type": "module"}` `package.json` 来调整它。）
+:::
 
-### 何时支持哪种格式？
+### 选择模块格式
 
 对于不同类型的库，模块格式的选择可能会有所不同。以下是两种常见的情况：
 

--- a/website/package.json
+++ b/website/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "build": "rspress build",
     "dev": "rspress dev",


### PR DESCRIPTION
## Summary

Update the output format guide to simplify ESM/CJS dilemma explanation and refer to the official Node.js Package Configuration Guide. Also set the website package type to module.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).