### PR TITLE
test: cleanup create-rslib unnecessary tests and suppress logs

### DIFF
--- a/packages/create-rslib/rstest.config.ts
+++ b/packages/create-rslib/rstest.config.ts
@@ -5,4 +5,5 @@ export default defineConfig({
   ...shared,
   name: 'unit-create',
   include: ['./test/*.{test,spec}.?(c|m)[jt]s?(x)'],
+  onConsoleLog: () => false,
 });

--- a/packages/create-rslib/test/index.test.ts
+++ b/packages/create-rslib/test/index.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, test } from '@rstest/core';
-import { type Lang, parseTemplateName, TEMPLATES } from '../src/index';
+import { type Lang, parseTemplateName } from '../src/index';
 import { createAndValidate, type TemplateCase } from './helper';
 
 const createCase = (
@@ -56,22 +56,6 @@ const CASES_VUE: TemplateCase[] = [
 ];
 
 const BASE_NODE_ESM_JS = createCase('node-esm', 'js');
-
-// Test that all base templates are available
-test('should have all base templates', () => {
-  const expected = [
-    'node-dual-js',
-    'node-dual-ts',
-    'node-esm-js',
-    'node-esm-ts',
-    'react-js',
-    'react-ts',
-    'vue-js',
-    'vue-ts',
-  ].sort();
-  const actual = [...TEMPLATES].sort();
-  expect(actual).toEqual(expected);
-});
 
 describe('parseTemplateName', () => {
   test('should handle template with language suffix', () => {


### PR DESCRIPTION
## Summary
- Suppress console logs in `create-rslib` rstest configuration to reduce noise.
<img width="1254" height="376" alt="image" src="https://github.com/user-attachments/assets/c6e7f2d0-2bd5-4cc7-a8b2-62815688ba43" />

- Remove redundant template availability test in `create-rslib` as it is unnecessary after former refactor.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).