### PR TITLE
docs: add agent skill guide to tsc and tsup migration docs

### DIFF
--- a/website/docs/en/guide/migration/tsc.mdx
+++ b/website/docs/en/guide/migration/tsc.mdx
@@ -2,6 +2,16 @@
 
 This section introduces how to migrate a project using `tsc` (TypeScript Compiler) to Rslib.
 
+## Using Agent Skills
+
+If you are using a Coding Agent that supports Skills, install the [migrate-to-rslib](https://github.com/rstackjs/agent-skills#migrate-to-rslib) skill to help with the migration process.
+
+```bash
+npx skills add rstackjs/agent-skills --skill migrate-to-rslib
+```
+
+After installation, let the Coding Agent guide you through the migration process.
+
 ## Installing dependencies
 
 First, you need to add Rslib's core dependency.

--- a/website/docs/en/guide/migration/tsup.mdx
+++ b/website/docs/en/guide/migration/tsup.mdx
@@ -2,6 +2,16 @@
 
 This section introduces how to migrate a project using tsup to Rslib.
 
+## Using Agent Skills
+
+If you are using a Coding Agent that supports Skills, install the [migrate-to-rslib](https://github.com/rstackjs/agent-skills#migrate-to-rslib) skill to help with the migration process.
+
+```bash
+npx skills add rstackjs/agent-skills --skill migrate-to-rslib
+```
+
+After installation, let the Coding Agent guide you through the migration process.
+
 ## Installing dependencies
 
 First, you need to replace the npm dependencies of tsup with Rslib's dependencies.

--- a/website/docs/zh/guide/migration/tsc.mdx
+++ b/website/docs/zh/guide/migration/tsc.mdx
@@ -2,6 +2,16 @@
 
 本章节介绍如何将使用 `tsc` (TypeScript Compiler) 的项目迁移到 Rslib。
 
+## 使用 Agent Skills
+
+如果你在使用支持 Skills 的 Coding Agent，可以安装 [migrate-to-rslib](https://github.com/rstackjs/agent-skills#migrate-to-rslib) 技能来辅助完成迁移流程。
+
+```bash
+npx skills add rstackjs/agent-skills --skill migrate-to-rslib
+```
+
+安装后，让 Coding Agent 协助完成迁移即可。
+
 ## 安装依赖
 
 首先，你需要添加 Rslib 的核心依赖。

--- a/website/docs/zh/guide/migration/tsup.mdx
+++ b/website/docs/zh/guide/migration/tsup.mdx
@@ -2,6 +2,16 @@
 
 本章节介绍如何将使用 tsup 的项目迁移到 Rslib。
 
+## 使用 Agent Skills
+
+如果你在使用支持 Skills 的 Coding Agent，可以安装 [migrate-to-rslib](https://github.com/rstackjs/agent-skills#migrate-to-rslib) 技能来辅助完成迁移流程。
+
+```bash
+npx skills add rstackjs/agent-skills --skill migrate-to-rslib
+```
+
+安装后，让 Coding Agent 协助完成迁移即可。
+
 ## 安装依赖
 
 首先，你需要将 tsup 的 npm 依赖替换为 Rslib 的依赖。


### PR DESCRIPTION
## Summary

Add a 'Using Agent Skills' section to the `tsc` and `tsup` migration guides (both English and Chinese). This section recommends the [migrate-to-rslib](https://github.com/rstackjs/agent-skills#migrate-to-rslib) skill for users who are using Coding Agents to assist with their migration to Rslib.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).