### PR TITLE
fix: validate glob entry correctness in bundle mode

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1182,7 +1182,9 @@ const composeEntryConfig = async (
           // Existed file.
         }
       } else {
-        if (isDirLike) {
+        const isGlobLike = entry.startsWith('!') || /[*?[{\]}]/.test(entry);
+
+        if (isDirLike || isGlobLike) {
           // Non-existed dir.
           entryErrorReasons.push(dirError);
         } else {

--- a/tests/integration/entry/index.test.ts
+++ b/tests/integration/entry/index.test.ts
@@ -176,7 +176,9 @@ test('validate entry and throw errors', async () => {
   expect(stripAnsi(errMsg)).toMatchInlineSnapshot(`
     "Error: Glob pattern "./src" is not supported when "bundle" is "true", considering "bundle" to "false" to use bundleless mode, or specify a file entry to bundle. See https://rslib.rs/guide/basic/output-structure for more details.
 
-    Error: Glob pattern "!./src/ignored" is not supported when "bundle" is "true", considering "bundle" to "false" to use bundleless mode, or specify a file entry to bundle. See https://rslib.rs/guide/basic/output-structure for more details."
+    Error: Glob pattern "!./src/ignored" is not supported when "bundle" is "true", considering "bundle" to "false" to use bundleless mode, or specify a file entry to bundle. See https://rslib.rs/guide/basic/output-structure for more details.
+    
+    Error: Glob pattern "!src/404/**/*.md" is not supported when "bundle" is "true", considering "bundle" to "false" to use bundleless mode, or specify a file entry to bundle. See https://rslib.rs/guide/basic/output-structure for more details."
   `);
 
   try {

--- a/tests/integration/entry/validate/bundleWithGlob.config.ts
+++ b/tests/integration/entry/validate/bundleWithGlob.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     generateBundleEsmConfig({
       source: {
         entry: {
-          index: ['./src', '!./src/ignored'],
+          index: ['./src', '!./src/ignored', '!src/404/**/*.md'],
         },
       },
     }),


### PR DESCRIPTION
## Summary

validate glob entry correctness in bundle mode.

before:
<img width="898" height="138" alt="image" src="https://github.com/user-attachments/assets/b7ace9f5-aaf6-4675-92e2-3979cc2e2bcd" />

after:
<img width="893" height="107" alt="image" src="https://github.com/user-attachments/assets/5ef3d6ee-bd04-427d-a7c1-eb38bbcf2df6" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
