### PR TITLE
feat: updates the default contenthash length in filenames from 8 to 10

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -987,7 +987,7 @@ const composeOutputFilenameConfig = (
     if (typeof filenameHash === 'string') {
       return filenameHash ? `.[${filenameHash}]` : '';
     }
-    return filenameHash ? '.[contenthash:8]' : '';
+    return filenameHash ? '.[contenthash:10]' : '';
   };
 
   // Copied from https://github.com/web-infra-dev/rspack/blob/2efea8673f86a562559e26a9351680e8df4d9ae9/packages/rspack/src/config/defaults.ts#L667-L680.

--- a/tests/integration/asset/hash/rslib.config.ts
+++ b/tests/integration/asset/hash/rslib.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       output: {
         distPath: './dist/esm/bundle',
         filename: {
-          image: '[name].[contenthash:8][ext]',
+          image: '[name].[contenthash:10][ext]',
         },
       },
     }),
@@ -19,7 +19,7 @@ export default defineConfig({
       output: {
         distPath: './dist/cjs/bundle',
         filename: {
-          image: '[name].[contenthash:8][ext]',
+          image: '[name].[contenthash:10][ext]',
         },
       },
     }),
@@ -30,7 +30,7 @@ export default defineConfig({
       output: {
         distPath: './dist/esm/bundleless',
         filename: {
-          image: '[name].[contenthash:8][ext]',
+          image: '[name].[contenthash:10][ext]',
         },
       },
     }),
@@ -40,7 +40,7 @@ export default defineConfig({
       output: {
         distPath: './dist/cjs/bundleless',
         filename: {
-          image: '[name].[contenthash:8][ext]',
+          image: '[name].[contenthash:10][ext]',
         },
       },
     }),

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -90,12 +90,12 @@ test('set the assets filename with hash', async () => {
   // esm
   const { content: indexJs0 } = queryContent(contents.esm0!, /index\.js/);
   expect(indexJs0).toContain(
-    'import image_namespaceObject from "./static/image/image.c74653c1.png";',
+    'import image_namespaceObject from "./static/image/image.c74653c171.png";',
   );
   // cjs
   const { content: indexCjs0 } = queryContent(contents.cjs0!, /index\.cjs/);
   expect(indexCjs0).toContain(
-    'const image_namespaceObject = require("./static/image/image.c74653c1.png");',
+    'const image_namespaceObject = require("./static/image/image.c74653c171.png");',
   );
 
   // 1. bundleless default
@@ -105,7 +105,7 @@ test('set the assets filename with hash', async () => {
     /assets\/image\.js/,
   );
   expect(imageJs1).toMatchInlineSnapshot(`
-    "import image_namespaceObject from "../static/image/image.c74653c1.png";
+    "import image_namespaceObject from "../static/image/image.c74653c171.png";
     export default image_namespaceObject;
     "
   `);
@@ -118,7 +118,7 @@ test('set the assets filename with hash', async () => {
     ""use strict";
     var __webpack_modules__ = {
         "./src/assets/image.png" (module) {
-            module.exports = require("../static/image/image.c74653c1.png");
+            module.exports = require("../static/image/image.c74653c171.png");
         }
     };
     var __webpack_module_cache__ = {};

--- a/tests/integration/auto-extension/index.test.ts
+++ b/tests/integration/auto-extension/index.test.ts
@@ -46,15 +46,15 @@ describe('should respect output.filename.js and output.filenameHash to override 
     // override output.filename.js
     expect(extname(entryFiles.esm0!)).toEqual('.mjs');
     expect(entryFiles.cjs0).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename/index.a4fcc622.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename/index.a4fcc622bc.js"`,
     );
 
     // override output.filenameHash
     expect(entryFiles.esm1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/esm-override-filename-hash/index.3ac7e0ff.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/esm-override-filename-hash/index.3ac7e0ff07.js"`,
     );
     expect(entryFiles.cjs1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename-hash/index.a4fcc622.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename-hash/index.a4fcc622bc.js"`,
     );
 
     // override different file types with function
@@ -80,16 +80,16 @@ describe('should respect output.filename.js and output.filenameHash to override 
 
     // override output.filename.js
     expect(entryFiles.esm0).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm-override-filename/index.3ac7e0ff.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm-override-filename/index.3ac7e0ff07.js"`,
     );
     expect(extname(entryFiles.cjs0!)).toEqual('.cjs');
 
     // override output.filenameHash
     expect(entryFiles.esm1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm-override-filename-hash/index.3ac7e0ff.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm-override-filename-hash/index.3ac7e0ff07.js"`,
     );
     expect(entryFiles.cjs1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/cjs-override-filename-hash/index.a4fcc622.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/cjs-override-filename-hash/index.a4fcc622bc.js"`,
     );
 
     // override different file types with function

--- a/tests/integration/auto-extension/type-commonjs/config-override/rslib.config.mts
+++ b/tests/integration/auto-extension/type-commonjs/config-override/rslib.config.mts
@@ -15,7 +15,7 @@ export default defineConfig({
     generateBundleCjsConfig({
       output: {
         filename: {
-          js: '[name].[contenthash:8].js',
+          js: '[name].[contenthash:10].js',
         },
         distPath: './dist/cjs-override-filename',
       },

--- a/tests/integration/auto-extension/type-module/config-override/rslib.config.ts
+++ b/tests/integration/auto-extension/type-module/config-override/rslib.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     generateBundleEsmConfig({
       output: {
         filename: {
-          js: '[name].[contenthash:8].js',
+          js: '[name].[contenthash:10].js',
         },
         distPath: './dist/esm-override-filename',
       },

--- a/tests/integration/output/chunkFileName-multi/rslib2.config.ts
+++ b/tests/integration/output/chunkFileName-multi/rslib2.config.ts
@@ -4,7 +4,7 @@ import { generateBundleEsmConfig } from 'test-helper';
 export default defineConfig({
   output: {
     filename: {
-      js: 'static/js/[name].[contenthash:8].js',
+      js: 'static/js/[name].[contenthash:10].js',
     },
   },
   lib: [

--- a/tests/integration/output/chunkFileName-multi/rslib3.config.ts
+++ b/tests/integration/output/chunkFileName-multi/rslib3.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       },
       output: {
         filename: {
-          js: 'static2/js/[name].[contenthash:8].js',
+          js: 'static2/js/[name].[contenthash:10].js',
         },
       },
     }),

--- a/tests/integration/output/index.test.ts
+++ b/tests/integration/output/index.test.ts
@@ -31,10 +31,10 @@ describe('output config', () => {
 
       expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
       expect(rspackConfig[0]!.output?.chunkFilename).toBe(
-        'static/js/0~[name].[contenthash:8].js',
+        'static/js/0~[name].[contenthash:10].js',
       );
       expect(rspackConfig[1]!.output?.chunkFilename).toBe(
-        'static/js/1~[name].[contenthash:8].js',
+        'static/js/1~[name].[contenthash:10].js',
       );
 
       const esm0BaseNames = (files.esm0 ?? []).map((p) => basename(p));
@@ -60,7 +60,7 @@ describe('output config', () => {
         'static1/js/0~[name].js',
       );
       expect(rspackConfig[1]!.output?.chunkFilename).toBe(
-        'static2/js/1~[name].[contenthash:8].js',
+        'static2/js/1~[name].[contenthash:10].js',
       );
 
       expect(

--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -218,11 +218,11 @@ Once static assets are imported, they will automatically be output to the build 
 export default {
   output: {
     filename: {
-      svg: '[name].[contenthash:8].svg',
-      font: '[name].[contenthash:8][ext]',
-      image: '[name].[contenthash:8][ext]',
-      media: '[name].[contenthash:8][ext]',
-      assets: '[name].[contenthash:8][ext]',
+      svg: '[name].[contenthash:10].svg',
+      font: '[name].[contenthash:10][ext]',
+      image: '[name].[contenthash:10][ext]',
+      media: '[name].[contenthash:10][ext]',
+      assets: '[name].[contenthash:10][ext]',
     },
   },
 };

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -218,11 +218,11 @@ export default {
 export default {
   output: {
     filename: {
-      svg: '[name].[contenthash:8].svg',
-      font: '[name].[contenthash:8][ext]',
-      image: '[name].[contenthash:8][ext]',
-      media: '[name].[contenthash:8][ext]',
-      assets: '[name].[contenthash:8][ext]',
+      svg: '[name].[contenthash:10].svg',
+      font: '[name].[contenthash:10][ext]',
+      image: '[name].[contenthash:10][ext]',
+      media: '[name].[contenthash:10][ext]',
+      assets: '[name].[contenthash:10][ext]',
     },
   },
 };


### PR DESCRIPTION
## Summary

Align Rslib with the Rsbuild v2 contenthash default change by switching the default `output.filenameHash: true` expansion in `@rslib/core` from `.[contenthash:8]` to `.[contenthash:10]`.

## Related Links
- https://github.com/web-infra-dev/rsbuild/pull/7154

## Checklist
- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
