### PR TITLE
fix(core): allow preserve jsx in bundleless mode to coexist with bundle mode

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -784,22 +784,18 @@ const fixJsModuleTypePlugin = (): RsbuildPlugin => ({
 const BundlePlugin = (): RsbuildPlugin => ({
   name: 'rslib:bundle',
   setup(api) {
-    api.onBeforeBuild({
+    api.onBeforeEnvironmentCompile({
       order: 'post',
-      handler: ({ bundlerConfigs }) => {
-        if (bundlerConfigs) {
-          for (const config of bundlerConfigs) {
-            if (config?.module?.parser?.javascript?.jsx === true) {
-              logger.error(
-                'Bundle mode does not support preserving JSX syntax. Set "bundle" to "false" or change the JSX runtime to `automatic` or `classic`. Check out ' +
-                  color.green(
-                    'https://rslib.rs/guide/solution/react#jsx-transform',
-                  ) +
-                  ' for more details.',
-              );
-              process.exit(1);
-            }
-          }
+      handler: ({ bundlerConfig }) => {
+        if (bundlerConfig?.module?.parser?.javascript?.jsx === true) {
+          logger.error(
+            'Bundle mode does not support preserving JSX syntax. Set "bundle" to "false" or change the JSX runtime to `automatic` or `classic`. Check out ' +
+              color.green(
+                'https://rslib.rs/guide/solution/react#jsx-transform',
+              ) +
+              ' for more details.',
+          );
+          process.exit(1);
         }
       },
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1026,6 +1026,8 @@ importers:
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
+  tests/integration/preserve-jsx/preserve-jsx-with-environment: {}
+
   tests/integration/redirect/asset: {}
 
   tests/integration/redirect/dts:

--- a/tests/integration/preserve-jsx/index.test.ts
+++ b/tests/integration/preserve-jsx/index.test.ts
@@ -58,3 +58,12 @@ test('throw error when preserve JSX with bundle mode', async () => {
     restore();
   }
 });
+
+test('preserve JSX in bundleless mode should not throw error when coexisting with bundle mode', async () => {
+  const fixturePath = join(__dirname, 'preserve-jsx-with-environment');
+  const { contents, isSuccess } = await buildAndGetResults({ fixturePath });
+
+  expect(isSuccess).toBeTruthy();
+  expect(contents.esm0).toBeDefined();
+  expect(contents.esm1).toBeDefined();
+});

--- a/tests/integration/preserve-jsx/preserve-jsx-with-environment/package.json
+++ b/tests/integration/preserve-jsx/preserve-jsx-with-environment/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "preserve-jsx-preserve-jsx-with-environment-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/preserve-jsx/preserve-jsx-with-environment/rslib.config.ts
+++ b/tests/integration/preserve-jsx/preserve-jsx-with-environment/rslib.config.ts
@@ -1,0 +1,27 @@
+import { pluginReact } from '@rsbuild/plugin-react';
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: true,
+      output: {
+        distPath: 'dist/bundle',
+      },
+    }),
+    generateBundleEsmConfig({
+      bundle: false,
+      output: {
+        distPath: 'dist/bundle-false',
+      },
+      plugins: [
+        pluginReact({
+          swcReactOptions: {
+            runtime: 'preserve',
+          },
+        }),
+      ],
+    }),
+  ],
+});

--- a/tests/integration/preserve-jsx/preserve-jsx-with-environment/src/index.tsx
+++ b/tests/integration/preserve-jsx/preserve-jsx-with-environment/src/index.tsx
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/tests/integration/preserve-jsx/preserve-jsx-with-environment/tsconfig.json
+++ b/tests/integration/preserve-jsx/preserve-jsx-with-environment/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": ".",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "lib": ["DOM", "ESNext"],
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "exclude": ["**/node_modules"],
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Previously, the `rslib:bundle` plugin checked all `bundlerConfigs` inside the `onBeforeBuild` hook to see if any of them had `jsx: true`, throwing an error if they did. This prevented bundleless mode (which can preserve JSX) from being used in the same process alongside bundle mode (which does not support preserving JSX), even if bundle mode wasn't the environment preserving JSX.

This change updates the plugin to use `onBeforeEnvironmentCompile`, inspecting only the `bundlerConfig` of the current environment. This allows `bundle: false` and `bundle: true` configurations to coexist even when `jsx: 'preserve'` is set in the bundleless configuration.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).