### PR TITLE
chore(deps): update @rsbuild/core to 2.0.0-beta.8

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.24.1",
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@rsbuild/plugin-react": "^1.4.5",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -22,7 +22,7 @@
     "@module-federation/enhanced": "^0.24.1",
     "@module-federation/rsbuild-plugin": "^0.24.1",
     "@module-federation/storybook-addon": "^5.0.6",
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@rsbuild/plugin-react": "^1.4.5",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.2.16",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.24.1",
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@rsbuild/plugin-react": "^1.4.5",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.2.16",
     "@storybook/addon-onboarding": "^10.2.16",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@storybook/addon-docs": "^10.2.16",
     "@storybook/addon-onboarding": "^10.2.16",
     "@storybook/react": "^10.2.16",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@storybook/addon-docs": "^10.2.16",
     "@storybook/addon-onboarding": "^10.2.16",
     "@storybook/react": "^10.2.16",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@storybook/addon-docs": "^10.2.16",
     "@storybook/addon-onboarding": "^10.2.16",
     "@storybook/vue3": "^10.2.16",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@storybook/addon-docs": "^10.2.16",
     "@storybook/addon-onboarding": "^10.2.16",
     "@storybook/vue3": "^10.2.16",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.57.6",
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@rslib/tsconfig": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20260308.1",
     "magic-string": "^0.30.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,10 @@ importers:
         version: 0.2.1
       '@rstest/adapter-rslib':
         specifier: ^0.2.1
-        version: 0.2.1(@rslib/core@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@24.12.0))(typescript@5.9.3))(@rstest/core@0.9.0)(typescript@5.9.3)
+        version: 0.2.1(@rslib/core@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@24.12.0))(@module-federation/runtime-tools@0.24.1)(typescript@5.9.3))(@rstest/core@0.9.0(@module-federation/runtime-tools@0.24.1))(typescript@5.9.3)
       '@rstest/core':
         specifier: ^0.9.0
-        version: 0.9.0
+        version: 0.9.0(@module-federation/runtime-tools@0.24.1)
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -94,13 +94,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.24.1
-        version: 0.24.1(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+        version: 0.24.1(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@rsbuild/core':
-        specifier: 2.0.0-canary-20260309140114
-        version: 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+        specifier: 2.0.0-beta.8
+        version: 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.4.5(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -115,19 +115,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^0.24.1
-        version: 0.24.1(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+        version: 0.24.1(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.24.1
-        version: 0.24.1(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+        version: 0.24.1(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@module-federation/storybook-addon':
         specifier: ^5.0.6
-        version: 5.0.6(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))(webpack-virtual-modules@0.6.2)
+        version: 5.0.6(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
-        specifier: 2.0.0-canary-20260309140114
-        version: 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+        specifier: 2.0.0-beta.8
+        version: 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.4.5(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -157,10 +157,10 @@ importers:
         version: 10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-rslib:
         specifier: ^3.3.0
-        version: 3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+        version: 3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
       storybook-react-rsbuild:
         specifier: ^3.3.0
-        version: 3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.56.0)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.56.0)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -173,13 +173,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.24.1
-        version: 0.24.1(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+        version: 0.24.1(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@rsbuild/core':
-        specifier: 2.0.0-canary-20260309140114
-        version: 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+        specifier: 2.0.0-beta.8
+        version: 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.4.5(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -301,8 +301,8 @@ importers:
   examples/vue-component-bundleless:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.0.0-canary-20260309140114
-        version: 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+        specifier: 2.0.0-beta.8
+        version: 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -317,16 +317,16 @@ importers:
         version: 10.2.16(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.29(typescript@5.9.3))
       rsbuild-plugin-unplugin-vue:
         specifier: ^0.1.0
-        version: 0.1.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.29(typescript@5.9.3))(yaml@2.8.2)
+        version: 0.1.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.29(typescript@5.9.3))(yaml@2.8.2)
       storybook:
         specifier: ^10.2.16
         version: 10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-rslib:
         specifier: ^3.3.0
-        version: 3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+        version: 3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.0
-        version: 3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3))
+        version: 3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -340,15 +340,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: 2.0.0-canary-20260309140114
-        version: 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+        specifier: 2.0.0-beta.8
+        version: 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.24.1
-        version: 0.24.1(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+        version: 0.24.1(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -378,7 +378,7 @@ importers:
         version: 1.6.2(typescript@5.9.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 0.3.4(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       rslib:
         specifier: npm:@rslib/core@0.20.0-canary-202603101
         version: '@rslib/core@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@25.2.0))(@module-federation/runtime-tools@0.24.1)(@typescript/native-preview@7.0.0-dev.20260308.1)(typescript@5.9.3)'
@@ -436,8 +436,8 @@ importers:
         specifier: ^7.57.6
         version: 7.57.6(@types/node@25.2.0)
       '@rsbuild/core':
-        specifier: 2.0.0-canary-20260309140114
-        version: 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+        specifier: 2.0.0-beta.8
+        version: 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -455,7 +455,7 @@ importers:
         version: 1.6.2(typescript@5.9.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 0.3.4(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       rslib:
         specifier: npm:@rslib/core@0.20.0-canary-202603101
         version: '@rslib/core@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@25.2.0))(@module-federation/runtime-tools@0.24.1)(@typescript/native-preview@7.0.0-dev.20260308.1)(typescript@5.9.3)'
@@ -485,31 +485,31 @@ importers:
         version: 4.0.1(vite@6.3.5(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@module-federation/rsbuild-plugin':
         specifier: ^0.24.1
-        version: 0.24.1(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+        version: 0.24.1(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@rsbuild/core':
-        specifier: 2.0.0-canary-20260309140114
-        version: 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+        specifier: 2.0.0-beta.8
+        version: 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@rsbuild/plugin-less':
         specifier: ^1.6.0
-        version: 1.6.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.6.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.4.5(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@rsbuild/plugin-sass':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.5.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@rsbuild/plugin-toml':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.1.2(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.2.2(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.4
-        version: 1.0.4(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.0.4(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -958,11 +958,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.0.0-canary-20260309140114
-        version: 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+        specifier: 2.0.0-beta.8
+        version: 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.4.4(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -971,11 +971,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.0.0-canary-20260309140114
-        version: 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+        specifier: 2.0.0-beta.8
+        version: 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.4.4(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1248,16 +1248,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^0.24.1
-        version: 0.24.1(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+        version: 0.24.1(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@rsbuild/core':
-        specifier: 2.0.0-canary-20260309140114
-        version: 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+        specifier: 2.0.0-beta.8
+        version: 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.4.5(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@rsbuild/plugin-sass':
         specifier: ^1.5.0
-        version: 1.5.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.5.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1305,10 +1305,10 @@ importers:
         version: 19.2.4(react@19.2.4)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.5
-        version: 1.0.5(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.0.5(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       rsbuild-plugin-open-graph:
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+        version: 1.1.2(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       rspress-plugin-file-tree:
         specifier: ^1.0.4
         version: 1.0.4(@rspress/core@2.0.4(@module-federation/runtime-tools@0.24.1)(@types/react@19.2.14))
@@ -2712,6 +2712,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.0.0-beta.8':
+    resolution: {integrity: sha512-MUxbKJPE1agOK3eCHjKvBIiA+CcZ0TJU/ANKDBLMjK2Er+wq4r5c2ne53+Pi7DtIExoMbSSWBx+RP3CMewKGVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/core@2.0.0-canary-20260309140114':
     resolution: {integrity: sha512-xVBn15queLoGcqN6ykJ9c35x4HDJei81t8q27naK0IvbUopLPH3X0pGtw7ibEuV6u++42SJEFGE7jnKXVhqhoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2927,13 +2937,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.0.0-beta.6':
+    resolution: {integrity: sha512-FQ8zflthQJJf0cM0vDFnfnXrTOnRvwz886tiafbwu1RO5qmh+pJH+xg1eQaLPnRPqLTlcmnpngyacYFUxw+1AA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.0.0-beta.3':
     resolution: {integrity: sha512-EysmBq+sz+Ph0bu0gXpU1uuZG9gXgjqY+w3MJel+ieTFyQO3L/R56V32McgssMbheJbYcviDDn7Tz4D+lTvdJA==}
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.0.0-beta.6':
+    resolution: {integrity: sha512-Cr4P19anOIaHtK8Z20Hl12PPUcs3LM24ZSQPfs0gPS0etzSOE4JRsqW/79GnnjZd/A+Wola/dZcnMVS44e3c3A==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.0.0-beta.3':
     resolution: {integrity: sha512-iFPj4TQZKewnqWPfTbyk3F8QCBI/Edv7TVSRIPBHRnCM0lvYZl/8IZlUzXSamLvrtDpouF0nUzht/fktoWOhAg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.6':
+    resolution: {integrity: sha512-MgTzspaj3v9/4T3KQ/fRuj+cit3BnEcgFe4OP+BvUWlTQvxlckDWpDymVhPuIqpx7pJvLcXwdz8mQhvZ87AD5g==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2944,8 +2970,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.0.0-beta.6':
+    resolution: {integrity: sha512-5vyjbrj3u8x4Crb77QvFJSZkq7QwOuVJff8oStbS/v7cC+NEAQQYB/6Bl0JwyDFAcMMX8ZRyaDjc1o1qQ0Q31g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@2.0.0-beta.3':
     resolution: {integrity: sha512-U8a+bcP/tkMyiwiO9XfeRYYO20YPGiZNxWWt7FEsdmRuRAl6M+EmWaJllJFQtKH+GG8IN93pNoVPMvARjLoJOQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.0.0-beta.6':
+    resolution: {integrity: sha512-GmNJgFHoK5LFQ2m96HrXIgf1zZNe+4yaaOD/5qqcI163QXRqRflfZprmdr2L4R6VsU2i+YQ2Ap2s20Y/zSt6RQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -2956,12 +2994,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.0.0-beta.6':
+    resolution: {integrity: sha512-tI2S3v8yXel5GL3yPnBNnFZ/dye4TyRM2j7mfJ49M6uTWjfRFyAcuxqw7z9Pyvyhsc1AoOnnXejtqqJpZkBQoA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.0.0-beta.3':
     resolution: {integrity: sha512-tzGd8H2oj5F3oR/Hxp+J68zVU/nG+9ndH2KK3/RieVjNAiVNHCR0/ZU9D47s6fnmvWOqAQ1qO8gnVoVLopC4YA==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.0.0-beta.6':
+    resolution: {integrity: sha512-Bv9o1zZIDTOzjbliyAwMOGjsL6wiGIPRttJ9CLsdRoKI5XcMTEFHjwlnm1Zs4/EP+zC+bTgseq1EFngIy+nZRg==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.0.0-beta.3':
     resolution: {integrity: sha512-TZZRSWa34sm5WyoQHwnyBjLJ4w3fcWRYA9ybYjSVWjUU6tVGdMiHiZp+WexUpIETvChLXU1JENNmBg/U7wvZEA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.6':
+    resolution: {integrity: sha512-R/j0VTVKn3gU4a0xKAXJUX6jzmanHsuBHtLSpgnRqKW/20csFzsnsqY9PxaiAObTHVPMCrNvTG5KXHYIqYgACg==}
     cpu: [arm64]
     os: [win32]
 
@@ -2970,16 +3023,41 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.6':
+    resolution: {integrity: sha512-v3Gc+gRFTBNLSmyHAgI6mE30W94T0g8jD7S1qamUfX6i50YjDylyiMG1prG/8i/YVNWQynQeQi4Cjfg+Hi7alQ==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.0.0-beta.3':
     resolution: {integrity: sha512-rwZ6Y3b3oqPj+ZDPPRxr3136HUPKDSlPQa4v7bBOPLDlrFDFOynMIEqDUUi5+8lPaUQ8WWR0aJK4cgcTTT0Siw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.0.0-beta.6':
+    resolution: {integrity: sha512-PjaKOG2rQqzOwsmu03EAyTb7oA52CrO1I8JXiBT07adrDysHvKV/Gi+P0XPuDLDMnxNpndoGJMmvfxsymRpwyA==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@2.0.0-beta.3':
     resolution: {integrity: sha512-GSj+d8AlLs1oElhYq32vIN/eAsxWG9jy0EiNgSxWTt5Gdamv87kcvsV4jwfWIjlltdnBIJgey2RnU+hDZlTAvw==}
 
+  '@rspack/binding@2.0.0-beta.6':
+    resolution: {integrity: sha512-oJytPDJT57cz2is0e/e1myWVNxn+ZcII1/fF2Y3TiXVUIihLC/KDm6ISTgaZKr8ZyjTlVIV3V4wSO7IHlYV6aw==}
+
   '@rspack/core@2.0.0-beta.3':
     resolution: {integrity: sha512-VuLteRIesuyFFTXZaciUY0lwDZiwMc7JcpE8guvjArztDhtpVvlaOcLlVBp/Yza8c/Tk8Dxwe1ARzFL7xG1/0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.0.0-beta.6':
+    resolution: {integrity: sha512-dvi10ijR9Rr0W75GRFqWvswAEdLBsbXCGhxzm6zXxFNSanNL9s9xPelZ8XfnIU13QZkN2VNHGl9O/8KQEmYdEw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8755,7 +8833,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.24.1(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))':
+  '@module-federation/enhanced@0.24.1(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.24.1
       '@module-federation/cli': 0.24.1(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
@@ -8765,7 +8843,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 0.24.1(@module-federation/runtime-tools@0.24.1)
       '@module-federation/managers': 0.24.1
       '@module-federation/manifest': 0.24.1(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
-      '@module-federation/rspack': 0.24.1(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+      '@module-federation/rspack': 0.24.1(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@module-federation/runtime-tools': 0.24.1
       '@module-federation/sdk': 0.24.1
       btoa: 1.2.1
@@ -8810,9 +8888,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.30(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))':
+  '@module-federation/node@2.7.30(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))':
     dependencies:
-      '@module-federation/enhanced': 0.24.1(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+      '@module-federation/enhanced': 0.24.1(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@module-federation/runtime': 0.24.1
       '@module-federation/sdk': 0.24.1
       btoa: 1.2.1
@@ -8829,14 +8907,14 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.24.1(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))':
+  '@module-federation/rsbuild-plugin@0.24.1(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))':
     dependencies:
-      '@module-federation/enhanced': 0.24.1(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
-      '@module-federation/node': 2.7.30(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+      '@module-federation/enhanced': 0.24.1(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+      '@module-federation/node': 2.7.30(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@module-federation/sdk': 0.24.1
       fs-extra: 11.3.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8849,7 +8927,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.24.1(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))':
+  '@module-federation/rspack@0.24.1(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.24.1
       '@module-federation/dts-plugin': 0.24.1(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
@@ -8858,7 +8936,7 @@ snapshots:
       '@module-federation/manifest': 0.24.1(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@module-federation/runtime-tools': 0.24.1
       '@module-federation/sdk': 0.24.1
-      '@rspack/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19)
+      '@rspack/core': 2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.3
@@ -8887,12 +8965,12 @@ snapshots:
 
   '@module-federation/sdk@0.24.1': {}
 
-  '@module-federation/storybook-addon@5.0.6(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@5.0.6(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 0.24.1(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
+      '@module-federation/enhanced': 0.24.1(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
       '@module-federation/sdk': 0.24.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -9114,6 +9192,13 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
+  '@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)':
+    dependencies:
+      '@rspack/core': 2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19)
+      '@swc/helpers': 0.5.19
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)':
     dependencies:
       '@rspack/core': '@rspack-canary/core@2.0.0-canary-511d0b77-20260309140114(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19)'
@@ -9147,13 +9232,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))':
+    dependencies:
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
+      deepmerge: 4.3.1
+      reduce-configs: 1.1.1
+
   '@rsbuild/plugin-less@1.6.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))':
     dependencies:
       '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
-  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))':
+  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9179,7 +9270,7 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
 
   '@rsbuild/plugin-preact@1.7.1(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(preact@10.28.4)':
     dependencies:
@@ -9199,6 +9290,14 @@ snapshots:
     transitivePeerDependencies:
       - webpack-hot-middleware
 
+  '@rsbuild/plugin-react@1.4.5(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))':
+    dependencies:
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
+      '@rspack/plugin-react-refresh': 1.6.0(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    transitivePeerDependencies:
+      - webpack-hot-middleware
+
   '@rsbuild/plugin-react@1.4.5(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))':
     dependencies:
       '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
@@ -9206,6 +9305,15 @@ snapshots:
       react-refresh: 0.18.0
     transitivePeerDependencies:
       - webpack-hot-middleware
+
+  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))':
+    dependencies:
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.5.6
+      reduce-configs: 1.1.1
+      sass-embedded: 1.97.3
 
   '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))':
     dependencies:
@@ -9253,36 +9361,36 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))':
+  '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))':
     dependencies:
       toml: 3.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3)':
+  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.2.3(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3)
+      ts-checker-rspack-plugin: 1.2.3(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))':
+  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))':
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
 
-  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))':
+  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))':
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
 
   '@rslib/core@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@24.12.0))(@module-federation/runtime-tools@0.24.1)(typescript@5.9.3)':
     dependencies:
       '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
-      rsbuild-plugin-dts: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@24.12.0))(@rsbuild/core@2.0.0-canary-20260309140114)(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@24.12.0))(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(typescript@5.9.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.57.6(@types/node@24.12.0)
       typescript: 5.9.3
@@ -9385,19 +9493,37 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.0-beta.3':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.0.0-beta.6':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.0.0-beta.3':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.0-beta.6':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.0-beta.3':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.6':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.0.0-beta.3':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.0-beta.6':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.0-beta.3':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.0.0-beta.6':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.0.0-beta.3':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.0-beta.6':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.0-beta.3':
@@ -9405,13 +9531,27 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.0.0-beta.6':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.7
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.0.0-beta.3':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.6':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.0-beta.3':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.6':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.0.0-beta.3':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.0-beta.6':
     optional: true
 
   '@rspack/binding@2.0.0-beta.3':
@@ -9427,9 +9567,29 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.0-beta.3
       '@rspack/binding-win32-x64-msvc': 2.0.0-beta.3
 
+  '@rspack/binding@2.0.0-beta.6':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.0-beta.6
+      '@rspack/binding-darwin-x64': 2.0.0-beta.6
+      '@rspack/binding-linux-arm64-gnu': 2.0.0-beta.6
+      '@rspack/binding-linux-arm64-musl': 2.0.0-beta.6
+      '@rspack/binding-linux-x64-gnu': 2.0.0-beta.6
+      '@rspack/binding-linux-x64-musl': 2.0.0-beta.6
+      '@rspack/binding-wasm32-wasi': 2.0.0-beta.6
+      '@rspack/binding-win32-arm64-msvc': 2.0.0-beta.6
+      '@rspack/binding-win32-ia32-msvc': 2.0.0-beta.6
+      '@rspack/binding-win32-x64-msvc': 2.0.0-beta.6
+
   '@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19)':
     dependencies:
       '@rspack/binding': 2.0.0-beta.3
+    optionalDependencies:
+      '@module-federation/runtime-tools': 0.24.1
+      '@swc/helpers': 0.5.19
+
+  '@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19)':
+    dependencies:
+      '@rspack/binding': 2.0.0-beta.6
     optionalDependencies:
       '@module-federation/runtime-tools': 0.24.1
       '@swc/helpers': 0.5.19
@@ -9566,16 +9726,16 @@ snapshots:
       - react
       - react-dom
 
-  '@rstest/adapter-rslib@0.2.1(@rslib/core@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@24.12.0))(typescript@5.9.3))(@rstest/core@0.9.0)(typescript@5.9.3)':
+  '@rstest/adapter-rslib@0.2.1(@rslib/core@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@24.12.0))(@module-federation/runtime-tools@0.24.1)(typescript@5.9.3))(@rstest/core@0.9.0(@module-federation/runtime-tools@0.24.1))(typescript@5.9.3)':
     dependencies:
       '@rslib/core': 0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@24.12.0))(@module-federation/runtime-tools@0.24.1)(typescript@5.9.3)
-      '@rstest/core': 0.9.0
+      '@rstest/core': 0.9.0(@module-federation/runtime-tools@0.24.1)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@rstest/core@0.9.0':
+  '@rstest/core@0.9.0(@module-federation/runtime-tools@0.24.1)':
     dependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@types/chai': 5.2.3
       tinypool: 2.1.0
     transitivePeerDependencies:
@@ -13666,7 +13826,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@24.12.0))(@rsbuild/core@2.0.0-canary-20260309140114)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.20.0-canary-202603101(@microsoft/api-extractor@7.57.6(@types/node@24.12.0))(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
@@ -13683,20 +13843,27 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260308.1
       typescript: 5.9.3
 
-  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)):
+  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)):
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
 
-  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)):
+  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)):
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
+
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)):
+    dependencies:
+      picocolors: 1.1.1
+      publint: 0.3.17
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
 
   rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)):
     dependencies:
@@ -13704,6 +13871,26 @@ snapshots:
       publint: 0.3.17
     optionalDependencies:
       '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+
+  rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.29(typescript@5.9.3))(yaml@2.8.2):
+    dependencies:
+      unplugin-vue: 6.2.0(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.29(typescript@5.9.3))(yaml@2.8.2)
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - vue
+      - yaml
 
   rsbuild-plugin-unplugin-vue@0.1.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(vue@3.5.29(typescript@5.9.3))(yaml@2.8.2):
     dependencies:
@@ -14116,18 +14303,18 @@ snapshots:
 
   stdin-discarder@0.3.1: {}
 
-  storybook-addon-rslib@3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3):
+  storybook-addon-rslib@3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3):
     dependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook-builder-rsbuild: 3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
       typescript: 5.9.3
 
-  storybook-builder-rsbuild@3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  storybook-builder-rsbuild@3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3)
       '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14139,7 +14326,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))
       sirv: 2.0.4
       storybook: 10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
@@ -14155,10 +14342,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.56.0)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  storybook-react-rsbuild@3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.56.0)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@storybook/react': 10.2.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.9.3)
       find-up: 5.0.0
@@ -14169,7 +14356,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
       storybook: 10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook-builder-rsbuild: 3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook-builder-rsbuild: 3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -14181,12 +14368,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3)):
+  storybook-vue3-rsbuild@3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3)):
     dependencies:
-      '@rsbuild/core': 2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1)
+      '@rsbuild/core': 2.0.0-beta.8(@module-federation/runtime-tools@0.24.1)
       '@storybook/vue3': 10.2.16(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.29(typescript@5.9.3))
       storybook: 10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook-builder-rsbuild: 3.3.0(@rsbuild/core@2.0.0-canary-20260309140114(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook-builder-rsbuild: 3.3.0(@rsbuild/core@2.0.0-beta.8(@module-federation/runtime-tools@0.24.1))(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.16(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.3.5(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vue: 3.5.29(typescript@5.9.3)
       vue-docgen-api: 4.79.2(vue@3.5.29(typescript@5.9.3))
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2(vue@3.5.29(typescript@5.9.3)))
@@ -14445,7 +14632,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.2.3(@rspack/core@2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3):
+  ts-checker-rspack-plugin@1.2.3(@rspack/core@2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19))(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@rspack/lite-tapable': 1.1.0
@@ -14456,7 +14643,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.9.3
     optionalDependencies:
-      '@rspack/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19)
+      '@rspack/core': 2.0.0-beta.6(@module-federation/runtime-tools@0.24.1)(@swc/helpers@0.5.19)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@rsbuild/plugin-node-polyfill": "^1.4.4"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@rsbuild/plugin-node-polyfill": "^1.4.4"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^0.24.1",
     "@playwright/test": "1.58.2",
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@rsbuild/plugin-less": "^1.6.0",
     "@rsbuild/plugin-react": "^1.4.5",
     "@rsbuild/plugin-sass": "^1.5.0",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^0.24.1",
-    "@rsbuild/core": "2.0.0-canary-20260309140114",
+    "@rsbuild/core": "2.0.0-beta.8",
     "@rsbuild/plugin-react": "^1.4.5",
     "@rsbuild/plugin-sass": "^1.5.0",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

Update `@rsbuild/core` from `2.0.0-canary-20260309140114` to `2.0.0-beta.8` across the workspace.

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.0-beta.8

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).