### PR TITLE
docs: remove docs scope from create-pr skill

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -40,7 +40,6 @@ Rslib uses [Conventional Commits](https://www.conventionalcommits.org/):
 - `core` — `packages/core`
 - `dts` — `packages/plugin-dts`
 - `create-rslib` — `packages/create-rslib`
-- `docs` — website / documentation
 - `examples` — examples directory
 - `deps` — dependency updates
 


### PR DESCRIPTION
## Summary

Remove the `docs` scope from the `create-pr` agent skill's list of valid conventional commit scopes.