### PR TITLE
chore(CI): speed up playwright browser setup

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -58,12 +58,6 @@ jobs:
         if: ${{ steps.changes.outputs.changed == 'true' }}
         run: pnpm install
 
-      - name: Install Playwright browsers (only for e2e)
-        if: ${{ steps.changes.outputs.changed == 'true' && inputs.task == 'e2e' }}
-        run: |
-          cd ./tests || exit 0
-          pnpm playwright install chromium
-
       - name: Type Check
         if: ${{ steps.changes.outputs.changed == 'true' && inputs.task == 'ut' }}
         run: pnpm run type-check

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,14 +1,19 @@
 import { defineConfig } from '@playwright/test';
 
+const isCI = Boolean(process.env.CI);
+
 export default defineConfig({
   // Playwright test files with `.pw.` to distinguish from Rstest test files
   testMatch: /.*pw.(test|spec).(js|ts|mjs)/,
   // Retry on CI
-  retries: process.env.CI ? 3 : 0,
+  retries: isCI ? 3 : 0,
   // Print line for each test being run in CI
   reporter: 'list',
+  use: {
+    channel: isCI ? 'chrome' : undefined,
+  },
   expect: {
-    timeout: process.env.CI ? 30_000 : 5_000,
+    timeout: isCI ? 30_000 : 5_000,
   },
   webServer: [
     {


### PR DESCRIPTION
## Summary

Use system Chrome for Playwright in CI and drop the explicit browser install step to cut e2e setup time.

## Related Links

- [rsbuild#6877](https://github.com/web-infra-dev/rsbuild/pull/6877)

## Checklist

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).