### PR TITLE
feat: upgrade rsbuild and sync node builtin handling

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.3.1",
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@rsbuild/plugin-react": "^1.4.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -22,7 +22,7 @@
     "@module-federation/enhanced": "^2.3.1",
     "@module-federation/rsbuild-plugin": "^2.3.1",
     "@module-federation/storybook-addon": "^6.0.8",
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@rsbuild/plugin-react": "^1.4.6",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.3.4",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.3.1",
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@rsbuild/plugin-react": "^1.4.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@rsbuild/plugin-vue": "^1.2.7",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.3.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -552,7 +552,7 @@ const composeFormatConfig = ({
     new rspack.experiments.RslibPlugin({
       interceptApiPlugin: true,
       forceNodeShims: enabledShims.esm.__dirname || enabledShims.esm.__filename,
-      externalEsmNodeBuiltin: format === 'esm' && target === 'node',
+      autoCjsNodeBuiltin: format === 'esm' && target === 'node',
     }),
   ].filter(Boolean);
 
@@ -1657,16 +1657,14 @@ const composeTargetConfig = (
           },
         },
         target: 'node',
-        externalsConfig:
-          format === 'esm'
-            ? {}
-            : {
-                output: {
-                  // For non-ESM Node.js outputs, keep built-in modules externalized.
-                  // https://github.com/webpack/webpack/blob/dd44b206a9c50f4b4cb4d134e1a0bd0387b159a3/lib/node/NodeTargetPlugin.js#L81
-                  externals: nodeBuiltInModules,
-                },
-              },
+        externalsConfig: {
+          output: {
+            // When output.target is 'node', Node.js's built-in will be treated as externals of type `node-commonjs`.
+            // Keep Node.js built-in modules externalized for all Node.js targets.
+            // https://github.com/webpack/webpack/blob/dd44b206a9c50f4b4cb4d134e1a0bd0387b159a3/lib/node/NodeTargetPlugin.js#L81
+            externals: nodeBuiltInModules,
+          },
+        },
       };
     // TODO: Support `neutral` target, however Rsbuild don't list it as an option in the target field.
     // case 'neutral':

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -87,7 +87,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     define: {},
     preEntry: [],
     decorators: {
-      version: '2022-03'
+      version: '2023-11'
     },
     tsconfigPath: '<WORKSPACE>/tsconfig.json'
   },
@@ -329,7 +329,63 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     '@rsbuild/core',
     'rsbuild-plugin-dts',
     '@microsoft/api-extractor',
-    'typescript'
+    'typescript',
+    'assert',
+    'assert/strict',
+    'async_hooks',
+    'buffer',
+    'child_process',
+    'cluster',
+    'console',
+    'constants',
+    'crypto',
+    'dgram',
+    'diagnostics_channel',
+    'dns',
+    'dns/promises',
+    'domain',
+    'events',
+    'fs',
+    'fs/promises',
+    'http',
+    'http2',
+    'https',
+    'inspector',
+    'inspector/promises',
+    'module',
+    'net',
+    'os',
+    'path',
+    'path/posix',
+    'path/win32',
+    'perf_hooks',
+    'process',
+    'punycode',
+    'querystring',
+    'readline',
+    'readline/promises',
+    'repl',
+    'stream',
+    'stream/consumers',
+    'stream/promises',
+    'stream/web',
+    'string_decoder',
+    'sys',
+    'timers',
+    'timers/promises',
+    'tls',
+    'trace_events',
+    'tty',
+    'url',
+    'util',
+    'util/types',
+    'v8',
+    'vm',
+    'wasi',
+    'worker_threads',
+    'zlib',
+    /^node:/,
+    'pnpapi'
   ],
   node: {
     __dirname: false,
@@ -545,7 +601,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                     },
                     transform: {
                       legacyDecorator: false,
-                      decoratorVersion: '2022-03'
+                      decoratorVersion: '2023-11'
                     }
                   },
                   isModule: 'unknown',
@@ -592,7 +648,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                 },
                 transform: {
                   legacyDecorator: false,
-                  decoratorVersion: '2022-03'
+                  decoratorVersion: '2023-11'
                 }
               },
               isModule: 'unknown',
@@ -923,7 +979,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         {
           interceptApiPlugin: true,
           forceNodeShims: false,
-          externalEsmNodeBuiltin: true
+          autoCjsNodeBuiltin: true
         }
       ]
     },
@@ -1253,7 +1309,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                     },
                     transform: {
                       legacyDecorator: false,
-                      decoratorVersion: '2022-03'
+                      decoratorVersion: '2023-11'
                     }
                   },
                   isModule: 'unknown',
@@ -1300,7 +1356,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                 },
                 transform: {
                   legacyDecorator: false,
-                  decoratorVersion: '2022-03'
+                  decoratorVersion: '2023-11'
                 }
               },
               isModule: 'unknown',
@@ -1630,7 +1686,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         {
           interceptApiPlugin: true,
           forceNodeShims: false,
-          externalEsmNodeBuiltin: false
+          autoCjsNodeBuiltin: false
         }
       ]
     },
@@ -1940,7 +1996,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                     },
                     transform: {
                       legacyDecorator: false,
-                      decoratorVersion: '2022-03'
+                      decoratorVersion: '2023-11'
                     }
                   },
                   isModule: 'unknown',
@@ -1987,7 +2043,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                 },
                 transform: {
                   legacyDecorator: false,
-                  decoratorVersion: '2022-03'
+                  decoratorVersion: '2023-11'
                 }
               },
               isModule: 'unknown',
@@ -2242,7 +2298,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         {
           interceptApiPlugin: true,
           forceNodeShims: false,
-          externalEsmNodeBuiltin: false
+          autoCjsNodeBuiltin: false
         }
       ]
     },
@@ -2552,7 +2608,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                     },
                     transform: {
                       legacyDecorator: false,
-                      decoratorVersion: '2022-03'
+                      decoratorVersion: '2023-11'
                     }
                   },
                   isModule: 'unknown',
@@ -2599,7 +2655,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                 },
                 transform: {
                   legacyDecorator: false,
-                  decoratorVersion: '2022-03'
+                  decoratorVersion: '2023-11'
                 }
               },
               isModule: 'unknown',
@@ -2855,7 +2911,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         {
           interceptApiPlugin: true,
           forceNodeShims: false,
-          externalEsmNodeBuiltin: false
+          autoCjsNodeBuiltin: false
         }
       ]
     },
@@ -3116,7 +3172,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                     },
                     transform: {
                       legacyDecorator: false,
-                      decoratorVersion: '2022-03'
+                      decoratorVersion: '2023-11'
                     }
                   },
                   isModule: 'unknown',
@@ -3168,7 +3224,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
                 },
                 transform: {
                   legacyDecorator: false,
-                  decoratorVersion: '2022-03'
+                  decoratorVersion: '2023-11'
                 }
               },
               isModule: 'unknown',
@@ -3459,6 +3515,62 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "rsbuild-plugin-dts",
         "@microsoft/api-extractor",
         "typescript",
+        "assert",
+        "assert/strict",
+        "async_hooks",
+        "buffer",
+        "child_process",
+        "cluster",
+        "console",
+        "constants",
+        "crypto",
+        "dgram",
+        "diagnostics_channel",
+        "dns",
+        "dns/promises",
+        "domain",
+        "events",
+        "fs",
+        "fs/promises",
+        "http",
+        "http2",
+        "https",
+        "inspector",
+        "inspector/promises",
+        "module",
+        "net",
+        "os",
+        "path",
+        "path/posix",
+        "path/win32",
+        "perf_hooks",
+        "process",
+        "punycode",
+        "querystring",
+        "readline",
+        "readline/promises",
+        "repl",
+        "stream",
+        "stream/consumers",
+        "stream/promises",
+        "stream/web",
+        "string_decoder",
+        "sys",
+        "timers",
+        "timers/promises",
+        "tls",
+        "trace_events",
+        "tty",
+        "url",
+        "util",
+        "util/types",
+        "v8",
+        "vm",
+        "wasi",
+        "worker_threads",
+        "zlib",
+        /\\^node:/,
+        "pnpapi",
       ],
       "filename": {
         "js": "[name].js",
@@ -3601,7 +3713,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             RslibPlugin {
               "_args": [
                 {
-                  "externalEsmNodeBuiltin": true,
+                  "autoCjsNodeBuiltin": true,
                   "forceNodeShims": false,
                   "interceptApiPlugin": true,
                 },
@@ -3879,7 +3991,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             RslibPlugin {
               "_args": [
                 {
-                  "externalEsmNodeBuiltin": false,
+                  "autoCjsNodeBuiltin": false,
                   "forceNodeShims": false,
                   "interceptApiPlugin": true,
                 },
@@ -4116,7 +4228,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             RslibPlugin {
               "_args": [
                 {
-                  "externalEsmNodeBuiltin": false,
+                  "autoCjsNodeBuiltin": false,
                   "forceNodeShims": false,
                   "interceptApiPlugin": true,
                 },
@@ -4355,7 +4467,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             RslibPlugin {
               "_args": [
                 {
-                  "externalEsmNodeBuiltin": false,
+                  "autoCjsNodeBuiltin": false,
                   "forceNodeShims": false,
                   "interceptApiPlugin": true,
                 },

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@storybook/addon-docs": "^10.3.4",
     "@storybook/addon-onboarding": "^10.3.4",
     "@storybook/react": "^10.3.4",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@storybook/addon-docs": "^10.3.4",
     "@storybook/addon-onboarding": "^10.3.4",
     "@storybook/react": "^10.3.4",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@storybook/addon-docs": "^10.3.4",
     "@storybook/addon-onboarding": "^10.3.4",
     "@storybook/vue3": "^10.3.4",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@storybook/addon-docs": "^10.3.4",
     "@storybook/addon-onboarding": "^10.3.4",
     "@storybook/vue3": "^10.3.4",

--- a/packages/create-rslib/test/index.test.ts
+++ b/packages/create-rslib/test/index.test.ts
@@ -145,6 +145,7 @@ describe('help output', () => {
     const output = execSync('node ../dist/index.js --help', {
       cwd: __dirname,
       encoding: 'utf-8',
+      stdio: 'pipe',
     });
 
     expect(output).toContain('--skill <skill>');
@@ -167,7 +168,7 @@ describe('optional skills', () => {
       `node ../dist/index.js --dir ${projectName} --template node-esm-js --skill rslib-best-practices`,
       {
         cwd: __dirname,
-        stdio: 'inherit',
+        stdio: 'ignore',
       },
     );
 

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.1",
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@rslib/tsconfig": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20260406.1",
     "magic-string": "^0.30.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,10 @@ importers:
         version: 0.3.4(jiti@2.6.1)
       '@rstest/adapter-rslib':
         specifier: ^0.2.2
-        version: 0.2.2(@rslib/core@0.20.3(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(typescript@6.0.2))(@rstest/core@0.9.6)(typescript@6.0.2)
+        version: 0.2.2(@rslib/core@0.20.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@module-federation/runtime-tools@2.3.1)(typescript@6.0.2))(@rstest/core@0.9.6(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)
       '@rstest/core':
         specifier: ^0.9.6
-        version: 0.9.6
+        version: 0.9.6(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -94,13 +94,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@rsbuild/core':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -115,19 +115,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.3.1
-        version: 2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@module-federation/storybook-addon':
         specifier: ^6.0.8
-        version: 6.0.8(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(webpack-virtual-modules@0.6.2)
+        version: 6.0.8(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -157,10 +157,10 @@ importers:
         version: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-rslib:
         specifier: ^3.3.2
-        version: 3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2))(typescript@6.0.2)
+        version: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2))(typescript@6.0.2)
       storybook-react-rsbuild:
         specifier: ^3.3.2
-        version: 3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+        version: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -173,13 +173,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@rsbuild/core':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -194,10 +194,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.7.2
-        version: 1.7.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(preact@10.29.1)
+        version: 1.7.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(preact@10.29.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -209,10 +209,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -227,10 +227,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -245,10 +245,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -263,13 +263,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(solid-js@1.9.12)
+        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(solid-js@1.9.12)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -284,7 +284,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -301,11 +301,11 @@ importers:
   examples/vue-component-bundleless:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -323,10 +323,10 @@ importers:
         version: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-rslib:
         specifier: ^3.3.2
-        version: 3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2))(typescript@6.0.2)
+        version: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2))(typescript@6.0.2)
       storybook-vue3-rsbuild:
         specifier: ^3.3.2
-        version: 3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))
+        version: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -340,15 +340,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -375,7 +375,7 @@ importers:
         version: 1.6.4(typescript@6.0.2)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 0.3.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       rslib:
         specifier: npm:@rslib/core@0.20.3
         version: '@rslib/core@0.20.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@25.2.0))(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)'
@@ -412,7 +412,7 @@ importers:
         version: 11.3.4
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 0.3.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       rslib:
         specifier: npm:@rslib/core@0.20.3
         version: '@rslib/core@0.20.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@module-federation/runtime-tools@2.3.1)(typescript@6.0.2)'
@@ -433,8 +433,8 @@ importers:
         specifier: ^7.58.1
         version: 7.58.1(@types/node@25.2.0)
       '@rsbuild/core':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -449,7 +449,7 @@ importers:
         version: 1.6.4(typescript@6.0.2)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 0.3.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       rslib:
         specifier: npm:@rslib/core@0.20.3
         version: '@rslib/core@0.20.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@25.2.0))(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)'
@@ -479,34 +479,34 @@ importers:
         version: 4.0.1
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
       '@rsbuild/core':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-less':
         specifier: ^1.6.2
-        version: 1.6.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
+        version: 1.6.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-toml':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.2.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.4
-        version: 1.0.4(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.0.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -580,7 +580,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
 
   tests/integration/asset/json: {}
 
@@ -596,10 +596,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-svgr':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)
+        version: 1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -693,10 +693,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-svgr':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)
+        version: 1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)
 
   tests/integration/cli/build: {}
 
@@ -724,7 +724,7 @@ importers:
 
   tests/integration/copy: {}
 
-  tests/integration/decorators/2023-11: {}
+  tests/integration/decorators/2022-03: {}
 
   tests/integration/decorators/default: {}
 
@@ -977,11 +977,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -990,11 +990,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1028,7 +1028,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       babel-plugin-polyfill-corejs3:
         specifier: ^0.14.2
         version: 0.14.2(@babel/core@7.29.0)
@@ -1041,7 +1041,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1182,13 +1182,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
+        version: 1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
+        version: 1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -1251,10 +1251,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.6.2
-        version: 1.6.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
+        version: 1.6.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
       vue:
         specifier: ^3.5.32
         version: 3.5.32(typescript@6.0.2)
@@ -1263,20 +1263,24 @@ importers:
 
   tests/scripts: {}
 
+  tests/type-tests/resolution-bundler: {}
+
+  tests/type-tests/resolution-nodenext: {}
+
   website:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@rsbuild/core':
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1324,10 +1328,10 @@ importers:
         version: 19.2.4(react@19.2.4)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.5
-        version: 1.0.5(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.0.5(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       rsbuild-plugin-open-graph:
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       rspress-plugin-file-tree:
         specifier: ^1.0.4
         version: 1.0.4(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))
@@ -2601,6 +2605,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.0.0-rc.1':
+    resolution: {integrity: sha512-eqxtRlQiFSm/ibCNGiPj8ozsGSNK91NY+GksmPuTCPmWQExGtPqM1V+s13UYeWZS6fYbMRs7NlQKD896e0QkKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.1.2':
     resolution: {integrity: sha512-qIZzosQlkj7VyFz8mmz1vAKDFlk79xrIvCRYzROqNwQHDXep+gd91nCnUPJdRPHrktzN8Yqa190CPTii3rON6w==}
     peerDependencies:
@@ -2775,6 +2789,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.0.0-rc.1':
+    resolution: {integrity: sha512-fYbeDDDg6QKZzXYt/J0/j0Qhr01wQLuISUsYnNhu5MLwdXVUSVcqz+CTqgF3d0EQVVn6FqLV63lbNRzUGfSq9g==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.0.0-beta.9':
     resolution: {integrity: sha512-sP6gusMsxm3W4aHpRsmVaBQU09n1p/1+XpLHT/gZy6nJ7Wy3nqfNKNoybNBORwCuFcGUon6cVRcieN9AEm6iJA==}
     cpu: [x64]
@@ -2782,6 +2801,11 @@ packages:
 
   '@rspack/binding-darwin-x64@2.0.0-rc.0':
     resolution: {integrity: sha512-oVzDuXwtn1uM9ovV12gTwkTHCwN1q0U0oxfclJjEjb1EhE/a/UGGABUsLl84wSbIW1fvcd9UwAr7vBqPWsjB4Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.0.0-rc.1':
+    resolution: {integrity: sha512-MvXi9kr8xXn1y0PD1WI/4YphRNOdbykJjKdEsAG4JxEVoERmhIHOTwKvUqlejajizAwlVZcxQl/FacoPLsKN5Q==}
     cpu: [x64]
     os: [darwin]
 
@@ -2793,6 +2817,12 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@2.0.0-rc.0':
     resolution: {integrity: sha512-f0EQ0uBWXmknhZ7HR8ud+AhEtLSKbMK9IFHNkhMH3rN4J6wMI+uCPAs+ZlIrNk076bv8YB/z2Amx1ByDLjOBRA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.0.0-rc.1':
+    resolution: {integrity: sha512-j6WsHEwGSdUoiy4BsQBW0RjFl+MBzozdybSYhkiyVSoHlbm7CPt3XaaS3elH5YcwuLHORmVHPP91QhwWl9UFJg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2809,6 +2839,12 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.0.0-rc.1':
+    resolution: {integrity: sha512-MPoZE0aS8oH+Wr0R5tIYch8gbUwYYf4LsiGdP6enMKMTrmpJyOVGlhPHVSwsrFgBg7fjTGOuxHuibtsvDUdLOQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@2.0.0-beta.9':
     resolution: {integrity: sha512-z/EOUKEq5rq4sYsVSFL9uzdPtTPVA82x3gsRJlDTfEcruZZI7Y6JKUkpDYkC0LivXqyOnoOz8slAFd2/dByRtA==}
     cpu: [x64]
@@ -2817,6 +2853,12 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@2.0.0-rc.0':
     resolution: {integrity: sha512-n1XXXjTcPyCUoV+t3BPfBoF16CgsBxXI7WQuajIgQ33ifm7AEkRi8OVC2ci6908/MnYJSBFHlZvuDE42EwEstQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.0.0-rc.1':
+    resolution: {integrity: sha512-gOlPCwtIg9GsFG/8ZdUyV5SyXDaGq2kmtXmyyFU7RO33MaalltNEBMf2hevRPj9z39eSzxwgJDonMOdx5Fo0Og==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -2833,12 +2875,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.0.0-rc.1':
+    resolution: {integrity: sha512-K6Swk1rfP4z4b6bp84NlikGlUWMOPpIWCtlPr/W0TWgc2C/cd844oHdoIu7WtmOH7y9AwB5UG2bWpgFAVwykCw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.0.0-beta.9':
     resolution: {integrity: sha512-Vl7aDAt7DCqtZ/RJd8hLFjQqufX+efL/XZG3qADsagl/SspH1ItJ7N6X1S8o50eKoshy27Jr7mQYZEdufX9qhQ==}
     cpu: [wasm32]
 
   '@rspack/binding-wasm32-wasi@2.0.0-rc.0':
     resolution: {integrity: sha512-zu+iW0kEYJd2AEEqYMSU64f98RMOXVwevnQuPtMg3WhVL79FOfkfXOlf16ZYzB8di8hpMRss7m4traGEUEyjZA==}
+    cpu: [wasm32]
+
+  '@rspack/binding-wasm32-wasi@2.0.0-rc.1':
+    resolution: {integrity: sha512-aa9oUTqOb1QjwsHVlMr5sV+7mcBI4MLQ/xhFO2CIEcfVnJIPl8XpKUbDEgqMwcFlzcgzKmHg5cVmIvd82BLgow==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@2.0.0-beta.9':
@@ -2848,6 +2900,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@2.0.0-rc.0':
     resolution: {integrity: sha512-QDOVpN0SdjrW4OicHmkuj8T7PWSqEbUs20FX2pTRBw4ReU7BABAp7wwGdtQzZIaPKDv3CTNz/1DygmInbiNgJg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.0-rc.1':
+    resolution: {integrity: sha512-+UxF0c7E9bE3siFbMHi+mmoeQJzcTKl1j3x+Y6MY/PJ3V70cU23wOaxMvmSsCyq2JNJBT2RCNZ9HaL+o3kReug==}
     cpu: [arm64]
     os: [win32]
 
@@ -2861,6 +2918,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.0.0-rc.1':
+    resolution: {integrity: sha512-gc0JdkdxSWo+o/b1qTCT6mZ3DrlGe32eW+Ps3xInxcG4UHjUG7hTDgFtOgVQ6VhQ8WMUXG+TQOz0CySVpYjsoQ==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.0.0-beta.9':
     resolution: {integrity: sha512-7UFjyy7QMtWvf1CBEVQkHL6bJBKaVY9yq9+Qxb7ggtxvpBbkoYykdsrhMTvr/f5TBjBqHmyeb0/oYXqo5pWFBQ==}
     cpu: [x64]
@@ -2871,11 +2933,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.0.0-rc.1':
+    resolution: {integrity: sha512-Dnj0jthyVUikf65MGEyZy3akshtSmR1xsp/Xr0h/NWTo5JFWHKAFNYFE+jFfY0uzC8e4IDcLQLYoFomqV1DsEg==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@2.0.0-beta.9':
     resolution: {integrity: sha512-QgkOvzl6BJc4Vg5eaY9r7MkHNfXvVZPgTIeYkdBEOYPowdyCLhlG9vH7QltqLKP9KDNel70YIeMyUrpTqez01w==}
 
   '@rspack/binding@2.0.0-rc.0':
     resolution: {integrity: sha512-zWjMryvt8J8H/Z/sa0MHWfblUTHNCwXhw2x13Yz9Nw2P8JjZ/k/h3ni0xBBl/QubIVoA1IfN2OaiNCtFlVmDrQ==}
+
+  '@rspack/binding@2.0.0-rc.1':
+    resolution: {integrity: sha512-rhJqtbyiRPOjTAZW0xTZFbOrS5yP5yL1SF0DPE9kvFfzePz30IqjMDMxL0KuhkDZd/M1eUINJyoqd8NTbR9wHw==}
 
   '@rspack/core@2.0.0-beta.9':
     resolution: {integrity: sha512-4sN3f72l4cj8n/dSCdWn6FkSjfHiDxHWrO1Kmqd0Bk0MmgyW+ldHitsSWPETCAxjTJGXY34r5sou5sYzb0DRww==}
@@ -2891,6 +2961,18 @@ packages:
 
   '@rspack/core@2.0.0-rc.0':
     resolution: {integrity: sha512-hFc2284m/075etKLLNsECAwOcyNQ8NHUaBhwJCQJQ3J9iqjDoZisefGC8I457u2iieoc1KNSANB9hxZ0ZOHuJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.0.0-rc.1':
+    resolution: {integrity: sha512-OIfkYn05/IWtVIdZ8Y/a0y/k4ipzqfApxIZqnJM59G/bGwQKMBrLHpOMGgV2Wmq1j9UMXzF7ZtsFMUbYBhFb9A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8578,7 +8660,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/cli': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
@@ -8588,7 +8670,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
       '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
@@ -8607,7 +8689,7 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/cli': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
@@ -8617,7 +8699,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
       '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
@@ -8636,7 +8718,7 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/cli': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
@@ -8646,7 +8728,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
       '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
@@ -8665,7 +8747,7 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/cli': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
@@ -8675,7 +8757,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
       '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
@@ -8738,9 +8820,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.39(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/node@2.7.39(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
     dependencies:
-      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
       '@module-federation/runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       encoding: 0.1.13
@@ -8756,9 +8838,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.39(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/node@2.7.39(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
     dependencies:
-      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@module-federation/runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       encoding: 0.1.13
@@ -8774,14 +8856,14 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/rsbuild-plugin@2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
     dependencies:
-      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/node': 2.7.39(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      '@module-federation/node': 2.7.39(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       fs-extra: 11.3.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8794,14 +8876,14 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/rsbuild-plugin@2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
     dependencies:
-      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/node': 2.7.39(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      '@module-federation/node': 2.7.39(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       fs-extra: 11.3.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8814,7 +8896,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
@@ -8823,7 +8905,7 @@ snapshots:
       '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@rspack/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
     optionalDependencies:
       typescript: 5.9.3
       vue-tsc: 3.2.6(typescript@5.9.3)
@@ -8833,7 +8915,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
@@ -8842,7 +8924,7 @@ snapshots:
       '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@rspack/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
     optionalDependencies:
       typescript: 6.0.2
       vue-tsc: 3.2.6(typescript@6.0.2)
@@ -8852,7 +8934,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
@@ -8861,7 +8943,7 @@ snapshots:
       '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@rspack/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
     optionalDependencies:
       typescript: 6.0.2
       vue-tsc: 3.2.6(typescript@6.0.2)
@@ -8897,12 +8979,12 @@ snapshots:
     optionalDependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 
-  '@module-federation/storybook-addon@6.0.8(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.8(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -9144,7 +9226,16 @@ snapshots:
       - '@emnapi/runtime'
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)':
+    dependencies:
+      '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
+      '@swc/helpers': 0.5.21
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -9153,23 +9244,23 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.6.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))':
+  '@rsbuild/plugin-less@1.6.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
-      less-loader: 12.3.2(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(less@4.6.4)
+      less-loader: 12.3.2(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(less@4.6.4)
       reduce-configs: 1.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9195,16 +9286,16 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  '@rsbuild/plugin-preact@1.7.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(preact@10.29.1)':
+  '@rsbuild/plugin-preact@1.7.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(preact@10.29.1)':
     dependencies:
       '@prefresh/core': 1.5.9(preact@10.29.1)
       '@prefresh/utils': 1.2.1
       '@rspack/plugin-preact-refresh': 1.1.5(@prefresh/core@1.5.9(preact@10.29.1))(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh': 12.7.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - preact
 
@@ -9217,16 +9308,16 @@ snapshots:
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-react@1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-react@1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
     dependencies:
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.5.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-sass@1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9234,88 +9325,88 @@ snapshots:
       reduce-configs: 1.1.1
       sass-embedded: 1.97.3
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  '@rsbuild/plugin-solid@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(solid-js@1.9.12)':
+  '@rsbuild/plugin-solid@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(solid-js@1.9.12)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       babel-preset-solid: 1.9.10(@babel/core@7.29.0)(solid-js@1.9.12)
       solid-refresh: 0.7.8(solid-js@1.9.12)
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@1.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))':
+  '@rsbuild/plugin-stylus@1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))':
     dependencies:
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
       stylus: 0.64.0
-      stylus-loader: 8.1.3(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.3.1(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)':
+  '@rsbuild/plugin-svgr@1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)':
     dependencies:
-      '@rsbuild/plugin-react': 1.4.6(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+      '@rsbuild/plugin-react': 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       '@svgr/core': 8.1.0(typescript@6.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.2))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.2))(typescript@6.0.2)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
     dependencies:
       toml: 3.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)':
+  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.2.3(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)
+      ts-checker-rspack-plugin: 1.2.3(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))':
+  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
+      rspack-vue-loader: 17.5.0(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
   '@rslib/core@0.20.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@module-federation/runtime-tools@2.3.1)(typescript@6.0.2)':
     dependencies:
       '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
-      rsbuild-plugin-dts: 0.20.3(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@rsbuild/core@2.0.0-rc.0)(typescript@6.0.2)
+      rsbuild-plugin-dts: 0.20.3(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.1(@types/node@24.12.2)
       typescript: 6.0.2
@@ -9374,10 +9465,16 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.0-rc.0':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.0.0-rc.1':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.0.0-beta.9':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.0-rc.0':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.0-rc.1':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.0-beta.9':
@@ -9386,10 +9483,16 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.0.0-rc.0':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.0.0-rc.1':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.0.0-beta.9':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.0-rc.0':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.0-rc.1':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.0-beta.9':
@@ -9398,10 +9501,16 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.0.0-rc.0':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.0.0-rc.1':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.0.0-beta.9':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.0-rc.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.0-rc.1':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.0-beta.9':
@@ -9417,10 +9526,21 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.0.0-beta.9':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.0.0-rc.0':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.0-rc.1':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.0-beta.9':
@@ -9429,10 +9549,16 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@2.0.0-rc.0':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.0.0-rc.1':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.0.0-beta.9':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.0-rc.0':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.0-rc.1':
     optional: true
 
   '@rspack/binding@2.0.0-beta.9':
@@ -9464,6 +9590,22 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  '@rspack/binding@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.0-rc.1
+      '@rspack/binding-darwin-x64': 2.0.0-rc.1
+      '@rspack/binding-linux-arm64-gnu': 2.0.0-rc.1
+      '@rspack/binding-linux-arm64-musl': 2.0.0-rc.1
+      '@rspack/binding-linux-x64-gnu': 2.0.0-rc.1
+      '@rspack/binding-linux-x64-musl': 2.0.0-rc.1
+      '@rspack/binding-wasm32-wasi': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)
+      '@rspack/binding-win32-arm64-msvc': 2.0.0-rc.1
+      '@rspack/binding-win32-ia32-msvc': 2.0.0-rc.1
+      '@rspack/binding-win32-x64-msvc': 2.0.0-rc.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   '@rspack/core@2.0.0-beta.9(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)':
     dependencies:
       '@rspack/binding': 2.0.0-beta.9
@@ -9474,6 +9616,16 @@ snapshots:
   '@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)':
     dependencies:
       '@rspack/binding': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@swc/helpers': 0.5.21
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)':
+    dependencies:
+      '@rspack/binding': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)
     optionalDependencies:
       '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
       '@swc/helpers': 0.5.21
@@ -9612,14 +9764,14 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.12.5': {}
 
-  '@rstest/adapter-rslib@0.2.2(@rslib/core@0.20.3(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(typescript@6.0.2))(@rstest/core@0.9.6)(typescript@6.0.2)':
+  '@rstest/adapter-rslib@0.2.2(@rslib/core@0.20.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@module-federation/runtime-tools@2.3.1)(typescript@6.0.2))(@rstest/core@0.9.6(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)':
     dependencies:
       '@rslib/core': 0.20.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@module-federation/runtime-tools@2.3.1)(typescript@6.0.2)
-      '@rstest/core': 0.9.6
+      '@rstest/core': 0.9.6(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     optionalDependencies:
       typescript: 6.0.2
 
-  '@rstest/core@0.9.6':
+  '@rstest/core@0.9.6(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)':
     dependencies:
       '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@types/chai': 5.2.3
@@ -12090,11 +12242,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.2(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(less@4.6.4):
+  less-loader@12.3.2(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(less@4.6.4):
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      '@rspack/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
 
   less@4.6.4:
     dependencies:
@@ -13679,7 +13831,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.20.3(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@rsbuild/core@2.0.0-rc.0)(typescript@6.0.2):
+  rsbuild-plugin-dts@0.20.3(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
@@ -13696,36 +13848,36 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260406.1
       typescript: 6.0.2
 
-  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
+  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
+  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.17
     optionalDependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
   rslog@2.1.1: {}
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2)):
+  rspack-vue-loader@17.5.0(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
       vue: 3.5.32(typescript@6.0.2)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)):
@@ -14115,18 +14267,18 @@ snapshots:
 
   stdin-discarder@0.3.1: {}
 
-  storybook-addon-rslib@3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2))(typescript@6.0.2):
+  storybook-addon-rslib@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2))(typescript@6.0.2):
     dependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
     optionalDependencies:
       typescript: 6.0.2
 
-  storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2):
+  storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2):
     dependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14138,7 +14290,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
       sirv: 2.0.4
       storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
@@ -14154,10 +14306,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2):
+  storybook-react-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@storybook/react': 10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.2)
       find-up: 5.0.0
@@ -14168,7 +14320,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
       storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.2
@@ -14180,12 +14332,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)):
+  storybook-vue3-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)):
     dependencies:
-      '@rsbuild/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@storybook/vue3': 10.3.4(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.32(typescript@6.0.2))
       storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
       vue: 3.5.32(typescript@6.0.2)
       vue-docgen-api: 4.79.2(vue@3.5.32(typescript@6.0.2))
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2(vue@3.5.32(typescript@6.0.2)))
@@ -14304,13 +14456,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
 
   stylus@0.64.0:
     dependencies:
@@ -14434,7 +14586,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.2.3(@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2):
+  ts-checker-rspack-plugin@1.2.3(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@rspack/lite-tapable': 1.1.0
@@ -14445,7 +14597,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.2
     optionalDependencies:
-      '@rspack/core': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/integration/alias/__snapshots__/index.test.ts.snap
+++ b/tests/integration/alias/__snapshots__/index.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`source.alias 1`] = `
 "const a = 'hello world';
 console.info(a);
+export { };
 "
 `;
 

--- a/tests/integration/decorators/2022-03/package.json
+++ b/tests/integration/decorators/2022-03/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "decorators-2023-11-test",
+  "name": "decorators-2022-03-test",
   "version": "1.0.0",
   "private": true,
   "type": "module"

--- a/tests/integration/decorators/2022-03/rslib.config.ts
+++ b/tests/integration/decorators/2022-03/rslib.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       index: '../__fixtures__/src/index.ts',
     },
     decorators: {
-      version: '2023-11',
+      version: '2022-03',
     },
     tsconfigPath: '../__fixtures__/tsconfig.json',
   },

--- a/tests/integration/decorators/__snapshots__/index.test.ts.snap
+++ b/tests/integration/decorators/__snapshots__/index.test.ts.snap
@@ -1,6 +1,254 @@
 // Rstest Snapshot v1
 
-exports[`decorators default to 2022-03 1`] = `
+exports[`decorators default to 2023-11 1`] = `
+"function toPrimitive(input, hint) {
+    if ("object" != typeof input || null === input) return input;
+    var prim = input[Symbol.toPrimitive];
+    if (void 0 !== prim) {
+        var res = prim.call(input, hint || "default");
+        if ("object" != typeof res) return res;
+        throw new TypeError("@@toPrimitive must return a primitive value.");
+    }
+    return ("string" === hint ? String : Number)(input);
+}
+function toPropertyKey(arg) {
+    var key = toPrimitive(arg, "string");
+    return "symbol" == typeof key ? key : String(key);
+}
+function checkInRHS(value) {
+    if (Object(value) !== value) throw TypeError("right-hand side of 'in' should be an object, got " + (null !== value ? typeof value : "null"));
+    return value;
+}
+function setFunctionName(fn, name, prefix) {
+    if ("symbol" == typeof name) {
+        name = name.description;
+        name = name ? "[" + name + "]" : "";
+    }
+    try {
+        Object.defineProperty(fn, "name", {
+            configurable: true,
+            value: prefix ? prefix + " " + name : name
+        });
+    } catch (_) {}
+    return fn;
+}
+function _apply_decs_2311(targetClass, classDecs, memberDecs, classDecsHaveThis, instanceBrand, parentClass) {
+    var symbolMetadata = Symbol.metadata || Symbol.for("Symbol.metadata");
+    var defineProperty = Object.defineProperty;
+    var create = Object.create;
+    var metadata;
+    var existingNonFields = [
+        create(null),
+        create(null)
+    ];
+    var hasClassDecs = classDecs.length;
+    var _;
+    function createRunInitializers(initializers, useStaticThis, hasValue) {
+        return function(thisArg, value) {
+            if (useStaticThis) {
+                value = thisArg;
+                thisArg = targetClass;
+            }
+            for(var i = 0; i < initializers.length; i++)value = initializers[i].apply(thisArg, hasValue ? [
+                value
+            ] : []);
+            return hasValue ? value : thisArg;
+        };
+    }
+    function assertCallable(fn, hint1, hint2, throwUndefined) {
+        if ("function" != typeof fn) {
+            if (throwUndefined || void 0 !== fn) throw new TypeError(hint1 + " must " + (hint2 || "be") + " a function" + (throwUndefined ? "" : " or undefined"));
+        }
+        return fn;
+    }
+    function applyDec(Class, decInfo, decoratorsHaveThis, name, kind, initializers, ret, isStatic, isPrivate, isField, hasPrivateBrand) {
+        function assertInstanceIfPrivate(target) {
+            if (!hasPrivateBrand(target)) throw new TypeError("Attempted to access private element on non-instance");
+        }
+        var decs = [].concat(decInfo[0]);
+        var decVal = decInfo[3];
+        var isClass = !ret;
+        var isAccessor = 1 === kind;
+        var isGetter = 3 === kind;
+        var isSetter = 4 === kind;
+        var isMethod = 2 === kind;
+        function bindPropCall(name, useStaticThis, before) {
+            return function(_this, value) {
+                if (useStaticThis) {
+                    value = _this;
+                    _this = Class;
+                }
+                if (before) before(_this);
+                return desc[name].call(_this, value);
+            };
+        }
+        var desc1 = {};
+        var init = [];
+        var key = isGetter ? "get" : isSetter || isAccessor ? "set" : "value";
+        if (!isClass) {
+            if (isPrivate) {
+                if (isField || isAccessor) desc1 = {
+                    get: setFunctionName(function() {
+                        return decVal(this);
+                    }, name, "get"),
+                    set: function(value) {
+                        decInfo[4](this, value);
+                    }
+                };
+                else desc1[key] = decVal;
+                if (!isField) setFunctionName(desc1[key], name, isMethod ? "" : key);
+            } else if (!isField) desc1 = Object.getOwnPropertyDescriptor(Class, name);
+            if (!isField && !isPrivate) {
+                _ = existingNonFields[+isStatic][name];
+                if (_ && (_ ^ kind) !== 7) throw new Error("Decorating two elements with the same name (" + desc1[key].name + ") is not supported yet");
+                existingNonFields[+isStatic][name] = kind < 3 ? 1 : kind;
+            }
+        }
+        var newValue = Class;
+        for(var i = decs.length - 1; i >= 0; i -= decoratorsHaveThis ? 2 : 1){
+            var dec = assertCallable(decs[i], "A decorator", "be", true);
+            var decThis = decoratorsHaveThis ? decs[i - 1] : void 0;
+            var decoratorFinishedRef = {};
+            var ctx = {
+                kind: [
+                    "field",
+                    "accessor",
+                    "method",
+                    "getter",
+                    "setter",
+                    "class"
+                ][kind],
+                name: name,
+                metadata: metadata,
+                addInitializer: (function(decoratorFinishedRef, initializer) {
+                    if (decoratorFinishedRef.v) throw new TypeError("attempted to call addInitializer after decoration was finished");
+                    assertCallable(initializer, "An initializer", "be", true);
+                    initializers.push(initializer);
+                }).bind(null, decoratorFinishedRef)
+            };
+            if (isClass) {
+                _ = dec.call(decThis, newValue, ctx);
+                decoratorFinishedRef.v = 1;
+                if (assertCallable(_, "class decorators", "return")) newValue = _;
+                continue;
+            }
+            ctx.static = isStatic;
+            ctx.private = isPrivate;
+            _ = ctx.access = {
+                has: isPrivate ? hasPrivateBrand.bind() : function(target) {
+                    return name in target;
+                }
+            };
+            if (!isSetter) _.get = isPrivate ? isMethod ? function(_this) {
+                assertInstanceIfPrivate(_this);
+                return desc1.value;
+            } : bindPropCall("get", 0, assertInstanceIfPrivate) : function(target) {
+                return target[name];
+            };
+            if (!isMethod && !isGetter) _.set = isPrivate ? bindPropCall("set", 0, assertInstanceIfPrivate) : function(target, value) {
+                target[name] = value;
+            };
+            newValue = dec.call(decThis, isAccessor ? {
+                get: desc1.get,
+                set: desc1.set
+            } : desc1[key], ctx);
+            decoratorFinishedRef.v = 1;
+            if (isAccessor) {
+                if ("object" == typeof newValue && newValue) {
+                    if (_ = assertCallable(newValue.get, "accessor.get")) desc1.get = _;
+                    if (_ = assertCallable(newValue.set, "accessor.set")) desc1.set = _;
+                    if (_ = assertCallable(newValue.init, "accessor.init")) init.unshift(_);
+                } else if (void 0 !== newValue) throw new TypeError("accessor decorators must return an object with get, set, or init properties or undefined");
+            } else if (assertCallable(newValue, (isField ? "field" : "method") + " decorators", "return")) if (isField) init.unshift(newValue);
+            else desc1[key] = newValue;
+        }
+        if (kind < 2) ret.push(createRunInitializers(init, isStatic, 1), createRunInitializers(initializers, isStatic, 0));
+        if (!isField && !isClass) if (isPrivate) if (isAccessor) ret.splice(-1, 0, bindPropCall("get", isStatic), bindPropCall("set", isStatic));
+        else ret.push(isMethod ? desc1[key] : assertCallable.call.bind(desc1[key]));
+        else defineProperty(Class, name, desc1);
+        return newValue;
+    }
+    function applyMemberDecs() {
+        var ret = [];
+        var protoInitializers;
+        var staticInitializers;
+        var pushInitializers = function(initializers) {
+            if (initializers) ret.push(createRunInitializers(initializers));
+        };
+        var applyMemberDecsOfKind = function(isStatic, isField) {
+            for(var i = 0; i < memberDecs.length; i++){
+                var decInfo = memberDecs[i];
+                var kind = decInfo[1];
+                var kindOnly = 7 & kind;
+                if ((8 & kind) == isStatic && !kindOnly == isField) {
+                    var name = decInfo[2];
+                    var isPrivate = !!decInfo[3];
+                    var decoratorsHaveThis = 16 & kind;
+                    applyDec(isStatic ? targetClass : targetClass.prototype, decInfo, decoratorsHaveThis, isPrivate ? "#" + name : toPropertyKey(name), kindOnly, kindOnly < 2 ? [] : isStatic ? staticInitializers = staticInitializers || [] : protoInitializers = protoInitializers || [], ret, !!isStatic, isPrivate, isField, isStatic && isPrivate ? function(_) {
+                        return checkInRHS(_) === targetClass;
+                    } : instanceBrand);
+                }
+            }
+        };
+        applyMemberDecsOfKind(8, 0);
+        applyMemberDecsOfKind(0, 0);
+        applyMemberDecsOfKind(8, 1);
+        applyMemberDecsOfKind(0, 1);
+        pushInitializers(protoInitializers);
+        pushInitializers(staticInitializers);
+        return ret;
+    }
+    function defineMetadata(Class) {
+        return defineProperty(Class, symbolMetadata, {
+            configurable: true,
+            enumerable: true,
+            value: metadata
+        });
+    }
+    if (void 0 !== parentClass) metadata = parentClass[symbolMetadata];
+    metadata = create(null == metadata ? null : metadata);
+    _ = applyMemberDecs();
+    if (!hasClassDecs) defineMetadata(targetClass);
+    return {
+        e: _,
+        get c () {
+            var initializers = [];
+            return hasClassDecs && [
+                defineMetadata(targetClass = applyDec(targetClass, [
+                    classDecs
+                ], classDecsHaveThis, targetClass.name, 5, initializers)),
+                createRunInitializers(initializers, 1)
+            ];
+        }
+    };
+}
+let _dec, _initClass;
+function src_enhancer(name) {
+    return function(target) {
+        target.prototype.name = name;
+    };
+}
+_dec = src_enhancer('rslib');
+let _Person;
+class Person {
+    static{
+        ({ c: [_Person, _initClass] } = _apply_decs_2311(this, [
+            _dec
+        ], []));
+    }
+    constructor(){
+        this.version = '1.0.0';
+    }
+    version;
+    static{
+        _initClass();
+    }
+}
+export { _Person as Person };
+"
+`;
+
+exports[`decorators support 2022-03 config 1`] = `
 "function applyDecs2203RFactory() {
     function createAddInitializerMethod(initializers, decoratorFinishedRef) {
         return function(initializer) {
@@ -336,254 +584,6 @@ class Person {
         ({ c: [_Person, _initClass] } = _apply_decs_2203_r(this, [], [
             _dec
         ]));
-    }
-    constructor(){
-        this.version = '1.0.0';
-    }
-    version;
-    static{
-        _initClass();
-    }
-}
-export { _Person as Person };
-"
-`;
-
-exports[`decorators support 2023-11 config 1`] = `
-"function toPrimitive(input, hint) {
-    if ("object" != typeof input || null === input) return input;
-    var prim = input[Symbol.toPrimitive];
-    if (void 0 !== prim) {
-        var res = prim.call(input, hint || "default");
-        if ("object" != typeof res) return res;
-        throw new TypeError("@@toPrimitive must return a primitive value.");
-    }
-    return ("string" === hint ? String : Number)(input);
-}
-function toPropertyKey(arg) {
-    var key = toPrimitive(arg, "string");
-    return "symbol" == typeof key ? key : String(key);
-}
-function checkInRHS(value) {
-    if (Object(value) !== value) throw TypeError("right-hand side of 'in' should be an object, got " + (null !== value ? typeof value : "null"));
-    return value;
-}
-function setFunctionName(fn, name, prefix) {
-    if ("symbol" == typeof name) {
-        name = name.description;
-        name = name ? "[" + name + "]" : "";
-    }
-    try {
-        Object.defineProperty(fn, "name", {
-            configurable: true,
-            value: prefix ? prefix + " " + name : name
-        });
-    } catch (_) {}
-    return fn;
-}
-function _apply_decs_2311(targetClass, classDecs, memberDecs, classDecsHaveThis, instanceBrand, parentClass) {
-    var symbolMetadata = Symbol.metadata || Symbol.for("Symbol.metadata");
-    var defineProperty = Object.defineProperty;
-    var create = Object.create;
-    var metadata;
-    var existingNonFields = [
-        create(null),
-        create(null)
-    ];
-    var hasClassDecs = classDecs.length;
-    var _;
-    function createRunInitializers(initializers, useStaticThis, hasValue) {
-        return function(thisArg, value) {
-            if (useStaticThis) {
-                value = thisArg;
-                thisArg = targetClass;
-            }
-            for(var i = 0; i < initializers.length; i++)value = initializers[i].apply(thisArg, hasValue ? [
-                value
-            ] : []);
-            return hasValue ? value : thisArg;
-        };
-    }
-    function assertCallable(fn, hint1, hint2, throwUndefined) {
-        if ("function" != typeof fn) {
-            if (throwUndefined || void 0 !== fn) throw new TypeError(hint1 + " must " + (hint2 || "be") + " a function" + (throwUndefined ? "" : " or undefined"));
-        }
-        return fn;
-    }
-    function applyDec(Class, decInfo, decoratorsHaveThis, name, kind, initializers, ret, isStatic, isPrivate, isField, hasPrivateBrand) {
-        function assertInstanceIfPrivate(target) {
-            if (!hasPrivateBrand(target)) throw new TypeError("Attempted to access private element on non-instance");
-        }
-        var decs = [].concat(decInfo[0]);
-        var decVal = decInfo[3];
-        var isClass = !ret;
-        var isAccessor = 1 === kind;
-        var isGetter = 3 === kind;
-        var isSetter = 4 === kind;
-        var isMethod = 2 === kind;
-        function bindPropCall(name, useStaticThis, before) {
-            return function(_this, value) {
-                if (useStaticThis) {
-                    value = _this;
-                    _this = Class;
-                }
-                if (before) before(_this);
-                return desc[name].call(_this, value);
-            };
-        }
-        var desc1 = {};
-        var init = [];
-        var key = isGetter ? "get" : isSetter || isAccessor ? "set" : "value";
-        if (!isClass) {
-            if (isPrivate) {
-                if (isField || isAccessor) desc1 = {
-                    get: setFunctionName(function() {
-                        return decVal(this);
-                    }, name, "get"),
-                    set: function(value) {
-                        decInfo[4](this, value);
-                    }
-                };
-                else desc1[key] = decVal;
-                if (!isField) setFunctionName(desc1[key], name, isMethod ? "" : key);
-            } else if (!isField) desc1 = Object.getOwnPropertyDescriptor(Class, name);
-            if (!isField && !isPrivate) {
-                _ = existingNonFields[+isStatic][name];
-                if (_ && (_ ^ kind) !== 7) throw new Error("Decorating two elements with the same name (" + desc1[key].name + ") is not supported yet");
-                existingNonFields[+isStatic][name] = kind < 3 ? 1 : kind;
-            }
-        }
-        var newValue = Class;
-        for(var i = decs.length - 1; i >= 0; i -= decoratorsHaveThis ? 2 : 1){
-            var dec = assertCallable(decs[i], "A decorator", "be", true);
-            var decThis = decoratorsHaveThis ? decs[i - 1] : void 0;
-            var decoratorFinishedRef = {};
-            var ctx = {
-                kind: [
-                    "field",
-                    "accessor",
-                    "method",
-                    "getter",
-                    "setter",
-                    "class"
-                ][kind],
-                name: name,
-                metadata: metadata,
-                addInitializer: (function(decoratorFinishedRef, initializer) {
-                    if (decoratorFinishedRef.v) throw new TypeError("attempted to call addInitializer after decoration was finished");
-                    assertCallable(initializer, "An initializer", "be", true);
-                    initializers.push(initializer);
-                }).bind(null, decoratorFinishedRef)
-            };
-            if (isClass) {
-                _ = dec.call(decThis, newValue, ctx);
-                decoratorFinishedRef.v = 1;
-                if (assertCallable(_, "class decorators", "return")) newValue = _;
-                continue;
-            }
-            ctx.static = isStatic;
-            ctx.private = isPrivate;
-            _ = ctx.access = {
-                has: isPrivate ? hasPrivateBrand.bind() : function(target) {
-                    return name in target;
-                }
-            };
-            if (!isSetter) _.get = isPrivate ? isMethod ? function(_this) {
-                assertInstanceIfPrivate(_this);
-                return desc1.value;
-            } : bindPropCall("get", 0, assertInstanceIfPrivate) : function(target) {
-                return target[name];
-            };
-            if (!isMethod && !isGetter) _.set = isPrivate ? bindPropCall("set", 0, assertInstanceIfPrivate) : function(target, value) {
-                target[name] = value;
-            };
-            newValue = dec.call(decThis, isAccessor ? {
-                get: desc1.get,
-                set: desc1.set
-            } : desc1[key], ctx);
-            decoratorFinishedRef.v = 1;
-            if (isAccessor) {
-                if ("object" == typeof newValue && newValue) {
-                    if (_ = assertCallable(newValue.get, "accessor.get")) desc1.get = _;
-                    if (_ = assertCallable(newValue.set, "accessor.set")) desc1.set = _;
-                    if (_ = assertCallable(newValue.init, "accessor.init")) init.unshift(_);
-                } else if (void 0 !== newValue) throw new TypeError("accessor decorators must return an object with get, set, or init properties or undefined");
-            } else if (assertCallable(newValue, (isField ? "field" : "method") + " decorators", "return")) if (isField) init.unshift(newValue);
-            else desc1[key] = newValue;
-        }
-        if (kind < 2) ret.push(createRunInitializers(init, isStatic, 1), createRunInitializers(initializers, isStatic, 0));
-        if (!isField && !isClass) if (isPrivate) if (isAccessor) ret.splice(-1, 0, bindPropCall("get", isStatic), bindPropCall("set", isStatic));
-        else ret.push(isMethod ? desc1[key] : assertCallable.call.bind(desc1[key]));
-        else defineProperty(Class, name, desc1);
-        return newValue;
-    }
-    function applyMemberDecs() {
-        var ret = [];
-        var protoInitializers;
-        var staticInitializers;
-        var pushInitializers = function(initializers) {
-            if (initializers) ret.push(createRunInitializers(initializers));
-        };
-        var applyMemberDecsOfKind = function(isStatic, isField) {
-            for(var i = 0; i < memberDecs.length; i++){
-                var decInfo = memberDecs[i];
-                var kind = decInfo[1];
-                var kindOnly = 7 & kind;
-                if ((8 & kind) == isStatic && !kindOnly == isField) {
-                    var name = decInfo[2];
-                    var isPrivate = !!decInfo[3];
-                    var decoratorsHaveThis = 16 & kind;
-                    applyDec(isStatic ? targetClass : targetClass.prototype, decInfo, decoratorsHaveThis, isPrivate ? "#" + name : toPropertyKey(name), kindOnly, kindOnly < 2 ? [] : isStatic ? staticInitializers = staticInitializers || [] : protoInitializers = protoInitializers || [], ret, !!isStatic, isPrivate, isField, isStatic && isPrivate ? function(_) {
-                        return checkInRHS(_) === targetClass;
-                    } : instanceBrand);
-                }
-            }
-        };
-        applyMemberDecsOfKind(8, 0);
-        applyMemberDecsOfKind(0, 0);
-        applyMemberDecsOfKind(8, 1);
-        applyMemberDecsOfKind(0, 1);
-        pushInitializers(protoInitializers);
-        pushInitializers(staticInitializers);
-        return ret;
-    }
-    function defineMetadata(Class) {
-        return defineProperty(Class, symbolMetadata, {
-            configurable: true,
-            enumerable: true,
-            value: metadata
-        });
-    }
-    if (void 0 !== parentClass) metadata = parentClass[symbolMetadata];
-    metadata = create(null == metadata ? null : metadata);
-    _ = applyMemberDecs();
-    if (!hasClassDecs) defineMetadata(targetClass);
-    return {
-        e: _,
-        get c () {
-            var initializers = [];
-            return hasClassDecs && [
-                defineMetadata(targetClass = applyDec(targetClass, [
-                    classDecs
-                ], classDecsHaveThis, targetClass.name, 5, initializers)),
-                createRunInitializers(initializers, 1)
-            ];
-        }
-    };
-}
-let _dec, _initClass;
-function src_enhancer(name) {
-    return function(target) {
-        target.prototype.name = name;
-    };
-}
-_dec = src_enhancer('rslib');
-let _Person;
-class Person {
-    static{
-        ({ c: [_Person, _initClass] } = _apply_decs_2311(this, [
-            _dec
-        ], []));
     }
     constructor(){
         this.version = '1.0.0';

--- a/tests/integration/decorators/index.test.ts
+++ b/tests/integration/decorators/index.test.ts
@@ -2,11 +2,11 @@ import { join } from 'node:path';
 import { expect, test } from '@rstest/core';
 import { buildAndGetResults } from 'test-helper';
 
-test('decorators default to 2022-03', async () => {
+test('decorators default to 2023-11', async () => {
   const fixturePath = join(__dirname, 'default');
   const { entries } = await buildAndGetResults({ fixturePath });
 
-  // use 2022-03 decorator by default
+  // use 2023-11 decorator by default
   expect(entries.esm).toMatchSnapshot();
 });
 
@@ -20,8 +20,8 @@ test('decorators with experimentalDecorators in tsconfig', async () => {
   expect(entries.esm1).toMatchSnapshot();
 });
 
-test('decorators support 2023-11 config', async () => {
-  const fixturePath = join(__dirname, '2023-11');
+test('decorators support 2022-03 config', async () => {
+  const fixturePath = join(__dirname, '2022-03');
   const { entries } = await buildAndGetResults({ fixturePath });
 
   expect(entries.esm).toMatchSnapshot();

--- a/tests/integration/extension-alias/__snapshots__/index.test.ts.snap
+++ b/tests/integration/extension-alias/__snapshots__/index.test.ts.snap
@@ -25,5 +25,6 @@ Object.defineProperty(exports, '__esModule', {
 
 exports[`resolve.extensionAlias should work 2`] = `
 "console.log("foobar");
+export { };
 "
 `;

--- a/tests/integration/externals/esm-node-builtin/rslib.config.ts
+++ b/tests/integration/externals/esm-node-builtin/rslib.config.ts
@@ -4,8 +4,27 @@ import { generateBundleEsmConfig } from 'test-helper';
 export default defineConfig({
   lib: [
     generateBundleEsmConfig({
+      id: 'esm-default',
       output: {
-        distPath: './dist/esm',
+        distPath: './dist/esm-default',
+      },
+    }),
+    generateBundleEsmConfig({
+      id: 'esm-external-false',
+      output: {
+        distPath: './dist/esm-false',
+        externals: {
+          'node:os': false,
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      id: 'esm-external-foo',
+      output: {
+        distPath: './dist/esm-foo',
+        externals: {
+          'node:path': 'foo',
+        },
       },
     }),
   ],

--- a/tests/integration/externals/esm-node-builtin/src/index.ts
+++ b/tests/integration/externals/esm-node-builtin/src/index.ts
@@ -2,3 +2,5 @@ import send from './send.cjs';
 
 export const SendStream = send.SendStream;
 export const sendStreamPrototypeIsInherited = send.isInheritedCorrectly;
+export const loadOsPlatform = async () => (await import('node:os')).platform();
+export const loadPathSep = async () => (await import('node:path')).sep;

--- a/tests/integration/externals/esm-node-builtin/src/send.cjs
+++ b/tests/integration/externals/esm-node-builtin/src/send.cjs
@@ -1,5 +1,5 @@
 const util = require('node:util');
-var Stream = require('stream');
+const Stream = require('stream');
 
 function SendStream() {}
 

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expect, test } from '@rstest/core';
 import { buildAndGetResults, proxyConsole, queryContent } from 'test-helper';
@@ -42,12 +43,67 @@ test('auto externalize Node.js built-in modules when `output.target` is "node"',
 
 test('should preserve CommonJS node built-in semantics in ESM output', async () => {
   const fixturePath = join(__dirname, 'esm-node-builtin');
-  const { entryFiles } = await buildAndGetResults({ fixturePath });
+  const { entries, entryFiles } = await buildAndGetResults({
+    fixturePath,
+    lib: ['esm-default'],
+  });
 
-  const esmOutput = await import(entryFiles.esm);
+  // Built-in modules required from bundled CommonJS should keep using createRequire.
+  expect(entries.esm0).toContain(
+    'module.exports = __rspack_createRequire_require("node:util");',
+  );
+  // Another built-in on the CommonJS path should follow the same node-commonjs runtime semantics.
+  expect(entries.esm0).toContain(
+    'module.exports = __rspack_createRequire_require("stream");',
+  );
+  // Lazy built-in imports should still be emitted in a runtime-safe form.
+  expect(entries.esm0).toContain('import("node:os")');
+  expect(entries.esm0).toContain('import("node:path")');
 
+  const esmOutput = await import(pathToFileURL(entryFiles.esm0!).href);
+
+  // The CommonJS helper should still run correctly after the built-in handling changes.
   expect(typeof esmOutput.SendStream).toBe('function');
   expect(esmOutput.sendStreamPrototypeIsInherited).toBe(true);
+  // The lazy built-in import should stay callable at runtime.
+  expect(typeof esmOutput.loadOsPlatform).toBe('function');
+  // The remapped built-in stays lazy, so importing the bundle itself should remain safe.
+  expect(typeof esmOutput.loadPathSep).toBe('function');
+});
+
+test('should report the node built-in error when user externals disables externalization', async () => {
+  const fixturePath = join(__dirname, 'esm-node-builtin');
+
+  const { logs, restore } = proxyConsole();
+  const build = buildAndGetResults({
+    fixturePath,
+    lib: ['esm-external-false'],
+  });
+
+  await expect(build).rejects.toThrowError('Rspack build failed.');
+
+  const errorLogs = logs.map((log) => stripAnsi(log)).join('\n');
+  expect(errorLogs).toContain(
+    'is a built-in Node.js module and cannot be imported in client-side code',
+  );
+
+  restore();
+});
+
+test('should remap node built-ins with user externals', async () => {
+  const fixturePath = join(__dirname, 'esm-node-builtin');
+  const { entries, entryFiles } = await buildAndGetResults({
+    fixturePath,
+    lib: ['esm-external-foo'],
+  });
+
+  // `node:path` should follow the user-configured external target instead of the default built-in external handling.
+  expect(entries.esm2).toContain('import("foo")');
+  expect(entries.esm2).not.toContain('node:path');
+
+  // The remapped built-in stays lazy, so importing the bundle itself should remain safe.
+  const esmOutput = await import(pathToFileURL(entryFiles.esm2!).href);
+  expect(typeof esmOutput.loadPathSep).toBe('function');
 });
 
 test('should get warn when use require in ESM', async () => {
@@ -89,7 +145,7 @@ test('require ESM from CJS', async () => {
   const { restore } = proxyConsole();
   const { entryFiles } = await buildAndGetResults({ fixturePath });
   restore();
-  const baz = (await import(entryFiles.cjs)).baz;
+  const baz = (await import(pathToFileURL(entryFiles.cjs).href)).baz;
   const bazValue = await baz();
   expect(bazValue).toBe('baz');
 });

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@rsbuild/plugin-node-polyfill": "^1.4.4"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@rsbuild/plugin-node-polyfill": "^1.4.4"
   }
 }

--- a/tests/integration/resolve/index.test.ts
+++ b/tests/integration/resolve/index.test.ts
@@ -10,6 +10,7 @@ test('resolve data url', async () => {
   expect(entries.esm).toMatchInlineSnapshot(`
     "const javascript_export_default_42 = 42;
     console.log('x:', javascript_export_default_42);
+    export { };
     "
   `);
 });
@@ -108,6 +109,7 @@ test('resolve with js extensions', async () => {
   expect(isSuccess).toBeTruthy();
   expect(entries.esm).toMatchInlineSnapshot(`
     "console.log(1);
+    export { };
     "
   `);
 });
@@ -119,9 +121,10 @@ test('resolve with main fields', async () => {
 
   expect(isSuccess).toBeTruthy();
   expect(Object.values(results[0]!)[0]).toMatchInlineSnapshot(`
-      "console.log(1);
-      "
-    `);
+    "console.log(1);
+    export { };
+    "
+  `);
   expect(Object.values(results[1]!)[0]).toContain('main');
   expect(Object.values(results[2]!)[0]).toContain('browser');
 });

--- a/tests/integration/worker/index.test.ts
+++ b/tests/integration/worker/index.test.ts
@@ -16,6 +16,7 @@ test('new Worker(new URL(...)) should be preserved', async () => {
     export { worker };
     ",
       "<ROOT>/tests/integration/worker/dist/esm/worker.js": "console.log('Hello from worker', self.name);
+    export { };
     ",
     }
   `);

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^2.3.1",
     "@playwright/test": "1.59.1",
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@rsbuild/plugin-less": "^1.6.2",
     "@rsbuild/plugin-react": "^1.4.6",
     "@rsbuild/plugin-sass": "^1.5.1",

--- a/website/docs/en/guide/basic/typescript.mdx
+++ b/website/docs/en/guide/basic/typescript.mdx
@@ -69,6 +69,7 @@ export default {
 
 ## Decorators version
 
-By default, Rslib uses the [`2022-03`](https://rsbuild.rs/config/source/decorators#2022-03) version of the decorators.
+- Since v0.21.0, Rslib uses the [`2023-11`](https://rsbuild.rs/config/source/decorators#2023-11) version of the decorators by default.
+- Before v0.21.0, Rslib uses the [`2022-03`](https://rsbuild.rs/config/source/decorators#2022-03) version of the decorators by default.
 
 If [experimentalDecorators](https://www.typescriptlang.org/tsconfig/#experimentalDecorators) is enabled in `tsconfig.json`, Rslib will set [source.decorators.version](/config/rsbuild/source#sourcedecorators) to `legacy` to use the legacy decorators.

--- a/website/docs/zh/guide/basic/typescript.mdx
+++ b/website/docs/zh/guide/basic/typescript.mdx
@@ -69,6 +69,7 @@ export default {
 
 ## 装饰器版本
 
-默认情况下，Rslib 会使用 [`2022-03`](https://rsbuild.rs/zh/config/source/decorators#2022-03) 版本的装饰器。
+- 从 v0.21.0 版本开始，Rslib 默认使用 [`2023-11`](https://rsbuild.rs/zh/config/source/decorators#2023-11) 版本的装饰器。
+- 在 v0.21.0 版本之前，Rslib 默认使用 [`2022-03`](https://rsbuild.rs/zh/config/source/decorators#2022-03) 版本的装饰器。
 
 如果在 `tsconfig.json` 中启用了 [experimentalDecorators](https://www.typescriptlang.org/tsconfig/#experimentalDecorators)，Rslib 会默认将 [source.decorators.version](/config/rsbuild/source#sourcedecorators) 设置为 `legacy` 来使用旧版本装饰器。

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.3.1",
-    "@rsbuild/core": "2.0.0-rc.0",
+    "@rsbuild/core": "2.0.0-rc.1",
     "@rsbuild/plugin-react": "^1.4.6",
     "@rsbuild/plugin-sass": "^1.5.1",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

Upgrade the workspace to `@rsbuild/core@2.0.0-rc.1` and refresh the affected lockfile entries, fixtures, docs, and snapshots to match the new behavior.

Adjust the Node target builtin handling in `@rslib/core` to keep builtins externalized again while switching to `autoCjsNodeBuiltin`, and add ESM node-builtin coverage for the default path, user remapping, and explicit `externals: false` errors.

This also picks up Rsbuild's decorators default change from `2022-03` to `2023-11`, so the decorators fixtures, docs, and snapshots are updated to match the new baseline.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1552
- https://github.com/web-infra-dev/rspack/pull/13627
- https://github.com/web-infra-dev/rspack/releases/tag/v2.0.0-rc.1
- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.0-rc.1

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
