### PR TITLE
chore(deps): enable pnpm dedupePeers

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: false
+  dedupePeers: true
   excludeLinksFromLockfile: false
 
 overrides:
@@ -22,7 +23,7 @@ importers:
         version: 0.3.4(jiti@2.6.1)
       '@rstest/adapter-rslib':
         specifier: ^0.2.2
-        version: 0.2.2(@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@module-federation/runtime-tools@2.3.1)(typescript@6.0.2))(@rstest/core@0.9.6(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)
+        version: 0.2.2(@rslib/core@0.21.0)(@rstest/core@0.9.6)(typescript@6.0.2)
       '@rstest/core':
         specifier: ^0.9.6
         version: 0.9.6(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
@@ -94,13 +95,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)
       '@rsbuild/core':
         specifier: 2.0.0-rc.1
         version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -115,31 +116,31 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.3.1
-        version: 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)
       '@module-federation/storybook-addon':
         specifier: ^6.0.8
-        version: 6.0.8(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(webpack-virtual-modules@0.6.2)
+        version: 6.0.8(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2)(vue-tsc@3.2.6)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
         specifier: 2.0.0-rc.1
         version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
       '@storybook/addon-docs':
         specifier: ^10.3.4
-        version: 10.3.4(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.3.4(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.4)
       '@storybook/addon-onboarding':
         specifier: ^10.3.4
-        version: 10.3.4(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.3.4(storybook@10.3.4)
       '@storybook/react':
         specifier: ^10.3.4
-        version: 10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+        version: 10.3.4(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -154,13 +155,13 @@ importers:
         version: 19.2.4(react@19.2.4)
       storybook:
         specifier: ^10.3.4
-        version: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       storybook-addon-rslib:
         specifier: ^3.3.2
-        version: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2))(typescript@6.0.2)
+        version: 3.3.2(@rsbuild/core@2.0.0-rc.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2)(typescript@6.0.2)
       storybook-react-rsbuild:
         specifier: ^3.3.2
-        version: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+        version: 3.3.2(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4)(typescript@6.0.2)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -173,13 +174,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)
       '@rsbuild/core':
         specifier: 2.0.0-rc.1
         version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -194,10 +195,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.7.2
-        version: 1.7.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(preact@10.29.1)
+        version: 1.7.2(@rsbuild/core@2.0.0-rc.1)(preact@10.29.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -209,10 +210,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -227,10 +228,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -245,10 +246,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -263,13 +264,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.1.2(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(solid-js@1.9.12)
+        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.0-rc.1)(solid-js@1.9.12)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -284,7 +285,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(vue@3.5.32)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -305,28 +306,28 @@ importers:
         version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(vue@3.5.32)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
       '@storybook/addon-docs':
         specifier: ^10.3.4
-        version: 10.3.4(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.3.4(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.4)
       '@storybook/addon-onboarding':
         specifier: ^10.3.4
-        version: 10.3.4(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 10.3.4(storybook@10.3.4)
       '@storybook/vue3':
         specifier: ^10.3.4
-        version: 10.3.4(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.32(typescript@6.0.2))
+        version: 10.3.4(storybook@10.3.4)(vue@3.5.32)
       storybook:
         specifier: ^10.3.4
-        version: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       storybook-addon-rslib:
         specifier: ^3.3.2
-        version: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2))(typescript@6.0.2)
+        version: 3.3.2(@rsbuild/core@2.0.0-rc.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2)(typescript@6.0.2)
       storybook-vue3-rsbuild:
         specifier: ^3.3.2
-        version: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))
+        version: 3.3.2(@rsbuild/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2)(vue@3.5.32)
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -348,7 +349,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -375,10 +376,10 @@ importers:
         version: 1.6.4(typescript@6.0.2)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 0.3.4(@rsbuild/core@2.0.0-rc.1)
       rslib:
         specifier: npm:@rslib/core@0.21.0
-        version: '@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@25.2.0))(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)'
+        version: '@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1)(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)'
       rslog:
         specifier: ^2.1.1
         version: 2.1.1
@@ -412,10 +413,10 @@ importers:
         version: 11.3.4
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 0.3.4(@rsbuild/core@2.0.0-rc.1)
       rslib:
         specifier: npm:@rslib/core@0.21.0
-        version: '@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@module-federation/runtime-tools@2.3.1)(typescript@6.0.2)'
+        version: '@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1)(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)'
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -449,10 +450,10 @@ importers:
         version: 1.6.4(typescript@6.0.2)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 0.3.4(@rsbuild/core@2.0.0-rc.1)
       rslib:
         specifier: npm:@rslib/core@0.21.0
-        version: '@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@25.2.0))(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)'
+        version: '@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1)(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)'
       tinyglobby:
         specifier: ^0.2.15
         version: 0.2.15
@@ -479,7 +480,7 @@ importers:
         version: 4.0.1
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -488,25 +489,25 @@ importers:
         version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-less':
         specifier: ^1.6.2
-        version: 1.6.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
+        version: 1.6.2(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-toml':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.1.2(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.2.2(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(vue@3.5.32)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.4
-        version: 1.0.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.0.4(@rsbuild/core@2.0.0-rc.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -580,7 +581,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
 
   tests/integration/asset/json: {}
 
@@ -596,10 +597,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-svgr':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)
+        version: 1.3.1(@rsbuild/core@2.0.0-rc.1)(typescript@6.0.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -693,10 +694,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-svgr':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)
+        version: 1.3.1(@rsbuild/core@2.0.0-rc.1)(typescript@6.0.2)
 
   tests/integration/cli/build: {}
 
@@ -981,7 +982,7 @@ importers:
         version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.4(@rsbuild/core@2.0.0-rc.1)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -994,7 +995,7 @@ importers:
         version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.4(@rsbuild/core@2.0.0-rc.1)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1028,7 +1029,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.1.2(@rsbuild/core@2.0.0-rc.1)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.14.2
         version: 0.14.2(@babel/core@7.29.0)
@@ -1041,7 +1042,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1182,13 +1183,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
+        version: 1.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
+        version: 1.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -1216,7 +1217,7 @@ importers:
     dependencies:
       '@arco-design/web-react':
         specifier: ^2.66.13
-        version: 2.66.13(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 2.66.13(react-dom@19.2.4)(react@19.2.4)
 
   tests/integration/transform-import/lodash:
     dependencies:
@@ -1251,10 +1252,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.6.2
-        version: 1.6.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))
+        version: 1.6.2(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(vue@3.5.32)
       vue:
         specifier: ^3.5.32
         version: 3.5.32(typescript@6.0.2)
@@ -1271,16 +1272,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.3.1
-        version: 2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 2.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)
       '@rsbuild/core':
         specifier: 2.0.0-rc.1
         version: 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rsbuild/plugin-react':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
-        version: 1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.5.1(@rsbuild/core@2.0.0-rc.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1292,19 +1293,19 @@ importers:
         version: 2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 2.0.8
-        version: 2.0.8(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 2.0.8(@rspress/core@2.0.8)(@types/react@19.2.14)(react-dom@19.2.4)(react@19.2.4)
       '@rspress/plugin-llms':
         specifier: 2.0.8
-        version: 2.0.8(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 2.0.8(@rspress/core@2.0.8)
       '@rspress/plugin-rss':
         specifier: 2.0.8
-        version: 2.0.8(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 2.0.8(@rspress/core@2.0.8)
       '@rspress/plugin-sitemap':
         specifier: 2.0.8
-        version: 2.0.8(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 2.0.8(@rspress/core@2.0.8)
       '@rspress/plugin-twoslash':
         specifier: 2.0.8
-        version: 2.0.8(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))(react@19.2.4)(typescript@6.0.2)
+        version: 2.0.8(@rspress/core@2.0.8)(react@19.2.4)(typescript@6.0.2)
       '@rstack-dev/doc-ui':
         specifier: 1.12.5
         version: 1.12.5
@@ -1328,16 +1329,16 @@ importers:
         version: 19.2.4(react@19.2.4)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.5
-        version: 1.0.5(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.0.5(@rsbuild/core@2.0.0-rc.1)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+        version: 1.1.2(@rsbuild/core@2.0.0-rc.1)
       rspress-plugin-file-tree:
         specifier: ^1.0.4
-        version: 1.0.4(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 1.0.4(@rspress/core@2.0.8)
       rspress-plugin-font-open-sans:
         specifier: 1.0.3
-        version: 1.0.3(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 1.0.3(@rspress/core@2.0.8)
 
 packages:
 
@@ -7615,7 +7616,7 @@ snapshots:
     dependencies:
       color: 3.2.1
 
-  '@arco-design/web-react@2.66.13(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@arco-design/web-react@2.66.13(react-dom@19.2.4)(react@19.2.4)':
     dependencies:
       '@arco-design/color': 0.4.0
       '@babel/runtime': 7.24.8
@@ -7629,7 +7630,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       react-focus-lock: 2.13.2(react@19.2.4)
       react-is: 18.3.1
-      react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-transition-group: 4.4.5(react-dom@19.2.4)(react@19.2.4)
       resize-observer-polyfill: 1.5.1
       scroll-into-view-if-needed: 2.2.20
       shallowequal: 1.1.0
@@ -8145,7 +8146,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@docsearch/core@4.6.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@docsearch/core@4.6.2(@types/react@19.2.14)(react-dom@19.2.4)(react@19.2.4)':
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.4
@@ -8153,10 +8154,10 @@ snapshots:
 
   '@docsearch/css@4.6.2': {}
 
-  '@docsearch/react@4.6.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@docsearch/react@4.6.2(@types/react@19.2.14)(react-dom@19.2.4)(react@19.2.4)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.2
-      '@docsearch/core': 4.6.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docsearch/core': 4.6.2(@types/react@19.2.14)(react-dom@19.2.4)(react@19.2.4)
       '@docsearch/css': 4.6.2
     optionalDependencies:
       '@types/react': 19.2.14
@@ -8491,15 +8492,6 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.4
 
-  '@microsoft/api-extractor-model@7.33.5(@types/node@24.12.2)':
-    dependencies:
-      '@microsoft/tsdoc': 0.16.0
-      '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.21.0(@types/node@24.12.2)
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
   '@microsoft/api-extractor-model@7.33.5(@types/node@25.2.0)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
@@ -8507,26 +8499,6 @@ snapshots:
       '@rushstack/node-core-library': 5.21.0(@types/node@25.2.0)
     transitivePeerDependencies:
       - '@types/node'
-
-  '@microsoft/api-extractor@7.58.1(@types/node@24.12.2)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.33.5(@types/node@24.12.2)
-      '@microsoft/tsdoc': 0.16.0
-      '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.21.0(@types/node@24.12.2)
-      '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.4(@types/node@24.12.2)
-      '@rushstack/ts-command-line': 5.3.4(@types/node@24.12.2)
-      diff: 8.0.2
-      lodash: 4.18.1
-      minimatch: 10.2.3
-      resolve: 1.22.11
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor@7.58.1(@types/node@25.2.0)':
     dependencies:
@@ -8556,18 +8528,18 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@module-federation/bridge-react-webpack-plugin@2.3.1(node-fetch@2.7.0(encoding@0.1.13))':
+  '@module-federation/bridge-react-webpack-plugin@2.3.1(node-fetch@2.7.0)':
     dependencies:
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       '@types/semver': 7.5.8
       semver: 7.6.3
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/cli@2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/cli@2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       chalk: 3.0.0
       commander: 11.1.0
       jiti: 2.4.2
@@ -8579,10 +8551,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/cli@2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/cli@2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       chalk: 3.0.0
       commander: 11.1.0
       jiti: 2.4.2
@@ -8594,10 +8566,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/data-prefetch@2.3.1(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@module-federation/data-prefetch@2.3.1(node-fetch@2.7.0)(react-dom@19.2.4)(react@19.2.4)':
     dependencies:
-      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       fs-extra: 9.1.0
     optionalDependencies:
       react: 19.2.4
@@ -8605,10 +8577,10 @@ snapshots:
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/data-prefetch@2.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@module-federation/data-prefetch@2.3.1(react-dom@19.2.4)(react@19.2.4)':
     dependencies:
-      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       fs-extra: 9.1.0
     optionalDependencies:
       react: 19.2.4
@@ -8616,11 +8588,11 @@ snapshots:
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/dts-plugin@2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/dts-plugin@2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)':
     dependencies:
       '@module-federation/error-codes': 2.3.1
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       '@module-federation/third-party-dts-extractor': 2.3.1
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
@@ -8638,11 +8610,11 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/dts-plugin@2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/dts-plugin@2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)':
     dependencies:
       '@module-federation/error-codes': 2.3.1
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       '@module-federation/third-party-dts-extractor': 2.3.1
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
@@ -8660,20 +8632,20 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1)(node-fetch@2.7.0)(react-dom@19.2.4)(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/cli': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/data-prefetch': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/cli': 2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/data-prefetch': 2.3.1(node-fetch@2.7.0)(react-dom@19.2.4)(react@19.2.4)
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
       '@module-federation/error-codes': 2.3.1
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0)
       schema-utils: 4.3.2
       tapable: 2.3.0
       upath: 2.0.1
@@ -8689,20 +8661,20 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1)(node-fetch@2.7.0)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/cli': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/data-prefetch': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/cli': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/data-prefetch': 2.3.1(node-fetch@2.7.0)(react-dom@19.2.4)(react@19.2.4)
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
       '@module-federation/error-codes': 2.3.1
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1)(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0)
       schema-utils: 4.3.2
       tapable: 2.3.0
       upath: 2.0.1
@@ -8718,20 +8690,20 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/cli': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/data-prefetch': 2.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/cli': 2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/data-prefetch': 2.3.1(react-dom@19.2.4)(react@19.2.4)
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
       '@module-federation/error-codes': 2.3.1
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0)
       schema-utils: 4.3.2
       tapable: 2.3.0
       upath: 2.0.1
@@ -8747,20 +8719,20 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/enhanced@2.3.1(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/cli': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/data-prefetch': 2.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/cli': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/data-prefetch': 2.3.1(react-dom@19.2.4)(react@19.2.4)
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
       '@module-federation/error-codes': 2.3.1
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/rspack': 2.3.1(@rspack/core@2.0.0-rc.1)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0)
       schema-utils: 4.3.2
       tapable: 2.3.0
       upath: 2.0.1
@@ -8780,21 +8752,21 @@ snapshots:
 
   '@module-federation/inject-external-runtime-core-plugin@2.3.1(@module-federation/runtime-tools@2.3.1)':
     dependencies:
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
 
-  '@module-federation/managers@2.3.1(node-fetch@2.7.0(encoding@0.1.13))':
+  '@module-federation/managers@2.3.1(node-fetch@2.7.0)':
     dependencies:
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       find-pkg: 2.0.0
       fs-extra: 9.1.0
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/manifest@2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/manifest@2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       chalk: 3.0.0
       find-pkg: 2.0.0
     transitivePeerDependencies:
@@ -8805,11 +8777,11 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/manifest@2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/manifest@2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       chalk: 3.0.0
       find-pkg: 2.0.0
     transitivePeerDependencies:
@@ -8820,11 +8792,11 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.39(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/node@2.7.39(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1)(node-fetch@2.7.0)(react-dom@19.2.4)(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
       tapable: 2.3.0
@@ -8838,11 +8810,11 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.39(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/node@2.7.39(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1)(node-fetch@2.7.0)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
       tapable: 2.3.0
@@ -8856,11 +8828,11 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/rsbuild-plugin@2.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/node': 2.7.39(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/node': 2.7.39(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       fs-extra: 11.3.0
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
@@ -8876,11 +8848,11 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/rsbuild-plugin@2.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/node': 2.7.39(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/node': 2.7.39(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       fs-extra: 11.3.0
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
@@ -8896,15 +8868,15 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))':
+  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.1)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.6)
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
     optionalDependencies:
       typescript: 5.9.3
@@ -8915,15 +8887,15 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.1)(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
     optionalDependencies:
       typescript: 6.0.2
@@ -8934,15 +8906,15 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))':
+  '@module-federation/rspack@2.3.1(@rspack/core@2.0.0-rc.1)(typescript@6.0.2)(vue-tsc@3.2.6)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      '@module-federation/bridge-react-webpack-plugin': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
       '@module-federation/inject-external-runtime-core-plugin': 2.3.1(@module-federation/runtime-tools@2.3.1)
-      '@module-federation/managers': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/managers': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/manifest': 2.3.1(node-fetch@2.7.0)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
       '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
     optionalDependencies:
       typescript: 6.0.2
@@ -8953,39 +8925,39 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/runtime-core@2.3.1(node-fetch@2.7.0(encoding@0.1.13))':
+  '@module-federation/runtime-core@2.3.1(node-fetch@2.7.0)':
     dependencies:
       '@module-federation/error-codes': 2.3.1
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/runtime-tools@2.3.1(node-fetch@2.7.0(encoding@0.1.13))':
+  '@module-federation/runtime-tools@2.3.1(node-fetch@2.7.0)':
     dependencies:
-      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/webpack-bundler-runtime': 2.3.1(node-fetch@2.7.0)
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/runtime@2.3.1(node-fetch@2.7.0(encoding@0.1.13))':
+  '@module-federation/runtime@2.3.1(node-fetch@2.7.0)':
     dependencies:
       '@module-federation/error-codes': 2.3.1
-      '@module-federation/runtime-core': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/runtime-core': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/sdk@2.3.1(node-fetch@2.7.0(encoding@0.1.13))':
+  '@module-federation/sdk@2.3.1(node-fetch@2.7.0)':
     optionalDependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 
-  '@module-federation/storybook-addon@6.0.8(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.8(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2)(vue-tsc@3.2.6)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/enhanced': 2.3.1(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(typescript@6.0.2)(vue-tsc@3.2.6)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
-      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -9004,11 +8976,11 @@ snapshots:
       fs-extra: 9.1.0
       resolve: 1.22.8
 
-  '@module-federation/webpack-bundler-runtime@2.3.1(node-fetch@2.7.0(encoding@0.1.13))':
+  '@module-federation/webpack-bundler-runtime@2.3.1(node-fetch@2.7.0)':
     dependencies:
       '@module-federation/error-codes': 2.3.1
-      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
-      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/runtime': 2.3.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.3.1(node-fetch@2.7.0)
     transitivePeerDependencies:
       - node-fetch
 
@@ -9235,7 +9207,7 @@ snapshots:
       - '@emnapi/runtime'
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.0-rc.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -9248,11 +9220,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.6.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))':
+  '@rsbuild/plugin-less@1.6.2(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
-      less-loader: 12.3.2(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(less@4.6.4)
+      less-loader: 12.3.2(@rspack/core@2.0.0-rc.1)(less@4.6.4)
       reduce-configs: 1.1.1
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
@@ -9260,7 +9232,7 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.0-rc.1)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9288,18 +9260,18 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  '@rsbuild/plugin-preact@1.7.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(preact@10.29.1)':
+  '@rsbuild/plugin-preact@1.7.2(@rsbuild/core@2.0.0-rc.1)(preact@10.29.1)':
     dependencies:
       '@prefresh/core': 1.5.9(preact@10.29.1)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 1.1.5(@prefresh/core@1.5.9(preact@10.29.1))(@prefresh/utils@1.2.1)
+      '@rspack/plugin-preact-refresh': 1.1.5(@prefresh/core@1.5.9)(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh': 12.7.0
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@1.4.6(@rsbuild/core@2.0.0-beta.11(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-react@1.4.6(@rsbuild/core@2.0.0-beta.11)':
     dependencies:
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
       react-refresh: 0.18.0
@@ -9308,7 +9280,7 @@ snapshots:
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-react@1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-react@1.4.6(@rsbuild/core@2.0.0-rc.1)':
     dependencies:
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
       react-refresh: 0.18.0
@@ -9317,7 +9289,7 @@ snapshots:
     transitivePeerDependencies:
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-sass@1.5.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-sass@1.5.1(@rsbuild/core@2.0.0-rc.1)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9327,9 +9299,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  '@rsbuild/plugin-solid@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(solid-js@1.9.12)':
+  '@rsbuild/plugin-solid@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.0-rc.1)(solid-js@1.9.12)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.0-rc.1)
       babel-preset-solid: 1.9.10(@babel/core@7.29.0)(solid-js@1.9.12)
       solid-refresh: 0.7.8(solid-js@1.9.12)
     optionalDependencies:
@@ -9339,12 +9311,12 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))':
+  '@rsbuild/plugin-stylus@1.3.1(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)':
     dependencies:
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
       stylus: 0.64.0
-      stylus-loader: 8.1.3(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.0.0-rc.1)(stylus@0.64.0)
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
@@ -9352,12 +9324,12 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.3.1(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)':
+  '@rsbuild/plugin-svgr@1.3.1(@rsbuild/core@2.0.0-rc.1)(typescript@6.0.2)':
     dependencies:
-      '@rsbuild/plugin-react': 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+      '@rsbuild/plugin-react': 1.4.6(@rsbuild/core@2.0.0-rc.1)
       '@svgr/core': 8.1.0(typescript@6.0.2)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.2))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.2))(typescript@6.0.2)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@6.0.2)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
@@ -9367,31 +9339,31 @@ snapshots:
       - typescript
       - webpack-hot-middleware
 
-  '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@2.0.0-rc.1)':
     dependencies:
       toml: 3.0.0
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)':
+  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(typescript@6.0.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.2.3(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)
+      ts-checker-rspack-plugin: 1.2.3(@rspack/core@2.0.0-rc.1)(typescript@6.0.2)
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-rc.1)':
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))':
+  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(vue@3.5.32)':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2))
+      rspack-vue-loader: 17.5.0(@rspack/core@2.0.0-rc.1)(vue@3.5.32)
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     transitivePeerDependencies:
@@ -9399,28 +9371,14 @@ snapshots:
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))':
+  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@2.0.0-rc.1)':
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  '@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@module-federation/runtime-tools@2.3.1)(typescript@6.0.2)':
+  '@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1)(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)':
     dependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
-      rsbuild-plugin-dts: 0.21.0(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.58.1(@types/node@24.12.2)
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@module-federation/runtime-tools'
-      - '@typescript/native-preview'
-      - core-js
-
-  '@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@25.2.0))(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)':
-    dependencies:
-      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
-      rsbuild-plugin-dts: 0.21.0(@microsoft/api-extractor@7.58.1(@types/node@25.2.0))(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)
+      rsbuild-plugin-dts: 0.21.0(@microsoft/api-extractor@7.58.1)(@rsbuild/core@2.0.0-rc.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.1(@types/node@25.2.0)
       typescript: 6.0.2
@@ -9610,14 +9568,14 @@ snapshots:
     dependencies:
       '@rspack/binding': 2.0.0-beta.9
     optionalDependencies:
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
       '@swc/helpers': 0.5.21
 
   '@rspack/core@2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)':
     dependencies:
       '@rspack/binding': 2.0.0-rc.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)
     optionalDependencies:
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
       '@swc/helpers': 0.5.21
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -9627,7 +9585,7 @@ snapshots:
     dependencies:
       '@rspack/binding': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)
     optionalDependencies:
-      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/runtime-tools': 2.3.1(node-fetch@2.7.0)
       '@swc/helpers': 0.5.21
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -9635,7 +9593,7 @@ snapshots:
 
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rspack/plugin-preact-refresh@1.1.5(@prefresh/core@1.5.9(preact@10.29.1))(@prefresh/utils@1.2.1)':
+  '@rspack/plugin-preact-refresh@1.1.5(@prefresh/core@1.5.9)(@prefresh/utils@1.2.1)':
     dependencies:
       '@prefresh/core': 1.5.9(preact@10.29.1)
       '@prefresh/utils': 1.2.1
@@ -9651,7 +9609,7 @@ snapshots:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
       '@rsbuild/core': 2.0.0-beta.11(@module-federation/runtime-tools@2.3.1)
-      '@rsbuild/plugin-react': 1.4.6(@rsbuild/core@2.0.0-beta.11(@module-federation/runtime-tools@2.3.1))
+      '@rsbuild/plugin-react': 1.4.6(@rsbuild/core@2.0.0-beta.11)
       '@rspress/shared': 2.0.8(@module-federation/runtime-tools@2.3.1)
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -9676,7 +9634,7 @@ snapshots:
       react-lazy-with-preload: 2.2.1
       react-reconciler: 0.33.0(react@19.2.4)
       react-render-to-markdown: 19.0.1(react@19.2.4)
-      react-router-dom: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router-dom: 7.13.2(react-dom@19.2.4)(react@19.2.4)
       rehype-external-links: 3.0.0
       rehype-raw: 7.0.0
       remark-cjk-friendly: 2.0.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
@@ -9703,10 +9661,10 @@ snapshots:
       - supports-color
       - webpack-hot-middleware
 
-  '@rspress/plugin-algolia@2.0.8(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@rspress/plugin-algolia@2.0.8(@rspress/core@2.0.8)(@types/react@19.2.14)(react-dom@19.2.4)(react@19.2.4)':
     dependencies:
       '@docsearch/css': 4.6.2
-      '@docsearch/react': 4.6.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docsearch/react': 4.6.2(@types/react@19.2.14)(react-dom@19.2.4)(react@19.2.4)
       '@rspress/core': 2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -9716,7 +9674,7 @@ snapshots:
       - react-dom
       - search-insights
 
-  '@rspress/plugin-llms@2.0.8(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rspress/plugin-llms@2.0.8(@rspress/core@2.0.8)':
     dependencies:
       '@rspress/core': 2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       remark-mdx: 3.1.1
@@ -9727,16 +9685,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rspress/plugin-rss@2.0.8(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rspress/plugin-rss@2.0.8(@rspress/core@2.0.8)':
     dependencies:
       '@rspress/core': 2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       feed: 5.2.0
 
-  '@rspress/plugin-sitemap@2.0.8(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rspress/plugin-sitemap@2.0.8(@rspress/core@2.0.8)':
     dependencies:
       '@rspress/core': 2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
-  '@rspress/plugin-twoslash@2.0.8(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))(react@19.2.4)(typescript@6.0.2)':
+  '@rspress/plugin-twoslash@2.0.8(@rspress/core@2.0.8)(react@19.2.4)(typescript@6.0.2)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@rspress/core': 2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
@@ -9764,9 +9722,9 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.12.5': {}
 
-  '@rstest/adapter-rslib@0.2.2(@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@module-federation/runtime-tools@2.3.1)(typescript@6.0.2))(@rstest/core@0.9.6(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2)':
+  '@rstest/adapter-rslib@0.2.2(@rslib/core@0.21.0)(@rstest/core@0.9.6)(typescript@6.0.2)':
     dependencies:
-      '@rslib/core': 0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@module-federation/runtime-tools@2.3.1)(typescript@6.0.2)
+      '@rslib/core': 0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1)(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)
       '@rstest/core': 0.9.6(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
     optionalDependencies:
       typescript: 6.0.2
@@ -9782,20 +9740,6 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rushstack/node-core-library@5.21.0(@types/node@24.12.2)':
-    dependencies:
-      ajv: 8.18.0
-      ajv-draft-04: 1.0.0(ajv@8.18.0)
-      ajv-formats: 3.0.1
-      fs-extra: 11.3.4
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.11
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 24.12.2
-    optional: true
-
   '@rushstack/node-core-library@5.21.0(@types/node@25.2.0)':
     dependencies:
       ajv: 8.18.0
@@ -9809,11 +9753,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.0
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@24.12.2)':
-    optionalDependencies:
-      '@types/node': 24.12.2
-    optional: true
-
   '@rushstack/problem-matcher@0.2.1(@types/node@25.2.0)':
     optionalDependencies:
       '@types/node': 25.2.0
@@ -9823,15 +9762,6 @@ snapshots:
       resolve: 1.22.11
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.22.4(@types/node@24.12.2)':
-    dependencies:
-      '@rushstack/node-core-library': 5.21.0(@types/node@24.12.2)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@24.12.2)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 24.12.2
-    optional: true
-
   '@rushstack/terminal@0.22.4(@types/node@25.2.0)':
     dependencies:
       '@rushstack/node-core-library': 5.21.0(@types/node@25.2.0)
@@ -9839,16 +9769,6 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 25.2.0
-
-  '@rushstack/ts-command-line@5.3.4(@types/node@24.12.2)':
-    dependencies:
-      '@rushstack/terminal': 0.22.4(@types/node@24.12.2)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@rushstack/ts-command-line@5.3.4(@types/node@25.2.0)':
     dependencies:
@@ -9928,15 +9848,15 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-docs@10.3.4(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-docs@10.3.4(@types/react@19.2.14)(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.4)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@storybook/react-dom-shim': 10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.4)
+      '@storybook/icons': 2.0.1(react-dom@19.2.4)(react@19.2.4)
+      '@storybook/react-dom-shim': 10.3.4(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -9945,13 +9865,13 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-onboarding@10.3.4(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-onboarding@10.3.4(storybook@10.3.4)':
     dependencies:
-      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
 
-  '@storybook/csf-plugin@10.3.4(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/csf-plugin@10.3.4(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.4)':
     dependencies:
-      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
@@ -9959,7 +9879,7 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@storybook/icons@2.0.1(react-dom@19.2.4)(react@19.2.4)':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -9977,30 +9897,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/react-dom-shim@10.3.4(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
 
-  '@storybook/react@10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)':
+  '@storybook/react@10.3.4(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/react-dom-shim': 10.3.4(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)
       react: 19.2.4
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@6.0.2)
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/vue3@10.3.4(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.32(typescript@6.0.2))':
+  '@storybook/vue3@10.3.4(storybook@10.3.4)(vue@3.5.32)':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       type-fest: 2.19.0
       vue: 3.5.32(typescript@6.0.2)
       vue-component-type-helpers: 3.2.6
@@ -10065,7 +9985,7 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.2))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
@@ -10075,7 +9995,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@6.0.2))(typescript@6.0.2)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@6.0.2)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@6.0.2)
       cosmiconfig: 8.3.6(typescript@6.0.2)
@@ -10486,7 +10406,7 @@ snapshots:
       '@vue/shared': 3.5.32
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.32(vue@3.5.32(typescript@6.0.2))':
+  '@vue/server-renderer@3.5.32(vue@3.5.32)':
     dependencies:
       '@vue/compiler-ssr': 3.5.32
       '@vue/shared': 3.5.32
@@ -12242,7 +12162,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.2(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(less@4.6.4):
+  less-loader@12.3.2(@rspack/core@2.0.0-rc.1)(less@4.6.4):
     dependencies:
       less: 4.6.4
     optionalDependencies:
@@ -13490,13 +13410,13 @@ snapshots:
       react: 19.2.4
       react-reconciler: 0.33.0(react@19.2.4)
 
-  react-router-dom@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router-dom@7.13.2(react-dom@19.2.4)(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-router: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router: 7.13.2(react-dom@19.2.4)(react@19.2.4)
 
-  react-router@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.13.2(react-dom@19.2.4)(react@19.2.4):
     dependencies:
       cookie: 1.1.1
       react: 19.2.4
@@ -13504,7 +13424,7 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
 
-  react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-transition-group@4.4.5(react-dom@19.2.4)(react@19.2.4):
     dependencies:
       '@babel/runtime': 7.24.8
       dom-helpers: 5.2.1
@@ -13831,15 +13751,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.21.0(@microsoft/api-extractor@7.58.1(@types/node@24.12.2))(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(typescript@6.0.2):
-    dependencies:
-      '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.58.1(@types/node@24.12.2)
-      typescript: 6.0.2
-
-  rsbuild-plugin-dts@0.21.0(@microsoft/api-extractor@7.58.1(@types/node@25.2.0))(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2):
+  rsbuild-plugin-dts@0.21.0(@microsoft/api-extractor@7.58.1)(@rsbuild/core@2.0.0-rc.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
@@ -13848,22 +13760,22 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260406.1
       typescript: 6.0.2
 
-  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
+  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.0-rc.1):
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.0-rc.1):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
+  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.0-rc.1):
     optionalDependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
 
-  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)):
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.0-rc.1):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.17
@@ -13872,7 +13784,7 @@ snapshots:
 
   rslog@2.1.1: {}
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(vue@3.5.32(typescript@6.0.2)):
+  rspack-vue-loader@17.5.0(@rspack/core@2.0.0-rc.1)(vue@3.5.32):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
@@ -13880,7 +13792,7 @@ snapshots:
       '@rspack/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21)
       vue: 3.5.32(typescript@6.0.2)
 
-  rspress-plugin-devkit@1.0.0(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)):
+  rspress-plugin-devkit@1.0.0(@rspress/core@2.0.8):
     dependencies:
       '@rspress/core': 2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@types/estree-jsx': 1.0.5
@@ -13905,14 +13817,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rspress-plugin-file-tree@1.0.4(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)):
+  rspress-plugin-file-tree@1.0.4(@rspress/core@2.0.8):
     dependencies:
       '@rspress/core': 2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
-      rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2))
+      rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.8)
     transitivePeerDependencies:
       - supports-color
 
-  rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)):
+  rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.8):
     dependencies:
       '@rspress/core': 2.0.8(@module-federation/runtime-tools@2.3.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
@@ -14267,18 +14179,18 @@ snapshots:
 
   stdin-discarder@0.3.1: {}
 
-  storybook-addon-rslib@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2))(typescript@6.0.2):
+  storybook-addon-rslib@3.3.2(@rsbuild/core@2.0.0-rc.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.2)(typescript@6.0.2):
     dependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2)
     optionalDependencies:
       typescript: 6.0.2
 
-  storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2):
+  storybook-builder-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2):
     dependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2)
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(typescript@6.0.2)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14290,9 +14202,9 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.0-rc.1)
       sirv: 2.0.4
-      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
@@ -14306,11 +14218,11 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2):
+  storybook-react-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(rollup@4.59.0)(storybook@10.3.4)(typescript@6.0.2):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
-      '@storybook/react': 10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+      '@storybook/react': 10.3.4(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.2)
       find-up: 5.0.0
       magic-string: 0.30.21
@@ -14319,8 +14231,8 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@6.0.2)
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.11
-      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
+      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.2
@@ -14332,15 +14244,15 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2)):
+  storybook-vue3-rsbuild@3.3.2(@rsbuild/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2)(vue@3.5.32):
     dependencies:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)
-      '@storybook/vue3': 10.3.4(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.32(typescript@6.0.2))
-      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1))(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+      '@storybook/vue3': 10.3.4(storybook@10.3.4)(vue@3.5.32)
+      storybook: 10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4)
+      storybook-builder-rsbuild: 3.3.2(@rsbuild/core@2.0.0-rc.1)(@rspack/core@2.0.0-rc.1)(react-dom@19.2.4)(react@19.2.4)(storybook@10.3.4)(typescript@6.0.2)
       vue: 3.5.32(typescript@6.0.2)
-      vue-docgen-api: 4.79.2(vue@3.5.32(typescript@6.0.2))
-      vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2(vue@3.5.32(typescript@6.0.2)))
+      vue-docgen-api: 4.79.2(vue@3.5.32)
+      vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - '@rspack/core'
@@ -14352,10 +14264,10 @@ snapshots:
       - vite
       - webpack
 
-  storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@10.3.4(prettier@3.8.1)(react-dom@19.2.4)(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/icons': 2.0.1(react-dom@19.2.4)(react@19.2.4)
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1
       '@vitest/expect': 3.2.4
@@ -14456,7 +14368,7 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.0.0-rc.1)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
@@ -14586,7 +14498,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.2.3(@rspack/core@2.0.0-rc.1(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@module-federation/runtime-tools@2.3.1)(@swc/helpers@0.5.21))(typescript@6.0.2):
+  ts-checker-rspack-plugin@1.2.3(@rspack/core@2.0.0-rc.1)(typescript@6.0.2):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@rspack/lite-tapable': 1.1.0
@@ -14823,7 +14735,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.6: {}
 
-  vue-docgen-api@4.79.2(vue@3.5.32(typescript@6.0.2)):
+  vue-docgen-api@4.79.2(vue@3.5.32):
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
@@ -14837,19 +14749,19 @@ snapshots:
       recast: 0.23.11
       ts-map: 1.0.3
       vue: 3.5.32(typescript@6.0.2)
-      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.32(typescript@6.0.2))
+      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.32)
 
-  vue-docgen-loader@2.0.1(vue-docgen-api@4.79.2(vue@3.5.32(typescript@6.0.2))):
+  vue-docgen-loader@2.0.1(vue-docgen-api@4.79.2):
     dependencies:
       clone: 2.1.2
       jscodeshift: 17.3.0
       loader-utils: 1.4.2
-      vue-docgen-api: 4.79.2(vue@3.5.32(typescript@6.0.2))
+      vue-docgen-api: 4.79.2(vue@3.5.32)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.32(typescript@6.0.2)):
+  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.32):
     dependencies:
       vue: 3.5.32(typescript@6.0.2)
 
@@ -14871,7 +14783,7 @@ snapshots:
       '@vue/compiler-dom': 3.5.32
       '@vue/compiler-sfc': 3.5.32
       '@vue/runtime-dom': 3.5.32
-      '@vue/server-renderer': 3.5.32(vue@3.5.32(typescript@6.0.2))
+      '@vue/server-renderer': 3.5.32(vue@3.5.32)
       '@vue/shared': 3.5.32
     optionalDependencies:
       typescript: 6.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,3 +21,4 @@ overrides:
 strictPeerDependencies: false
 autoInstallPeers: false
 hoistPattern: []
+dedupePeers: true


### PR DESCRIPTION
## Summary

Enable pnpm's opt-in `dedupePeers` workspace setting so peer IDs use the shorter version-based form introduced upstream.

This reduces peer dependency path duplication and keeps dependency resolution output more stable for the monorepo.

## Related Links

- https://github.com/pnpm/pnpm/issues/11070

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
