### PR TITLE
fix(create-rslib): add rootDir to tsconfig templates for TypeScript 6.0 compatibility

### DIFF
--- a/packages/create-rslib/template-node-dual-ts/tsconfig.json
+++ b/packages/create-rslib/template-node-dual-ts/tsconfig.json
@@ -7,7 +7,8 @@
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "useDefineForClassFields": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/packages/create-rslib/template-node-esm-ts/tsconfig.json
+++ b/packages/create-rslib/template-node-esm-ts/tsconfig.json
@@ -7,7 +7,8 @@
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "useDefineForClassFields": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/packages/create-rslib/template-react-ts/tsconfig.json
+++ b/packages/create-rslib/template-react-ts/tsconfig.json
@@ -6,7 +6,8 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/packages/create-rslib/template-vue-ts/tsconfig.json
+++ b/packages/create-rslib/template-vue-ts/tsconfig.json
@@ -16,7 +16,9 @@
 
     /* type checking */
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+
+    "rootDir": "src"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

add rootDir to tsconfig templates for TypeScript 6.0 compatibility

## Related Links

#1588 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
