### PR TITLE
fix(dts): align tinyglobby root resolution

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "rsbuild-plugin-publint": "^0.3.4",
     "rslib": "npm:@rslib/core@0.21.0",
     "rslog": "^2.1.1",
-    "tinyglobby": "^0.2.15",
+    "tinyglobby": "^0.2.16",
     "tsconfck": "3.1.6",
     "typescript": "^6.0.2"
   },

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -43,7 +43,7 @@
     "prebundle": "1.6.4",
     "rsbuild-plugin-publint": "^0.3.4",
     "rslib": "npm:@rslib/core@0.21.0",
-    "tinyglobby": "^0.2.15",
+    "tinyglobby": "^0.2.16",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^6.0.2"
   },

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -161,7 +161,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
 
         // clean dts files and maps
         if (config.output.cleanDistPath !== false) {
-          await cleanDtsFiles(dtsEmitPath);
+          await cleanDtsFiles(cwd, dtsEmitPath);
         }
 
         // clean .rslib temp folder

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -45,6 +45,7 @@ async function handleDiagnosticsAndProcessFiles(
   diagnostics: readonly Diagnostic[],
   configPath: string,
   bundle: boolean,
+  cwd: string,
   declarationDir: string,
   dtsExtension: string,
   redirect: DtsRedirect,
@@ -66,6 +67,7 @@ async function handleDiagnosticsAndProcessFiles(
 
   await processDtsFiles(
     bundle,
+    cwd,
     declarationDir,
     dtsExtension,
     redirect,
@@ -105,6 +107,7 @@ export async function emitDtsTsc(
     name,
     dtsExtension,
     rootDir,
+    cwd,
     banner,
     footer,
     paths,
@@ -161,6 +164,7 @@ export async function emitDtsTsc(
       }
       await processDtsFiles(
         bundle,
+        cwd,
         declarationDir,
         dtsExtension,
         redirect,
@@ -177,6 +181,7 @@ export async function emitDtsTsc(
       logger.error(logPrefixTsc, message);
       await processDtsFiles(
         bundle,
+        cwd,
         declarationDir,
         dtsExtension,
         redirect,
@@ -255,6 +260,7 @@ export async function emitDtsTsc(
         sortAndDeduplicateDiagnostics,
         configPath,
         bundle,
+        cwd,
         declarationDir,
         dtsExtension,
         redirect,
@@ -325,6 +331,7 @@ export async function emitDtsTsc(
         sortAndDeduplicateDiagnostics,
         configPath,
         bundle,
+        cwd,
         declarationDir,
         dtsExtension,
         redirect,
@@ -360,6 +367,7 @@ export async function emitDtsTsc(
 
       await processDtsFiles(
         bundle,
+        cwd,
         declarationDir,
         dtsExtension,
         redirect,

--- a/packages/plugin-dts/src/tsgo.ts
+++ b/packages/plugin-dts/src/tsgo.ts
@@ -79,6 +79,7 @@ async function handleDiagnosticsAndProcessFiles(
   tsConfigResult: ts.ParsedCommandLine,
   configPath: string,
   bundle: boolean,
+  cwd: string,
   declarationDir: string,
   dtsExtension: string,
   redirect: DtsRedirect,
@@ -89,7 +90,7 @@ async function handleDiagnosticsAndProcessFiles(
   name?: string,
 ): Promise<void> {
   if (!bundle) {
-    const dtsFiles = await globDtsFiles(declarationDir, [
+    const dtsFiles = await globDtsFiles(cwd, declarationDir, [
       '/**/*.d.ts',
       '/**/*.d.ts.map',
     ]);
@@ -114,6 +115,7 @@ async function handleDiagnosticsAndProcessFiles(
 
   await processDtsFiles(
     bundle,
+    cwd,
     declarationDir,
     dtsExtension,
     redirect,
@@ -208,6 +210,7 @@ export async function emitDtsTsgo(
           tsConfigResult,
           configPath,
           bundle,
+          cwd,
           declarationDir,
           dtsExtension,
           redirect,

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -511,6 +511,7 @@ export async function redirectDtsImports(
 
 export async function processDtsFiles(
   bundle: boolean,
+  cwd: string,
   dir: string,
   dtsExtension: string,
   redirect: DtsRedirect,
@@ -548,7 +549,7 @@ export async function processDtsFiles(
     );
   }
 
-  const dtsFiles = await globDtsFiles(dir, [`/**/*${dtsExtension}`]);
+  const dtsFiles = await globDtsFiles(cwd, dir, [`/**/*${dtsExtension}`]);
 
   await Promise.all(
     dtsFiles.map(async (file) => {
@@ -651,12 +652,14 @@ export async function calcLongestCommonPath(
 }
 
 export const globDtsFiles = async (
+  cwd: string,
   dir: string,
   patterns: string[],
 ): Promise<string[]> => {
   const dtsFiles = await Promise.all(
     patterns.map(async (pattern) =>
       glob(convertPath(join(dir, pattern)), {
+        cwd,
         absolute: true,
         dot: true,
       }),
@@ -666,7 +669,7 @@ export const globDtsFiles = async (
   return dtsFiles.flat();
 };
 
-export async function cleanDtsFiles(dir: string): Promise<void> {
+export async function cleanDtsFiles(cwd: string, dir: string): Promise<void> {
   const patterns = [
     '/**/*.d.ts',
     '/**/*.d.cts',
@@ -675,7 +678,7 @@ export async function cleanDtsFiles(dir: string): Promise<void> {
     '/**/*.d.cts.map',
     '/**/*.d.mts.map',
   ];
-  const allFiles = await globDtsFiles(dir, patterns);
+  const allFiles = await globDtsFiles(cwd, dir, patterns);
 
   await Promise.all(
     allFiles.map(async (file) => fsP.rm(file, { force: true })),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,8 +384,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       tinyglobby:
-        specifier: ^0.2.15
-        version: 0.2.15
+        specifier: ^0.2.16
+        version: 0.2.16
       tsconfck:
         specifier: 3.1.6
         version: 3.1.6(typescript@6.0.2)
@@ -455,8 +455,8 @@ importers:
         specifier: npm:@rslib/core@0.21.0
         version: '@rslib/core@0.21.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@microsoft/api-extractor@7.58.1)(@module-federation/runtime-tools@2.3.1)(@typescript/native-preview@7.0.0-dev.20260406.1)(typescript@6.0.2)'
       tinyglobby:
-        specifier: ^0.2.15
-        version: 0.2.15
+        specifier: ^0.2.16
+        version: 0.2.16
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -536,8 +536,8 @@ importers:
         specifier: workspace:*
         version: link:scripts
       tinyglobby:
-        specifier: ^0.2.15
-        version: 0.2.15
+        specifier: ^0.2.16
+        version: 0.2.16
 
   tests/e2e/react-component:
     dependencies:
@@ -6032,6 +6032,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -7148,8 +7152,8 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -9645,7 +9649,7 @@ snapshots:
       remark-stringify: 11.0.0
       scroll-into-view-if-needed: 3.1.0
       shiki: 4.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinypool: 1.1.1
       unified: 11.0.5
       unist-util-remove: 4.0.0
@@ -10098,7 +10102,7 @@ snapshots:
     dependencies:
       minimatch: 10.2.4
       path-browserify: 1.0.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -11433,9 +11437,9 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   feed@5.2.0:
     dependencies:
@@ -13133,6 +13137,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pify@4.0.1: {}
 
   pirates@4.0.6: {}
@@ -14147,7 +14153,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.3
       sort-object-keys: 2.0.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
 
   sorted-array-functions@1.3.0: {}
 
@@ -14451,10 +14457,10 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.16:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -33,6 +33,6 @@
     "fs-extra": "^11.3.4",
     "path-serializer": "0.6.0",
     "test-helper": "workspace:*",
-    "tinyglobby": "^0.2.15"
+    "tinyglobby": "^0.2.16"
   }
 }

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -148,6 +148,7 @@ export type BuildResult = {
 export async function getResults(
   rslibConfig: RslibConfig,
   type: 'js' | 'dts' | 'css',
+  cwd: string,
 ): Promise<Omit<BuildResult, 'rspackConfig' | 'rsbuildConfig' | 'isSuccess'>> {
   const files: Record<string, string[]> = {};
   const contents: Record<string, Record<string, string>> = {};
@@ -202,6 +203,7 @@ export async function getResults(
           : /\.(js|cjs|mjs|jsx)(\.map)?$/;
 
     const content: Record<string, string> = await globContentJSON(globFolder, {
+      cwd,
       absolute: true,
     });
 
@@ -334,9 +336,9 @@ export async function buildAndGetResults({
     origin: { bundlerConfigs, rsbuildConfig },
   } = await rslib.inspectConfig({ verbose: true });
   if (type === 'all') {
-    const jsResults = await getResults(rslibConfig, 'js');
-    const dtsResults = await getResults(rslibConfig, 'dts');
-    const cssResults = await getResults(rslibConfig, 'css');
+    const jsResults = await getResults(rslibConfig, 'js', fixturePath);
+    const dtsResults = await getResults(rslibConfig, 'dts', fixturePath);
+    const cssResults = await getResults(rslibConfig, 'css', fixturePath);
     return {
       js: {
         contents: jsResults.contents,
@@ -367,7 +369,7 @@ export async function buildAndGetResults({
       },
     };
   }
-  const results = await getResults(rslibConfig, type);
+  const results = await getResults(rslibConfig, type, fixturePath);
   return {
     contents: results.contents,
     files: results.files,


### PR DESCRIPTION
## Summary

Upgrade `tinyglobby` to `0.2.16` and stop relying on its implicit root handling when scanning declaration outputs.

Pass the project `cwd` explicitly when collecting test build artifacts and when `plugin-dts` cleans or post-processes generated `.d.ts` files, so bundleless DTS flows stay stable after `tinyglobby` narrowed root resolution.

## Related Links

- https://github.com/SuperchupuDev/tinyglobby/commit/2381b766d3447e078b3112e533ada07621f60526

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).