### PR TITLE
chore(deps): upgrade rslint to v0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
     "@changesets/cli": "^2.30.0",
-    "@rslint/core": "^0.3.4",
+    "@rslint/core": "^0.4.2",
     "@rstest/adapter-rslib": "^0.2.2",
     "@rstest/core": "^0.9.6",
     "@types/fs-extra": "^11.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^2.30.0
         version: 2.30.0(@types/node@24.12.2)
       '@rslint/core':
-        specifier: ^0.3.4
-        version: 0.3.4(jiti@2.6.1)
+        specifier: ^0.4.2
+        version: 0.4.2(jiti@2.6.1)
       '@rstest/adapter-rslib':
         specifier: ^0.2.2
         version: 0.2.2(@rslib/core@0.21.0)(@rstest/core@0.9.6)(typescript@6.0.2)
@@ -2741,8 +2741,8 @@ packages:
       typescript:
         optional: true
 
-  '@rslint/core@0.3.4':
-    resolution: {integrity: sha512-pSi6WJ5eIhuYiAkvJDJU5xKm7oxhaphC042g9K3Hp94GFeQVb6cFX263I+gJcyS3B7idB1ernm1YvZhRjlF6tA==}
+  '@rslint/core@0.4.2':
+    resolution: {integrity: sha512-YlTtjsJXoDftUf+xbMUabWEFnE9ya2p+VyPY3bJGFgqeF4u0yfEOn96/V2GoLMh7HqD6XMsSdg3/0SPxdE9bcA==}
     hasBin: true
     peerDependencies:
       jiti: ^2.0.0
@@ -2750,33 +2750,33 @@ packages:
       jiti:
         optional: true
 
-  '@rslint/darwin-arm64@0.3.4':
-    resolution: {integrity: sha512-1CrNIWyckkdNmJDF3EqRaPfWnvZX2GVuJ2a5XDYN4F1fdSxQFA6ZzOPy00LqLkNnkZZ/5xpr68HXamAVKyQqgQ==}
+  '@rslint/darwin-arm64@0.4.2':
+    resolution: {integrity: sha512-a+YeQA+I/RsNnj9ioak7KOpuKSWjt/hv8lvcMvxLy8r4uVcc6orhmccASfEfcpm1HdZHrEm+HJ25CFd3KZrCwA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rslint/darwin-x64@0.3.4':
-    resolution: {integrity: sha512-fOtfQiaD5SEqCdnjH0eXbK4hRuKo7S1+I7FkPO9xiIG4b/gEjzQITXOxmNeRckuF9HHdNqRF8xWELjelO4pcdA==}
+  '@rslint/darwin-x64@0.4.2':
+    resolution: {integrity: sha512-KrQ870EeDXc0V4ncfvZMUEX5uphwemy+Bhia5KDEKURR6rZtpROy/RLLKEn+UkavBJi8ygTv5HXRC4EI6OEHjA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rslint/linux-arm64@0.3.4':
-    resolution: {integrity: sha512-MwNZpfKXxcUWbg92Z1YfgW7HZ6yQESPhP7UoZwt7s0k6l64CDBcCA861F35xuJN1jFqMqnvPwLFqDFjT50DSvQ==}
+  '@rslint/linux-arm64@0.4.2':
+    resolution: {integrity: sha512-E2yEe0ZeMhZNuafrTfKrFy3iWKDMwpnnxCeRzq3AsTmwLmsQDgUZ2iuSxO5EL3eeAJn/7R/hQ3/MKirbcsIWlA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rslint/linux-x64@0.3.4':
-    resolution: {integrity: sha512-etzKwTSPZi6IyBY3FJQaHq2UDlHWeWy/579U0MNTlFVpj2bVl2EsUSOie0dzO4y7YzdZYRZUB1IHEBmlsBVcVw==}
+  '@rslint/linux-x64@0.4.2':
+    resolution: {integrity: sha512-vyVsZHLiaGrWrlRFN7l6I+XxCCH4sI3LkhItA//My/chFIo3zyUa6hwooqllpA3Pb/eXdKVfvurF0hceKEQFjw==}
     cpu: [x64]
     os: [linux]
 
-  '@rslint/win32-arm64@0.3.4':
-    resolution: {integrity: sha512-sIvTTA74ZsN3jh9uKlpNrzCxBu+9HvYvjloAHCW0Th28SZ+yT8ZmFE9Mlrablqs1wclxlfxwXyJN5klxSWA/YQ==}
+  '@rslint/win32-arm64@0.4.2':
+    resolution: {integrity: sha512-1dsU4zm5y+GoO45qLL9pxisXh7NFdX01m26a146rS1bCu9skHqSofmufVYLNrWtnMf7Wso2iaJKVsJya077PRQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rslint/win32-x64@0.3.4':
-    resolution: {integrity: sha512-JURuG6Q/+9cYWvSbN2ELx/fxnEp37gVf7JjbP82CIZ8ar/fw8uREpZoy/SQGf/onUXAjc/CZOovl9MT3Rbq/Fw==}
+  '@rslint/win32-x64@0.4.2':
+    resolution: {integrity: sha512-QBZHeBDW3f6pEHZLB7/2/w/KTv1O5RK1dtr9yLdqev93Tcgk9qwXXLm8TB/6JP9tx+0EyVo8f0XSAS1gtLJ9hQ==}
     cpu: [x64]
     os: [win32]
 
@@ -6028,10 +6028,6 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -9107,7 +9103,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.59.0
 
@@ -9393,32 +9389,34 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rslint/core@0.3.4(jiti@2.6.1)':
+  '@rslint/core@0.4.2(jiti@2.6.1)':
+    dependencies:
+      picomatch: 4.0.4
     optionalDependencies:
-      '@rslint/darwin-arm64': 0.3.4
-      '@rslint/darwin-x64': 0.3.4
-      '@rslint/linux-arm64': 0.3.4
-      '@rslint/linux-x64': 0.3.4
-      '@rslint/win32-arm64': 0.3.4
-      '@rslint/win32-x64': 0.3.4
+      '@rslint/darwin-arm64': 0.4.2
+      '@rslint/darwin-x64': 0.4.2
+      '@rslint/linux-arm64': 0.4.2
+      '@rslint/linux-x64': 0.4.2
+      '@rslint/win32-arm64': 0.4.2
+      '@rslint/win32-x64': 0.4.2
       jiti: 2.6.1
 
-  '@rslint/darwin-arm64@0.3.4':
+  '@rslint/darwin-arm64@0.4.2':
     optional: true
 
-  '@rslint/darwin-x64@0.3.4':
+  '@rslint/darwin-x64@0.4.2':
     optional: true
 
-  '@rslint/linux-arm64@0.3.4':
+  '@rslint/linux-arm64@0.4.2':
     optional: true
 
-  '@rslint/linux-x64@0.3.4':
+  '@rslint/linux-x64@0.4.2':
     optional: true
 
-  '@rslint/win32-arm64@0.3.4':
+  '@rslint/win32-arm64@0.4.2':
     optional: true
 
-  '@rslint/win32-x64@0.3.4':
+  '@rslint/win32-x64@0.4.2':
     optional: true
 
   '@rspack/binding-darwin-arm64@2.0.0-beta.9':
@@ -10392,7 +10390,7 @@ snapshots:
       alien-signals: 3.0.0
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   '@vue/reactivity@3.5.32':
     dependencies:
@@ -13135,8 +13133,6 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
@@ -14646,7 +14642,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   upath@2.0.1: {}

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig, ts } from '@rslint/core';
 
 export default defineConfig([
-  { ignores: ['**/dist/**', '**/dist-types/**', '**/compiled/**'] },
   ts.configs.recommended,
   {
     languageOptions: {
@@ -16,6 +15,12 @@ export default defineConfig([
       ],
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
+      'prefer-const': [
+        'error',
+        {
+          destructuring: 'all',
+        },
+      ],
     },
   },
 ]);

--- a/tests/e2e/module-federation/index.pw.test.ts
+++ b/tests/e2e/module-federation/index.pw.test.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { expect, test } from '@playwright/test';
 
 import { libText, remoteText } from './constant';

--- a/tests/integration/auto-external/module-import-warn/src/index.ts
+++ b/tests/integration/auto-external/module-import-warn/src/index.ts
@@ -1,3 +1,4 @@
+/* rslint-disable @typescript-eslint/no-require-imports */
 export const foo = () => {
   const React = require('react');
   const e1 = require('e1');

--- a/tests/integration/external-helpers/index.test.ts
+++ b/tests/integration/external-helpers/index.test.ts
@@ -16,7 +16,9 @@ test('should throw error when @swc/helpers is not be installed when externalHelp
   const fixturePath = join(__dirname, 'no-deps');
   try {
     await buildAndGetResults({ fixturePath });
-  } catch {}
+  } catch {
+    // do nothing
+  }
 
   const logStrings = logs.map((log) => stripAnsi(log));
 

--- a/tests/integration/externals/module-import-warn/src/index.ts
+++ b/tests/integration/externals/module-import-warn/src/index.ts
@@ -1,3 +1,4 @@
+/* rslint-disable @typescript-eslint/no-require-imports */
 export const baz = async () => {
   const foo = require('foo');
   const bar = require('bar');

--- a/tests/integration/externals/node/src/index.ts
+++ b/tests/integration/externals/node/src/index.ts
@@ -1,3 +1,4 @@
+/* rslint-disable @typescript-eslint/no-require-imports */
 import assert from 'node:assert'; // handle node built-in modules with node: protocol
 import fs from 'fs'; // handle bare node built-in modules
 import React from 'react'; // works with the externals option in rslib.config.ts

--- a/tests/integration/parser-javascript/require/require-dynamic/index.ts
+++ b/tests/integration/parser-javascript/require/require-dynamic/index.ts
@@ -1,3 +1,4 @@
+/* rslint-disable @typescript-eslint/no-require-imports */
 import { createRequire } from 'node:module';
 
 // Using CommonJS require.

--- a/tests/integration/polyfill/rslib.config.ts
+++ b/tests/integration/polyfill/rslib.config.ts
@@ -1,6 +1,9 @@
 import { type BabelTransformOptions, pluginBabel } from '@rsbuild/plugin-babel';
 import { defineConfig } from '@rslib/core';
 import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 const polyfillPlugin = (targets: BabelTransformOptions['targets']) =>
   pluginBabel({

--- a/tests/integration/resolve/with-condition-exports/entry4.ts
+++ b/tests/integration/resolve/with-condition-exports/entry4.ts
@@ -1,1 +1,2 @@
+/* rslint-disable @typescript-eslint/no-require-imports */
 console.log(require('lib1').value);

--- a/tests/integration/shims/esm/src/require.ts
+++ b/tests/integration/shims/esm/src/require.ts
@@ -1,1 +1,2 @@
+/* rslint-disable @typescript-eslint/no-require-imports */
 export const randomFile = require(process.env.RANDOM_FILE!);

--- a/tests/integration/style/less/bundle/rslib.config.ts
+++ b/tests/integration/style/less/bundle/rslib.config.ts
@@ -1,4 +1,4 @@
-import path, { resolve } from 'node:path';
+import { resolve } from 'node:path';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { defineConfig } from '@rslib/core';
 import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
@@ -23,7 +23,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '~': path.resolve(__dirname, '../__fixtures__/basic/src/nest'),
+      '~': resolve(__dirname, '../__fixtures__/basic/src/nest'),
     },
   },
   output: {

--- a/tests/integration/style/less/bundle/rslib.config.ts
+++ b/tests/integration/style/less/bundle/rslib.config.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path';
+import path, { resolve } from 'node:path';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { defineConfig } from '@rslib/core';
 import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
@@ -23,10 +23,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '~': require('node:path').resolve(
-        __dirname,
-        '../__fixtures__/basic/src/nest',
-      ),
+      '~': path.resolve(__dirname, '../__fixtures__/basic/src/nest'),
     },
   },
   output: {

--- a/tests/integration/style/postcss/bundle-false/rslib.config.ts
+++ b/tests/integration/style/postcss/bundle-false/rslib.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from '@rslib/core';
+import { createRequire } from 'node:module';
 import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+const require = createRequire(import.meta.url);
 
 export default defineConfig({
   lib: [

--- a/tests/integration/style/postcss/bundle/rslib.config.ts
+++ b/tests/integration/style/postcss/bundle/rslib.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from '@rslib/core';
 import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 export default defineConfig({
   lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],

--- a/tests/integration/transform-import/lodash/src/index.ts
+++ b/tests/integration/transform-import/lodash/src/index.ts
@@ -1,7 +1,7 @@
 import { get } from 'lodash';
 import { add } from 'lodash/fp';
 
-var object = { a: [{ b: { c: 'foo' } }] };
+const object = { a: [{ b: { c: 'foo' } }] };
 
 export const addOne = add(1);
 export const foo = get(object, 'a[0].b.c');

--- a/tests/integration/umd-globals/index.test.ts
+++ b/tests/integration/umd-globals/index.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@rstest/core';
+import { createRequire } from 'node:module';
 import { buildAndGetResults } from 'test-helper';
+
+const require = createRequire(import.meta.url);
 
 test('correct read globals from CommonJS', async () => {
   const fixturePath = __dirname;

--- a/tests/integration/umd/index.test.ts
+++ b/tests/integration/umd/index.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@rstest/core';
+import { createRequire } from 'node:module';
 import { buildAndGetResults } from 'test-helper';
+
+const require = createRequire(import.meta.url);
 
 test('read UMD value in CommonJS', async () => {
   process.env.NODE_ENV = 'production';

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -183,7 +183,16 @@ export async function getResults(
     const distPath =
       typeof libConfig?.output?.distPath === 'string'
         ? libConfig?.output?.distPath
-        : libConfig?.output?.distPath?.root!;
+        : libConfig?.output?.distPath?.root;
+
+    if (!distPath) {
+      throw new Error(
+        `Cannot determine distPath for format ${format} in libConfig ${JSON.stringify(
+          libConfig,
+        )}`,
+      );
+    }
+
     if (type === 'js' || type === 'css') {
       globFolder = distPath;
     } else if (type === 'dts' && libConfig.dts !== false) {

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -179,19 +179,11 @@ export async function getResults(
 
     key = currentFormatCount === 1 ? format : `${format}${currentFormatIndex}`;
 
-    let globFolder = '';
-    const distPath =
+    let globFolder: string | undefined = '';
+    const distPath: string | undefined =
       typeof libConfig?.output?.distPath === 'string'
         ? libConfig?.output?.distPath
         : libConfig?.output?.distPath?.root;
-
-    if (!distPath) {
-      throw new Error(
-        `Cannot determine distPath for format ${format} in libConfig ${JSON.stringify(
-          libConfig,
-        )}`,
-      );
-    }
 
     if (type === 'js' || type === 'css') {
       globFolder = distPath;

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -179,11 +179,11 @@ export async function getResults(
 
     key = currentFormatCount === 1 ? format : `${format}${currentFormatIndex}`;
 
-    let globFolder: string | undefined = '';
-    const distPath: string | undefined =
+    let globFolder = '';
+    const distPath: string =
       typeof libConfig?.output?.distPath === 'string'
         ? libConfig?.output?.distPath
-        : libConfig?.output?.distPath?.root;
+        : (libConfig?.output?.distPath?.root ?? '');
 
     if (type === 'js' || type === 'css') {
       globFolder = distPath;


### PR DESCRIPTION
## Summary

Upgrade `@rslint/core` to v0.4.2 and align the repo's lint configuration and compatibility fixtures with the new upstream rule set.

## Related Links

- [rslint v0.3.4...v0.4.2](https://github.com/web-infra-dev/rslint/compare/v0.3.4...v0.4.2)

## Checklist

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).