### PR TITLE
fix(create-rslib): add env.d.ts to React/Vue templates

### DIFF
--- a/packages/create-rslib/template-react-ts/src/env.d.ts
+++ b/packages/create-rslib/template-react-ts/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@rslib/core/types" />

--- a/packages/create-rslib/template-vue-ts/src/env.d.ts
+++ b/packages/create-rslib/template-vue-ts/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@rslib/core/types" />

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -77,6 +77,17 @@ export const createAndValidate = (
     expect(existsSync(path.join(dir, 'tsconfig.json'))).toBeTruthy();
   }
 
+  if (
+    templateCase.lang === 'ts' &&
+    (templateCase.template === 'react' || templateCase.template === 'vue')
+  ) {
+    const envDtsPath = path.join(dir, 'src/env.d.ts');
+    expect(existsSync(envDtsPath)).toBeTruthy();
+    expect(fse.readFileSync(envDtsPath, 'utf-8').trimEnd()).toBe(
+      '/// <reference types="@rslib/core/types" />',
+    );
+  }
+
   // tool - Storybook
   if (templateCase.tools.includes('storybook')) {
     for (const file of [


### PR DESCRIPTION
## Summary

Add `src/env.d.ts` to the React and Vue TypeScript templates in `create-rslib` so scaffolded projects pick up `@rslib/core/types` out of the box.

This avoids type errors in generated projects such as `Cannot find module or type declarations for side-effect import of './style.css'.`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
