### PR TITLE
fix(core): bundleless mode inlines internal imports of deps set to false in output.externals

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1485,6 +1485,14 @@ const composeBundlelessExternalConfig = (
                 return;
               }
 
+              // When a dependency is set to false in output.externals, it should be
+              // bundled normally. Treating its imports as relative externals produces
+              // broken import paths in the output.
+              if (normalizeSlash(issuer).includes('/node_modules/')) {
+                callback();
+                return;
+              }
+
               let resolvedRequest: string = request;
 
               const { path: redirectedPath, isResolved } =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,6 +929,12 @@ importers:
 
   tests/integration/externals/browser: {}
 
+  tests/integration/externals/bundleless-false:
+    devDependencies:
+      shell-quote:
+        specifier: 1.8.2
+        version: 1.8.2
+
   tests/integration/externals/esm-node-builtin: {}
 
   tests/integration/externals/module-import-warn: {}
@@ -6631,6 +6637,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.2:
+    resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
+    engines: {node: '>= 0.4'}
 
   shiki@4.0.2:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
@@ -13631,6 +13641,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.2: {}
 
   shiki@4.0.2:
     dependencies:

--- a/tests/integration/externals/bundleless-false/package.json
+++ b/tests/integration/externals/bundleless-false/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "externals-bundleless-false-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "shell-quote": "1.8.2"
+  }
+}

--- a/tests/integration/externals/bundleless-false/rslib.config.ts
+++ b/tests/integration/externals/bundleless-false/rslib.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      output: {
+        externals: {
+          'shell-quote': false,
+        },
+      },
+    }),
+  ],
+  source: {
+    entry: { index: './src/index.ts' },
+  },
+});

--- a/tests/integration/externals/bundleless-false/src/index.ts
+++ b/tests/integration/externals/bundleless-false/src/index.ts
@@ -1,0 +1,1 @@
+export { parse, quote } from 'shell-quote';

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -150,6 +150,27 @@ test('require ESM from CJS', async () => {
   expect(bazValue).toBe('baz');
 });
 
+test('should inline multi-file package when using externals: { [name]: false } in bundleless mode', async () => {
+  // Regression test for fix: internal imports in a package set to false in output.externals
+  // were being treated as relative externals in bundleless mode, breaking the output's import paths.
+  const fixturePath = join(__dirname, 'bundleless-false');
+  const { contents } = await buildAndGetResults({ fixturePath });
+
+  const entry = queryContent(contents.esm!, 'index.js', {
+    basename: true,
+  }).content;
+
+  // Internal files shouldn't appear as broken relative imports in the output.
+  expect(entry).not.toMatch(/from ["']parse(\.js)?["']/);
+  expect(entry).not.toMatch(/from ["']quote(\.js)?["']/);
+
+  // The package's internal files should be inlined as module factories.
+  expect(entry).toMatch(/node_modules\/shell-quote\/parse\.js/);
+  expect(entry).toMatch(/node_modules\/shell-quote\/quote\.js/);
+  expect(entry).toMatch(/var CONTROL/); // from parse.js
+  expect(entry).toMatch(/return xs\.map/); // from quote.js
+});
+
 test('user externals', async () => {
   // Ensure the priority of user externals higher than others.
   // - "memfs": userExternalsConfig > targetExternalsConfig


### PR DESCRIPTION
## Summary

This fixes a bug I experienced when using bundleless mode (`bundle: false`) and trying to include dependencies' code inline via `externals: { [name]: false }` simultaneously.

Internal import paths in packages like `"shell-quote"` were being referenced as relative external paths, like `'./parse.js'`, breaking the output's import paths by referencing non-existent files, instead of including and referencing the package's code inline to resolve those imports.

In my issue I created about this (#1595), I speculated that it had to do with CJS vs.ESM imports, but the bug had to do purely with a dependency's internal imports to other files, regardless of syntax. The test fixture uses a CJS dependency, but this can happen with either CJS or ESM imports.

I use the `"shell-quote"` library in the test fixture, since it is small, simple and causes this issue with the import paths to its `./quote.js` and `./parse.js` modules. 

I confirmed that the test I added fails without the fix to `packages/core/src/config.ts` and that `pnpm test:integration` and `pnpm lint` pass with the change.

## Related Links

Issue: #1595
My reproduction example: https://github.com/ScottMorse/rslib-issue-bundleless-externals

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
