### PR TITLE
fix(core): only rewrite requests whose context is in outBase in bundleless mode

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1383,6 +1383,16 @@ const composeBundlelessExternalConfig = (
     request.includes('rspack-vue-loader') &&
     (suffix ? request.includes(suffix) : true);
 
+  const isPathInOutBase = (resourcePath: string, outBase: string) => {
+    const normalizedOutBase = normalizeSlash(outBase).replace(/\/+$/, '');
+    const normalizedResourcePath = normalizeSlash(resourcePath);
+
+    return (
+      normalizedResourcePath === normalizedOutBase ||
+      normalizedResourcePath.startsWith(`${normalizedOutBase}/`)
+    );
+  };
+
   const styleRedirectPath = redirect.style?.path ?? true;
   const styleRedirectExtension = redirect.style?.extension ?? true;
   const jsRedirectPath = redirect.js?.path ?? true;
@@ -1474,6 +1484,17 @@ const composeBundlelessExternalConfig = (
             // Issuer is not empty string when the module is imported by another module.
             // Prevent from externalizing entry modules here.
             if (issuer) {
+              // Only rewrite requests emitted from source modules. If a dependency in
+              // node_modules is forced to bundle via `output.externals: { pkg: false }`,
+              // its own internal requests should keep following the normal bundling flow.
+              if (
+                typeof outBase === 'string' &&
+                !isPathInOutBase(context, outBase)
+              ) {
+                callback();
+                return;
+              }
+
               // Keep vue-loader generated virtual block requests and helper
               // modules bundled so they don't leak loader internals into
               // bundleless output.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,6 +929,8 @@ importers:
 
   tests/integration/externals/browser: {}
 
+  tests/integration/externals/bundleless-user-external-false: {}
+
   tests/integration/externals/esm-node-builtin: {}
 
   tests/integration/externals/module-import-warn: {}

--- a/tests/integration/bundle-false/basic/.gitignore
+++ b/tests/integration/bundle-false/basic/.gitignore
@@ -1,1 +1,2 @@
 !node_modules/
+node_modules/.*

--- a/tests/integration/externals/bundleless-user-external-false/.gitignore
+++ b/tests/integration/externals/bundleless-user-external-false/.gitignore
@@ -1,0 +1,1 @@
+!node_modules/

--- a/tests/integration/externals/bundleless-user-external-false/.gitignore
+++ b/tests/integration/externals/bundleless-user-external-false/.gitignore
@@ -1,1 +1,2 @@
 !node_modules/
+node_modules/.*

--- a/tests/integration/externals/bundleless-user-external-false/node_modules/foo/index.d.ts
+++ b/tests/integration/externals/bundleless-user-external-false/node_modules/foo/index.d.ts
@@ -1,0 +1,1 @@
+export declare const value: string;

--- a/tests/integration/externals/bundleless-user-external-false/node_modules/foo/index.js
+++ b/tests/integration/externals/bundleless-user-external-false/node_modules/foo/index.js
@@ -1,0 +1,3 @@
+const { getValue } = require('./lib/value.js');
+
+exports.value = getValue();

--- a/tests/integration/externals/bundleless-user-external-false/node_modules/foo/lib/message.js
+++ b/tests/integration/externals/bundleless-user-external-false/node_modules/foo/lib/message.js
@@ -1,0 +1,1 @@
+exports.message = 'inner';

--- a/tests/integration/externals/bundleless-user-external-false/node_modules/foo/lib/value.js
+++ b/tests/integration/externals/bundleless-user-external-false/node_modules/foo/lib/value.js
@@ -1,0 +1,3 @@
+const { message } = require('./message.js');
+
+exports.getValue = () => ['foo', message].join(':');

--- a/tests/integration/externals/bundleless-user-external-false/node_modules/foo/package.json
+++ b/tests/integration/externals/bundleless-user-external-false/node_modules/foo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/tests/integration/externals/bundleless-user-external-false/package.json
+++ b/tests/integration/externals/bundleless-user-external-false/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "externals-bundleless-user-external-false-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/externals/bundleless-user-external-false/rslib.config.ts
+++ b/tests/integration/externals/bundleless-user-external-false/rslib.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      output: {
+        externals: {
+          foo: false,
+        },
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+});

--- a/tests/integration/externals/bundleless-user-external-false/rslib.config.ts
+++ b/tests/integration/externals/bundleless-user-external-false/rslib.config.ts
@@ -1,20 +1,67 @@
 import { defineConfig } from '@rslib/core';
-import { generateBundleEsmConfig } from 'test-helper';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
 
 export default defineConfig({
   lib: [
     generateBundleEsmConfig({
+      id: 'esm-basic',
       bundle: false,
       output: {
+        distPath: './dist/esm-basic',
         externals: {
           foo: false,
         },
       },
+      source: {
+        entry: {
+          index: './src/index.ts',
+        },
+      },
+    }),
+    generateBundleCjsConfig({
+      id: 'cjs-basic',
+      bundle: false,
+      output: {
+        distPath: './dist/cjs-basic',
+        externals: {
+          foo: false,
+        },
+      },
+      source: {
+        entry: {
+          index: './src/index.ts',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      id: 'esm-shared',
+      bundle: false,
+      output: {
+        distPath: './dist/esm-shared',
+        externals: {
+          foo: false,
+        },
+      },
+      source: {
+        entry: {
+          index: ['./src/a.ts', './src/b.ts'],
+        },
+      },
+    }),
+    generateBundleCjsConfig({
+      id: 'cjs-shared',
+      bundle: false,
+      output: {
+        distPath: './dist/cjs-shared',
+        externals: {
+          foo: false,
+        },
+      },
+      source: {
+        entry: {
+          index: ['./src/a.ts', './src/b.ts'],
+        },
+      },
     }),
   ],
-  source: {
-    entry: {
-      index: './src/index.ts',
-    },
-  },
 });

--- a/tests/integration/externals/bundleless-user-external-false/src/a.ts
+++ b/tests/integration/externals/bundleless-user-external-false/src/a.ts
@@ -1,0 +1,3 @@
+import { value } from 'foo';
+
+export const a = `a:${value}`;

--- a/tests/integration/externals/bundleless-user-external-false/src/b.ts
+++ b/tests/integration/externals/bundleless-user-external-false/src/b.ts
@@ -1,0 +1,3 @@
+import { value } from 'foo';
+
+export const b = `b:${value}`;

--- a/tests/integration/externals/bundleless-user-external-false/src/index.ts
+++ b/tests/integration/externals/bundleless-user-external-false/src/index.ts
@@ -1,0 +1,3 @@
+import { value } from 'foo';
+
+export default value;

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -180,14 +180,54 @@ test('user externals', async () => {
   `);
 });
 
-test('bundleless user externals false should not re-externalize bundled package internals', async () => {
+test('bundleless user externals false should bundle dependency internals in basic outputs', async () => {
   const fixturePath = join(__dirname, 'bundleless-user-external-false');
   const { contents } = await buildAndGetResults({ fixturePath });
-  const { path: entryPath } = queryContent(contents.esm, 'index.js', {
+  const { path: esmPath } = queryContent(contents.esm0!, 'index.js', {
+    basename: true,
+  });
+  const { path: cjsPath } = queryContent(contents.cjs0!, 'index.cjs', {
     basename: true,
   });
 
-  const esmOutput = await import(pathToFileURL(entryPath).href);
+  expect((await import(pathToFileURL(esmPath).href)).default).toBe('foo:inner');
+  expect((await import(pathToFileURL(cjsPath).href)).default).toBe('foo:inner');
+});
 
-  expect(esmOutput.default).toBe('foo:inner');
+test('bundleless user externals false should preserve shared dependency behavior in esm and cjs', async () => {
+  const fixturePath = join(__dirname, 'bundleless-user-external-false');
+  const { contents, files } = await buildAndGetResults({ fixturePath });
+
+  expect(files.esm1).toMatchInlineSnapshot(`
+    [
+      "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/esm-shared/504.js",
+      "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/esm-shared/a.js",
+      "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/esm-shared/b.js",
+      "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/esm-shared/rslib-runtime.js",
+    ]
+  `);
+  expect(files.cjs1).toMatchInlineSnapshot(`
+    [
+      "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/cjs-shared/a.cjs",
+      "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/cjs-shared/b.cjs",
+    ]
+  `);
+
+  // CSS currently does not support splitting shared chunks in bundleless mode,
+  // so this case only verifies the shared behavior for JS dependency modules.
+  expect(
+    queryContent(contents.esm1!, 'a.js', { basename: true }).content,
+  ).toContain('import "./504.js";');
+  expect(
+    queryContent(contents.esm1!, 'b.js', { basename: true }).content,
+  ).toContain('import "./504.js";');
+  expect(
+    queryContent(contents.esm1!, '504.js', { basename: true }).content,
+  ).toContain('./node_modules/foo/index.js');
+  expect(
+    queryContent(contents.cjs1!, 'a.cjs', { basename: true }).content,
+  ).toContain('"./node_modules/foo/index.js"');
+  expect(
+    queryContent(contents.cjs1!, 'b.cjs', { basename: true }).content,
+  ).toContain('"./node_modules/foo/index.js"');
 });

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -179,3 +179,13 @@ test('user externals', async () => {
     "
   `);
 });
+
+test('bundleless user externals false should not re-externalize bundled package internals', async () => {
+  const fixturePath = join(__dirname, 'bundleless-user-external-false');
+  const { contents } = await buildAndGetResults({ fixturePath });
+  const { path: entryPath } = queryContent(contents.esm, /index\.js/);
+
+  const esmOutput = await import(pathToFileURL(entryPath).href);
+
+  expect(esmOutput.default).toBe('foo:inner');
+});

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -183,7 +183,9 @@ test('user externals', async () => {
 test('bundleless user externals false should not re-externalize bundled package internals', async () => {
   const fixturePath = join(__dirname, 'bundleless-user-external-false');
   const { contents } = await buildAndGetResults({ fixturePath });
-  const { path: entryPath } = queryContent(contents.esm, /index\.js/);
+  const { path: entryPath } = queryContent(contents.esm, 'index.js', {
+    basename: true,
+  });
 
   const esmOutput = await import(pathToFileURL(entryPath).href);
 

--- a/tests/integration/redirect/style/.gitignore
+++ b/tests/integration/redirect/style/.gitignore
@@ -1,1 +1,2 @@
 !node_modules/
+node_modules/.*


### PR DESCRIPTION
## Summary

Limit bundleless fallback request rewriting to requests whose resolve `context` is under `outBase`. This keeps bundleless path rewriting focused on emitted source modules instead of dependency-internal requests.

This also fixes the `output.externals: { foo: false }` case behind #1595, where a dependency can enter the module graph but its own relative imports should continue through normal bundling instead of being rewritten as external paths.

Add an integration fixture that tracks a stub multi-file dependency under `node_modules` and verifies the bundleless output still executes when that dependency resolves its own relative imports.

## Related Links

- Close: #1595
- Close: #1596

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).