### PR TITLE
feat(deps): upgrade Rsbuild plugins to v2

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.3.3",
     "@rsbuild/core": "^2.0.0",
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "typescript": "^6.0.3"

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -23,7 +23,7 @@
     "@module-federation/rsbuild-plugin": "^2.3.3",
     "@module-federation/storybook-addon": "^6.0.10",
     "@rsbuild/core": "^2.0.0",
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.3.5",
     "@storybook/addon-onboarding": "^10.3.5",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.3.3",
     "@rsbuild/core": "^2.0.0",
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "typescript": "^6.0.3"

--- a/examples/react-component-bundle-false/package.json
+++ b/examples/react-component-bundle-false/package.json
@@ -9,7 +9,7 @@
     "build": "rslib"
   },
   "devDependencies": {
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-sass": "^1.5.1",
     "@rslib/core": "workspace:*",
     "@types/react": "^19.2.14",

--- a/examples/react-component-bundle/package.json
+++ b/examples/react-component-bundle/package.json
@@ -9,7 +9,7 @@
     "build": "rslib"
   },
   "devDependencies": {
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-sass": "^1.5.1",
     "@rslib/core": "workspace:*",
     "@types/react": "^19.2.14",

--- a/examples/react-component-umd/package.json
+++ b/examples/react-component-umd/package.json
@@ -8,7 +8,7 @@
     "build": "rslib"
   },
   "devDependencies": {
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-sass": "^1.5.1",
     "@rslib/core": "workspace:*",
     "@types/react": "^19.2.14",

--- a/packages/create-rslib/template-react-js/package.json
+++ b/packages/create-rslib/template-react-js/package.json
@@ -15,7 +15,7 @@
     "dev": "rslib --watch"
   },
   "devDependencies": {
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@rslib/core": "workspace:*",
     "react": "^19.2.5"
   },

--- a/packages/create-rslib/template-react-ts/package.json
+++ b/packages/create-rslib/template-react-ts/package.json
@@ -17,7 +17,7 @@
     "dev": "rslib --watch"
   },
   "devDependencies": {
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@rslib/core": "workspace:*",
     "@types/react": "^19.2.14",
     "react": "^19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@module-federation/runtime-tools@2.3.3)
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -118,8 +118,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@module-federation/runtime-tools@2.3.3)
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -170,8 +170,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@module-federation/runtime-tools@2.3.3)
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -200,8 +200,8 @@ importers:
   examples/react-component-bundle:
     devDependencies:
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
         version: 1.5.1(@rsbuild/core@2.0.0)
@@ -218,8 +218,8 @@ importers:
   examples/react-component-bundle-false:
     devDependencies:
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
         version: 1.5.1(@rsbuild/core@2.0.0)
@@ -236,8 +236,8 @@ importers:
   examples/react-component-umd:
     devDependencies:
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
         version: 1.5.1(@rsbuild/core@2.0.0)
@@ -482,8 +482,8 @@ importers:
         specifier: ^1.6.2
         version: 1.6.2(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
         version: 1.5.1(@rsbuild/core@2.0.0)
@@ -571,8 +571,8 @@ importers:
         version: 19.2.5
     devDependencies:
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
 
   tests/integration/asset/json: {}
 
@@ -587,11 +587,11 @@ importers:
   tests/integration/asset/svgr:
     devDependencies:
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@rsbuild/plugin-svgr':
-        specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@2.0.0)(typescript@6.0.3)
+        specifier: ^2.0.1
+        version: 2.0.1(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)(typescript@6.0.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -684,11 +684,11 @@ importers:
         version: 19.2.5
     devDependencies:
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@rsbuild/plugin-svgr':
-        specifier: ^1.3.1
-        version: 1.3.1(@rsbuild/core@2.0.0)(typescript@6.0.3)
+        specifier: ^2.0.1
+        version: 2.0.1(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)(typescript@6.0.3)
 
   tests/integration/cli/build: {}
 
@@ -1034,8 +1034,8 @@ importers:
         version: 19.2.5
     devDependencies:
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1270,8 +1270,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@module-federation/runtime-tools@2.3.3)
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
         version: 1.5.1(@rsbuild/core@2.0.0)
@@ -2604,6 +2604,14 @@ packages:
       '@rsbuild/core':
         optional: true
 
+  '@rsbuild/plugin-react@2.0.0':
+    resolution: {integrity: sha512-/1gzt39EGUSFEqB83g46QoOwsgv172HI18i6au1b6lgIaX4sv9stuX4ijdHbHCp8PqYEq+MyQ99jIQMO6I+etg==}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
   '@rsbuild/plugin-sass@1.5.1':
     resolution: {integrity: sha512-rwou4KvDerqvAI0hstjlwF9jgzxPaSOr0PkwtEPjTnQcR5mK6AXZICpUBJbHGgjlAM0aTegKf5IYl/ENvaAQrQ==}
     peerDependencies:
@@ -2628,10 +2636,10 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-svgr@1.3.1':
-    resolution: {integrity: sha512-HQupp4ubDgoPg0VHva68BZKNEb2GM/bZfQP/Pit2tV7vu/SnOO8MZFdiFbjyK/VXCdQktIMbkNREG7xDgpo/ww==}
+  '@rsbuild/plugin-svgr@2.0.1':
+    resolution: {integrity: sha512-cnBGmwtuhj1ltPBScsQVAvsF29m9xmtKXM3sjWWpDfPISkSTxR/jIRvFOf5qYVY37bJIs41Rxfd+PgrGazIgag==}
     peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+      '@rsbuild/core': ^2.0.0-0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -2948,6 +2956,15 @@ packages:
       webpack-hot-middleware: 2.x
     peerDependenciesMeta:
       webpack-hot-middleware:
+        optional: true
+
+  '@rspack/plugin-react-refresh@2.0.0':
+    resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
+    peerDependencies:
+      '@rspack/core': ^2.0.0-0
+      react-refresh: '>=0.10.0 <1.0.0'
+    peerDependenciesMeta:
+      '@rspack/core':
         optional: true
 
   '@rspress/core@2.0.9':
@@ -4181,8 +4198,8 @@ packages:
   cspell-ban-words@0.0.4:
     resolution: {integrity: sha512-w+18WPFAEmo2F+Fr4L29+GdY5ckOLN95WPwb/arfrtuzzB5VzQRFyIujo0T7pq+xFE0Z2gjfLn33Wk/u5ctNQQ==}
 
-  css-select@5.1.0:
-    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
@@ -4192,8 +4209,8 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
-  css-what@6.1.0:
-    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
   css.escape@1.5.1:
@@ -4332,8 +4349,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  domutils@3.1.0:
-    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -4400,8 +4417,8 @@ packages:
     resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
     hasBin: true
 
-  error-ex@1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -4878,8 +4895,8 @@ packages:
   immutable@5.1.5:
     resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
-  import-fresh@3.3.0:
-    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
   import-lazy@4.0.0:
@@ -8880,15 +8897,6 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@1.4.6(@rsbuild/core@2.0.0)':
-    dependencies:
-      '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0(@module-federation/runtime-tools@2.3.3)
-    transitivePeerDependencies:
-      - webpack-hot-middleware
-
   '@rsbuild/plugin-react@1.4.6(@rsbuild/core@2.0.0-rc.1)':
     dependencies:
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
@@ -8897,6 +8905,15 @@ snapshots:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@module-federation/runtime-tools@2.3.3)
     transitivePeerDependencies:
       - webpack-hot-middleware
+
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.0)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0(@module-federation/runtime-tools@2.3.3)
+    transitivePeerDependencies:
+      - '@rspack/core'
 
   '@rsbuild/plugin-sass@1.5.1(@rsbuild/core@2.0.0)':
     dependencies:
@@ -8933,9 +8950,9 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@1.3.1(@rsbuild/core@2.0.0)(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.1(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 1.4.6(@rsbuild/core@2.0.0)
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.0)(@rspack/core@2.0.0)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@6.0.3)
@@ -8944,9 +8961,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0(@module-federation/runtime-tools@2.3.3)
     transitivePeerDependencies:
+      - '@rspack/core'
       - supports-color
       - typescript
-      - webpack-hot-middleware
 
   '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@2.0.0)':
     dependencies:
@@ -9207,6 +9224,12 @@ snapshots:
       error-stack-parser: 2.1.4
       html-entities: 2.6.0
       react-refresh: 0.18.0
+
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.0)(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.0.0(@module-federation/runtime-tools@2.3.3)(@swc/helpers@0.5.21)
 
   '@rspress/core@2.0.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@module-federation/runtime-tools@2.3.3)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
@@ -10526,7 +10549,7 @@ snapshots:
 
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
-      import-fresh: 3.3.0
+      import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
@@ -10596,12 +10619,12 @@ snapshots:
 
   cspell-ban-words@0.0.4: {}
 
-  css-select@5.1.0:
+  css-select@5.2.2:
     dependencies:
       boolbase: 1.0.0
-      css-what: 6.1.0
+      css-what: 6.2.2
       domhandler: 5.0.3
-      domutils: 3.1.0
+      domutils: 3.2.2
       nth-check: 2.1.1
 
   css-tree@2.2.1:
@@ -10614,7 +10637,7 @@ snapshots:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
 
-  css-what@6.1.0: {}
+  css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
 
@@ -10726,7 +10749,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  domutils@3.1.0:
+  domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
@@ -10803,7 +10826,7 @@ snapshots:
       prr: 1.0.1
     optional: true
 
-  error-ex@1.3.2:
+  error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
 
@@ -11446,7 +11469,7 @@ snapshots:
 
   immutable@5.1.5: {}
 
-  import-fresh@3.3.0:
+  import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
@@ -12551,7 +12574,7 @@ snapshots:
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.0
-      error-ex: 1.3.2
+      error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
@@ -13853,9 +13876,9 @@ snapshots:
   svgo@3.3.3:
     dependencies:
       commander: 7.2.0
-      css-select: 5.1.0
+      css-select: 5.2.2
       css-tree: 2.3.1
-      css-what: 6.1.0
+      css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,7 +370,7 @@ importers:
         version: 0.3.4(@rsbuild/core@2.0.0)
       rslib:
         specifier: npm:@rslib/core@0.21.2
-        version: '@rslib/core@0.21.2(@microsoft/api-extractor@7.58.5)(@module-federation/runtime-tools@2.3.3)(@typescript/native-preview@7.0.0-dev.20260419.1)(typescript@6.0.3)'
+        version: '@rslib/core@0.21.2(@microsoft/api-extractor@7.58.5)(@module-federation/runtime-tools@2.3.3)(typescript@6.0.3)'
       rslog:
         specifier: ^2.1.1
         version: 2.1.1
@@ -407,7 +407,7 @@ importers:
         version: 0.3.4(@rsbuild/core@2.0.0)
       rslib:
         specifier: npm:@rslib/core@0.21.2
-        version: '@rslib/core@0.21.2(@microsoft/api-extractor@7.58.5)(@module-federation/runtime-tools@2.3.3)(@typescript/native-preview@7.0.0-dev.20260419.1)(typescript@6.0.3)'
+        version: '@rslib/core@0.21.2(@microsoft/api-extractor@7.58.5)(@module-federation/runtime-tools@2.3.3)(typescript@6.0.3)'
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -488,8 +488,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1(@rsbuild/core@2.0.0)
       '@rsbuild/plugin-toml':
-        specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.2
         version: 1.2.2(@rsbuild/core@2.0.0)
@@ -2644,8 +2644,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-toml@1.1.2':
-    resolution: {integrity: sha512-nhRtk8JNFlA582B5FflU00NAGvErjMOdr1elQSdJQuvQ3Ztq2Gz1IFaj9w4mC/LtNVUKzwRe0F7gs2W0wqzz5A==}
+  '@rsbuild/plugin-toml@2.0.0':
+    resolution: {integrity: sha512-x1C8y1QAA8gfjK/6gS9zLwTdwI6DRHH6P3IAtYBFgaQuLNjXGxfmw1qKeSH7y88kVxscxlea/xkp0+7S2tGXqA==}
     peerDependencies:
       '@rsbuild/core': ^1.0.0 || ^2.0.0-0
     peerDependenciesMeta:
@@ -6996,8 +6996,9 @@ packages:
   token-stream@1.0.0:
     resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
 
-  toml@3.0.0:
-    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+  toml@4.1.1:
+    resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
+    engines: {node: '>=20'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -8135,6 +8136,15 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.5
 
+  '@microsoft/api-extractor-model@7.33.8(@types/node@24.12.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@24.12.2)
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   '@microsoft/api-extractor-model@7.33.8(@types/node@25.2.0)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
@@ -8142,6 +8152,25 @@ snapshots:
       '@rushstack/node-core-library': 5.23.1(@types/node@25.2.0)
     transitivePeerDependencies:
       - '@types/node'
+
+  '@microsoft/api-extractor@7.58.5(@types/node@24.12.2)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@24.12.2)
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@24.12.2)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.23.0(@types/node@24.12.2)
+      '@rushstack/ts-command-line': 5.3.8(@types/node@24.12.2)
+      diff: 8.0.2
+      minimatch: 10.2.3
+      resolve: 1.22.11
+      semver: 7.7.4
+      source-map: 0.6.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
 
   '@microsoft/api-extractor@7.58.5(@types/node@25.2.0)':
     dependencies:
@@ -8965,9 +8994,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-toml@1.1.2(@rsbuild/core@2.0.0)':
+  '@rsbuild/plugin-toml@2.0.0(@rsbuild/core@2.0.0)':
     dependencies:
-      toml: 3.0.0
+      toml: 4.1.1
     optionalDependencies:
       '@rsbuild/core': 2.0.0(@module-federation/runtime-tools@2.3.3)
 
@@ -9007,6 +9036,18 @@ snapshots:
       rsbuild-plugin-dts: 0.21.2(@microsoft/api-extractor@7.58.5)(@rsbuild/core@2.0.0-rc.3)(@typescript/native-preview@7.0.0-dev.20260419.1)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.5(@types/node@25.2.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@typescript/native-preview'
+      - core-js
+
+  '@rslib/core@0.21.2(@microsoft/api-extractor@7.58.5)(@module-federation/runtime-tools@2.3.3)(typescript@6.0.3)':
+    dependencies:
+      '@rsbuild/core': 2.0.0-rc.3(@module-federation/runtime-tools@2.3.3)
+      rsbuild-plugin-dts: 0.21.2(@microsoft/api-extractor@7.58.5)(@rsbuild/core@2.0.0-rc.3)(typescript@6.0.3)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.5(@types/node@24.12.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -9346,7 +9387,7 @@ snapshots:
 
   '@rstest/adapter-rslib@0.2.2(@rslib/core@0.21.2)(@rstest/core@0.9.8)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 0.21.2(@microsoft/api-extractor@7.58.5)(@module-federation/runtime-tools@2.3.3)(@typescript/native-preview@7.0.0-dev.20260419.1)(typescript@6.0.3)
+      '@rslib/core': 0.21.2(@microsoft/api-extractor@7.58.5)(@module-federation/runtime-tools@2.3.3)(typescript@6.0.3)
       '@rstest/core': 0.9.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@module-federation/runtime-tools@2.3.3)
     optionalDependencies:
       typescript: 6.0.3
@@ -9362,6 +9403,20 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
+  '@rushstack/node-core-library@5.23.1(@types/node@24.12.2)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1
+      fs-extra: 11.3.4
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.11
+      semver: 7.7.4
+    optionalDependencies:
+      '@types/node': 24.12.2
+    optional: true
+
   '@rushstack/node-core-library@5.23.1(@types/node@25.2.0)':
     dependencies:
       ajv: 8.18.0
@@ -9375,6 +9430,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.0
 
+  '@rushstack/problem-matcher@0.2.1(@types/node@24.12.2)':
+    optionalDependencies:
+      '@types/node': 24.12.2
+    optional: true
+
   '@rushstack/problem-matcher@0.2.1(@types/node@25.2.0)':
     optionalDependencies:
       '@types/node': 25.2.0
@@ -9384,6 +9444,15 @@ snapshots:
       jju: 1.4.0
       resolve: 1.22.11
 
+  '@rushstack/terminal@0.23.0(@types/node@24.12.2)':
+    dependencies:
+      '@rushstack/node-core-library': 5.23.1(@types/node@24.12.2)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@24.12.2)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 24.12.2
+    optional: true
+
   '@rushstack/terminal@0.23.0(@types/node@25.2.0)':
     dependencies:
       '@rushstack/node-core-library': 5.23.1(@types/node@25.2.0)
@@ -9391,6 +9460,16 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 25.2.0
+
+  '@rushstack/ts-command-line@5.3.8(@types/node@24.12.2)':
+    dependencies:
+      '@rushstack/terminal': 0.23.0(@types/node@24.12.2)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
 
   '@rushstack/ts-command-line@5.3.8(@types/node@25.2.0)':
     dependencies:
@@ -13249,6 +13328,14 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260419.1
       typescript: 6.0.3
 
+  rsbuild-plugin-dts@0.21.2(@microsoft/api-extractor@7.58.5)(@rsbuild/core@2.0.0-rc.3)(typescript@6.0.3):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 2.0.0-rc.3(@module-federation/runtime-tools@2.3.3)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.5(@types/node@24.12.2)
+      typescript: 6.0.3
+
   rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.0):
     optionalDependencies:
       '@rsbuild/core': 2.0.0(@module-federation/runtime-tools@2.3.3)
@@ -13949,7 +14036,7 @@ snapshots:
 
   token-stream@1.0.0: {}
 
-  toml@3.0.0: {}
+  toml@4.1.1: {}
 
   totalist@3.0.1: {}
 

--- a/tests/integration/asset/hash/package.json
+++ b/tests/integration/asset/hash/package.json
@@ -7,6 +7,6 @@
     "react": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/plugin-react": "^1.4.6"
+    "@rsbuild/plugin-react": "^2.0.0"
   }
 }

--- a/tests/integration/asset/svgr/package.json
+++ b/tests/integration/asset/svgr/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/plugin-react": "^1.4.6",
-    "@rsbuild/plugin-svgr": "^1.3.1"
+    "@rsbuild/plugin-react": "^2.0.0",
+    "@rsbuild/plugin-svgr": "^2.0.1"
   },
   "peerDependencies": {
     "react": "^18"

--- a/tests/integration/bundle-false/svgr/package.json
+++ b/tests/integration/bundle-false/svgr/package.json
@@ -7,7 +7,7 @@
     "react": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/plugin-react": "^1.4.6",
-    "@rsbuild/plugin-svgr": "^1.3.1"
+    "@rsbuild/plugin-react": "^2.0.0",
+    "@rsbuild/plugin-svgr": "^2.0.1"
   }
 }

--- a/tests/integration/preserve-jsx/default/package.json
+++ b/tests/integration/preserve-jsx/default/package.json
@@ -7,6 +7,6 @@
     "react": "^19.2.5"
   },
   "devDependencies": {
-    "@rsbuild/plugin-react": "^1.4.6"
+    "@rsbuild/plugin-react": "^2.0.0"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -20,7 +20,7 @@
     "@rsbuild/plugin-less": "^1.6.2",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-sass": "^1.5.1",
-    "@rsbuild/plugin-toml": "^1.1.2",
+    "@rsbuild/plugin-toml": "^2.0.0",
     "@rsbuild/plugin-typed-css-modules": "^1.2.2",
     "@rsbuild/plugin-vue": "^1.2.7",
     "@rsbuild/plugin-yaml": "^1.0.4",

--- a/tests/package.json
+++ b/tests/package.json
@@ -18,7 +18,7 @@
     "@playwright/test": "1.59.1",
     "@rsbuild/core": "^2.0.0",
     "@rsbuild/plugin-less": "^1.6.2",
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-sass": "^1.5.1",
     "@rsbuild/plugin-toml": "^1.1.2",
     "@rsbuild/plugin-typed-css-modules": "^1.2.2",

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.3.3",
     "@rsbuild/core": "^2.0.0",
-    "@rsbuild/plugin-react": "^1.4.6",
+    "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-sass": "^1.5.1",
     "@rslib/core": "workspace:*",
     "@rslib/tsconfig": "workspace:*",


### PR DESCRIPTION
## Summary

Upgrade `@rsbuild/plugin-react`, `@rsbuild/plugin-svgr`, and `@rsbuild/plugin-toml` to their latest major versions where they are used in the repo, including examples, tests, the website, and `create-rslib` React templates.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
