### PR TITLE
chore(core): add native preview dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "@module-federation/rsbuild-plugin": "^2.3.3",
     "@rslib/tsconfig": "workspace:*",
     "@types/fs-extra": "^11.0.4",
+    "@typescript/native-preview": "7.0.0-dev.20260419.1",
     "cac": "^7.0.0",
     "chokidar": "^5.0.0",
     "fs-extra": "^11.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,9 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260419.1
+        version: 7.0.0-dev.20260419.1
       cac:
         specifier: ^7.0.0
         version: 7.0.0
@@ -370,7 +373,7 @@ importers:
         version: 0.3.4(@rsbuild/core@2.0.0)
       rslib:
         specifier: npm:@rslib/core@0.21.2
-        version: '@rslib/core@0.21.2(@microsoft/api-extractor@7.58.5)(@module-federation/runtime-tools@2.3.3)(typescript@6.0.3)'
+        version: '@rslib/core@0.21.2(@microsoft/api-extractor@7.58.5)(@module-federation/runtime-tools@2.3.3)(@typescript/native-preview@7.0.0-dev.20260419.1)(typescript@6.0.3)'
       rslog:
         specifier: ^2.1.1
         version: 2.1.1


### PR DESCRIPTION
## Summary

Add the TypeScript native preview package to the core package so local tsgo declaration generation can resolve the optional peer dependency used by the build-time dts plugin.

This keeps `pnpm install` from failing during the prepare build path when `autoInstallPeers` is disabled.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an \"x\" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).