### PR TITLE
chore: enable tsgo in CI

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -13,8 +13,7 @@ export default defineConfig({
         alias: {
           rslog: './compiled/rslog',
         },
-        // Only use tsgo in local dev for faster build, disable it in CI until it's more stable
-        tsgo: !process.env.CI,
+        tsgo: true,
         distPath: './dist-types',
       },
       redirect: {

--- a/packages/plugin-dts/rslib.config.ts
+++ b/packages/plugin-dts/rslib.config.ts
@@ -8,8 +8,7 @@ export default defineConfig({
       syntax: ['es2023'],
       dts: {
         bundle: false,
-        // Only use tsgo in local dev for faster build, disable it in CI until it's more stable
-        tsgo: !process.env.CI,
+        tsgo: true,
       },
       redirect: {
         dts: {


### PR DESCRIPTION
## Summary

This PR enables tsgo for declaration generation in the core and dts plugin package builds in CI by removing the CI-specific fallback to tsc. Local comparison showed the emitted declaration API shape stays equivalent, with only formatter-level differences.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).