### PR TITLE
docs: type Storybook getAbsolutePath helpers

### DIFF
--- a/examples/module-federation/mf-react-component/.storybook/main.ts
+++ b/examples/module-federation/mf-react-component/.storybook/main.ts
@@ -6,7 +6,7 @@ import type { StorybookConfig } from 'storybook-react-rsbuild';
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
  */
-const getAbsolutePath = (value: string): any => {
+const getAbsolutePath = (value: string): string => {
   return resolve(
     fileURLToPath(
       new URL(import.meta.resolve(`${value}/package.json`, import.meta.url)),

--- a/examples/vue-component-bundleless/.storybook/main.ts
+++ b/examples/vue-component-bundleless/.storybook/main.ts
@@ -6,7 +6,7 @@ import type { StorybookConfig } from 'storybook-vue3-rsbuild';
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
  */
-const getAbsolutePath = (value: string): any => {
+const getAbsolutePath = (value: string): string => {
   return resolve(
     fileURLToPath(
       new URL(import.meta.resolve(`${value}/package.json`, import.meta.url)),

--- a/packages/create-rslib/template-storybook/react-ts/.storybook/main.ts
+++ b/packages/create-rslib/template-storybook/react-ts/.storybook/main.ts
@@ -7,7 +7,7 @@ import type { StorybookConfig } from 'storybook-react-rsbuild';
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
  */
-const getAbsolutePath = (value: string): any => {
+const getAbsolutePath = (value: string): string => {
   return resolve(
     fileURLToPath(
       new URL(import.meta.resolve(`${value}/package.json`, import.meta.url)),

--- a/packages/create-rslib/template-storybook/vue-ts/.storybook/main.ts
+++ b/packages/create-rslib/template-storybook/vue-ts/.storybook/main.ts
@@ -7,7 +7,7 @@ import type { StorybookConfig } from 'storybook-vue3-rsbuild';
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
  */
-const getAbsolutePath = (value: string): any => {
+const getAbsolutePath = (value: string): string => {
   return resolve(
     fileURLToPath(
       new URL(import.meta.resolve(`${value}/package.json`, import.meta.url)),

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -193,9 +193,8 @@ First, set up Storybook with the Rslib project. You can refer to the [Storybook 
    import { dirname, join } from 'node:path';
    import type { StorybookConfig } from 'storybook-react-rsbuild';
 
-   function getAbsolutePath(value: string): any {
-     return dirname(require.resolve(join(value, 'package.json')));
-   }
+   const getAbsolutePath = (value: string): string =>
+     dirname(require.resolve(join(value, 'package.json')));
 
    const config: StorybookConfig = {
      stories: [

--- a/website/docs/zh/guide/advanced/module-federation.mdx
+++ b/website/docs/zh/guide/advanced/module-federation.mdx
@@ -192,9 +192,8 @@ Rslib 支持使用 Storybook 开发 Rslib 模块联邦项目。
 import { dirname, join } from 'node:path';
 import type { StorybookConfig } from 'storybook-react-rsbuild';
 
-function getAbsolutePath(value: string): any {
-  return dirname(require.resolve(join(value, 'package.json')));
-}
+const getAbsolutePath = (value: string): string =>
+  dirname(require.resolve(join(value, 'package.json')));
 
 const config: StorybookConfig = {
   stories: [


### PR DESCRIPTION
## Summary

This PR updates Storybook helper examples to avoid `any` for `getAbsolutePath` return types. The helper always returns a resolved path string, so the Storybook templates, examples, and module federation docs now use `string` consistently.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).