### PR TITLE
feat(create-rslib): add rslint template mapping

### DIFF
--- a/packages/create-rslib/src/index.ts
+++ b/packages/create-rslib/src/index.ts
@@ -9,6 +9,7 @@ import {
   copyFolder,
   create,
   type ESLintTemplateName,
+  type RslintTemplateName,
   select,
 } from 'create-rstack';
 import { parseTemplateName } from './parseTemplateName';
@@ -60,25 +61,49 @@ async function getTemplateName({ template }: Argv) {
 }
 
 function mapESLintTemplate(templateName: string): ESLintTemplateName {
-  const language = templateName.split('-').pop();
-  return `vanilla-${language}` as ESLintTemplateName;
+  switch (templateName) {
+    case 'react-js':
+    case 'react-ts':
+    case 'vue-js':
+    case 'vue-ts':
+      return templateName;
+    default: {
+      const language = templateName.split('-').pop();
+      return `vanilla-${language}` as ESLintTemplateName;
+    }
+  }
+}
+
+function mapRslintTemplate(templateName: string): RslintTemplateName {
+  switch (templateName) {
+    case 'react-js':
+    case 'react-ts':
+      return templateName;
+    default: {
+      const language = templateName.split('-').pop();
+      return `vanilla-${language}` as RslintTemplateName;
+    }
+  }
 }
 
 function mapTestingToolTemplate(templateName: string): string {
-  if (templateName.startsWith('react-')) {
-    return templateName;
+  switch (templateName) {
+    case 'react-js':
+    case 'react-ts':
+    case 'vue-js':
+    case 'vue-ts':
+      return templateName;
+    case 'node-dual-js':
+    case 'node-esm-js':
+      return 'node-js';
+    case 'node-dual-ts':
+    case 'node-esm-ts':
+      return 'node-ts';
+    default: {
+      const language = templateName.split('-').pop();
+      return `node-${language}`;
+    }
   }
-  if (templateName.startsWith('vue-')) {
-    return templateName;
-  }
-  if (templateName.startsWith('node-dual-')) {
-    return templateName.replace('node-dual-', 'node-');
-  }
-  if (templateName.startsWith('node-esm-')) {
-    return templateName.replace('node-esm-', 'node-');
-  }
-  const language = templateName.split('-').pop();
-  return `node-${language}`;
 }
 
 function getPackageName(distFolder: string): string {
@@ -108,6 +133,7 @@ create({
   templates: TEMPLATES,
   getTemplateName,
   mapESLintTemplate,
+  mapRslintTemplate,
   extraTools: [
     {
       value: 'rspress',

--- a/packages/create-rslib/test/index.test.ts
+++ b/packages/create-rslib/test/index.test.ts
@@ -155,6 +155,87 @@ describe('linter and formatter', () => {
     clean();
   });
 
+  test('should create React project with eslint as expected', async () => {
+    const { dir, pkgJson, clean } = createAndValidate(
+      __dirname,
+      createCase('react', 'ts'),
+      {
+        name: 'test-temp-react-eslint',
+        tools: ['eslint'],
+        clean: false,
+      },
+    );
+    expect(pkgJson.devDependencies.eslint).toBeTruthy();
+    expect(pkgJson.devDependencies['eslint-plugin-react-hooks']).toBeTruthy();
+    expect(pkgJson.devDependencies['eslint-plugin-react-refresh']).toBeTruthy();
+
+    const configContent = readFileSync(join(dir, 'eslint.config.mjs'), 'utf-8');
+    expect(configContent).toContain(
+      "reactHooks.configs.flat['recommended-latest']",
+    );
+    expect(configContent).toContain('reactRefresh.configs.recommended');
+    clean();
+  });
+
+  test('should create Vue project with eslint as expected', async () => {
+    const { dir, pkgJson, clean } = createAndValidate(
+      __dirname,
+      createCase('vue', 'ts'),
+      {
+        name: 'test-temp-vue-eslint',
+        tools: ['eslint'],
+        clean: false,
+      },
+    );
+    expect(pkgJson.devDependencies.eslint).toBeTruthy();
+    expect(pkgJson.devDependencies['eslint-plugin-vue']).toBeTruthy();
+    expect(
+      pkgJson.devDependencies['@vue/eslint-config-typescript'],
+    ).toBeTruthy();
+
+    const configContent = readFileSync(join(dir, 'eslint.config.mjs'), 'utf-8');
+    expect(configContent).toContain("pluginVue.configs['flat/essential']");
+    expect(configContent).toContain('vueTsConfigs.recommended');
+    clean();
+  });
+
+  test('should create React project with rslint as expected', async () => {
+    const { dir, pkgJson, clean } = createAndValidate(
+      __dirname,
+      createCase('react', 'ts'),
+      {
+        name: 'test-temp-react-rslint',
+        tools: ['rslint'],
+        clean: false,
+      },
+    );
+    expect(pkgJson.devDependencies['@rslint/core']).toBeTruthy();
+
+    const configContent = readFileSync(join(dir, 'rslint.config.ts'), 'utf-8');
+    expect(configContent).toContain('reactPlugin.configs.recommended');
+    expect(configContent).toContain('ts.configs.recommended');
+    clean();
+  });
+
+  test('should create Vue project with vanilla rslint as expected', async () => {
+    const { dir, pkgJson, clean } = createAndValidate(
+      __dirname,
+      createCase('vue', 'js'),
+      {
+        name: 'test-temp-vue-rslint',
+        tools: ['rslint'],
+        clean: false,
+      },
+    );
+    expect(pkgJson.devDependencies['@rslint/core']).toBeTruthy();
+
+    const configContent = readFileSync(join(dir, 'rslint.config.ts'), 'utf-8');
+    expect(configContent).toContain('js.configs.recommended');
+    expect(configContent).not.toContain('ts.configs.recommended');
+    expect(configContent).not.toContain('reactPlugin');
+    clean();
+  });
+
   test('should create project with prettier as expected', async () => {
     const { dir, pkgJson, clean } = createAndValidate(
       __dirname,


### PR DESCRIPTION
## Summary

This PR updates create-rslib tool template mapping so framework projects receive the matching ESLint templates, while Rslint now maps React projects to React templates and other project types to vanilla templates. It also adds coverage for React/Vue ESLint generation and React/Vue Rslint generation.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/7578

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).