### PR TITLE
chore: update VS Code workspace config

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "rstack.rslint",
+    "rstack.rstest",
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
     "unifiedjs.vscode-mdx"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
   },
   "mdx.validate.validateFileLinks": "ignore",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "json.schemas": [
     {
       "fileMatch": ["**/_meta.json"],


### PR DESCRIPTION
## Summary

This PR keeps the repository VS Code workspace recommendations aligned with the current tooling by recommending the Rstest extension and updating the TypeScript SDK setting to the newer `js/ts.tsdk.path` key.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).