### PR TITLE
chore(deps): update rsbuild to 2.0.5

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -2,8 +2,7 @@ name: Ecosystem CI
 
 on:
   push:
-    # TODO: remove `ci-test` after testing.
-    branches: ['main', 'ci-test']
+    branches: ['main']
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -58,6 +58,7 @@ jobs:
         if: ${{ steps.changes.outputs.changed == 'true' }}
         run: pnpm install
 
+      # TODO: remove it after Rslint fix skipLibCheck issue
       - name: Type Check
         if: ${{ steps.changes.outputs.changed == 'true' && inputs.task == 'ut' }}
         run: pnpm run type-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 - Build: `pnpm build` (all) and `pnpm build:examples`.
 - Watch dev: `pnpm -C packages/core dev` (or other package).
 - Lint/format: `pnpm lint`; auto-fix: `pnpm format`.
-- Type-check: `pnpm type-check`.
+- Type-check: `pnpm lint`.
 - Tests:
   - `pnpm test` runs the entire suites.
   - `pnpm test:unit` scopes to unit tests.

--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.4.0",
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -22,7 +22,7 @@
     "@module-federation/enhanced": "^2.4.0",
     "@module-federation/rsbuild-plugin": "^2.4.0",
     "@module-federation/storybook-addon": "^6.0.11",
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.3.6",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.4.0",
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@rsbuild/plugin-vue": "^1.2.7",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.3.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "type-check": "tsc --noEmit && tsc --noEmit -p tests"
   },
   "dependencies": {
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -482,7 +482,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         oneOf: [
           /* config.module.rule('css').oneOf('css-url') */
           {
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             use: [
               /* config.module.rule('css').oneOf('css-url').use('css-url') */
               {
@@ -717,7 +717,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('image').oneOf('image-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/image/[name][ext]'
             }
@@ -770,7 +770,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('svg').oneOf('svg-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/svg/[name].svg'
             }
@@ -825,7 +825,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('media').oneOf('media-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/media/[name][ext]'
             }
@@ -878,7 +878,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('font').oneOf('font-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/font/[name][ext]'
             }
@@ -1236,7 +1236,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         oneOf: [
           /* config.module.rule('css').oneOf('css-url') */
           {
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             use: [
               /* config.module.rule('css').oneOf('css-url').use('css-url') */
               {
@@ -1471,7 +1471,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('image').oneOf('image-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/image/[name][ext]'
             }
@@ -1524,7 +1524,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('svg').oneOf('svg-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/svg/[name].svg'
             }
@@ -1579,7 +1579,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('media').oneOf('media-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/media/[name][ext]'
             }
@@ -1632,7 +1632,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('font').oneOf('font-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/font/[name][ext]'
             }
@@ -1972,7 +1972,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         oneOf: [
           /* config.module.rule('css').oneOf('css-url') */
           {
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             use: [
               /* config.module.rule('css').oneOf('css-url').use('css-url') */
               {
@@ -2204,7 +2204,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('image').oneOf('image-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/image/[name][ext]'
             }
@@ -2240,7 +2240,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('svg').oneOf('svg-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/svg/[name].svg'
             }
@@ -2276,7 +2276,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('media').oneOf('media-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/media/[name][ext]'
             }
@@ -2312,7 +2312,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('font').oneOf('font-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/font/[name][ext]'
             }
@@ -2630,7 +2630,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         oneOf: [
           /* config.module.rule('css').oneOf('css-url') */
           {
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             use: [
               /* config.module.rule('css').oneOf('css-url').use('css-url') */
               {
@@ -2862,7 +2862,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('image').oneOf('image-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/image/[name][ext]'
             }
@@ -2898,7 +2898,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('svg').oneOf('svg-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/svg/[name].svg'
             }
@@ -2934,7 +2934,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('media').oneOf('media-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/media/[name][ext]'
             }
@@ -2970,7 +2970,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('font').oneOf('font-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/font/[name][ext]'
             }
@@ -3225,7 +3225,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         oneOf: [
           /* config.module.rule('css').oneOf('css-url') */
           {
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             use: [
               /* config.module.rule('css').oneOf('css-url').use('css-url') */
               {
@@ -3481,7 +3481,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('image').oneOf('image-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/image/[name][ext]'
             }
@@ -3517,7 +3517,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('svg').oneOf('svg-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/svg/[name].svg'
             }
@@ -3553,7 +3553,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('media').oneOf('media-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/media/[name][ext]'
             }
@@ -3589,7 +3589,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('font').oneOf('font-asset-url') */
           {
             type: 'asset/resource',
-            resourceQuery: /^\\?url$/,
+            resourceQuery: /[?&]url(?:&|=|$)/,
             generator: {
               filename: 'static/font/[name][ext]'
             }

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@storybook/addon-docs": "^10.3.6",
     "@storybook/addon-onboarding": "^10.3.6",
     "@storybook/react": "^10.3.6",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@storybook/addon-docs": "^10.3.6",
     "@storybook/addon-onboarding": "^10.3.6",
     "@storybook/react": "^10.3.6",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@storybook/addon-docs": "^10.3.6",
     "@storybook/addon-onboarding": "^10.3.6",
     "@storybook/vue3": "^10.3.6",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@storybook/addon-docs": "^10.3.6",
     "@storybook/addon-onboarding": "^10.3.6",
     "@storybook/vue3": "^10.3.6",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.7",
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@rslib/tsconfig": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20260503.1",
     "magic-string": "^0.30.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,13 +80,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.4.0
-        version: 2.4.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+        version: 2.4.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@rsbuild/core':
-        specifier: ~2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.4.0)
+        specifier: ~2.0.5
+        version: 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -101,19 +101,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.4.0
-        version: 2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+        version: 2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.4.0
-        version: 2.4.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+        version: 2.4.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@module-federation/storybook-addon':
         specifier: ^6.0.11
-        version: 6.0.11(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(node-fetch@2.7.0)(storybook@10.3.6)(typescript@6.0.3)(vue-tsc@3.2.7)(webpack-virtual-modules@0.6.2)
+        version: 6.0.11(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(node-fetch@2.7.0)(storybook@10.3.6)(typescript@6.0.3)(vue-tsc@3.2.7)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
-        specifier: ~2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.4.0)
+        specifier: ~2.0.5
+        version: 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -143,10 +143,10 @@ importers:
         version: 10.3.6(prettier@3.8.3)(react-dom@19.2.5)(react@19.2.5)
       storybook-addon-rslib:
         specifier: ^3.3.3
-        version: 3.3.3(@rsbuild/core@2.0.3)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.3)(typescript@6.0.3)
+        version: 3.3.3(@rsbuild/core@2.0.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.3)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: ^3.3.3
-        version: 3.3.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(react-dom@19.2.5)(react@19.2.5)(rollup@4.59.0)(storybook@10.3.6)(typescript@6.0.3)
+        version: 3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(react-dom@19.2.5)(react@19.2.5)(rollup@4.59.0)(storybook@10.3.6)(typescript@6.0.3)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -159,13 +159,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.4.0
-        version: 2.4.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+        version: 2.4.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@rsbuild/core':
-        specifier: ~2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.4.0)
+        specifier: ~2.0.5
+        version: 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -180,10 +180,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.7.2
-        version: 1.7.2(@rsbuild/core@2.0.3)(preact@10.29.1)
+        version: 1.7.2(@rsbuild/core@2.0.5)(preact@10.29.1)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.3)
+        version: 1.5.2(@rsbuild/core@2.0.5)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -195,10 +195,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.3)
+        version: 1.5.2(@rsbuild/core@2.0.5)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -213,10 +213,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.3)
+        version: 1.5.2(@rsbuild/core@2.0.5)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -231,10 +231,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.3)
+        version: 1.5.2(@rsbuild/core@2.0.5)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -249,13 +249,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.3)
+        version: 1.1.2(@rsbuild/core@2.0.5)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.3)
+        version: 1.5.2(@rsbuild/core@2.0.5)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.3)(solid-js@1.9.12)
+        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.5)(solid-js@1.9.12)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -270,7 +270,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(vue@3.5.33)
+        version: 1.2.7(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(vue@3.5.33)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -287,11 +287,11 @@ importers:
   examples/vue-component-bundleless:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.4.0)
+        specifier: ~2.0.5
+        version: 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(vue@3.5.33)
+        version: 1.2.7(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(vue@3.5.33)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -309,10 +309,10 @@ importers:
         version: 10.3.6(prettier@3.8.3)(react-dom@19.2.5)(react@19.2.5)
       storybook-addon-rslib:
         specifier: ^3.3.3
-        version: 3.3.3(@rsbuild/core@2.0.3)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.3)(typescript@6.0.3)
+        version: 3.3.3(@rsbuild/core@2.0.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.3)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.3
-        version: 3.3.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)(vue@3.5.33)
+        version: 3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)(vue@3.5.33)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -326,15 +326,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.4.0)
+        specifier: ~2.0.5
+        version: 2.0.5(@module-federation/runtime-tools@2.4.0)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.4.0
-        version: 2.4.0(@rsbuild/core@2.0.3)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+        version: 2.4.0(@rsbuild/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -364,7 +364,7 @@ importers:
         version: 1.6.4(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.3)
+        version: 0.3.4(@rsbuild/core@2.0.5)
       rslib:
         specifier: npm:@rslib/core@0.21.3
         version: '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)'
@@ -401,7 +401,7 @@ importers:
         version: 11.3.4
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.3)
+        version: 0.3.4(@rsbuild/core@2.0.5)
       rslib:
         specifier: npm:@rslib/core@0.21.3
         version: '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(typescript@6.0.3)'
@@ -422,8 +422,8 @@ importers:
         specifier: ^7.58.7
         version: 7.58.7(@types/node@25.2.0)
       '@rsbuild/core':
-        specifier: ~2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.4.0)
+        specifier: ~2.0.5
+        version: 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -438,7 +438,7 @@ importers:
         version: 1.6.4(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.3)
+        version: 0.3.4(@rsbuild/core@2.0.5)
       rslib:
         specifier: npm:@rslib/core@0.21.3
         version: '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)'
@@ -468,34 +468,34 @@ importers:
         version: 4.0.1
       '@module-federation/rsbuild-plugin':
         specifier: ^2.4.0
-        version: 2.4.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
+        version: 2.4.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
       '@rsbuild/core':
-        specifier: ~2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.4.0)
+        specifier: ~2.0.5
+        version: 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@rsbuild/plugin-less':
         specifier: ^1.6.3
-        version: 1.6.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 1.6.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.3)
+        version: 1.5.2(@rsbuild/core@2.0.5)
       '@rsbuild/plugin-toml':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)
+        version: 2.0.0(@rsbuild/core@2.0.5)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@2.0.3)
+        version: 1.2.2(@rsbuild/core@2.0.5)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(vue@3.5.33)
+        version: 1.2.7(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(vue@3.5.33)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.4
-        version: 1.0.4(@rsbuild/core@2.0.3)
+        version: 1.0.4(@rsbuild/core@2.0.5)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -569,7 +569,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
 
   tests/integration/asset/json: {}
 
@@ -585,10 +585,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(typescript@6.0.3)
+        version: 2.0.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(typescript@6.0.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -682,10 +682,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(typescript@6.0.3)
+        version: 2.0.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(typescript@6.0.3)
 
   tests/integration/cli/build: {}
 
@@ -968,11 +968,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.4.0)
+        specifier: ~2.0.5
+        version: 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.3)
+        version: 1.4.4(@rsbuild/core@2.0.5)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -981,11 +981,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.4.0)
+        specifier: ~2.0.5
+        version: 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.3)
+        version: 1.4.4(@rsbuild/core@2.0.5)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1019,7 +1019,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.3)
+        version: 1.1.2(@rsbuild/core@2.0.5)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.14.2
         version: 0.14.2(@babel/core@7.29.0)
@@ -1032,7 +1032,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1158,13 +1158,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 1.3.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^1.3.2
-        version: 1.3.2(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 1.3.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
@@ -1227,10 +1227,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.6.3
-        version: 1.6.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 1.6.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(vue@3.5.33)
+        version: 1.2.7(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(vue@3.5.33)
       vue:
         specifier: ^3.5.33
         version: 3.5.33(typescript@6.0.3)
@@ -1247,16 +1247,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.4.0
-        version: 2.4.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+        version: 2.4.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@rsbuild/core':
-        specifier: ~2.0.3
-        version: 2.0.3(@module-federation/runtime-tools@2.4.0)
+        specifier: ~2.0.5
+        version: 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.3)
+        version: 1.5.2(@rsbuild/core@2.0.5)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1265,7 +1265,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 2.0.10
-        version: 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.2)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 2.0.10
         version: 2.0.10(@rspress/core@2.0.10)(@types/react@19.2.14)(react-dom@19.2.5)(react@19.2.5)
@@ -1304,10 +1304,10 @@ importers:
         version: 19.2.5(react@19.2.5)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.5
-        version: 1.0.5(@rsbuild/core@2.0.3)
+        version: 1.0.5(@rsbuild/core@2.0.5)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.3)
+        version: 1.1.2(@rsbuild/core@2.0.5)
       rspress-plugin-file-tree:
         specifier: ^1.0.5
         version: 1.0.5(@rspress/core@2.0.10)
@@ -2420,8 +2420,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@2.0.3':
-    resolution: {integrity: sha512-2myp7jUgGen50saxW8OJD/eMVKp7HnuBN5MUzwRb6mDbRZZVpoorfI4LQqiGSBNjGLB6jltvx/R2yHmcmnchwg==}
+  '@rsbuild/core@2.0.5':
+    resolution: {integrity: sha512-KajO50hbXb32S8MsyDh2f+xKcVeRy9Gfzdcy0JjpMLj22djHugly6jrGo7jH7ls9X6/TDcyCTncSuNK4+D2lTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2594,64 +2594,64 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@2.0.1':
-    resolution: {integrity: sha512-CGFO5zmajD1Itch1lxAI7+gvKiagzyqXopHv/jHG9Su2WWQ2/Nhn2/rkSpdp6ptE9ri6+6tCOOahf099/v/Xog==}
+  '@rspack/binding-darwin-arm64@2.0.2':
+    resolution: {integrity: sha512-0o7lbgBBsDlICWdjIH0q3e0BsSco4GRiImHWVfZSVEG+q2+ykZJvSvYCVhPM1Co375Z0S3VMPa/8SjcY1FHwlw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.1':
-    resolution: {integrity: sha512-2vvBNBoS09/PurupBwSrlTZd8283o00B8v20ncsNUdEff41uCR/hzIrYoTIVWnVST+Gt5O1+cfcfORp397lajg==}
+  '@rspack/binding-darwin-x64@2.0.2':
+    resolution: {integrity: sha512-tOwxZpoPlTlRs/w6UyUinXJ4TYRVHMlR7+eQxO1R3muKpixvhXQjtvoaY16HuFyTVky5F0IfOoWr3x9FEsgdLg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.1':
-    resolution: {integrity: sha512-uvNXk6ahE3AH3h2avnd1Mgno68YQpS4cfX1OkOGWIC/roL+NrOP2XVXV4yfVAoydPALDO7AfbIfN0QdmBK3rsA==}
+  '@rspack/binding-linux-arm64-gnu@2.0.2':
+    resolution: {integrity: sha512-1ZD4YFhG1rmgqj+W8hfwHyKV8xDxGsc/3KgU0FwmiVEX7JfzhCkgBO/xlCG79kRKSrzuVzt4icO/G3cCKn0pag==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.0.1':
-    resolution: {integrity: sha512-S/a6uN9PiZ5O/PjSqyIXhuRC1lVzeJkJV69NeLk5sIEUiDQ/aQGZG97uN+tluwpbo1tPbLJkdHYETfjspOX4Pg==}
+  '@rspack/binding-linux-arm64-musl@2.0.2':
+    resolution: {integrity: sha512-/PtTkM/DsDLjeuXTmeJeRfbjCDbcL9jvoVgZrgxYFZ28y2cdLvbChbW9uigOzs5dQEs1CIBQXMTTj7KhdBTuQg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.0.1':
-    resolution: {integrity: sha512-C13Kk0OkZiocZVj187Sf753UH6pDXnuEu6vzUvi3qv9ltibG1ki0H2Y8isXBYL2cHQOV+hk0g1S6/4z3TTB97A==}
+  '@rspack/binding-linux-x64-gnu@2.0.2':
+    resolution: {integrity: sha512-bBjsZxMHRaPo6X9SokApm6ucs+UhXtAJFyJJyuk2BH4XJsLeCU9Dz1vMwioeohFbJUUeTASVPm6/BL+RhSaunw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.0.1':
-    resolution: {integrity: sha512-TQsiBFpEDGkuvK9tNdGj/Uc+AIytzqhxXH/1jKU6M24cWB1DTw/Cx7DdrkCBDyq3129K3POLdujvbWCGqBzQUw==}
+  '@rspack/binding-linux-x64-musl@2.0.2':
+    resolution: {integrity: sha512-HjlpInqzabDNkhVsUJpsHPqa9QYVWBViJoyWNjzXCAW0vKMDvwaphyUvokSinX8FGTlZi/sr5UEaHJo6XtQ35g==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.0.1':
-    resolution: {integrity: sha512-wk3gyUgBW/ayP49bI54bkY8+EQnfBHxdoe9dz3oobSTZQc8AOWwmUUDEPltW8rUvPOM6dfHECTOUMnfaf2f5yA==}
+  '@rspack/binding-wasm32-wasi@2.0.2':
+    resolution: {integrity: sha512-YaRYNFLJRpkGfYjSWR7n9f+nQKtrlmrrffpAn/blc2geHcRvXoBc5SCs1idPtsLhj7H9qWWhs7ucjyHy4csWFg==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.1':
-    resolution: {integrity: sha512-rHjLcy3VcAC3+x+PxH+gwhwv6tPe0JdXTNT5eAOs9wgZIM6T9p4wre49+K4Qy98+Fb7TTbLX0ObUitlOkGwTSA==}
+  '@rspack/binding-win32-arm64-msvc@2.0.2':
+    resolution: {integrity: sha512-d/3kTEKq+asLjRFPO96t+wfWiM7DLN76VQEPDD9bc1kdsZXlVJBuvyXfsgK8bbEvKplWXYcSsokhmEnuXrLOpg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.1':
-    resolution: {integrity: sha512-Ad1vVqMBBnd4T8rsORngu9sl2kyRTlS4kMlvFudjzl1X2UFArEDBe0YVGNN7ZvahM12CErUx2WiN8Sd8pb+qXQ==}
+  '@rspack/binding-win32-ia32-msvc@2.0.2':
+    resolution: {integrity: sha512-161cWineq3RW+Jdm1FAfSpXeUtYWvhB3kAbm46vNT9h/YYz+spwsFMvveAZ1nsVSVL0IC5lDBGUte7yUAY8K2g==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.1':
-    resolution: {integrity: sha512-oPM2Jtm7HOlmxl/aBfleAVlL6t9VeHx6WvEets7BBJMInemFXAQd4CErRqybf7rXutACzLeUWBOue4Jpd1/ykw==}
+  '@rspack/binding-win32-x64-msvc@2.0.2':
+    resolution: {integrity: sha512-y7Q0S1FE+OlkL5GMqLG0PwxrPw6E1r892KhGrGKE1Vdufe5YTEx6xTPxzZ+b7N2KPD7s9G1/iJmWHQxb1+Bjkg==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.0.1':
-    resolution: {integrity: sha512-ynV1gw4KqFtQ0P+ZZh76SUj49wBb2FuHW3zSmHverHWuxBhzvrZS6/dZ+fCFQG8bTTPtrPz0RQUTN3uEDbPVBQ==}
+  '@rspack/binding@2.0.2':
+    resolution: {integrity: sha512-0kZPplW9GWx8mfC6DfsaRY3QBIYPuUs42JfmSM6aSb8tMHZAXQeLeMB8M+h8i4SeI+aFtCgO6UuYGtyWf7+L+A==}
 
-  '@rspack/core@2.0.1':
-    resolution: {integrity: sha512-lgfZiExh8kDR/3obgi3RQKwKG5av1Xf5qDN1aVde777W9pbmx0Pqvrww1qtNvJ+gobEjbrrn5HEZWYGe0VLmcA==}
+  '@rspack/core@2.0.2':
+    resolution: {integrity: sha512-VM3UHOo26uC+4QSqY5tU1ybI7KuXY5rTof8nhFOaBY9SYau0Smvr+hMSAPmrmHwknB6dXT8yaNVxrj7I+qxE1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -7876,7 +7876,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)':
+  '@module-federation/enhanced@2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.4.0(node-fetch@2.7.0)
       '@module-federation/cli': 2.4.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
@@ -7885,7 +7885,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.4.0(@module-federation/runtime-tools@2.4.0)
       '@module-federation/managers': 2.4.0(node-fetch@2.7.0)
       '@module-federation/manifest': 2.4.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
-      '@module-federation/rspack': 2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
+      '@module-federation/rspack': 2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
       '@module-federation/runtime-tools': 2.4.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.4.0(node-fetch@2.7.0)
@@ -7901,7 +7901,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)':
+  '@module-federation/enhanced@2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.4.0(node-fetch@2.7.0)
       '@module-federation/cli': 2.4.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
@@ -7910,7 +7910,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.4.0(@module-federation/runtime-tools@2.4.0)
       '@module-federation/managers': 2.4.0(node-fetch@2.7.0)
       '@module-federation/manifest': 2.4.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
-      '@module-federation/rspack': 2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+      '@module-federation/rspack': 2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@module-federation/runtime-tools': 2.4.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.4.0(node-fetch@2.7.0)
@@ -7965,9 +7965,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.42(@rspack/core@2.0.1)(typescript@5.9.3)(vue-tsc@3.2.7)':
+  '@module-federation/node@2.7.42(@rspack/core@2.0.2)(typescript@5.9.3)(vue-tsc@3.2.7)':
     dependencies:
-      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
+      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
       '@module-federation/runtime': 2.4.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -7980,9 +7980,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.42(@rspack/core@2.0.1)(typescript@6.0.3)(vue-tsc@3.2.7)':
+  '@module-federation/node@2.7.42(@rspack/core@2.0.2)(typescript@6.0.3)(vue-tsc@3.2.7)':
     dependencies:
-      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@module-federation/runtime': 2.4.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -7997,7 +7997,7 @@ snapshots:
 
   '@module-federation/node@2.7.42(typescript@6.0.3)(vue-tsc@3.2.7)':
     dependencies:
-      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@module-federation/runtime': 2.4.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -8010,13 +8010,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.4.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)':
+  '@module-federation/rsbuild-plugin@2.4.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)':
     dependencies:
-      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
-      '@module-federation/node': 2.7.42(@rspack/core@2.0.1)(typescript@5.9.3)(vue-tsc@3.2.7)
+      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
+      '@module-federation/node': 2.7.42(@rspack/core@2.0.2)(typescript@5.9.3)(vue-tsc@3.2.7)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8026,13 +8026,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.4.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)':
+  '@module-federation/rsbuild-plugin@2.4.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)':
     dependencies:
-      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
-      '@module-federation/node': 2.7.42(@rspack/core@2.0.1)(typescript@6.0.3)(vue-tsc@3.2.7)
+      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+      '@module-federation/node': 2.7.42(@rspack/core@2.0.2)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8042,13 +8042,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.4.0(@rsbuild/core@2.0.3)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)':
+  '@module-federation/rsbuild-plugin@2.4.0(@rsbuild/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)':
     dependencies:
-      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@module-federation/node': 2.7.42(typescript@6.0.3)(vue-tsc@3.2.7)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8058,7 +8058,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)':
+  '@module-federation/rspack@2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.4.0(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.4.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
@@ -8067,7 +8067,7 @@ snapshots:
       '@module-federation/manifest': 2.4.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.2.7)
       '@module-federation/runtime-tools': 2.4.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
-      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
     optionalDependencies:
       typescript: 5.9.3
       vue-tsc: 3.2.7(typescript@5.9.3)
@@ -8076,7 +8076,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/rspack@2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)':
+  '@module-federation/rspack@2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.4.0(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.4.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
@@ -8085,7 +8085,7 @@ snapshots:
       '@module-federation/manifest': 2.4.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@module-federation/runtime-tools': 2.4.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
-      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.2.7(typescript@6.0.3)
@@ -8120,12 +8120,12 @@ snapshots:
     optionalDependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 
-  '@module-federation/storybook-addon@6.0.11(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(node-fetch@2.7.0)(storybook@10.3.6)(typescript@6.0.3)(vue-tsc@3.2.7)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.11(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(node-fetch@2.7.0)(storybook@10.3.6)(typescript@6.0.3)(vue-tsc@3.2.7)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
+      '@module-federation/enhanced': 2.4.0(@rspack/core@2.0.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.2.7)
       '@module-federation/sdk': 2.4.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
       storybook: 10.3.6(prettier@3.8.3)(react-dom@19.2.5)(react@19.2.5)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -8340,14 +8340,14 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.4.0)':
+  '@rsbuild/core@2.0.5(@module-federation/runtime-tools@2.4.0)':
     dependencies:
-      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
       '@swc/helpers': 0.5.21
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.5)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -8356,23 +8356,23 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.6.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)':
+  '@rsbuild/plugin-less@1.6.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
-      less-loader: 12.3.2(@rspack/core@2.0.1)(less@4.6.4)
+      less-loader: 12.3.2(@rspack/core@2.0.2)(less@4.6.4)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.5)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -8398,29 +8398,29 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
 
-  '@rsbuild/plugin-preact@1.7.2(@rsbuild/core@2.0.3)(preact@10.29.1)':
+  '@rsbuild/plugin-preact@1.7.2(@rsbuild/core@2.0.5)(preact@10.29.1)':
     dependencies:
       '@prefresh/core': 1.5.9(preact@10.29.1)
       '@prefresh/utils': 1.2.1
       '@rspack/plugin-preact-refresh': 1.1.5(@prefresh/core@1.5.9)(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh': 12.7.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)':
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.1)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.2)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@2.0.5)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -8428,88 +8428,88 @@ snapshots:
       reduce-configs: 1.1.2
       sass-embedded: 1.99.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
 
-  '@rsbuild/plugin-solid@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.3)(solid-js@1.9.12)':
+  '@rsbuild/plugin-solid@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.5)(solid-js@1.9.12)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.3)
+      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.5)
       babel-preset-solid: 1.9.10(@babel/core@7.29.0)(solid-js@1.9.12)
       solid-refresh: 0.7.8(solid-js@1.9.12)
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@1.3.2(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)':
+  '@rsbuild/plugin-stylus@1.3.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)':
     dependencies:
       deepmerge: 4.3.1
       reduce-configs: 1.1.2
       stylus: 0.64.0
-      stylus-loader: 8.1.3(@rspack/core@2.0.1)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.0.2)(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-toml@2.0.0(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-toml@2.0.0(@rsbuild/core@2.0.5)':
     dependencies:
       toml: 4.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
 
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.1)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.2)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.5)':
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
 
-  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(vue@3.5.33)':
+  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(vue@3.5.33)':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@2.0.1)(vue@3.5.33)
+      rspack-vue-loader: 17.5.0(@rspack/core@2.0.2)(vue@3.5.33)
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@2.0.3)':
+  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@2.0.5)':
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
 
   '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
-      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.3)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
+      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.2.0)
       typescript: 6.0.3
@@ -8520,8 +8520,8 @@ snapshots:
 
   '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
-      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.3)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
+      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.2)
       typescript: 6.0.3
@@ -8532,8 +8532,8 @@ snapshots:
 
   '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
-      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.3)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
+      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.2)
       typescript: 6.0.3
@@ -8573,56 +8573,56 @@ snapshots:
   '@rslint/win32-x64@0.5.1':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.1':
+  '@rspack/binding-darwin-arm64@2.0.2':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.1':
+  '@rspack/binding-darwin-x64@2.0.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.1':
+  '@rspack/binding-linux-arm64-gnu@2.0.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.1':
+  '@rspack/binding-linux-arm64-musl@2.0.2':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.1':
+  '@rspack/binding-linux-x64-gnu@2.0.2':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.1':
+  '@rspack/binding-linux-x64-musl@2.0.2':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.0.1':
+  '@rspack/binding-wasm32-wasi@2.0.2':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.1':
+  '@rspack/binding-win32-arm64-msvc@2.0.2':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.1':
+  '@rspack/binding-win32-ia32-msvc@2.0.2':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.1':
+  '@rspack/binding-win32-x64-msvc@2.0.2':
     optional: true
 
-  '@rspack/binding@2.0.1':
+  '@rspack/binding@2.0.2':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.1
-      '@rspack/binding-darwin-x64': 2.0.1
-      '@rspack/binding-linux-arm64-gnu': 2.0.1
-      '@rspack/binding-linux-arm64-musl': 2.0.1
-      '@rspack/binding-linux-x64-gnu': 2.0.1
-      '@rspack/binding-linux-x64-musl': 2.0.1
-      '@rspack/binding-wasm32-wasi': 2.0.1
-      '@rspack/binding-win32-arm64-msvc': 2.0.1
-      '@rspack/binding-win32-ia32-msvc': 2.0.1
-      '@rspack/binding-win32-x64-msvc': 2.0.1
+      '@rspack/binding-darwin-arm64': 2.0.2
+      '@rspack/binding-darwin-x64': 2.0.2
+      '@rspack/binding-linux-arm64-gnu': 2.0.2
+      '@rspack/binding-linux-arm64-musl': 2.0.2
+      '@rspack/binding-linux-x64-gnu': 2.0.2
+      '@rspack/binding-linux-x64-musl': 2.0.2
+      '@rspack/binding-wasm32-wasi': 2.0.2
+      '@rspack/binding-win32-arm64-msvc': 2.0.2
+      '@rspack/binding-win32-ia32-msvc': 2.0.2
+      '@rspack/binding-win32-x64-msvc': 2.0.2
 
-  '@rspack/core@2.0.1(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)':
+  '@rspack/core@2.0.2(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)':
     dependencies:
-      '@rspack/binding': 2.0.1
+      '@rspack/binding': 2.0.2
     optionalDependencies:
       '@module-federation/runtime-tools': 2.4.0(node-fetch@2.7.0)
       '@swc/helpers': 0.5.21
@@ -8634,18 +8634,18 @@ snapshots:
       '@prefresh/core': 1.5.9(preact@10.29.1)
       '@prefresh/utils': 1.2.1
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.1)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.2)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
 
-  '@rspress/core@2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.2)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)
       '@rspress/shared': 2.0.10(@module-federation/runtime-tools@2.4.0)
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -8694,7 +8694,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.2
       '@docsearch/react': 4.6.2(@types/react@19.2.14)(react-dom@19.2.5)(react@19.2.5)
-      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.2)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -8705,7 +8705,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.10(@rspress/core@2.0.10)':
     dependencies:
-      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.2)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       remark-mdx: 3.1.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -8716,17 +8716,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.10(@rspress/core@2.0.10)':
     dependencies:
-      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.2)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.10(@rspress/core@2.0.10)':
     dependencies:
-      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.2)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rspress/plugin-twoslash@2.0.10(@rspress/core@2.0.10)(react@19.2.5)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.2)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@shikijs/twoslash': 4.0.2(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3
       mdast-util-gfm: 3.1.0
@@ -8740,7 +8740,7 @@ snapshots:
 
   '@rspress/shared@2.0.10(@module-federation/runtime-tools@2.4.0)':
     dependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@shikijs/rehype': 4.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -8758,7 +8758,7 @@ snapshots:
 
   '@rstest/core@0.9.10':
     dependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@types/chai': 5.2.3
       tinypool: 2.1.0
     transitivePeerDependencies:
@@ -11073,11 +11073,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.2(@rspack/core@2.0.1)(less@4.6.4):
+  less-loader@12.3.2(@rspack/core@2.0.2)(less@4.6.4):
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
 
   less@4.6.4:
     dependencies:
@@ -12627,58 +12627,58 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.3)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.2.0)
       '@typescript/native-preview': 7.0.0-dev.20260503.1
       typescript: 6.0.3
 
-  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.3)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.2)
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.3):
+  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.5):
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.3):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.5):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
 
-  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.3):
+  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.5):
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
 
-  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.3):
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.5):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.17
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
 
   rslog@2.1.1: {}
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.0.1)(vue@3.5.33):
+  rspack-vue-loader@17.5.0(@rspack/core@2.0.2)(vue@3.5.33):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
       vue: 3.5.33(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.10):
     dependencies:
-      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.2)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -12703,14 +12703,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.10):
     dependencies:
-      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.2)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.10)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.10):
     dependencies:
-      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.1)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.10(@module-federation/runtime-tools@2.4.0)(@rspack/core@2.0.2)(@types/mdast@4.0.4)(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   run-applescript@7.1.0: {}
 
@@ -13032,18 +13032,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.3.3(@rsbuild/core@2.0.3)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.3)(typescript@6.0.3):
+  storybook-addon-rslib@3.3.3(@rsbuild/core@2.0.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.3)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -13055,7 +13055,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.3)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.5)
       sirv: 2.0.4
       storybook: 10.3.6(prettier@3.8.3)(react-dom@19.2.5)(react@19.2.5)
       ts-dedent: 2.2.0
@@ -13071,10 +13071,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(react-dom@19.2.5)(react@19.2.5)(rollup@4.59.0)(storybook@10.3.6)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(react-dom@19.2.5)(react@19.2.5)(rollup@4.59.0)(storybook@10.3.6)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@storybook/react': 10.3.6(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)
       find-up: 5.0.0
@@ -13085,7 +13085,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       resolve: 1.22.11
       storybook: 10.3.6(prettier@3.8.3)(react-dom@19.2.5)(react@19.2.5)
-      storybook-builder-rsbuild: 3.3.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -13097,12 +13097,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)(vue@3.5.33):
+  storybook-vue3-rsbuild@3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)(vue@3.5.33):
     dependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.4.0)
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@storybook/vue3': 10.3.6(storybook@10.3.6)(vue@3.5.33)
       storybook: 10.3.6(prettier@3.8.3)(react-dom@19.2.5)(react@19.2.5)
-      storybook-builder-rsbuild: 3.3.3(@rsbuild/core@2.0.3)(@rspack/core@2.0.1)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.2)(react-dom@19.2.5)(react@19.2.5)(storybook@10.3.6)(typescript@6.0.3)
       vue: 3.5.33(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.33)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -13217,13 +13217,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.0.1)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.0.2)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
 
   stylus@0.64.0:
     dependencies:
@@ -13338,7 +13338,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.1)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.2)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
@@ -13346,7 +13346,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.2(@module-federation/runtime-tools@2.4.0)(@swc/helpers@0.5.21)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/integration/asset/__snapshots__/index.test.ts.snap
+++ b/tests/integration/asset/__snapshots__/index.test.ts.snap
@@ -82,8 +82,8 @@ var __webpack_require__ = {};
 var __webpack_exports__ = {};
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-    default: ()=>logo,
-    ReactComponent: ()=>SvgLogo
+    ReactComponent: ()=>SvgLogo,
+    default: ()=>logo
 });
 const jsx_runtime_namespaceObject = require("react/jsx-runtime");
 require("react");

--- a/tests/integration/bundle-false/__snapshots__/index.test.ts.snap
+++ b/tests/integration/bundle-false/__snapshots__/index.test.ts.snap
@@ -58,8 +58,8 @@ var __webpack_require__ = {};
 var __webpack_exports__ = {};
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-    default: ()=>logo,
-    ReactComponent: ()=>SvgLogo
+    ReactComponent: ()=>SvgLogo,
+    default: ()=>logo
 });
 const jsx_runtime_namespaceObject = require("react/jsx-runtime");
 require("react");

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@rsbuild/plugin-node-polyfill": "^1.4.4"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@rsbuild/plugin-node-polyfill": "^1.4.4"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,7 +16,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^2.4.0",
     "@playwright/test": "1.59.1",
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@rsbuild/plugin-less": "^1.6.3",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-sass": "^1.5.2",

--- a/tests/type-tests/resolution-bundler/package.json
+++ b/tests/type-tests/resolution-bundler/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "type-check": "node -e \"console.log('// TODO: Re-enable tsc --noEmit after upstream Rspack fixes missing hono types.')\""
+    "type-check": "tsc --noEmit"
   }
 }

--- a/tests/type-tests/resolution-nodenext/package.json
+++ b/tests/type-tests/resolution-nodenext/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "type-check": "node -e \"console.log('// TODO: Re-enable tsc --noEmit after upstream Rspack fixes missing hono types.')\""
+    "type-check": "tsc --noEmit"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.4.0",
-    "@rsbuild/core": "~2.0.3",
+    "@rsbuild/core": "~2.0.5",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-sass": "^1.5.2",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

This PR updates @rsbuild/core from ~2.0.3 to ~2.0.5 across Rslib packages, examples, tests, templates, and the website so the repo stays aligned with the latest Rsbuild patch release. It refreshes the pnpm lockfile and generated snapshots for the updated Rsbuild/Rspack output, re-enables the resolution type-check fixtures, and keeps related CI/docs maintenance tweaks in the same dependency update.

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.5

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).