### PR TITLE
chore(deps): update fast-uri to 3.1.2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "path-serializer": "0.6.0",
     "prebundle": "1.6.4",
     "rsbuild-plugin-publint": "^0.3.4",
-    "rslib": "npm:@rslib/core@0.21.3",
+    "rslib": "npm:@rslib/core@0.21.4",
     "rslog": "^2.1.1",
     "tinyglobby": "^0.2.16",
     "tsconfck": "3.1.6",

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^24.12.2",
     "fs-extra": "^11.3.4",
     "rsbuild-plugin-publint": "^0.3.4",
-    "rslib": "npm:@rslib/core@0.21.3",
+    "rslib": "npm:@rslib/core@0.21.4",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3"
   },

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -42,7 +42,7 @@
     "magic-string": "^0.30.21",
     "prebundle": "1.6.4",
     "rsbuild-plugin-publint": "^0.3.4",
-    "rslib": "npm:@rslib/core@0.21.3",
+    "rslib": "npm:@rslib/core@0.21.4",
     "tinyglobby": "^0.2.16",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^6.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 0.2.2(@rslib/core@0.21.4)(@rstest/core@0.9.10)(typescript@6.0.3)
       '@rstest/core':
         specifier: ^0.9.10
-        version: 0.9.10(@module-federation/runtime-tools@2.4.0)
+        version: 0.9.10
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -366,8 +366,8 @@ importers:
         specifier: ^0.3.4
         version: 0.3.4(@rsbuild/core@2.0.5)
       rslib:
-        specifier: npm:@rslib/core@0.21.3
-        version: '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)'
+        specifier: npm:@rslib/core@0.21.4
+        version: '@rslib/core@0.21.4(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)'
       rslog:
         specifier: ^2.1.1
         version: 2.1.1
@@ -403,8 +403,8 @@ importers:
         specifier: ^0.3.4
         version: 0.3.4(@rsbuild/core@2.0.5)
       rslib:
-        specifier: npm:@rslib/core@0.21.3
-        version: '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(typescript@6.0.3)'
+        specifier: npm:@rslib/core@0.21.4
+        version: '@rslib/core@0.21.4(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(typescript@6.0.3)'
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -440,8 +440,8 @@ importers:
         specifier: ^0.3.4
         version: 0.3.4(@rsbuild/core@2.0.5)
       rslib:
-        specifier: npm:@rslib/core@0.21.3
-        version: '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)'
+        specifier: npm:@rslib/core@0.21.4
+        version: '@rslib/core@0.21.4(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)'
       tinyglobby:
         specifier: ^0.2.16
         version: 0.2.16
@@ -2542,19 +2542,6 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@0.21.3':
-    resolution: {integrity: sha512-3kyF273GQWIky4rAGD+Nkewlc7OraRwM2rG6wMJ19cYeomN0OKokVbk0vvfLAcQu43mtEO+dnZk6BchUoRmQOg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@microsoft/api-extractor': ^7
-      typescript: ^5 || ^6
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      typescript:
-        optional: true
-
   '@rslib/core@0.21.4':
     resolution: {integrity: sha512-lGQ3znngCmzYaIbPZcfEm4t+fGhSM4os1GKwXaLydUOB2mf3Q/MDffpEkuMtbzrW+PmAGJ8NIbjgipXd9mlcsg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3289,6 +3276,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/react@2.1.13':
     resolution: {integrity: sha512-gC48tNJ0UtbithkiKCc2WUlxbVVk5o171EtruS2w2hQUblfYFHzCPu2hljjT1e0tUHXXqN8EMv7mpxHddMB2sg==}
@@ -4335,15 +4323,6 @@ packages:
   focus-lock@1.3.5:
     resolution: {integrity: sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==}
     engines: {node: '>=10'}
-
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -6016,22 +5995,6 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
-
-  rsbuild-plugin-dts@0.21.3:
-    resolution: {integrity: sha512-8E3/npwRp99gc/Bl5bE1KKN5eIS2TQ3fuA7fBEk67R1RF7V4OtFKVI7mhk3X8zoH/9cclV9v909dguegZDgncw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@microsoft/api-extractor': ^7
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-      '@typescript/native-preview': 7.x
-      typescript: ^5 || ^6
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      '@typescript/native-preview':
-        optional: true
-      typescript:
-        optional: true
 
   rsbuild-plugin-dts@0.21.4:
     resolution: {integrity: sha512-hqXzk3pQFcbviCZNECxIZsH8ygyf9F9n3UZWHpjcAZmYeH5wLPsGqa6CyXWh4+EDXkO++7iXTVuIuw2x2hGn/w==}
@@ -8535,10 +8498,10 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
 
-  '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)':
+  '@rslib/core@0.21.4(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
-      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.21.4(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.2.0)
       typescript: 6.0.3
@@ -8547,10 +8510,10 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(typescript@6.0.3)':
+  '@rslib/core@0.21.4(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
-      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.21.4(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.2)
       typescript: 6.0.3
@@ -8559,7 +8522,7 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rslib/core@0.21.4(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(typescript@6.0.3)':
+  '@rslib/core@0.21.4(@microsoft/api-extractor@7.58.7)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
       rsbuild-plugin-dts: 0.21.4(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3)
@@ -8780,12 +8743,12 @@ snapshots:
 
   '@rstest/adapter-rslib@0.2.2(@rslib/core@0.21.4)(@rstest/core@0.9.10)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 0.21.4(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(typescript@6.0.3)
-      '@rstest/core': 0.9.10(@module-federation/runtime-tools@2.4.0)
+      '@rslib/core': 0.21.4(@microsoft/api-extractor@7.58.7)(typescript@6.0.3)
+      '@rstest/core': 0.9.10
     optionalDependencies:
       typescript: 6.0.3
 
-  '@rstest/core@0.9.10(@module-federation/runtime-tools@2.4.0)':
+  '@rstest/core@0.9.10':
     dependencies:
       '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@types/chai': 5.2.3
@@ -10534,8 +10497,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  follow-redirects@1.15.11: {}
-
   follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
@@ -10852,7 +10813,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -12656,21 +12617,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.4(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(@typescript/native-preview@7.0.0-dev.20260503.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.2.0)
       '@typescript/native-preview': 7.0.0-dev.20260503.1
-      typescript: 6.0.3
-
-  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3):
-    dependencies:
-      '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.58.7(@types/node@24.12.2)
       typescript: 6.0.3
 
   rsbuild-plugin-dts@0.21.4(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,10 +14,10 @@ importers:
         version: 0.5.1(jiti@2.6.1)
       '@rstest/adapter-rslib':
         specifier: ^0.2.2
-        version: 0.2.2(@rslib/core@0.21.3)(@rstest/core@0.9.10)(typescript@6.0.3)
+        version: 0.2.2(@rslib/core@0.21.4)(@rstest/core@0.9.10)(typescript@6.0.3)
       '@rstest/core':
         specifier: ^0.9.10
-        version: 0.9.10
+        version: 0.9.10(@module-federation/runtime-tools@2.4.0)
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -2555,6 +2555,19 @@ packages:
       typescript:
         optional: true
 
+  '@rslib/core@0.21.4':
+    resolution: {integrity: sha512-lGQ3znngCmzYaIbPZcfEm4t+fGhSM4os1GKwXaLydUOB2mf3Q/MDffpEkuMtbzrW+PmAGJ8NIbjgipXd9mlcsg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      typescript:
+        optional: true
+
   '@rslint/core@0.5.1':
     resolution: {integrity: sha512-UGcalhkpNvm4zN7E2DiQsuwM10LMi3CazOiANVevf5hn+NB7WKEMWYKn3bFySptg7Ll042IKMUlIXaFQjWs9lQ==}
     hasBin: true
@@ -4241,8 +4254,8 @@ packages:
   fast-json-parse@1.0.3:
     resolution: {integrity: sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -6006,6 +6019,22 @@ packages:
 
   rsbuild-plugin-dts@0.21.3:
     resolution: {integrity: sha512-8E3/npwRp99gc/Bl5bE1KKN5eIS2TQ3fuA7fBEk67R1RF7V4OtFKVI7mhk3X8zoH/9cclV9v909dguegZDgncw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+      '@typescript/native-preview': 7.x
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+
+  rsbuild-plugin-dts@0.21.4:
+    resolution: {integrity: sha512-hqXzk3pQFcbviCZNECxIZsH8ygyf9F9n3UZWHpjcAZmYeH5wLPsGqa6CyXWh4+EDXkO++7iXTVuIuw2x2hGn/w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -8530,10 +8559,10 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7)(typescript@6.0.3)':
+  '@rslib/core@0.21.4(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
-      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.21.4(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.2)
       typescript: 6.0.3
@@ -8749,14 +8778,14 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.13.3': {}
 
-  '@rstest/adapter-rslib@0.2.2(@rslib/core@0.21.3)(@rstest/core@0.9.10)(typescript@6.0.3)':
+  '@rstest/adapter-rslib@0.2.2(@rslib/core@0.21.4)(@rstest/core@0.9.10)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 0.21.3(@microsoft/api-extractor@7.58.7)(typescript@6.0.3)
-      '@rstest/core': 0.9.10
+      '@rslib/core': 0.21.4(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.4.0)(typescript@6.0.3)
+      '@rstest/core': 0.9.10(@module-federation/runtime-tools@2.4.0)
     optionalDependencies:
       typescript: 6.0.3
 
-  '@rstest/core@0.9.10':
+  '@rstest/core@0.9.10(@module-federation/runtime-tools@2.4.0)':
     dependencies:
       '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
       '@types/chai': 5.2.3
@@ -9514,7 +9543,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10419,7 +10448,7 @@ snapshots:
 
   fast-json-parse@1.0.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.17.1:
     dependencies:
@@ -12637,6 +12666,14 @@ snapshots:
       typescript: 6.0.3
 
   rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.7(@types/node@24.12.2)
+      typescript: 6.0.3
+
+  rsbuild-plugin-dts@0.21.4(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.5)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.5(@module-federation/runtime-tools@2.4.0)

--- a/website/docs/en/guide/solution/react.mdx
+++ b/website/docs/en/guide/solution/react.mdx
@@ -190,7 +190,7 @@ The `include` pattern uses `/\.[jt]sx?$/` to match `.js`, `.jsx`, `.ts`, and `.t
 If you only want to compile JSX/TSX files, you can use `include: /\.(?:jsx|tsx)$/` instead, but custom hooks in `.ts` files will not be optimized.
 :::
 
-> You can also refer to the [example project](https://github.com/rstackjs/rstack-examples/tree/main/rslib/react-compiler-babel).
+> You can also refer to the [example project](https://github.com/rstackjs/rstack-examples/tree/main/rslib/react-compiler).
 
 ### Configuration
 

--- a/website/docs/zh/guide/solution/react.mdx
+++ b/website/docs/zh/guide/solution/react.mdx
@@ -190,7 +190,7 @@ export default defineConfig({
 如果你只想编译 JSX/TSX 文件，可以使用 `include: /\.(?:jsx|tsx)$/`，但 `.ts` 文件中的自定义 Hooks 将不会被优化。
 :::
 
-> 你也可以参考 [示例项目](https://github.com/rstackjs/rstack-examples/tree/main/rslib/react-compiler-babel)。
+> 你也可以参考 [示例项目](https://github.com/rstackjs/rstack-examples/tree/main/rslib/react-compiler)。
 
 ### 配置
 


### PR DESCRIPTION
## Summary

This PR refreshes the lockfile to apply the Dependabot security dependency resolution, updating the transitive `fast-uri` package from `3.1.0` to `3.1.2`. It also refreshes the related `@rstest/adapter-rslib` peer dependency graph in `pnpm-lock.yaml` without changing package manifests.

## Related Links

https://github.com/web-infra-dev/rslib/security/dependabot

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
