### PR TITLE
chore: tighten pnpm workspace install settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,13 +8,27 @@ packages:
   - '!**/compile/**'
   - '!**/dist-types/**'
 
-onlyBuiltDependencies:
-  - 'core-js'
-  - 'core-js-pure'
-  - 'esbuild'
-  - 'simple-git-hooks'
+allowBuilds:
+  core-js-pure: false
+  esbuild: true
+  simple-git-hooks: false
+
+autoInstallPeers: false
+dedupePeers: true
+hoistPattern: []
+
+# Reduce the risk of installing compromised packages
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@rspack/*'
+  - '@rsbuild/*'
+  - '@rslib/*'
+  - '@rspress/*'
+  - '@rstest/*'
+  - '@rsdoctor/*'
+  - '@rslint/*'
+
+# Prevent un-reviewed build scripts
+strictDepBuilds: true
 
 strictPeerDependencies: false
-autoInstallPeers: false
-hoistPattern: []
-dedupePeers: true


### PR DESCRIPTION
## Summary

This PR updates the pnpm workspace install policy to reduce supply-chain risk by requiring reviewed dependency build scripts and delaying newly published package versions before installation. It also migrates build-script handling from `onlyBuiltDependencies` to `allowBuilds` while keeping `esbuild` allowed.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).