### PR TITLE
fix(core): set iife chunk output defaults

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -710,9 +710,11 @@ const composeFormatConfig = ({
             output: {
               iife: true,
               asyncChunks: false,
+              chunkFormat: false,
               library: {
                 type: 'module',
               },
+              chunkLoading: 'import',
             },
             optimization: {
               nodeEnv: process.env.NODE_ENV,

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -2558,6 +2558,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     webassemblyModuleFilename: 'static/wasm/[contenthash:10].module.wasm',
     iife: true,
     asyncChunks: false,
+    chunkFormat: false,
+    chunkLoading: 'import',
     globalObject: 'globalThis'
   },
   resolve: {
@@ -4683,6 +4685,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           },
           "output": {
             "asyncChunks": false,
+            "chunkFormat": false,
+            "chunkLoading": "import",
             "iife": true,
             "library": {
               "type": "module",


### PR DESCRIPTION
## Summary

This PR fixes Rspack v2 compatibility for Rslib's IIFE format by explicitly setting the chunk output defaults that ESM-style module library output requires. IIFE builds now set `chunkFormat: false` and `chunkLoading: 'import'`, matching the expected runtime behavior when `library.type` is `module` and avoiding Rspack's default chunk format inference failure for Node targets.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
