### PR TITLE
chore: update renovate security config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
     'config:recommended',
     'schedule:weekly',
     'helpers:pinGitHubActionDigests',
+    'github>rstackjs/renovate:security',
   ],
   packageRules: [
     // Use chore as semantic commit type for commit messages


### PR DESCRIPTION
## Summary

This PR enables the shared Renovate security preset so security-related dependency updates follow the central Rstack Renovate configuration.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).