### PR TITLE
chore: exclude rsbuild-plugin-dts from release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ minimumReleaseAgeExclude:
   - '@rstest/*'
   - '@rsdoctor/*'
   - '@rslint/*'
+  - rsbuild-plugin-dts
 
 # Prevent un-reviewed build scripts
 strictDepBuilds: true


### PR DESCRIPTION
## Summary

This PR excludes `rsbuild-plugin-dts` from pnpm's minimum release age check so this first-party package is not delayed by the workspace supply-chain freshness gate.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).