### PR TITLE
fix(dts): preserve explicit module extensions

### DIFF
--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -469,9 +469,38 @@ export async function redirectDtsImports(
       if (ext) {
         if (JS_EXTENSIONS_PATTERN.test(redirectImportPath)) {
           if (redirect.extension) {
+            let redirectJsExtension = jsExtension;
+            const pathWithoutExtension = redirectImportPath.replace(
+              /\.[^.]+$/,
+              '',
+            );
+            let importDtsExtension: '.d.mts' | '.d.cts' | undefined;
+
+            // A source may explicitly import './foo.mjs' while foo is emitted
+            // as foo.d.mts. In that case, keep the module-kind extension instead
+            // of blindly using the current declaration file's JS extension.
+            if (['.mjs', '.mjsx', '.mts', '.mtsx'].includes(ext)) {
+              importDtsExtension = '.d.mts';
+            } else if (['.cjs', '.cjsx', '.cts', '.ctsx'].includes(ext)) {
+              importDtsExtension = '.d.cts';
+            }
+
+            if (
+              importDtsExtension &&
+              (await pathExists(
+                join(
+                  dirname(dtsFile),
+                  `${pathWithoutExtension}${importDtsExtension}`,
+                ),
+              ))
+            ) {
+              redirectJsExtension =
+                importDtsExtension === '.d.mts' ? '.mjs' : '.cjs';
+            }
+
             redirectImportPath = redirectImportPath.replace(
               /\.[^.]+$/,
-              jsExtension,
+              redirectJsExtension,
             );
           }
         } else {

--- a/tests/integration/redirect/dts.test.ts
+++ b/tests/integration/redirect/dts.test.ts
@@ -17,396 +17,412 @@ describe('dts redirect', () => {
 
   test('redirect.dts.path: true with redirect.dts.extension: false - default', async () => {
     expect(contents.esm0).toMatchInlineSnapshot(`
-    {
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/a.b/index.d.ts": "export declare const ab = "a.b";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/config.d.ts": "export * from './config/load';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/config/load.d.ts": "export declare const loadConfig: () => void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/foo/foo.d.ts": "import { logRequest } from '../logger';
-    import { logger } from '../../../../compile/prebundle-pkg';
-    import { logRequest as logRequest2 } from '../logger';
-    export { logRequest, logRequest2, logger };
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/foo/index.d.ts": "export type Barrel = string;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/index.d.ts": "import { logRequest } from './logger';
-    import { logger } from '../../../compile/prebundle-pkg';
-    import type { Baz } from './';
-    import type { LoggerOptions } from './types';
-    import { defaultOptions } from './types.js';
-    type sources = typeof import('./logger');
-    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
-    export * from './foo';
-    export * from './logger';
-    export type { Foo } from './types';
-    export type { TypesValue } from '../../../compile/types-pkg/types';
-    export { Router } from 'express';
-    export * from '../../../compile/prebundle-pkg';
-    export type { Bar } from './types';
-    export * from './.hidden';
-    export * from './.hidden-folder';
-    export * from './a.b';
-    export * from './bar.baz';
-    export * from './config';
-    export * from './foo';
-    export * from './types';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/logger.d.ts": "import type { Request } from 'express';
-    import type { LoggerOptions } from './types';
-    export declare function logRequest(req: Request, options: LoggerOptions): void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/default/esm/types.d.ts": "export interface LoggerOptions {
-        logLevel: 'info' | 'debug' | 'warn' | 'error';
-        logBody: boolean;
-    }
-    export declare const defaultOptions: LoggerOptions;
-    export interface Foo {
-        foo: string;
-    }
-    export interface Bar {
-        bar: string;
-    }
-    export interface Baz {
-        baz: string;
-    }
-    ",
-    }
-  `);
+      {
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/a.b/index.d.ts": "export declare const ab = "a.b";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/config.d.ts": "export * from './config/load';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/config/load.d.ts": "export declare const loadConfig: () => void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/foo/foo.d.ts": "import { logRequest } from '../logger';
+      import { logger } from '../../../../compile/prebundle-pkg';
+      import { logRequest as logRequest2 } from '../logger';
+      export { logRequest, logRequest2, logger };
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/foo/index.d.ts": "export type Barrel = string;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/index.d.ts": "import { logRequest } from './logger';
+      import { logger } from '../../../compile/prebundle-pkg';
+      import { fooMjs } from './foo.mjs';
+      import type { Baz } from './';
+      import type { LoggerOptions } from './types';
+      import { defaultOptions } from './types.js';
+      type sources = typeof import('./logger');
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
+      export * from './foo';
+      export * from './logger';
+      export type { Foo } from './types';
+      export type { TypesValue } from '../../../compile/types-pkg/types';
+      export { Router } from 'express';
+      export * from '../../../compile/prebundle-pkg';
+      export type { Bar } from './types';
+      export * from './.hidden';
+      export * from './.hidden-folder';
+      export * from './a.b';
+      export * from './bar.baz';
+      export * from './config';
+      export * from './foo';
+      export * from './types';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/logger.d.ts": "import type { Request } from 'express';
+      import type { LoggerOptions } from './types';
+      export declare function logRequest(req: Request, options: LoggerOptions): void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/types.d.ts": "export interface LoggerOptions {
+          logLevel: 'info' | 'debug' | 'warn' | 'error';
+          logBody: boolean;
+      }
+      export declare const defaultOptions: LoggerOptions;
+      export interface Foo {
+          foo: string;
+      }
+      export interface Bar {
+          bar: string;
+      }
+      export interface Baz {
+          baz: string;
+      }
+      ",
+      }
+    `);
   });
 
   test('redirect.dts.path: false with redirect.dts.extension: false', async () => {
     expect(contents.esm1).toMatchInlineSnapshot(`
-    {
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/a.b/index.d.ts": "export declare const ab = "a.b";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/config.d.ts": "export * from './config/load';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/config/load.d.ts": "export declare const loadConfig: () => void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/foo/foo.d.ts": "import { logRequest } from '@src/logger';
-    import { logger } from 'prebundle-pkg';
-    import { logRequest as logRequest2 } from '../logger';
-    export { logRequest, logRequest2, logger };
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/foo/index.d.ts": "export type Barrel = string;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/index.d.ts": "import { logRequest } from '@src/logger';
-    import { logger } from 'prebundle-pkg';
-    import type { Baz } from 'self-entry';
-    import type { LoggerOptions } from './types';
-    import { defaultOptions } from './types.js';
-    type sources = typeof import('@src/logger');
-    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
-    export * from '@src/foo';
-    export * from '@src/logger';
-    export type { Foo } from '@src/types';
-    export type { TypesValue } from 'types-pkg';
-    export { Router } from 'express';
-    export * from 'prebundle-pkg';
-    export type { Bar } from 'types';
-    export * from './.hidden';
-    export * from './.hidden-folder';
-    export * from './a.b';
-    export * from './bar.baz';
-    export * from './config';
-    export * from './foo';
-    export * from './types';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/logger.d.ts": "import type { Request } from 'express';
-    import type { LoggerOptions } from './types';
-    export declare function logRequest(req: Request, options: LoggerOptions): void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/types.d.ts": "export interface LoggerOptions {
-        logLevel: 'info' | 'debug' | 'warn' | 'error';
-        logBody: boolean;
-    }
-    export declare const defaultOptions: LoggerOptions;
-    export interface Foo {
-        foo: string;
-    }
-    export interface Bar {
-        bar: string;
-    }
-    export interface Baz {
-        baz: string;
-    }
-    ",
-    }
-  `);
+      {
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/a.b/index.d.ts": "export declare const ab = "a.b";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/config.d.ts": "export * from './config/load';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/config/load.d.ts": "export declare const loadConfig: () => void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/foo/foo.d.ts": "import { logRequest } from '@src/logger';
+      import { logger } from 'prebundle-pkg';
+      import { logRequest as logRequest2 } from '../logger';
+      export { logRequest, logRequest2, logger };
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/foo/index.d.ts": "export type Barrel = string;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/index.d.ts": "import { logRequest } from '@src/logger';
+      import { logger } from 'prebundle-pkg';
+      import { fooMjs } from './foo.mjs';
+      import type { Baz } from 'self-entry';
+      import type { LoggerOptions } from './types';
+      import { defaultOptions } from './types.js';
+      type sources = typeof import('@src/logger');
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
+      export * from '@src/foo';
+      export * from '@src/logger';
+      export type { Foo } from '@src/types';
+      export type { TypesValue } from 'types-pkg';
+      export { Router } from 'express';
+      export * from 'prebundle-pkg';
+      export type { Bar } from 'types';
+      export * from './.hidden';
+      export * from './.hidden-folder';
+      export * from './a.b';
+      export * from './bar.baz';
+      export * from './config';
+      export * from './foo';
+      export * from './types';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/logger.d.ts": "import type { Request } from 'express';
+      import type { LoggerOptions } from './types';
+      export declare function logRequest(req: Request, options: LoggerOptions): void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false/esm/types.d.ts": "export interface LoggerOptions {
+          logLevel: 'info' | 'debug' | 'warn' | 'error';
+          logBody: boolean;
+      }
+      export declare const defaultOptions: LoggerOptions;
+      export interface Foo {
+          foo: string;
+      }
+      export interface Bar {
+          bar: string;
+      }
+      export interface Baz {
+          baz: string;
+      }
+      ",
+      }
+    `);
   });
 
   test('redirect.dts.path: true with redirect.dts.extension: true', async () => {
     expect(contents.esm2).toMatchInlineSnapshot(`
-    {
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/a.b/index.d.ts": "export declare const ab = "a.b";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/config.d.ts": "export * from './config/load.js';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/config/load.d.ts": "export declare const loadConfig: () => void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/foo/foo.d.ts": "import { logRequest } from '../logger.js';
-    import { logger } from '../../../../compile/prebundle-pkg/index.js';
-    import { logRequest as logRequest2 } from '../logger.js';
-    export { logRequest, logRequest2, logger };
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/foo/index.d.ts": "export type Barrel = string;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/index.d.ts": "import { logRequest } from './logger.js';
-    import { logger } from '../../../compile/prebundle-pkg/index.js';
-    import type { Baz } from './index.js';
-    import type { LoggerOptions } from './types.js';
-    import { defaultOptions } from './types.js';
-    type sources = typeof import('./logger.js');
-    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
-    export * from './foo/index.js';
-    export * from './logger.js';
-    export type { Foo } from './types.js';
-    export type { TypesValue } from '../../../compile/types-pkg/types.js';
-    export { Router } from 'express';
-    export * from '../../../compile/prebundle-pkg/index.js';
-    export type { Bar } from './types.js';
-    export * from './.hidden.js';
-    export * from './.hidden-folder/index.js';
-    export * from './a.b/index.js';
-    export * from './bar.baz.js';
-    export * from './config.js';
-    export * from './foo/index.js';
-    export * from './types.js';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/logger.d.ts": "import type { Request } from 'express';
-    import type { LoggerOptions } from './types.js';
-    export declare function logRequest(req: Request, options: LoggerOptions): void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/types.d.ts": "export interface LoggerOptions {
-        logLevel: 'info' | 'debug' | 'warn' | 'error';
-        logBody: boolean;
-    }
-    export declare const defaultOptions: LoggerOptions;
-    export interface Foo {
-        foo: string;
-    }
-    export interface Bar {
-        bar: string;
-    }
-    export interface Baz {
-        baz: string;
-    }
-    ",
-    }
-  `);
+      {
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/a.b/index.d.ts": "export declare const ab = "a.b";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/config.d.ts": "export * from './config/load.js';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/config/load.d.ts": "export declare const loadConfig: () => void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/foo/foo.d.ts": "import { logRequest } from '../logger.js';
+      import { logger } from '../../../../compile/prebundle-pkg/index.js';
+      import { logRequest as logRequest2 } from '../logger.js';
+      export { logRequest, logRequest2, logger };
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/foo/index.d.ts": "export type Barrel = string;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/index.d.ts": "import { logRequest } from './logger.js';
+      import { logger } from '../../../compile/prebundle-pkg/index.js';
+      import { fooMjs } from './foo.mjs';
+      import type { Baz } from './index.js';
+      import type { LoggerOptions } from './types.js';
+      import { defaultOptions } from './types.js';
+      type sources = typeof import('./logger.js');
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
+      export * from './foo/index.js';
+      export * from './logger.js';
+      export type { Foo } from './types.js';
+      export type { TypesValue } from '../../../compile/types-pkg/types.js';
+      export { Router } from 'express';
+      export * from '../../../compile/prebundle-pkg/index.js';
+      export type { Bar } from './types.js';
+      export * from './.hidden.js';
+      export * from './.hidden-folder/index.js';
+      export * from './a.b/index.js';
+      export * from './bar.baz.js';
+      export * from './config.js';
+      export * from './foo/index.js';
+      export * from './types.js';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/logger.d.ts": "import type { Request } from 'express';
+      import type { LoggerOptions } from './types.js';
+      export declare function logRequest(req: Request, options: LoggerOptions): void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/types.d.ts": "export interface LoggerOptions {
+          logLevel: 'info' | 'debug' | 'warn' | 'error';
+          logBody: boolean;
+      }
+      export declare const defaultOptions: LoggerOptions;
+      export interface Foo {
+          foo: string;
+      }
+      export interface Bar {
+          bar: string;
+      }
+      export interface Baz {
+          baz: string;
+      }
+      ",
+      }
+    `);
   });
 
   test('redirect.dts.path: false with dts.redirect.extension: true', async () => {
     expect(contents.esm3).toMatchInlineSnapshot(`
-    {
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/a.b/index.d.ts": "export declare const ab = "a.b";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/config.d.ts": "export * from './config/load.js';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/config/load.d.ts": "export declare const loadConfig: () => void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/foo/foo.d.ts": "import { logRequest } from '@src/logger';
-    import { logger } from 'prebundle-pkg';
-    import { logRequest as logRequest2 } from '../logger.js';
-    export { logRequest, logRequest2, logger };
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/foo/index.d.ts": "export type Barrel = string;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/index.d.ts": "import { logRequest } from '@src/logger';
-    import { logger } from 'prebundle-pkg';
-    import type { Baz } from 'self-entry';
-    import type { LoggerOptions } from './types.js';
-    import { defaultOptions } from './types.js';
-    type sources = typeof import('@src/logger');
-    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
-    export * from '@src/foo';
-    export * from '@src/logger';
-    export type { Foo } from '@src/types';
-    export type { TypesValue } from 'types-pkg';
-    export { Router } from 'express';
-    export * from 'prebundle-pkg';
-    export type { Bar } from 'types';
-    export * from './.hidden.js';
-    export * from './.hidden-folder/index.js';
-    export * from './a.b/index.js';
-    export * from './bar.baz.js';
-    export * from './config.js';
-    export * from './foo/index.js';
-    export * from './types.js';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/logger.d.ts": "import type { Request } from 'express';
-    import type { LoggerOptions } from './types.js';
-    export declare function logRequest(req: Request, options: LoggerOptions): void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/types.d.ts": "export interface LoggerOptions {
-        logLevel: 'info' | 'debug' | 'warn' | 'error';
-        logBody: boolean;
-    }
-    export declare const defaultOptions: LoggerOptions;
-    export interface Foo {
-        foo: string;
-    }
-    export interface Bar {
-        bar: string;
-    }
-    export interface Baz {
-        baz: string;
-    }
-    ",
-    }
-  `);
+      {
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/a.b/index.d.ts": "export declare const ab = "a.b";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/config.d.ts": "export * from './config/load.js';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/config/load.d.ts": "export declare const loadConfig: () => void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/foo/foo.d.ts": "import { logRequest } from '@src/logger';
+      import { logger } from 'prebundle-pkg';
+      import { logRequest as logRequest2 } from '../logger.js';
+      export { logRequest, logRequest2, logger };
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/foo/index.d.ts": "export type Barrel = string;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/index.d.ts": "import { logRequest } from '@src/logger';
+      import { logger } from 'prebundle-pkg';
+      import { fooMjs } from './foo.mjs';
+      import type { Baz } from 'self-entry';
+      import type { LoggerOptions } from './types.js';
+      import { defaultOptions } from './types.js';
+      type sources = typeof import('@src/logger');
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
+      export * from '@src/foo';
+      export * from '@src/logger';
+      export type { Foo } from '@src/types';
+      export type { TypesValue } from 'types-pkg';
+      export { Router } from 'express';
+      export * from 'prebundle-pkg';
+      export type { Bar } from 'types';
+      export * from './.hidden.js';
+      export * from './.hidden-folder/index.js';
+      export * from './a.b/index.js';
+      export * from './bar.baz.js';
+      export * from './config.js';
+      export * from './foo/index.js';
+      export * from './types.js';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/logger.d.ts": "import type { Request } from 'express';
+      import type { LoggerOptions } from './types.js';
+      export declare function logRequest(req: Request, options: LoggerOptions): void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/path-false-extension-true/esm/types.d.ts": "export interface LoggerOptions {
+          logLevel: 'info' | 'debug' | 'warn' | 'error';
+          logBody: boolean;
+      }
+      export declare const defaultOptions: LoggerOptions;
+      export interface Foo {
+          foo: string;
+      }
+      export interface Bar {
+          bar: string;
+      }
+      export interface Baz {
+          baz: string;
+      }
+      ",
+      }
+    `);
   });
 
   test('redirect.dts.extension: true with dts.autoExtension: true', async () => {
     expect(contents.esm4).toMatchInlineSnapshot(`
-    {
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden-folder/index.d.mts": "export declare const hiddenFolder = "This is a hidden folder";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden.d.mts": "export declare const hidden = "This is a hidden file";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/a.b/index.d.mts": "export declare const ab = "a.b";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/a.b/index.d.ts": "export declare const ab = "a.b";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/bar.baz.d.mts": "export declare const bar = "bar-baz";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/bar.baz.d.ts": "export declare const bar = "bar-baz";
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/config.d.mts": "export * from './config/load.mjs';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/config.d.ts": "export * from './config/load.js';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/config/load.d.mts": "export declare const loadConfig: () => void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/config/load.d.ts": "export declare const loadConfig: () => void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/foo.d.mts": "import { logRequest } from '../logger.mjs';
-    import { logger } from '../../../compile/prebundle-pkg/index.js';
-    import { logRequest as logRequest2 } from '../logger.mjs';
-    export { logRequest, logRequest2, logger };
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/foo.d.ts": "import { logRequest } from '../logger.js';
-    import { logger } from '../../../compile/prebundle-pkg/index.js';
-    import { logRequest as logRequest2 } from '../logger.js';
-    export { logRequest, logRequest2, logger };
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/index.d.mts": "export type Barrel = string;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/index.d.ts": "export type Barrel = string;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/index.d.mts": "import { logRequest } from './logger.mjs';
-    import { logger } from '../../compile/prebundle-pkg/index.js';
-    import type { Baz } from './index.mjs';
-    import type { LoggerOptions } from './types.mjs';
-    import { defaultOptions } from './types.mjs';
-    type sources = typeof import('./logger.mjs');
-    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
-    export * from './foo/index.mjs';
-    export * from './logger.mjs';
-    export type { Foo } from './types.mjs';
-    export type { TypesValue } from '../../compile/types-pkg/types.js';
-    export { Router } from 'express';
-    export * from '../../compile/prebundle-pkg/index.js';
-    export type { Bar } from './types.mjs';
-    export * from './.hidden.mjs';
-    export * from './.hidden-folder/index.mjs';
-    export * from './a.b/index.mjs';
-    export * from './bar.baz.mjs';
-    export * from './config.mjs';
-    export * from './foo/index.mjs';
-    export * from './types.mjs';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/index.d.ts": "import { logRequest } from './logger.js';
-    import { logger } from '../../compile/prebundle-pkg/index.js';
-    import type { Baz } from './index.js';
-    import type { LoggerOptions } from './types.js';
-    import { defaultOptions } from './types.js';
-    type sources = typeof import('./logger.js');
-    export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
-    export * from './foo/index.js';
-    export * from './logger.js';
-    export type { Foo } from './types.js';
-    export type { TypesValue } from '../../compile/types-pkg/types.js';
-    export { Router } from 'express';
-    export * from '../../compile/prebundle-pkg/index.js';
-    export type { Bar } from './types.js';
-    export * from './.hidden.js';
-    export * from './.hidden-folder/index.js';
-    export * from './a.b/index.js';
-    export * from './bar.baz.js';
-    export * from './config.js';
-    export * from './foo/index.js';
-    export * from './types.js';
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/logger.d.mts": "import type { Request } from 'express';
-    import type { LoggerOptions } from './types.mjs';
-    export declare function logRequest(req: Request, options: LoggerOptions): void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/logger.d.ts": "import type { Request } from 'express';
-    import type { LoggerOptions } from './types.js';
-    export declare function logRequest(req: Request, options: LoggerOptions): void;
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/types.d.mts": "export interface LoggerOptions {
-        logLevel: 'info' | 'debug' | 'warn' | 'error';
-        logBody: boolean;
-    }
-    export declare const defaultOptions: LoggerOptions;
-    export interface Foo {
-        foo: string;
-    }
-    export interface Bar {
-        bar: string;
-    }
-    export interface Baz {
-        baz: string;
-    }
-    ",
-      "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/types.d.ts": "export interface LoggerOptions {
-        logLevel: 'info' | 'debug' | 'warn' | 'error';
-        logBody: boolean;
-    }
-    export declare const defaultOptions: LoggerOptions;
-    export interface Foo {
-        foo: string;
-    }
-    export interface Bar {
-        bar: string;
-    }
-    export interface Baz {
-        baz: string;
-    }
-    ",
-    }
-  `);
+      {
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden-folder/index.d.mts": "export declare const hiddenFolder = "This is a hidden folder";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden.d.mts": "export declare const hidden = "This is a hidden file";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/a.b/index.d.mts": "export declare const ab = "a.b";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/a.b/index.d.ts": "export declare const ab = "a.b";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/bar.baz.d.mts": "export declare const bar = "bar-baz";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/bar.baz.d.ts": "export declare const bar = "bar-baz";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/config.d.mts": "export * from './config/load.mjs';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/config.d.ts": "export * from './config/load.js';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/config/load.d.mts": "export declare const loadConfig: () => void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/config/load.d.ts": "export declare const loadConfig: () => void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/foo.d.mts": "import { logRequest } from '../logger.mjs';
+      import { logger } from '../../../compile/prebundle-pkg/index.js';
+      import { logRequest as logRequest2 } from '../logger.mjs';
+      export { logRequest, logRequest2, logger };
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/foo.d.ts": "import { logRequest } from '../logger.js';
+      import { logger } from '../../../compile/prebundle-pkg/index.js';
+      import { logRequest as logRequest2 } from '../logger.js';
+      export { logRequest, logRequest2, logger };
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/index.d.mts": "export type Barrel = string;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/foo/index.d.ts": "export type Barrel = string;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/index.d.mts": "import { logRequest } from './logger.mjs';
+      import { logger } from '../../compile/prebundle-pkg/index.js';
+      import { fooMjs } from './foo.mjs';
+      import type { Baz } from './index.mjs';
+      import type { LoggerOptions } from './types.mjs';
+      import { defaultOptions } from './types.mjs';
+      type sources = typeof import('./logger.mjs');
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
+      export * from './foo/index.mjs';
+      export * from './logger.mjs';
+      export type { Foo } from './types.mjs';
+      export type { TypesValue } from '../../compile/types-pkg/types.js';
+      export { Router } from 'express';
+      export * from '../../compile/prebundle-pkg/index.js';
+      export type { Bar } from './types.mjs';
+      export * from './.hidden.mjs';
+      export * from './.hidden-folder/index.mjs';
+      export * from './a.b/index.mjs';
+      export * from './bar.baz.mjs';
+      export * from './config.mjs';
+      export * from './foo/index.mjs';
+      export * from './types.mjs';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/index.d.ts": "import { logRequest } from './logger.js';
+      import { logger } from '../../compile/prebundle-pkg/index.js';
+      import { fooMjs } from './foo.mjs';
+      import type { Baz } from './index.js';
+      import type { LoggerOptions } from './types.js';
+      import { defaultOptions } from './types.js';
+      type sources = typeof import('./logger.js');
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
+      export * from './foo/index.js';
+      export * from './logger.js';
+      export type { Foo } from './types.js';
+      export type { TypesValue } from '../../compile/types-pkg/types.js';
+      export { Router } from 'express';
+      export * from '../../compile/prebundle-pkg/index.js';
+      export type { Bar } from './types.js';
+      export * from './.hidden.js';
+      export * from './.hidden-folder/index.js';
+      export * from './a.b/index.js';
+      export * from './bar.baz.js';
+      export * from './config.js';
+      export * from './foo/index.js';
+      export * from './types.js';
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/logger.d.mts": "import type { Request } from 'express';
+      import type { LoggerOptions } from './types.mjs';
+      export declare function logRequest(req: Request, options: LoggerOptions): void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/logger.d.ts": "import type { Request } from 'express';
+      import type { LoggerOptions } from './types.js';
+      export declare function logRequest(req: Request, options: LoggerOptions): void;
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/types.d.mts": "export interface LoggerOptions {
+          logLevel: 'info' | 'debug' | 'warn' | 'error';
+          logBody: boolean;
+      }
+      export declare const defaultOptions: LoggerOptions;
+      export interface Foo {
+          foo: string;
+      }
+      export interface Bar {
+          bar: string;
+      }
+      export interface Baz {
+          baz: string;
+      }
+      ",
+        "<ROOT>/tests/integration/redirect/dts/dist/auto-extension-true/types.d.ts": "export interface LoggerOptions {
+          logLevel: 'info' | 'debug' | 'warn' | 'error';
+          logBody: boolean;
+      }
+      export declare const defaultOptions: LoggerOptions;
+      export interface Foo {
+          foo: string;
+      }
+      export interface Bar {
+          bar: string;
+      }
+      export interface Baz {
+          baz: string;
+      }
+      ",
+      }
+    `);
   });
 });

--- a/tests/integration/redirect/dts/src/foo.mts
+++ b/tests/integration/redirect/dts/src/foo.mts
@@ -1,0 +1,1 @@
+export const fooMjs = 'foo-mjs';

--- a/tests/integration/redirect/dts/src/index.ts
+++ b/tests/integration/redirect/dts/src/index.ts
@@ -1,5 +1,6 @@
 import { logRequest } from '@src/logger';
 import { logger } from 'prebundle-pkg';
+import { fooMjs } from './foo.mjs';
 import type { Baz } from 'self-entry';
 import type { LoggerOptions } from './types';
 import { defaultOptions } from './types.js';
@@ -11,6 +12,7 @@ export {
   type Baz as self,
   logRequest,
   logger,
+  fooMjs,
   type LoggerOptions,
   defaultOptions,
 };

--- a/tests/integration/redirect/dtsTsgo.test.ts
+++ b/tests/integration/redirect/dtsTsgo.test.ts
@@ -31,6 +31,8 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/foo/foo.d.ts": "import { logRequest } from '../logger';
       import { logger } from '../../../../compile/prebundle-pkg';
       import { logRequest as logRequest2 } from '../logger';
@@ -40,11 +42,12 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/index.d.ts": "import { logRequest } from './logger';
       import { logger } from '../../../compile/prebundle-pkg';
+      import { fooMjs } from './foo.mjs';
       import type { Baz } from './';
       import type { LoggerOptions } from './types';
       import { defaultOptions } from './types.js';
       type sources = typeof import('./logger');
-      export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
       export * from './foo';
       export * from './logger';
       export type { Foo } from './types';
@@ -98,6 +101,8 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/path-false/esm/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/path-false/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/path-false/esm/foo/foo.d.ts": "import { logRequest } from '@src/logger';
       import { logger } from 'prebundle-pkg';
       import { logRequest as logRequest2 } from '../logger';
@@ -107,11 +112,12 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/path-false/esm/index.d.ts": "import { logRequest } from '@src/logger';
       import { logger } from 'prebundle-pkg';
+      import { fooMjs } from './foo.mjs';
       import type { Baz } from 'self-entry';
       import type { LoggerOptions } from './types';
       import { defaultOptions } from './types.js';
       type sources = typeof import('@src/logger');
-      export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
       export * from '@src/foo';
       export * from '@src/logger';
       export type { Foo } from '@src/types';
@@ -165,6 +171,8 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/foo/foo.d.ts": "import { logRequest } from '../logger.js';
       import { logger } from '../../../../compile/prebundle-pkg/index.js';
       import { logRequest as logRequest2 } from '../logger.js';
@@ -174,11 +182,12 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/index.d.ts": "import { logRequest } from './logger.js';
       import { logger } from '../../../compile/prebundle-pkg/index.js';
+      import { fooMjs } from './foo.mjs';
       import type { Baz } from './index.js';
       import type { LoggerOptions } from './types.js';
       import { defaultOptions } from './types.js';
       type sources = typeof import('./logger.js');
-      export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
       export * from './foo/index.js';
       export * from './logger.js';
       export type { Foo } from './types.js';
@@ -232,6 +241,8 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/path-false-extension-true/esm/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/path-false-extension-true/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/path-false-extension-true/esm/foo/foo.d.ts": "import { logRequest } from '@src/logger';
       import { logger } from 'prebundle-pkg';
       import { logRequest as logRequest2 } from '../logger.js';
@@ -241,11 +252,12 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/path-false-extension-true/esm/index.d.ts": "import { logRequest } from '@src/logger';
       import { logger } from 'prebundle-pkg';
+      import { fooMjs } from './foo.mjs';
       import type { Baz } from 'self-entry';
       import type { LoggerOptions } from './types.js';
       import { defaultOptions } from './types.js';
       type sources = typeof import('@src/logger');
-      export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
       export * from '@src/foo';
       export * from '@src/logger';
       export type { Foo } from '@src/types';
@@ -299,6 +311,8 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/auto-extension-true/esm/config/load.d.mts": "export declare const loadConfig: () => void;
       ",
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/auto-extension-true/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/auto-extension-true/esm/foo/foo.d.mts": "import { logRequest } from '../logger.mjs';
       import { logger } from '../../../../compile/prebundle-pkg/index.js';
       import { logRequest as logRequest2 } from '../logger.mjs';
@@ -308,11 +322,12 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/auto-extension-true/esm/index.d.mts": "import { logRequest } from './logger.mjs';
       import { logger } from '../../../compile/prebundle-pkg/index.js';
+      import { fooMjs } from './foo.mjs';
       import type { Baz } from './index.mjs';
       import type { LoggerOptions } from './types.mjs';
       import { defaultOptions } from './types.mjs';
       type sources = typeof import('./logger.mjs');
-      export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
       export * from './foo/index.mjs';
       export * from './logger.mjs';
       export type { Foo } from './types.mjs';
@@ -363,6 +378,8 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/auto-extension-true/cjs/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/auto-extension-true/cjs/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+      ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/auto-extension-true/cjs/foo/foo.d.ts": "import { logRequest } from '../logger.js';
       import { logger } from '../../../../compile/prebundle-pkg/index.js';
       import { logRequest as logRequest2 } from '../logger.js';
@@ -372,11 +389,12 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/auto-extension-true/cjs/index.d.ts": "import { logRequest } from './logger.js';
       import { logger } from '../../../compile/prebundle-pkg/index.js';
+      import { fooMjs } from './foo.mjs';
       import type { Baz } from './index.js';
       import type { LoggerOptions } from './types.js';
       import { defaultOptions } from './types.js';
       type sources = typeof import('./logger.js');
-      export { sources, type Baz as self, logRequest, logger, type LoggerOptions, defaultOptions, };
+      export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
       export * from './foo/index.js';
       export * from './logger.js';
       export type { Foo } from './types.js';


### PR DESCRIPTION
## Summary

This PR fixes declaration import redirection for explicit module-kind specifiers. When source code imports a path like `./foo.mjs` and declaration emit produces `foo.d.mts`, `redirect.dts.extension` now preserves the `.mjs` specifier instead of rewriting it to the current declaration file's default JS extension.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).