### PR TITLE
chore: harden GitHub Actions permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,8 @@ on:
         required: true
         default: 'main'
 
+permissions: {}
+
 jobs:
   benchmark:
     runs-on: ubuntu-24.04
@@ -23,7 +25,7 @@ jobs:
         run: echo "TODO:\ Support benchmark in Rstest, this job is only a placeholder for the time being."
 
       # - name: Checkout
-      #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       #   with:
       #     fetch-depth: 10
       #     ref: ${{ inputs.ref || 'main' }}
@@ -34,7 +36,7 @@ jobs:
       #     corepack enable
 
       # - name: Setup Node.js ${{ matrix.node-version }}
-      #   uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      #   uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       #   with:
       #     node-version: ${{ matrix.node-version }}
       #     cache: 'pnpm'
@@ -44,7 +46,7 @@ jobs:
 
       # # only run benchmark in Ubuntu
       # - name: Benchmarks (Rstest)
-      #   uses: CodSpeedHQ/action@0010eb0ca6e89b80c88e8edaaa07cfe5f3e6664d # v3
+      #   uses: CodSpeedHQ/action@0010eb0ca6e89b80c88e8edaaa07cfe5f3e6664d # v3.5.0
       #   with:
       #     run: pnpm run test:benchmark
       #     # token retrieved from the CodSpeed app at the previous step

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -11,20 +11,19 @@ on:
         required: true
         default: 'main'
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   changes:
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rslib' && github.event_name != 'workflow_dispatch'
+    permissions:
+      contents: read
     outputs:
       changed: ${{ steps.changes.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -41,9 +40,13 @@ jobs:
     name: Dispatch ecosystem CI
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rslib' && github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@4949c44494d7fd3503abd791f11534c798a2a1d0 # main
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@ca8d345a115158ea5ab3807378357f2162be7467 # main
         with:
           github-token: ${{ secrets.REPO_RSLIB_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev
@@ -56,9 +59,11 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rslib' && github.event_name != 'workflow_dispatch' && needs.changes.outputs.changed == 'true'
+    permissions:
+      contents: read
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@4949c44494d7fd3503abd791f11534c798a2a1d0 # main
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@ca8d345a115158ea5ab3807378357f2162be7467 # main
         with:
           github-token: ${{ secrets.REPO_RSLIB_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,16 +9,17 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -28,10 +29,10 @@ jobs:
           corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+          package-manager-cache: false
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,17 +11,18 @@ on:
         required: true
         default: 'main'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   preview:
     if: github.repository == 'web-infra-dev/rslib'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ github.event.inputs.branch }}
@@ -41,10 +42,10 @@ jobs:
 
       - name: Setup Node.js
         if: steps.changes.outputs.changed == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+          package-manager-cache: false
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,7 @@ on:
         required: true
         default: 'main'
 
-permissions:
-  # Provenance generation in GitHub Actions requires "write" access to the "id-token"
-  id-token: write
+permissions: {}
 
 jobs:
   release:
@@ -29,9 +27,13 @@ jobs:
     if: github.repository == 'web-infra-dev/rslib' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: npm
+    permissions:
+      contents: read
+      # Provenance generation in GitHub Actions requires "write" access to the "id-token"
+      id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ github.event.inputs.branch }}
@@ -42,10 +44,10 @@ jobs:
           corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+          package-manager-cache: false
 
       # Update npm to the latest version to enable OIDC
       - name: Update npm

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -13,15 +13,16 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:
     runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -49,10 +50,10 @@ jobs:
 
       - name: Setup Node.js ${{ inputs.node-version }}
         if: ${{ steps.changes.outputs.changed == 'true' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: 'pnpm'
+          package-manager-cache: false
 
       - name: Install Dependencies
         if: ${{ steps.changes.outputs.changed == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,7 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   ut:
@@ -19,6 +18,8 @@ jobs:
         runner: [ubuntu-latest, windows-latest]
         node-version: [24]
     uses: ./.github/workflows/reusable-test.yml
+    permissions:
+      contents: read
     with:
       runner: ${{ matrix.runner }}
       node-version: ${{ matrix.node-version }}
@@ -31,6 +32,8 @@ jobs:
         node-version: [24]
 
     uses: ./.github/workflows/reusable-test.yml
+    permissions:
+      contents: read
     with:
       runner: ${{ matrix.runner }}
       node-version: ${{ matrix.node-version }}
@@ -43,6 +46,8 @@ jobs:
         node-version: ['25']
 
     uses: ./.github/workflows/reusable-test.yml
+    permissions:
+      contents: read
     with:
       runner: ${{ matrix.runner }}
       node-version: ${{ matrix.node-version }}
@@ -54,6 +59,8 @@ jobs:
         runner: [ubuntu-latest, windows-latest]
         node-version: [24]
     uses: ./.github/workflows/reusable-test.yml
+    permissions:
+      contents: read
     with:
       runner: ${{ matrix.runner }}
       node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary

- Scope GitHub Actions token permissions to `permissions: {}` at the workflow level and grant only the required permissions per job.
- Update the pinned ecosystem CI action commit while keeping external actions pinned to commit SHAs.
- Document exact action versions in comments and disable `setup-node` package-manager caching for pnpm workflows.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).