### PR TITLE
docs: fix rsbuild assetsInclude badge

### DIFF
--- a/website/docs/en/config/rsbuild/source.mdx
+++ b/website/docs/en/config/rsbuild/source.mdx
@@ -9,7 +9,7 @@ import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
 
 Options for input source code.
 
-## source.assetsInclude <RsbuildDocBadge path="/config/source/assets-include" text="source.include" />
+## source.assetsInclude <RsbuildDocBadge path="/config/source/assets-include" text="source.assetsInclude" />
 
 Include additional files that should be treated as static assets.
 

--- a/website/docs/zh/config/rsbuild/source.mdx
+++ b/website/docs/zh/config/rsbuild/source.mdx
@@ -8,7 +8,7 @@ import { RsbuildDocBadge } from '@components/RsbuildDocBadge';
 
 与输入的源代码相关的选项。
 
-## source.assetsInclude <RsbuildDocBadge path="/config/source/assets-include" text="source.include" />
+## source.assetsInclude <RsbuildDocBadge path="/config/source/assets-include" text="source.assetsInclude" />
 
 指定需要被视为静态资源的额外文件类型。
 


### PR DESCRIPTION
## Summary

This PR fixes the Rsbuild `source.assetsInclude` documentation badge so the linked option label matches the section heading in both English and Chinese docs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).