### PR TITLE
docs: fix stale Rsbuild doc links

### DIFF
--- a/website/docs/en/guide/basic/configure-rslib.mdx
+++ b/website/docs/en/guide/basic/configure-rslib.mdx
@@ -199,13 +199,13 @@ export default defineConfig({
 Rslib allows you to use most of the Rsbuild configurations. Currently, the `environments` config is not supported because it is generated internally by Rslib.
 
 - Refer to [Rsbuild Configuration](/config/rsbuild/) for common Rsbuild configurations.
-- Refer to [Rsbuild Documentation](https://rsbuild.rs/config/index#config-overview) for all Rsbuild configurations.
+- Refer to [Rsbuild Documentation](https://rsbuild.rs/config/) for all Rsbuild configurations.
 
 ## Configure Rspack
 
 Rslib is built on top of Rsbuild and Rsbuild supports directly modifying the Rspack configuration object and also supports modifying the built-in Rspack configuration of Rsbuild through `rspack-chain`. This means you can configure Rspack related configurations in an Rslib project as well.
 
-For more details, refer to [Configure Rspack](https://rsbuild.rs/guide/basic/configure-rspack).
+For more details, refer to [Configure Rspack](https://rsbuild.rs/guide/configuration/rspack).
 
 ## Debug mode
 

--- a/website/docs/zh/config/lib/id.mdx
+++ b/website/docs/zh/config/lib/id.mdx
@@ -11,7 +11,7 @@ description: '配置 lib.id，为不同库产物指定 ID，便于在 CLI 和 Ja
 
 :::tip
 
-Rslib 在底层使用了 Rsbuild 的 [environments](https://rsbuild.rs/guide/advanced/environments) 特性来在单个项目中构建多个库。`lib.id` 将被用作生成的 Rsbuild environment 的键名。
+Rslib 在底层使用了 Rsbuild 的 [environments](https://rsbuild.rs/zh/config/environments) 特性来在单个项目中构建多个库。`lib.id` 将被用作生成的 Rsbuild environment 的键名。
 
 :::
 

--- a/website/docs/zh/guide/basic/configure-rslib.mdx
+++ b/website/docs/zh/guide/basic/configure-rslib.mdx
@@ -83,7 +83,7 @@ Rslib 会在内部生成 Rsbuild 的 [environments](https://rsbuild.rs/zh/config
 
 我们推荐使用 `.mjs` 或 `.ts` 格式的配置文件，并从 `@rslib/core` 中导入 `defineConfig` 工具函数, 它提供了友好的 TypeScript 类型推导和自动补全，可以帮助你避免配置中的错误。
 
-比如在 `rslib.config.ts` 中，你可以定义 Rslib 的 [syntax](/config/lib/syntax) 配置和 Rsbuild 的 [output.target](https://rsbuild.rs/config/output/target#outputtarget) 配置：
+比如在 `rslib.config.ts` 中，你可以定义 Rslib 的 [syntax](/config/lib/syntax) 配置和 Rsbuild 的 [output.target](https://rsbuild.rs/zh/config/output/target#outputtarget) 配置：
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
@@ -199,13 +199,13 @@ export default defineConfig({
 Rslib 允许你使用绝大部分的 Rsbuild 配置。目前不支持使用 `environments` 配置，因为该字段会在 Rslib 内部生成。
 
 - 参考 [Rsbuild 配置](/config/rsbuild/) 了解常用的 Rsbuild 配置。
-- 参考 [Rsbuild 文档](https://rsbuild.rs/config/index#config-overview) 了解所有 Rsbuild 配置。
+- 参考 [Rsbuild 文档](https://rsbuild.rs/zh/config/) 了解所有 Rsbuild 配置。
 
 ## 配置 Rspack
 
 Rslib 基于 Rsbuild 构建，Rsbuild 支持直接修改 Rspack 配置对象，也支持通过 `rspack-chain` 修改 Rsbuild 内置的 Rspack 配置。这意味着你可以在 Rslib 项目中配置 Rspack 相关配置。
 
-详情请参考 [配置 Rspack](https://rsbuild.rs/guide/basic/configure-rspack)。
+详情请参考 [配置 Rspack](https://rsbuild.rs/zh/guide/configuration/rspack)。
 
 ## 调试模式
 

--- a/website/docs/zh/shared/components/MF.mdx
+++ b/website/docs/zh/shared/components/MF.mdx
@@ -1,3 +1,3 @@
 模块联邦是一种用于 JavaScript 应用程序分解的架构模式（类似于服务器端的微服务），允许你在多个 JavaScript 应用程序（或微前端）之间共享代码和资源。
 
-请参阅 [模块联邦](https://rsbuild.rs/guide/advanced/module-federation) 以获取更多详细信息。
+请参阅 [模块联邦](https://rsbuild.rs/zh/guide/advanced/module-federation) 以获取更多详细信息。


### PR DESCRIPTION
## Summary

This PR cleans up stale Rsbuild links in the Rslib docs.

- Fix links that now lead to 40x pages
- Replace links that return 30x redirects with their final URLs
- zh-CN docs should link to zh-CN docs