### PR TITLE
chore: restore Renovate workspace scanning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     'helpers:pinGitHubActionDigests',
     'github>rstackjs/renovate:security',
   ],
+  ignorePaths: ['**/node_modules/**'],
   packageRules: [
     // Use chore as semantic commit type for commit messages
     {


### PR DESCRIPTION
## Summary

Restore the explicit Renovate ignore path override so `config:recommended` no longer ignores package files under `examples/**` and `tests/**`. This keeps Renovate dependency updates aligned with the packages declared in `pnpm-workspace.yaml` while still ignoring `node_modules/**`.

## Related Links

https://github.com/web-infra-dev/rslib/pull/1627

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).