### PR TITLE
chore(deps): upgrade pnpm to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "simple-git-hooks": "^2.13.1",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.4.0",
   "engines": {
     "node": "^20.19.0 || >=22.12.0",
-    "pnpm": ">=10.33.4"
+    "pnpm": ">=11.4.0"
   }
 }

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -18,7 +18,8 @@
     "create-rslib": "./dist/index.js"
   },
   "files": [
-    "template-*",
+    "template-*/**",
+    "template-*/**/.*",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary

Upgrade pnpm from 10.33.4 to 11.4.0 so the repo uses the latest pnpm v11 release. This also updates the `create-rslib` package `files` list to include nested template contents and dotfile directories, which avoids pnpm 11 publish/pack behavior omitting the generated templates.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/7767
- https://github.com/pnpm/pnpm/releases/tag/v11.4.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
