### PR TITLE
chore(vscode): sort TypeScript imports on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,16 @@
   },
   "mdx.validate.validateFileLinks": "ignore",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.codeActionsOnSave": {
+      "source.sortImports": "always"
+    }
+  },
+  "[typescriptreact]": {
+    "editor.codeActionsOnSave": {
+      "source.sortImports": "always"
+    }
+  },
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "json.schemas": [
     {


### PR DESCRIPTION
## Summary

This PR configures VS Code to sort TypeScript imports on save for TypeScript and TSX files, keeping editor behavior consistent without affecting other file types.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).