### PR TITLE
chore(deps): upgrade rsbuild to 2.0.8

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.0",
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -22,7 +22,7 @@
     "@module-federation/enhanced": "^2.5.0",
     "@module-federation/rsbuild-plugin": "^2.5.0",
     "@module-federation/storybook-addon": "^6.0.12",
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.4.1",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.0",
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@rsbuild/plugin-vue": "^1.2.8",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.4.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "test": "rstest"
   },
   "dependencies": {
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@storybook/addon-docs": "^10.4.1",
     "@storybook/addon-onboarding": "^10.4.1",
     "@storybook/react": "^10.4.1",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@storybook/addon-docs": "^10.4.1",
     "@storybook/addon-onboarding": "^10.4.1",
     "@storybook/react": "^10.4.1",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@storybook/addon-docs": "^10.4.1",
     "@storybook/addon-onboarding": "^10.4.1",
     "@storybook/vue3": "^10.4.1",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@storybook/addon-docs": "^10.4.1",
     "@storybook/addon-onboarding": "^10.4.1",
     "@storybook/vue3": "^10.4.1",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.7",
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@rslib/tsconfig": "workspace:*",
     "@typescript/native-preview": "7.0.0-dev.20260523.1",
     "magic-string": "^0.30.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 0.10.2(@rslib/core@0.21.5)(@rstest/core@0.10.2)(typescript@6.0.3)
       '@rstest/core':
         specifier: ^0.10.2
-        version: 0.10.2
+        version: 0.10.2(@module-federation/runtime-tools@2.5.0)
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -80,13 +80,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+        version: 2.5.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@rsbuild/core':
-        specifier: ~2.0.7
-        version: 2.0.7(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.8
+        version: 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -101,19 +101,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.5.0
-        version: 2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+        version: 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+        version: 2.5.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@module-federation/storybook-addon':
         specifier: ^6.0.12
-        version: 6.0.12(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.1)(webpack-virtual-modules@0.6.2)
+        version: 6.0.12(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.1)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
-        specifier: ~2.0.7
-        version: 2.0.7(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.8
+        version: 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -143,10 +143,10 @@ importers:
         version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.7)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.0.8)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.59.0)(storybook@10.4.1)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.59.0)(storybook@10.4.1)(typescript@6.0.3)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -159,13 +159,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+        version: 2.5.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@rsbuild/core':
-        specifier: ~2.0.7
-        version: 2.0.7(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.8
+        version: 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -180,10 +180,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.7.2
-        version: 1.7.2(@rsbuild/core@2.0.7)(preact@10.29.2)
+        version: 1.7.2(@rsbuild/core@2.0.8)(preact@10.29.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.7)
+        version: 1.5.2(@rsbuild/core@2.0.8)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -195,10 +195,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.7)
+        version: 1.5.2(@rsbuild/core@2.0.8)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -213,10 +213,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.7)
+        version: 1.5.2(@rsbuild/core@2.0.8)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -231,10 +231,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.7)
+        version: 1.5.2(@rsbuild/core@2.0.8)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -249,13 +249,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.7)
+        version: 1.1.2(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.7)
+        version: 1.5.2(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-solid':
         specifier: ^1.2.0
-        version: 1.2.0(@babel/core@7.29.0)(@rsbuild/core@2.0.7)(solid-js@1.9.13)
+        version: 1.2.0(@babel/core@7.29.0)(@rsbuild/core@2.0.8)(solid-js@1.9.13)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -270,7 +270,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.2.8
-        version: 1.2.8(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(vue@3.5.34)
+        version: 1.2.8(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(vue@3.5.34)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -287,11 +287,11 @@ importers:
   examples/vue-component-bundleless:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.7
-        version: 2.0.7(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.8
+        version: 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.8
-        version: 1.2.8(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(vue@3.5.34)
+        version: 1.2.8(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(vue@3.5.34)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -309,10 +309,10 @@ importers:
         version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.7)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.0.8)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vue@3.5.34)
+        version: 3.3.4(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vue@3.5.34)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -326,15 +326,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~2.0.7
-        version: 2.0.7(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.8
+        version: 2.0.8(@module-federation/runtime-tools@2.5.0)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.7)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+        version: 2.5.0(@rsbuild/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -364,7 +364,7 @@ importers:
         version: 1.6.4(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.7)
+        version: 0.3.4(@rsbuild/core@2.0.8)
       rslib:
         specifier: npm:@rslib/core@0.21.5
         version: '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)'
@@ -401,7 +401,7 @@ importers:
         version: 11.3.5
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.7)
+        version: 0.3.4(@rsbuild/core@2.0.8)
       rslib:
         specifier: npm:@rslib/core@0.21.5
         version: '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(typescript@6.0.3)'
@@ -422,8 +422,8 @@ importers:
         specifier: ^7.58.7
         version: 7.58.7(@types/node@25.2.0)
       '@rsbuild/core':
-        specifier: ~2.0.7
-        version: 2.0.7(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.8
+        version: 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -438,7 +438,7 @@ importers:
         version: 1.6.4(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.7)
+        version: 0.3.4(@rsbuild/core@2.0.8)
       rslib:
         specifier: npm:@rslib/core@0.21.5
         version: '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)'
@@ -468,34 +468,34 @@ importers:
         version: 4.0.1
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
+        version: 2.5.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
       '@rsbuild/core':
-        specifier: ~2.0.7
-        version: 2.0.7(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.8
+        version: 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-less':
         specifier: ^1.6.3
-        version: 1.6.3(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 1.6.3(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.7)
+        version: 1.5.2(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-toml':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)
+        version: 2.0.0(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@2.0.7)
+        version: 1.2.2(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.8
-        version: 1.2.8(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(vue@3.5.34)
+        version: 1.2.8(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(vue@3.5.34)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.4
-        version: 1.0.4(@rsbuild/core@2.0.7)
+        version: 1.0.4(@rsbuild/core@2.0.8)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -569,7 +569,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
 
   tests/integration/asset/json: {}
 
@@ -585,10 +585,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(typescript@6.0.3)
+        version: 2.0.2(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(typescript@6.0.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -682,10 +682,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(typescript@6.0.3)
+        version: 2.0.2(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(typescript@6.0.3)
 
   tests/integration/cli/build: {}
 
@@ -978,11 +978,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.7
-        version: 2.0.7(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.8
+        version: 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.7)
+        version: 1.4.4(@rsbuild/core@2.0.8)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -991,11 +991,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.7
-        version: 2.0.7(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.8
+        version: 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.4
-        version: 1.4.4(@rsbuild/core@2.0.7)
+        version: 1.4.4(@rsbuild/core@2.0.8)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1029,7 +1029,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.7)
+        version: 1.1.2(@rsbuild/core@2.0.8)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.14.2
         version: 0.14.2(@babel/core@7.29.0)
@@ -1042,7 +1042,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1168,19 +1168,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)
+        version: 2.0.0(@rsbuild/core@2.0.8)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1189,7 +1189,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)
+        version: 2.0.0(@rsbuild/core@2.0.8)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1237,10 +1237,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.6.3
-        version: 1.6.3(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 1.6.3(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.8
-        version: 1.2.8(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(vue@3.5.34)
+        version: 1.2.8(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(vue@3.5.34)
       vue:
         specifier: ^3.5.34
         version: 3.5.34(typescript@6.0.3)
@@ -1257,16 +1257,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+        version: 2.5.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@rsbuild/core':
-        specifier: ~2.0.7
-        version: 2.0.7(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.8
+        version: 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.2
-        version: 1.5.2(@rsbuild/core@2.0.7)
+        version: 1.5.2(@rsbuild/core@2.0.8)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1275,7 +1275,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 2.0.12
-        version: 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 2.0.12
         version: 2.0.12(@rspress/core@2.0.12)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)
@@ -1314,10 +1314,10 @@ importers:
         version: 19.2.6(react@19.2.6)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.5
-        version: 1.0.5(@rsbuild/core@2.0.7)
+        version: 1.0.5(@rsbuild/core@2.0.8)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.7)
+        version: 1.1.2(@rsbuild/core@2.0.8)
       rspress-plugin-file-tree:
         specifier: ^1.0.5
         version: 1.0.5(@rspress/core@2.0.12)
@@ -2840,6 +2840,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.0.8':
+    resolution: {integrity: sha512-V5Bhn3zqljsaB5grw9oMkSk6XZFvMkr6UpIYPZnDmOWsRAT1fNQ6XF6cn8fVUKv/KILblBrKLUZf0DpvDt3exw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.1.2':
     resolution: {integrity: sha512-qIZzosQlkj7VyFz8mmz1vAKDFlk79xrIvCRYzROqNwQHDXep+gd91nCnUPJdRPHrktzN8Yqa190CPTii3rON6w==}
     peerDependencies:
@@ -3017,13 +3027,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.0.5':
+    resolution: {integrity: sha512-++wjLQjQ20GcR0DwbzQmVXg9qy4XCX5NlfSzkzj2icHoDxr3KkrXhyVrQkdWuNG6l/bQrGLPnvLEAqkroC2Y7A==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.0.4':
     resolution: {integrity: sha512-oO5J2QYf7+H+aYRj85EiGrDOoDEE9EDDl7NgXv46iWvIF0wXowEHXqnjMFxHxRq2Vf6scT+0yYQX9blWcvMWAA==}
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.0.5':
+    resolution: {integrity: sha512-JBD5mCN3JKjV64Mh9nDYx8lLUrWDfEl5tLBuMkREUnqEKbo+z4nfwotyqHHM8/XgZwL+Gr7ps4GLWuQQrZB8+Q==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.0.4':
     resolution: {integrity: sha512-BEk6mIYBK4BihW9qXXITJORrVXecTlkRjrqhgefili4xjXtLdcUnxAm9sN/2oJ8m378n2h33qDh4gr2orPBFWQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.0.5':
+    resolution: {integrity: sha512-JI8+//woanJPNsfL7iGjX39zyiWumnrKHznWQM/7lEtE5nPmk+j+X7TYXxczSWC9zfZegiqI74D3L5JPDC84Fw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3034,8 +3060,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.0.5':
+    resolution: {integrity: sha512-5LujilxLtJFRiiPz5i5iWcWJriK9oy4gN7gZtTo8YRB7wwmwA8LMypTjjO0GLbkPS4/KeCfY4fDfTC29KmK+tA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@2.0.4':
     resolution: {integrity: sha512-xHorBPBZAg0Pn9Q0k9dWZ9euowieDxcSOzQ9JhTCmhDY6wZH5M/kCBFlCs/OQeW5/NUArW3x3MwEdO/0QJHMxg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.0.5':
+    resolution: {integrity: sha512-241wqE132jh+/U/pn97qUPV4KpIy4bSrTH0tqfzQCocgw+8hrUj02GqNG+3MXVC3qtwaQeJFYgEBy3TqFKsrIQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3046,12 +3084,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.0.5':
+    resolution: {integrity: sha512-BhaXZD064Lci3Kia0kLDAb4TyxO2C+0UidMlj44e8+ctasxIfFZgnrhCJrhTFHAtOiAwqhU3FHun2UuxPqX0Eg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.0.4':
     resolution: {integrity: sha512-YhN8HkiH46ONU9tm5dyoXDImDWGpU7E4SPqGI4OyAVF0445uIChurIUmTIOYcD6cg81GGeIjozWJOcb635Dcqw==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.0.5':
+    resolution: {integrity: sha512-duEkRoXrl9SW8uGHv7JURJ5lgKu87qFDQ4Exy6UQPvsUJVXhtRXTfvMHCb/CejVJuW2Bw2D632/axZq3qRSuBQ==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.0.4':
     resolution: {integrity: sha512-MUlYIz82xQRN0aoiXXyEBrNVUwiOSSFRi7nuCgUKduaSdlbPWzCY31IdtOygZ06LVp5JIGUEtyqSrjQq4FrMRw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.5':
+    resolution: {integrity: sha512-q2WT3HFoWL+2g84l3s2kY7CiE1gEZ1bwB3txx3eZzQQ6YKP7bE82z6sl6S/pTOHGjHdAO4snQXpSaHwUt3LX5g==}
     cpu: [arm64]
     os: [win32]
 
@@ -3060,13 +3113,26 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.0.5':
+    resolution: {integrity: sha512-nMJGIY7kvgbyMolEE7tXDe+Z9jSItDshTIqMQQkkD3WTHdjlBQozHxk4kBtKLsunO+3NkCLe5Oa3hXg1yyStIg==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.0.4':
     resolution: {integrity: sha512-MnYKPfdrAEbtpKg/1SZ6cNtzreIRyQJK4APbxLLPXENdTH5QXQkaTjLMKEeJcJ51FRhI/+yNpOUm2oTHdCQ1Og==}
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.0.5':
+    resolution: {integrity: sha512-vP0BR6fxdPL9cb02HAuZATg/CjR07aecWel3s1vqRwW1aDffgXh9PVmqEKIHTgyaNsNR55kSKNJsB9AcQ8/QrA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@2.0.4':
     resolution: {integrity: sha512-/QeJDPUw/lWkBJESG264KA9u6/rAjvoJhKncU4rkTi5Ap45kue5HTgOzr0ufxKdd2Xl72fjFBuqlKmtFDD5LiQ==}
+
+  '@rspack/binding@2.0.5':
+    resolution: {integrity: sha512-Ta1y4WXJA87wM1OstqaMddoPsBGv7Cu779bYToKxEAqR/Yy9DxLkp7bdgBaAx2JH++BwVjV+toWts2V9AaiTFQ==}
 
   '@rspack/core@2.0.4':
     resolution: {integrity: sha512-OuxdQeeKWQpNvFBRDOcnoSaQvp6E4APM/6JJMM/k0p6oL1TEFQVGdNu3VGY4mRAsebnNBXapMVMhj+v66Bn2pg==}
@@ -3074,6 +3140,18 @@ packages:
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
       '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.0.5':
+    resolution: {integrity: sha512-9tv2HAnSiTote5WPH2tmz1hLZ1zKbzkiZc1eYp7LP/8jcsiJBuf40ihiWidAgbbuYtJo3kWET6q+qOm5UhNiGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
     peerDependenciesMeta:
       '@module-federation/runtime-tools':
         optional: true
@@ -3425,6 +3503,9 @@ packages:
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@swc/plugin-prefresh@12.7.0':
     resolution: {integrity: sha512-1d+YWDPdeHcxbK6WXwm+TYMDwKSsSzf6OoqFrBpUujr3XvE2ydK+egocGJS7Z8bhwIUD4bHst6CqZVO+v32o/Q==}
@@ -8420,7 +8501,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)':
+  '@module-federation/enhanced@2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/cli': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
@@ -8429,7 +8510,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.5.0(@module-federation/runtime-tools@2.5.0)
       '@module-federation/managers': 2.5.0(node-fetch@2.7.0)
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
-      '@module-federation/rspack': 2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
+      '@module-federation/rspack': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.5.0(node-fetch@2.7.0)
@@ -8445,7 +8526,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)':
+  '@module-federation/enhanced@2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/cli': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
@@ -8454,7 +8535,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.5.0(@module-federation/runtime-tools@2.5.0)
       '@module-federation/managers': 2.5.0(node-fetch@2.7.0)
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
-      '@module-federation/rspack': 2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+      '@module-federation/rspack': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.5.0(node-fetch@2.7.0)
@@ -8509,9 +8590,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.43(@rspack/core@2.0.4)(typescript@5.9.3)(vue-tsc@3.3.1)':
+  '@module-federation/node@2.7.43(@rspack/core@2.0.5)(typescript@5.9.3)(vue-tsc@3.3.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
       '@module-federation/runtime': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -8524,9 +8605,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.43(@rspack/core@2.0.4)(typescript@6.0.3)(vue-tsc@3.3.1)':
+  '@module-federation/node@2.7.43(@rspack/core@2.0.5)(typescript@6.0.3)(vue-tsc@3.3.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@module-federation/runtime': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -8541,7 +8622,7 @@ snapshots:
 
   '@module-federation/node@2.7.43(typescript@6.0.3)(vue-tsc@3.3.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@module-federation/runtime': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -8554,13 +8635,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)':
+  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
-      '@module-federation/node': 2.7.43(@rspack/core@2.0.4)(typescript@5.9.3)(vue-tsc@3.3.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
+      '@module-federation/node': 2.7.43(@rspack/core@2.0.5)(typescript@5.9.3)(vue-tsc@3.3.1)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8570,13 +8651,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)':
+  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
-      '@module-federation/node': 2.7.43(@rspack/core@2.0.4)(typescript@6.0.3)(vue-tsc@3.3.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+      '@module-federation/node': 2.7.43(@rspack/core@2.0.5)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8586,13 +8667,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.7)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)':
+  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@module-federation/node': 2.7.43(typescript@6.0.3)(vue-tsc@3.3.1)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8602,7 +8683,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)':
+  '@module-federation/rspack@2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
@@ -8611,7 +8692,7 @@ snapshots:
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.1)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 5.9.3
       vue-tsc: 3.3.1(typescript@5.9.3)
@@ -8620,7 +8701,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/rspack@2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)':
+  '@module-federation/rspack@2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
@@ -8629,7 +8710,7 @@ snapshots:
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.1(typescript@6.0.3)
@@ -8664,12 +8745,12 @@ snapshots:
     optionalDependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 
-  '@module-federation/storybook-addon@6.0.12(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.1)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.12(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.1)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.1)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -9029,7 +9110,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.7)':
+  '@rsbuild/core@2.0.8(@module-federation/runtime-tools@2.5.0)':
+    dependencies:
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.8)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -9038,23 +9126,23 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.6.3(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)':
+  '@rsbuild/plugin-less@1.6.3(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
-      less-loader: 12.3.2(@rspack/core@2.0.4)(less@4.6.4)
+      less-loader: 12.3.2(@rspack/core@2.0.5)(less@4.6.4)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.7)':
+  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.8)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9080,29 +9168,38 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 
-  '@rsbuild/plugin-preact@1.7.2(@rsbuild/core@2.0.7)(preact@10.29.2)':
+  '@rsbuild/plugin-preact@1.7.2(@rsbuild/core@2.0.8)(preact@10.29.2)':
     dependencies:
       '@prefresh/core': 1.5.9(preact@10.29.2)
       '@prefresh/utils': 1.2.1
       '@rspack/plugin-preact-refresh': 1.1.5(@prefresh/core@1.5.9)(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh': 12.7.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)':
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.5)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.4)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@2.0.7)':
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@2.0.8)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9110,90 +9207,90 @@ snapshots:
       reduce-configs: 1.1.2
       sass-embedded: 1.99.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 
-  '@rsbuild/plugin-solid@1.2.0(@babel/core@7.29.0)(@rsbuild/core@2.0.7)(solid-js@1.9.13)':
+  '@rsbuild/plugin-solid@1.2.0(@babel/core@7.29.0)(@rsbuild/core@2.0.8)(solid-js@1.9.13)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.7)
+      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.8)
       babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.13)
       solid-refresh: 0.7.8(solid-js@1.9.13)
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)':
+  '@rsbuild/plugin-stylus@2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0
-      stylus-loader: 8.1.3(@rspack/core@2.0.4)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.0.5)(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.0(@rsbuild/core@2.0.7)':
+  '@rsbuild/plugin-tailwindcss@2.0.0(@rsbuild/core@2.0.8)':
     dependencies:
       '@tailwindcss/webpack': 4.3.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - webpack
 
-  '@rsbuild/plugin-toml@2.0.0(@rsbuild/core@2.0.7)':
+  '@rsbuild/plugin-toml@2.0.0(@rsbuild/core@2.0.8)':
     dependencies:
       toml: 4.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.4)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.5)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.7)':
+  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.8)':
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 
-  '@rsbuild/plugin-vue@1.2.8(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(vue@3.5.34)':
+  '@rsbuild/plugin-vue@1.2.8(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(vue@3.5.34)':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@2.0.4)(vue@3.5.34)
+      rspack-vue-loader: 17.5.0(@rspack/core@2.0.5)(vue@3.5.34)
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@2.0.7)':
+  '@rsbuild/plugin-yaml@1.0.4(@rsbuild/core@2.0.8)':
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 
   '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)':
     dependencies:
@@ -9208,18 +9305,6 @@ snapshots:
       - core-js
 
   '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(typescript@6.0.3)':
-    dependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
-      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.7)(typescript@6.0.3)
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.58.7(@types/node@24.12.4)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@typescript/native-preview'
-      - core-js
-
-  '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
       rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.7)(typescript@6.0.3)
@@ -9265,19 +9350,37 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.4':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.0.5':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.0.4':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.5':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.4':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.0.5':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.0.4':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.5':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.4':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.0.5':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.0.4':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.5':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.4':
@@ -9287,13 +9390,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.0.5':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.0.4':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.5':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.4':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.0.5':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.0.4':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.5':
     optional: true
 
   '@rspack/binding@2.0.4':
@@ -9309,12 +9428,32 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.4
       '@rspack/binding-win32-x64-msvc': 2.0.4
 
+  '@rspack/binding@2.0.5':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.5
+      '@rspack/binding-darwin-x64': 2.0.5
+      '@rspack/binding-linux-arm64-gnu': 2.0.5
+      '@rspack/binding-linux-arm64-musl': 2.0.5
+      '@rspack/binding-linux-x64-gnu': 2.0.5
+      '@rspack/binding-linux-x64-musl': 2.0.5
+      '@rspack/binding-wasm32-wasi': 2.0.5
+      '@rspack/binding-win32-arm64-msvc': 2.0.5
+      '@rspack/binding-win32-ia32-msvc': 2.0.5
+      '@rspack/binding-win32-x64-msvc': 2.0.5
+
   '@rspack/core@2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@rspack/binding': 2.0.4
     optionalDependencies:
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@swc/helpers': 0.5.21
+
+  '@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.0.5
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
+      '@swc/helpers': 0.5.23
 
   '@rspack/lite-tapable@1.1.0': {}
 
@@ -9323,18 +9462,18 @@ snapshots:
       '@prefresh/core': 1.5.9(preact@10.29.2)
       '@prefresh/utils': 1.2.1
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.4)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.15)(react@19.2.6)
       '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.5)
       '@rspress/shared': 2.0.12(@module-federation/runtime-tools@2.5.0)
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -9383,7 +9522,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)
-      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -9394,7 +9533,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.12(@rspress/core@2.0.12)':
     dependencies:
-      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       remark-mdx: 3.1.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -9405,17 +9544,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.12(@rspress/core@2.0.12)':
     dependencies:
-      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.12(@rspress/core@2.0.12)':
     dependencies:
-      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rspress/plugin-twoslash@2.0.12(@rspress/core@2.0.12)(react@19.2.6)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@shikijs/twoslash': 4.0.2(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3
       mdast-util-gfm: 3.1.0
@@ -9438,16 +9577,16 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.2(@rspress/core@2.0.12)':
     optionalDependencies:
-      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rstest/adapter-rslib@0.10.2(@rslib/core@0.21.5)(@rstest/core@0.10.2)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 0.21.5(@microsoft/api-extractor@7.58.7)(typescript@6.0.3)
-      '@rstest/core': 0.10.2
+      '@rslib/core': 0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(typescript@6.0.3)
+      '@rstest/core': 0.10.2(@module-federation/runtime-tools@2.5.0)
     optionalDependencies:
       typescript: 6.0.3
 
-  '@rstest/core@0.10.2':
+  '@rstest/core@0.10.2(@module-federation/runtime-tools@2.5.0)':
     dependencies:
       '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
       '@types/chai': 5.2.3
@@ -9784,6 +9923,10 @@ snapshots:
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
+
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -11811,11 +11954,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.2(@rspack/core@2.0.4)(less@4.6.4):
+  less-loader@12.3.2(@rspack/core@2.0.5)(less@4.6.4):
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   less@4.6.4:
     dependencies:
@@ -13432,41 +13575,41 @@ snapshots:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.4)
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.7):
+  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.8):
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.7):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.8):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 
-  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.7):
+  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.8):
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 
-  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.7):
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.8):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.17
     optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 
   rslog@2.1.1: {}
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.0.4)(vue@3.5.34):
+  rspack-vue-loader@17.5.0(@rspack/core@2.0.5)(vue@3.5.34):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       vue: 3.5.34(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.12):
     dependencies:
-      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -13491,14 +13634,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.12):
     dependencies:
-      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.12)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.12):
     dependencies:
-      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.12(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   run-applescript@7.1.0: {}
 
@@ -13820,18 +13963,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.0.7)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.0.8)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -13843,7 +13986,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.7)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.8)
       sirv: 2.0.4
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       ts-dedent: 2.2.0
@@ -13859,10 +14002,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.59.0)(storybook@10.4.1)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.59.0)(storybook@10.4.1)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@storybook/react': 10.4.1(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)
       find-up: 5.0.0
@@ -13873,7 +14016,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       resolve: 1.22.12
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -13887,12 +14030,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vue@3.5.34):
+  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vue@3.5.34):
     dependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@storybook/vue3': 10.4.1(storybook@10.4.1)(vue@3.5.34)
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.7)(@rspack/core@2.0.4)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
       vue: 3.5.34(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.34)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -14012,13 +14155,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.0.4)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.0.5)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   stylus@0.64.0:
     dependencies:
@@ -14133,7 +14276,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.4)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.5)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
@@ -14141,7 +14284,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   ts-dedent@2.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 0.10.2(@rslib/core@0.21.5)(@rstest/core@0.10.2)(typescript@6.0.3)
       '@rstest/core':
         specifier: ^0.10.2
-        version: 0.10.2(@module-federation/runtime-tools@2.5.0)
+        version: 0.10.2
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -2830,16 +2830,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@2.0.7':
-    resolution: {integrity: sha512-LsBONEzsjzOAqO72ot39eI7g53zSfF9QuDXTu4ks8IUX+EZsxRSniQfc+1zVA6a6y3b9KUUtG96avoMLKbWklQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
   '@rsbuild/core@2.0.8':
     resolution: {integrity: sha512-V5Bhn3zqljsaB5grw9oMkSk6XZFvMkr6UpIYPZnDmOWsRAT1fNQ6XF6cn8fVUKv/KILblBrKLUZf0DpvDt3exw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3022,19 +3012,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@2.0.4':
-    resolution: {integrity: sha512-0Q1QXFEsZfDc4opiDnb8q50KlBbC2VovViDaYlMJZBzvjAo325mh3itXPfz7YZ31M+TxRE7TUiJXH3ltiV1Hdg==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@2.0.5':
     resolution: {integrity: sha512-++wjLQjQ20GcR0DwbzQmVXg9qy4XCX5NlfSzkzj2icHoDxr3KkrXhyVrQkdWuNG6l/bQrGLPnvLEAqkroC2Y7A==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@2.0.4':
-    resolution: {integrity: sha512-oO5J2QYf7+H+aYRj85EiGrDOoDEE9EDDl7NgXv46iWvIF0wXowEHXqnjMFxHxRq2Vf6scT+0yYQX9blWcvMWAA==}
-    cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@2.0.5':
@@ -3042,23 +3022,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.4':
-    resolution: {integrity: sha512-BEk6mIYBK4BihW9qXXITJORrVXecTlkRjrqhgefili4xjXtLdcUnxAm9sN/2oJ8m378n2h33qDh4gr2orPBFWQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-arm64-gnu@2.0.5':
     resolution: {integrity: sha512-JI8+//woanJPNsfL7iGjX39zyiWumnrKHznWQM/7lEtE5nPmk+j+X7TYXxczSWC9zfZegiqI74D3L5JPDC84Fw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rspack/binding-linux-arm64-musl@2.0.4':
-    resolution: {integrity: sha512-Hyt3z1RwNcSMIoaoWLN4Hb/696/O5JPukf8rXQASvf2UkC+X3ij7tr+8lMSYi3Zysi1QL375CnT4fNoABEW0JA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-arm64-musl@2.0.5':
     resolution: {integrity: sha512-5LujilxLtJFRiiPz5i5iWcWJriK9oy4gN7gZtTo8YRB7wwmwA8LMypTjjO0GLbkPS4/KeCfY4fDfTC29KmK+tA==}
@@ -3066,23 +3034,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.0.4':
-    resolution: {integrity: sha512-xHorBPBZAg0Pn9Q0k9dWZ9euowieDxcSOzQ9JhTCmhDY6wZH5M/kCBFlCs/OQeW5/NUArW3x3MwEdO/0QJHMxg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-x64-gnu@2.0.5':
     resolution: {integrity: sha512-241wqE132jh+/U/pn97qUPV4KpIy4bSrTH0tqfzQCocgw+8hrUj02GqNG+3MXVC3qtwaQeJFYgEBy3TqFKsrIQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rspack/binding-linux-x64-musl@2.0.4':
-    resolution: {integrity: sha512-QLxEGUXofF0kVNU12Y2NT3Qi9lGs+WbnYpapVeb+2IXtrAXJfU7Rhy7lAp5GLMzYMQNrKKL9SVnTWKbODbNW9Q==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-x64-musl@2.0.5':
     resolution: {integrity: sha512-BhaXZD064Lci3Kia0kLDAb4TyxO2C+0UidMlj44e8+ctasxIfFZgnrhCJrhTFHAtOiAwqhU3FHun2UuxPqX0Eg==}
@@ -3090,27 +3046,13 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.0.4':
-    resolution: {integrity: sha512-YhN8HkiH46ONU9tm5dyoXDImDWGpU7E4SPqGI4OyAVF0445uIChurIUmTIOYcD6cg81GGeIjozWJOcb635Dcqw==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@2.0.5':
     resolution: {integrity: sha512-duEkRoXrl9SW8uGHv7JURJ5lgKu87qFDQ4Exy6UQPvsUJVXhtRXTfvMHCb/CejVJuW2Bw2D632/axZq3qRSuBQ==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.4':
-    resolution: {integrity: sha512-MUlYIz82xQRN0aoiXXyEBrNVUwiOSSFRi7nuCgUKduaSdlbPWzCY31IdtOygZ06LVp5JIGUEtyqSrjQq4FrMRw==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rspack/binding-win32-arm64-msvc@2.0.5':
     resolution: {integrity: sha512-q2WT3HFoWL+2g84l3s2kY7CiE1gEZ1bwB3txx3eZzQQ6YKP7bE82z6sl6S/pTOHGjHdAO4snQXpSaHwUt3LX5g==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@2.0.4':
-    resolution: {integrity: sha512-D7UcIFMzlY2yhhyuW4Ej15gBWmTwUM5DxuObl3Kv31qRv/pmV3MsqUeG5m2dqLbUxzqPH87qnp0cArbkJQ1b+w==}
-    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@2.0.5':
@@ -3118,33 +3060,13 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.4':
-    resolution: {integrity: sha512-MnYKPfdrAEbtpKg/1SZ6cNtzreIRyQJK4APbxLLPXENdTH5QXQkaTjLMKEeJcJ51FRhI/+yNpOUm2oTHdCQ1Og==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@2.0.5':
     resolution: {integrity: sha512-vP0BR6fxdPL9cb02HAuZATg/CjR07aecWel3s1vqRwW1aDffgXh9PVmqEKIHTgyaNsNR55kSKNJsB9AcQ8/QrA==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.0.4':
-    resolution: {integrity: sha512-/QeJDPUw/lWkBJESG264KA9u6/rAjvoJhKncU4rkTi5Ap45kue5HTgOzr0ufxKdd2Xl72fjFBuqlKmtFDD5LiQ==}
-
   '@rspack/binding@2.0.5':
     resolution: {integrity: sha512-Ta1y4WXJA87wM1OstqaMddoPsBGv7Cu779bYToKxEAqR/Yy9DxLkp7bdgBaAx2JH++BwVjV+toWts2V9AaiTFQ==}
-
-  '@rspack/core@2.0.4':
-    resolution: {integrity: sha512-OuxdQeeKWQpNvFBRDOcnoSaQvp6E4APM/6JJMM/k0p6oL1TEFQVGdNu3VGY4mRAsebnNBXapMVMhj+v66Bn2pg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
 
   '@rspack/core@2.0.5':
     resolution: {integrity: sha512-9tv2HAnSiTote5WPH2tmz1hLZ1zKbzkiZc1eYp7LP/8jcsiJBuf40ihiWidAgbbuYtJo3kWET6q+qOm5UhNiGA==}
@@ -9103,13 +9025,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@rsbuild/core@2.0.7(@module-federation/runtime-tools@2.5.0)':
-    dependencies:
-      '@rspack/core': 2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
-      '@swc/helpers': 0.5.21
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
   '@rsbuild/core@2.0.8(@module-federation/runtime-tools@2.5.0)':
     dependencies:
       '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
@@ -9180,15 +9095,6 @@ snapshots:
       '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - preact
-
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.5)':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
 
   '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)':
     dependencies:
@@ -9294,8 +9200,8 @@ snapshots:
 
   '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
-      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.7)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
+      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.2.0)
       typescript: 6.0.3
@@ -9306,8 +9212,20 @@ snapshots:
 
   '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
-      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.7)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
+      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.8)(typescript@6.0.3)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.7(@types/node@24.12.4)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@typescript/native-preview'
+      - core-js
+
+  '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(typescript@6.0.3)':
+    dependencies:
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
+      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.8)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.4)
       typescript: 6.0.3
@@ -9347,47 +9265,22 @@ snapshots:
   '@rslint/win32-x64@0.5.3':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.4':
-    optional: true
-
   '@rspack/binding-darwin-arm64@2.0.5':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.0.4':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.5':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.4':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@2.0.5':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@2.0.4':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.5':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.4':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@2.0.5':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.4':
-    optional: true
-
   '@rspack/binding-linux-x64-musl@2.0.5':
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.0.4':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.5':
@@ -9397,36 +9290,14 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.4':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@2.0.5':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@2.0.4':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.5':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.4':
-    optional: true
-
   '@rspack/binding-win32-x64-msvc@2.0.5':
     optional: true
-
-  '@rspack/binding@2.0.4':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.4
-      '@rspack/binding-darwin-x64': 2.0.4
-      '@rspack/binding-linux-arm64-gnu': 2.0.4
-      '@rspack/binding-linux-arm64-musl': 2.0.4
-      '@rspack/binding-linux-x64-gnu': 2.0.4
-      '@rspack/binding-linux-x64-musl': 2.0.4
-      '@rspack/binding-wasm32-wasi': 2.0.4
-      '@rspack/binding-win32-arm64-msvc': 2.0.4
-      '@rspack/binding-win32-ia32-msvc': 2.0.4
-      '@rspack/binding-win32-x64-msvc': 2.0.4
 
   '@rspack/binding@2.0.5':
     optionalDependencies:
@@ -9440,13 +9311,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 2.0.5
       '@rspack/binding-win32-ia32-msvc': 2.0.5
       '@rspack/binding-win32-x64-msvc': 2.0.5
-
-  '@rspack/core@2.0.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)':
-    dependencies:
-      '@rspack/binding': 2.0.4
-    optionalDependencies:
-      '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
-      '@swc/helpers': 0.5.21
 
   '@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)':
     dependencies:
@@ -9472,8 +9336,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.15)(react@19.2.6)
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.7)(@rspack/core@2.0.5)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5)
       '@rspress/shared': 2.0.12(@module-federation/runtime-tools@2.5.0)
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -9568,7 +9432,7 @@ snapshots:
 
   '@rspress/shared@2.0.12(@module-federation/runtime-tools@2.5.0)':
     dependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@shikijs/rehype': 4.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9581,14 +9445,14 @@ snapshots:
 
   '@rstest/adapter-rslib@0.10.2(@rslib/core@0.21.5)(@rstest/core@0.10.2)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(typescript@6.0.3)
-      '@rstest/core': 0.10.2(@module-federation/runtime-tools@2.5.0)
+      '@rslib/core': 0.21.5(@microsoft/api-extractor@7.58.7)(typescript@6.0.3)
+      '@rstest/core': 0.10.2
     optionalDependencies:
       typescript: 6.0.3
 
-  '@rstest/core@0.10.2(@module-federation/runtime-tools@2.5.0)':
+  '@rstest/core@0.10.2':
     dependencies:
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
       '@types/chai': 5.2.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -13558,19 +13422,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.7)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.2.0)
       '@typescript/native-preview': 7.0.0-dev.20260523.1
       typescript: 6.0.3
 
-  rsbuild-plugin-dts@0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.7)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.5(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.8)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.7(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.4)
       typescript: 6.0.3

--- a/tests/integration/asset/__snapshots__/index.test.ts.snap
+++ b/tests/integration/asset/__snapshots__/index.test.ts.snap
@@ -59,11 +59,15 @@ exports[`use svgr > mixedImport: true should contain export { url as default, Re
 ""use strict";
 var __webpack_require__ = {};
 (()=>{
-    __webpack_require__.d = (exports1, definition)=>{
-        for(var key in definition)if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
-            enumerable: true,
-            get: definition[key]
-        });
+    __webpack_require__.d = (exports1, getters, values)=>{
+        var define = (defs, kind)=>{
+            for(var key in defs)if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
+                enumerable: true,
+                [kind]: defs[key]
+            });
+        };
+        define(getters, "get");
+        define(values, "value");
     };
 })();
 (()=>{
@@ -154,11 +158,15 @@ exports[`use svgr > should only contain svgr default export 2`] = `
 ""use strict";
 var __webpack_require__ = {};
 (()=>{
-    __webpack_require__.d = (exports1, definition)=>{
-        for(var key in definition)if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
-            enumerable: true,
-            get: definition[key]
-        });
+    __webpack_require__.d = (exports1, getters, values)=>{
+        var define = (defs, kind)=>{
+            for(var key in defs)if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
+                enumerable: true,
+                [kind]: defs[key]
+            });
+        };
+        define(getters, "get");
+        define(values, "value");
     };
 })();
 (()=>{

--- a/tests/integration/auto-extension/index.test.ts
+++ b/tests/integration/auto-extension/index.test.ts
@@ -46,7 +46,7 @@ describe('should respect output.filename.js and output.filenameHash to override 
     // override output.filename.js
     expect(extname(entryFiles.esm0!)).toEqual('.mjs');
     expect(entryFiles.cjs0).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename/index.a4fcc622bc.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename/index.6e60045198.js"`,
     );
 
     // override output.filenameHash
@@ -54,7 +54,7 @@ describe('should respect output.filename.js and output.filenameHash to override 
       `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/esm-override-filename-hash/index.3ac7e0ff07.js"`,
     );
     expect(entryFiles.cjs1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename-hash/index.a4fcc622bc.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename-hash/index.6e60045198.js"`,
     );
 
     // override different file types with function
@@ -89,7 +89,7 @@ describe('should respect output.filename.js and output.filenameHash to override 
       `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm-override-filename-hash/index.3ac7e0ff07.js"`,
     );
     expect(entryFiles.cjs1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/cjs-override-filename-hash/index.a4fcc622bc.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/cjs-override-filename-hash/index.6e60045198.js"`,
     );
 
     // override different file types with function

--- a/tests/integration/bundle-false/__snapshots__/index.test.ts.snap
+++ b/tests/integration/bundle-false/__snapshots__/index.test.ts.snap
@@ -35,11 +35,15 @@ exports[`svgr in bundleless 2`] = `
 ""use strict";
 var __webpack_require__ = {};
 (()=>{
-    __webpack_require__.d = (exports1, definition)=>{
-        for(var key in definition)if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
-            enumerable: true,
-            get: definition[key]
-        });
+    __webpack_require__.d = (exports1, getters, values)=>{
+        var define = (defs, kind)=>{
+            for(var key in defs)if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
+                enumerable: true,
+                [kind]: defs[key]
+            });
+        };
+        define(getters, "get");
+        define(values, "value");
     };
 })();
 (()=>{

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -54,8 +54,8 @@ describe('minify config (mf)', () => {
     const fixturePath = join(__dirname, 'mf/default');
     const { mfExposeEntry } = await buildAndGetResults({ fixturePath });
     expect(mfExposeEntry).toMatchInlineSnapshot(`
-      "/*! LICENSE: __federation_expose_default_export.3aa30e97f0.js.LICENSE.txt */
-      "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([[525],{2115(__unused_rspack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);__webpack_require__.d(__webpack_exports__,{Button:()=>Button,foo:()=>foo});var react_jsx_runtime__rspack_import_0=__webpack_require__(491);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__rspack_import_0.jsx)("button",{})}}]);"
+      "/*! LICENSE: __federation_expose_default_export.3ca2a77c59.js.LICENSE.txt */
+      "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([[525],{2115(__unused_rspack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);var react_jsx_runtime__rspack_import_0=__webpack_require__(491);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__rspack_import_0.jsx)("button",{});__webpack_require__.d(__webpack_exports__,{},{Button:Button,foo:foo})}}]);"
     `);
   });
 
@@ -68,10 +68,6 @@ describe('minify config (mf)', () => {
       (globalThis["disable_minify"] = globalThis["disable_minify"] || []).push([[525], {
       2115(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
       __webpack_require__.r(__webpack_exports__);
-      __webpack_require__.d(__webpack_exports__, {
-        Button: () => (Button),
-        foo: () => (foo)
-      });
       /* import */ var react_jsx_runtime__rspack_import_0 = __webpack_require__(491);
       /* import */ var react_jsx_runtime__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(react_jsx_runtime__rspack_import_0);
       /*! Legal Comment */ 
@@ -82,6 +78,12 @@ describe('minify config (mf)', () => {
       };
       // normal comment
       const Button = ()=>/*#__PURE__*/ (0,react_jsx_runtime__rspack_import_0.jsx)('button', {});
+
+      __webpack_require__.d(__webpack_exports__, {
+      }, {
+        Button: Button,
+        foo: foo
+      });
 
 
       },

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@rsbuild/plugin-node-polyfill": "^1.4.4"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@rsbuild/plugin-node-polyfill": "^1.4.4"
   }
 }

--- a/tests/integration/node-polyfill/index.test.ts
+++ b/tests/integration/node-polyfill/index.test.ts
@@ -6,7 +6,7 @@ test('`Buffer` should be imported from polyfill when bundled', async () => {
   const fixturePath = join(__dirname, './bundle');
   const { entries, entryFiles } = await buildAndGetResults({ fixturePath });
   const bufferRegex =
-    /var .* = __webpack_require__\(".*\/node_modules\/buffer\/index\.js"\)\[".*"\]/g;
+    /var [\w$]+ = __webpack_require__\(".*\/node_modules\/buffer\/index\.js"\)\.[\w$]+/g;
 
   for (const format of ['esm', 'cjs'] as const) {
     expect(entries[format].match(bufferRegex)?.length).toBe(2);

--- a/tests/integration/preserve-jsx/__snapshots__/index.test.ts.snap
+++ b/tests/integration/preserve-jsx/__snapshots__/index.test.ts.snap
@@ -4,11 +4,15 @@ exports[`JSX syntax should be preserved 1`] = `
 ""use strict";
 var __webpack_require__ = {};
 (()=>{
-    __webpack_require__.d = (exports1, definition)=>{
-        for(var key in definition)if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
-            enumerable: true,
-            get: definition[key]
-        });
+    __webpack_require__.d = (exports1, getters, values)=>{
+        var define = (defs, kind)=>{
+            for(var key in defs)if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
+                enumerable: true,
+                [kind]: defs[key]
+            });
+        };
+        define(getters, "get");
+        define(values, "value");
     };
 })();
 (()=>{

--- a/tests/integration/resolve/index.test.ts
+++ b/tests/integration/resolve/index.test.ts
@@ -8,8 +8,7 @@ test('resolve data url', async () => {
 
   expect(isSuccess).toBeTruthy();
   expect(entries.esm).toMatchInlineSnapshot(`
-    "const javascript_export_default_42 = 42;
-    console.log('x:', javascript_export_default_42);
+    "console.log('x:', 42);
     export { };
     "
   `);
@@ -43,11 +42,15 @@ test('resolve false', async () => {
         };
     })();
     (()=>{
-        __webpack_require__.d = (exports, definition)=>{
-            for(var key in definition)if (__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, {
-                enumerable: true,
-                get: definition[key]
-            });
+        __webpack_require__.d = (exports, getters, values)=>{
+            var define = (defs, kind)=>{
+                for(var key in defs)if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, {
+                    enumerable: true,
+                    [kind]: defs[key]
+                });
+            };
+            define(getters, "get");
+            define(values, "value");
         };
     })();
     (()=>{

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^2.5.0",
     "@playwright/test": "1.60.0",
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@rsbuild/plugin-less": "^1.6.3",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-sass": "^1.5.2",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.0",
-    "@rsbuild/core": "~2.0.7",
+    "@rsbuild/core": "~2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-sass": "^1.5.2",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

This PR upgrades `@rsbuild/core` to 2.0.8 across packages, examples, and integration fixtures. It refreshes affected integration snapshots for the updated Rspack output and adjusts the node-polyfill `Buffer` assertion to match the new dot-property export access emitted by Rsbuild/Rspack.

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.8

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).