### PR TITLE
chore: update workspace dependency policies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,7 @@
     "memfs": "^4.57.2",
     "path-serializer": "0.6.0",
     "prebundle": "1.6.4",
-    "rsbuild-plugin-publint": "^0.3.4",
+    "rsbuild-plugin-publint": "^1.0.0",
     "rslib": "npm:@rslib/core@0.21.5",
     "rslog": "^2.1.1",
     "tinyglobby": "^0.2.16",

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -36,7 +36,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^24.12.4",
     "fs-extra": "^11.3.5",
-    "rsbuild-plugin-publint": "^0.3.4",
+    "rsbuild-plugin-publint": "^1.0.0",
     "rslib": "npm:@rslib/core@0.21.5",
     "tsx": "^4.22.3",
     "typescript": "^6.0.3"

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -41,7 +41,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260523.1",
     "magic-string": "^0.30.21",
     "prebundle": "1.6.4",
-    "rsbuild-plugin-publint": "^0.3.4",
+    "rsbuild-plugin-publint": "^1.0.0",
     "rslib": "npm:@rslib/core@0.21.5",
     "tinyglobby": "^0.2.16",
     "tsconfig-paths": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: 1.6.4
         version: 1.6.4(typescript@6.0.3)
       rsbuild-plugin-publint:
-        specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.8)
+        specifier: ^1.0.0
+        version: 1.0.0(@rsbuild/core@2.0.8)
       rslib:
         specifier: npm:@rslib/core@0.21.5
         version: '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)'
@@ -400,8 +400,8 @@ importers:
         specifier: ^11.3.5
         version: 11.3.5
       rsbuild-plugin-publint:
-        specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.8)
+        specifier: ^1.0.0
+        version: 1.0.0(@rsbuild/core@2.0.8)
       rslib:
         specifier: npm:@rslib/core@0.21.5
         version: '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(typescript@6.0.3)'
@@ -437,8 +437,8 @@ importers:
         specifier: 1.6.4
         version: 1.6.4(typescript@6.0.3)
       rsbuild-plugin-publint:
-        specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.8)
+        specifier: ^1.0.0
+        version: 1.0.0(@rsbuild/core@2.0.8)
       rslib:
         specifier: npm:@rslib/core@0.21.5
         version: '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260523.1)(typescript@6.0.3)'
@@ -2668,8 +2668,8 @@ packages:
   '@prefresh/utils@1.2.1':
     resolution: {integrity: sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw==}
 
-  '@publint/pack@0.1.3':
-    resolution: {integrity: sha512-dHDWeutAerz+Z2wFYAce7Y51vd4rbLBfUh0BNnyul4xKoVsPUVJBrOAFsJvtvYBwGFJSqKsxyyHf/7evZ8+Q5Q==}
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
     engines: {node: '>=18'}
 
   '@reduxjs/toolkit@2.12.0':
@@ -6114,8 +6114,8 @@ packages:
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
 
-  publint@0.3.17:
-    resolution: {integrity: sha512-Q3NLegA9XM6usW+dYQRG1g9uEHiYUzcCVBJDJ7yMcWRqVU9LYZUWdqbwMZfmTCFC5PZLQpLAmhvRcQRl3exqkw==}
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6499,8 +6499,9 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  rsbuild-plugin-publint@0.3.4:
-    resolution: {integrity: sha512-0oIeQlTNRQoiyi2K5RT6C0+3q8J1HZEX66pkTtDAvmNNHiLf+YyBn2bx8S2w5T7MEVt323ULKoGV4rRROIOatQ==}
+  rsbuild-plugin-publint@1.0.0:
+    resolution: {integrity: sha512-QNu6zL0TOmFZfrCiKSmkw092jDhhPpiA1QYDRkvhkW1wDLowuVEYOqdV87Eo/I6geV0nuKKnCgLHT+Fevbz6pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rsbuild/core': ^1.0.0 || ^2.0.0-0
     peerDependenciesMeta:
@@ -8929,7 +8930,7 @@ snapshots:
 
   '@prefresh/utils@1.2.1': {}
 
-  '@publint/pack@0.1.3': {}
+  '@publint/pack@0.1.4': {}
 
   '@reduxjs/toolkit@2.12.0(react@19.2.6)':
     dependencies:
@@ -12924,9 +12925,9 @@ snapshots:
       randombytes: 2.1.0
       safe-buffer: 5.2.1
 
-  publint@0.3.17:
+  publint@0.3.21:
     dependencies:
-      '@publint/pack': 0.1.3
+      '@publint/pack': 0.1.4
       package-manager-detector: 1.6.0
       picocolors: 1.1.1
       sade: 1.8.1
@@ -13454,10 +13455,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 
-  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.8):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.0.8):
     dependencies:
-      picocolors: 1.1.1
-      publint: 0.3.17
+      publint: 0.3.21
     optionalDependencies:
       '@rsbuild/core': 2.0.8(@module-federation/runtime-tools@2.5.0)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,11 @@ minimumReleaseAgeExclude:
   - '@rstest/*'
   - '@rsdoctor/*'
   - '@rslint/*'
-  - rsbuild-plugin-dts
+  - reduce-configs
+  - '@rstack-dev/doc-ui'
+  - 'rsbuild-plugin-*'
+  - '@swc/*'
+  - heading-case
 
 # Prevent un-reviewed build scripts
 strictDepBuilds: true


### PR DESCRIPTION
## Summary

This PR keeps the workspace supply-chain policy aligned with the package families used by Rslib, expanding `minimumReleaseAgeExclude` for the needed Rsbuild/Rstack-related packages while replacing the single `rsbuild-plugin-dts` entry with `rsbuild-plugin-*`. It also updates `rsbuild-plugin-publint` to `^1.0.0` across the packages that use it and refreshes the lockfile.

## Related Links

https://github.com/rstackjs/rsbuild-plugin-publint/releases/tag/v1.0.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).