### PR TITLE
docs: clarify dts.isolated performance guidance

### DIFF
--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -355,12 +355,12 @@ When enabling this option, we recommend also enabling `isolatedDeclarations` in 
 
 #### Use cases
 
-By default, `rsbuild-plugin-dts` generates declaration files through the TypeScript Compiler API, and it can also generate declaration files by enabling [tsgo](#tsgo). Unlike these two approaches, `isolated` does not perform full type checking during declaration file generation, so it is more suitable for use with another independent, high-performance type checking workflow.
+By default, `rsbuild-plugin-dts` generates declaration files through the TypeScript Compiler API, and it can also generate declaration files by enabling [tsgo](#tsgo). Unlike these two approaches, `isolated` is the fastest option and is suitable for scenarios that prioritize build performance.
 
-For example, in a monorepo project, you can use this option together with [`rslint --type-check`](https://rslint.rs/guide/type-checking):
+Since `isolated` does not perform type checking during declaration generation, it is usually used together with another independent, high-performance type checking workflow. For example, in a monorepo project, you can use this option together with [`rslint --type-check`](https://rslint.rs/guide/type-checking):
 
-- Use `rslint --type-check` as the unified type checking step.
-- Use `isolated` to quickly output declaration files when building each package.
+- Daily builds: use `isolated` to quickly output declaration files when building each package.
+- Global checks: run `rslint --type-check` in CI or pre-commit hooks to perform unified type checking when needed.
 
 This preserves full type checking while reducing the cost of repeatedly running TypeScript type analysis, loading TypeScript or `tsgo` related packages, and loading native bindings during each package build, making the overall build pipeline lighter.
 

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -358,12 +358,12 @@ When enabling this option, we recommend also enabling [isolatedDeclarations](htt
 
 #### Use cases
 
-By default, Rslib generates declaration files through the TypeScript Compiler API, and it can also generate declaration files with `tsgo` through `dts.tsgo`. Unlike these two approaches, `dts.isolated` does not perform full type checking during declaration file generation, so it is more suitable for use with another independent, high-performance type checking workflow.
+By default, Rslib generates declaration files through the TypeScript Compiler API, and it can also generate declaration files with `tsgo` through `dts.tsgo`. Unlike these two approaches, `dts.isolated` is the fastest option and is suitable for scenarios that prioritize build performance.
 
-For example, in a monorepo project, you can use this option together with [`rslint --type-check`](https://rslint.rs/guide/type-checking):
+Since `dts.isolated` does not perform type checking during declaration generation, it is usually used together with another independent, high-performance type checking workflow. For example, in a monorepo project, you can use this option together with [`rslint --type-check`](https://rslint.rs/guide/type-checking):
 
-- Use `rslint --type-check` as the unified type checking step.
-- Use `dts.isolated` to quickly output declaration files when building each package.
+- Daily builds: use `dts.isolated` to quickly output declaration files when building each package.
+- Global checks: run `rslint --type-check` in CI or pre-commit hooks to perform unified type checking when needed.
 
 This preserves full type checking while reducing the cost of repeatedly running TypeScript type analysis, loading TypeScript or `tsgo` related packages, and loading native bindings during each package build, making the overall build pipeline lighter.
 

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -358,12 +358,12 @@ export default {
 
 #### 适用场景
 
-Rslib 默认通过 TypeScript Compiler API 生成类型声明文件，也可以通过 `dts.tsgo` 使用 `tsgo` 生成类型声明文件。与这两种方式不同，`dts.isolated` 不会在声明文件生成阶段执行完整类型检查，因此更适合与其他独立的高性能类型检查流程搭配使用。
+Rslib 默认通过 TypeScript Compiler API 生成类型声明文件，也可以通过 `dts.tsgo` 使用 `tsgo` 生成类型声明文件。与这两种方式不同，`dts.isolated` 速度最快，适合追求构建性能的场景。
 
-例如在 monorepo 项目中，可以配合 [`rslint --type-check`](https://rslint.rs/guide/type-checking) 使用该选项：
+由于 `dts.isolated` 不会在声明文件生成阶段执行类型检查，所以通常需要与其他独立的高性能类型检查流程搭配使用。例如在 monorepo 项目中，可以配合 [`rslint --type-check`](https://rslint.rs/guide/type-checking) 使用该选项：
 
-- 由 `rslint --type-check` 作为统一的类型检查步骤。
-- 由 `dts.isolated` 负责在各个包构建时快速输出类型声明文件。
+- 日常构建：由 `dts.isolated` 负责在各个包构建时快速输出类型声明文件。
+- 全局检查：在 CI 或 pre-commit hook 中运行 `rslint --type-check`，按需执行统一的类型检查。
 
 这样既能保留完整的类型检查，又能减少每个包在构建阶段重复执行 TypeScript 类型分析、加载 TypeScript 或 `tsgo` 相关包及 native binding 的开销，让整体构建链路更轻量。
 


### PR DESCRIPTION
## Summary

This PR clarifies the `dts.isolated` docs by moving the performance guidance into the use-case section. It explains that isolated declarations are the fastest option for build performance, notes that type checking should be handled by an independent workflow, and updates the `rslint --type-check` example to distinguish daily declaration emits from global checks in CI or pre-commit hooks.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).