### PR TITLE
chore(deps): upgrade rsbuild to 2.0.11

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.0",
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@rsbuild/plugin-react": "^2.0.1",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -22,7 +22,7 @@
     "@module-federation/enhanced": "^2.5.0",
     "@module-federation/rsbuild-plugin": "^2.5.0",
     "@module-federation/storybook-addon": "^6.0.12",
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@rsbuild/plugin-react": "^2.0.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.4.1",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.0",
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@rsbuild/plugin-react": "^2.0.1",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@rsbuild/plugin-vue": "^1.2.9",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.4.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "test": "rstest"
   },
   "dependencies": {
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@storybook/addon-docs": "^10.4.1",
     "@storybook/addon-onboarding": "^10.4.1",
     "@storybook/react": "^10.4.1",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@storybook/addon-docs": "^10.4.1",
     "@storybook/addon-onboarding": "^10.4.1",
     "@storybook/react": "^10.4.1",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@storybook/addon-docs": "^10.4.1",
     "@storybook/addon-onboarding": "^10.4.1",
     "@storybook/vue3": "^10.4.1",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@storybook/addon-docs": "^10.4.1",
     "@storybook/addon-onboarding": "^10.4.1",
     "@storybook/vue3": "^10.4.1",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.7",
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@rslib/tsconfig": "workspace:*",
     "magic-string": "^0.30.21",
     "prebundle": "1.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 0.10.3(@rslib/core@0.22.0)(@rstest/core@0.10.3)(typescript@6.0.3)
       '@rstest/core':
         specifier: ^0.10.3
-        version: 0.10.3
+        version: 0.10.3(@module-federation/runtime-tools@2.5.0)
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -83,13 +83,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+        version: 2.5.0(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@rsbuild/core':
-        specifier: ~2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -104,19 +104,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.5.0
-        version: 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+        version: 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+        version: 2.5.0(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/storybook-addon':
         specifier: ^6.0.12
-        version: 6.0.12(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack-virtual-modules@0.6.2)
+        version: 6.0.12(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
-        specifier: ~2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -146,10 +146,10 @@ importers:
         version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.0.11)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.4)(storybook@10.4.1)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.4)(storybook@10.4.1)(typescript@6.0.3)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -162,13 +162,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+        version: 2.5.0(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@rsbuild/core':
-        specifier: ~2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -183,10 +183,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.7.3
-        version: 1.7.3(@rsbuild/core@2.0.9)(preact@10.29.2)
+        version: 1.7.3(@rsbuild/core@2.0.11)(preact@10.29.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.9)
+        version: 1.5.3(@rsbuild/core@2.0.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -198,10 +198,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.9)
+        version: 1.5.3(@rsbuild/core@2.0.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -216,10 +216,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.9)
+        version: 1.5.3(@rsbuild/core@2.0.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -234,10 +234,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.9)
+        version: 1.5.3(@rsbuild/core@2.0.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -252,13 +252,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.2.1
-        version: 1.2.1(@rsbuild/core@2.0.9)
+        version: 1.2.1(@rsbuild/core@2.0.11)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.9)
+        version: 1.5.3(@rsbuild/core@2.0.11)
       '@rsbuild/plugin-solid':
         specifier: ^1.2.1
-        version: 1.2.1(@babel/core@7.29.0)(@rsbuild/core@2.0.9)(solid-js@1.9.13)
+        version: 1.2.1(@babel/core@7.29.0)(@rsbuild/core@2.0.11)(solid-js@1.9.13)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -273,7 +273,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(vue@3.5.35)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -290,11 +290,11 @@ importers:
   examples/vue-component-bundleless:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(vue@3.5.35)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -312,10 +312,10 @@ importers:
         version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.0.11)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vue@3.5.35)
+        version: 3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vue@3.5.35)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -329,15 +329,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.0)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.9)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+        version: 2.5.0(@rsbuild/core@2.0.11)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -364,7 +364,7 @@ importers:
         version: 1.6.5(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.0.9)
+        version: 1.0.0(@rsbuild/core@2.0.11)
       rslib:
         specifier: npm:@rslib/core@0.22.0
         version: '@rslib/core@0.22.0(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)'
@@ -401,7 +401,7 @@ importers:
         version: 11.3.5
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.0.9)
+        version: 1.0.0(@rsbuild/core@2.0.11)
       rslib:
         specifier: npm:@rslib/core@0.22.0
         version: '@rslib/core@0.22.0(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)'
@@ -422,8 +422,8 @@ importers:
         specifier: ^7.58.7
         version: 7.58.7(@types/node@25.2.0)
       '@rsbuild/core':
-        specifier: ~2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -435,7 +435,7 @@ importers:
         version: 1.6.5(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.0.9)
+        version: 1.0.0(@rsbuild/core@2.0.11)
       rslib:
         specifier: npm:@rslib/core@0.22.0
         version: '@rslib/core@0.22.0(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)'
@@ -465,34 +465,34 @@ importers:
         version: 4.0.1
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
+        version: 2.5.0(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
       '@rsbuild/core':
-        specifier: ~2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-less':
         specifier: ^1.6.4
-        version: 1.6.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 1.6.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.9)
+        version: 1.5.3(@rsbuild/core@2.0.11)
       '@rsbuild/plugin-toml':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)
+        version: 2.0.1(@rsbuild/core@2.0.11)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.3
-        version: 1.2.3(@rsbuild/core@2.0.9)
+        version: 1.2.3(@rsbuild/core@2.0.11)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(vue@3.5.35)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@2.0.9)
+        version: 1.0.5(@rsbuild/core@2.0.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -566,7 +566,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
 
   tests/integration/asset/json: {}
 
@@ -582,10 +582,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(typescript@6.0.3)
+        version: 2.0.3(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(typescript@6.0.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -679,10 +679,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(typescript@6.0.3)
+        version: 2.0.3(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(typescript@6.0.3)
 
   tests/integration/cli/build: {}
 
@@ -975,11 +975,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.9)
+        version: 1.4.5(@rsbuild/core@2.0.11)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -988,11 +988,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.5
-        version: 1.4.5(@rsbuild/core@2.0.9)
+        version: 1.4.5(@rsbuild/core@2.0.11)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1026,7 +1026,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.2.1
-        version: 1.2.1(@rsbuild/core@2.0.9)
+        version: 1.2.1(@rsbuild/core@2.0.11)
       babel-plugin-polyfill-corejs3:
         specifier: ^0.14.2
         version: 0.14.2(@babel/core@7.29.0)
@@ -1039,7 +1039,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1165,19 +1165,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)
+        version: 2.0.1(@rsbuild/core@2.0.11)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1186,7 +1186,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)
+        version: 2.0.1(@rsbuild/core@2.0.11)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1234,10 +1234,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.6.4
-        version: 1.6.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 1.6.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(vue@3.5.35)
       vue:
         specifier: ^3.5.35
         version: 3.5.35(typescript@6.0.3)
@@ -1254,16 +1254,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+        version: 2.5.0(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@rsbuild/core':
-        specifier: ~2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0)
+        specifier: ~2.0.11
+        version: 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.9)
+        version: 1.5.3(@rsbuild/core@2.0.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1272,7 +1272,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 2.0.13
-        version: 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 2.0.13
         version: 2.0.13(@rspress/core@2.0.13)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)
@@ -1311,10 +1311,10 @@ importers:
         version: 19.2.6(react@19.2.6)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.6
-        version: 1.0.6(@rsbuild/core@2.0.9)
+        version: 1.0.6(@rsbuild/core@2.0.11)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.0.9)
+        version: 1.1.3(@rsbuild/core@2.0.11)
       rspress-plugin-file-tree:
         specifier: ^1.0.5
         version: 1.0.5(@rspress/core@2.0.13)
@@ -2827,6 +2827,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rsbuild/core@2.0.11':
+    resolution: {integrity: sha512-Mpp/viUSkVdSWJkFipdZxM2nUztrBwSnMm6Q86bPzLHtHnXqQ3VFpSMlA4wWRyySNddP6s6efKiVpx0ZOCf7Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/core@2.0.9':
     resolution: {integrity: sha512-lK2bMNuwh3TuLXLskS7nG3fnQk+6eaLeeZiquJWcna4JZx9iaI59JSd+iLcg5TeZLjEVygkwn/HcE+yuYDQRAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3014,13 +3024,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.0.6':
+    resolution: {integrity: sha512-0giCKiWlBfcM4i2scv1j2k9HlSecO9Ybhaa5wsMUyvcFeKr9HbNHh7C2eDFlC6zaI85IUdY71TXF/g/Tcxr9MA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.0.5':
     resolution: {integrity: sha512-JBD5mCN3JKjV64Mh9nDYx8lLUrWDfEl5tLBuMkREUnqEKbo+z4nfwotyqHHM8/XgZwL+Gr7ps4GLWuQQrZB8+Q==}
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.0.6':
+    resolution: {integrity: sha512-/mMo2IpI02aOKMlHbVbZue3TJxFqHGX+ibVTdEO+6bzRSuHs7+R9KM5U3XH2YxcWJy5Sid1X1T1pJAjsXcE3rA==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.0.5':
     resolution: {integrity: sha512-JI8+//woanJPNsfL7iGjX39zyiWumnrKHznWQM/7lEtE5nPmk+j+X7TYXxczSWC9zfZegiqI74D3L5JPDC84Fw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.0.6':
+    resolution: {integrity: sha512-H6ACzeM1KBxYDEF8YAim3501Jb1aCsSG79Gjm1M4pwJ5OJPK2ydiJEa438ugXmh0962eKYMHI2yZY0sQq8txaw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3031,8 +3057,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.0.6':
+    resolution: {integrity: sha512-QTFmBg0n+L397Wi8CIjbd5pe/hxpHnqCDaG1A7e2NWX8Fj9zulAoKLiKflQa1ELEhAY4Foq88aX75+Ilt2tHcw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@2.0.5':
     resolution: {integrity: sha512-241wqE132jh+/U/pn97qUPV4KpIy4bSrTH0tqfzQCocgw+8hrUj02GqNG+3MXVC3qtwaQeJFYgEBy3TqFKsrIQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.0.6':
+    resolution: {integrity: sha512-rerCAz022zf0ewxI+7n3SrqLEaxCL+MXRxKjK5FLUGFa8UkIrivq+VUP/1OB6JLh2Bucebc7Y9WoWHvtk22mLA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3043,12 +3081,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.0.6':
+    resolution: {integrity: sha512-96IgOFXQjX6Wbxd+DCYJFy2r/VMu1OoHifW4Cr3kGTYDKoQOIMLwb0ieu/ILp2dGWFMZo5S8odiByAmNICAOIA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.0.5':
     resolution: {integrity: sha512-duEkRoXrl9SW8uGHv7JURJ5lgKu87qFDQ4Exy6UQPvsUJVXhtRXTfvMHCb/CejVJuW2Bw2D632/axZq3qRSuBQ==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.0.6':
+    resolution: {integrity: sha512-0aWiF+qmdb0csp1x+MaR2o1pscoquLaEbLTVdKjmoTRs6sguMemtB1ObnVTahAUL73P66WePuNpFAJ81zNdqzQ==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.0.5':
     resolution: {integrity: sha512-q2WT3HFoWL+2g84l3s2kY7CiE1gEZ1bwB3txx3eZzQQ6YKP7bE82z6sl6S/pTOHGjHdAO4snQXpSaHwUt3LX5g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.6':
+    resolution: {integrity: sha512-BX638A1MXsjc2E3tUskVh3X/WBIHjLKK+lo395v7MmEL9u2BA6l3F6RyW+YaJOt5aEOOv83iA7iCZsviVZ49Uw==}
     cpu: [arm64]
     os: [win32]
 
@@ -3057,16 +3110,41 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.0.6':
+    resolution: {integrity: sha512-DCK/+MlN35uvH7tp4j0hbg8wIs9MHArMIrNZXtiD8xP6DNw2wrXcGC1VaxxR5apyWpqXAfIL/KsXBiWS3ygCvg==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.0.5':
     resolution: {integrity: sha512-vP0BR6fxdPL9cb02HAuZATg/CjR07aecWel3s1vqRwW1aDffgXh9PVmqEKIHTgyaNsNR55kSKNJsB9AcQ8/QrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.0.6':
+    resolution: {integrity: sha512-TxutgzdEX9BkAU/5liKxdQmggJ23INz7EZDWtzSJO6C2SiSYzTJdyPQDIJi1ddkM5TX/drzH184gAJMVOQefng==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@2.0.5':
     resolution: {integrity: sha512-Ta1y4WXJA87wM1OstqaMddoPsBGv7Cu779bYToKxEAqR/Yy9DxLkp7bdgBaAx2JH++BwVjV+toWts2V9AaiTFQ==}
 
+  '@rspack/binding@2.0.6':
+    resolution: {integrity: sha512-z5EO9mPlmYNpHAlRGub0Chr6D+Klgy+tX36n7tCm7VRGRlwTmTU9wSENrYbHcCpFbegtrE0s30rDeTBeOu+JiQ==}
+
   '@rspack/core@2.0.5':
     resolution: {integrity: sha512-9tv2HAnSiTote5WPH2tmz1hLZ1zKbzkiZc1eYp7LP/8jcsiJBuf40ihiWidAgbbuYtJo3kWET6q+qOm5UhNiGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.0.6':
+    resolution: {integrity: sha512-ronRqH1T2dYdMFVOQbGvDNxYaLugQK8qhNYYtS2DbOvPKQYvdIYWDenL9k/WV+hLoknnPWMn2ME2cKJcK3Po+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8406,7 +8484,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)':
+  '@module-federation/enhanced@2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/cli': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
@@ -8415,7 +8493,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.5.0(@module-federation/runtime-tools@2.5.0)
       '@module-federation/managers': 2.5.0(node-fetch@2.7.0)
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
-      '@module-federation/rspack': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
+      '@module-federation/rspack': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.5.0(node-fetch@2.7.0)
@@ -8431,7 +8509,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)':
+  '@module-federation/enhanced@2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/cli': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
@@ -8440,7 +8518,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.5.0(@module-federation/runtime-tools@2.5.0)
       '@module-federation/managers': 2.5.0(node-fetch@2.7.0)
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
-      '@module-federation/rspack': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+      '@module-federation/rspack': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.5.0(node-fetch@2.7.0)
@@ -8495,9 +8573,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.43(@rspack/core@2.0.5)(typescript@5.9.3)(vue-tsc@3.3.3)':
+  '@module-federation/node@2.7.43(@rspack/core@2.0.6)(typescript@5.9.3)(vue-tsc@3.3.3)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
       '@module-federation/runtime': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -8510,9 +8588,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.43(@rspack/core@2.0.5)(typescript@6.0.3)(vue-tsc@3.3.3)':
+  '@module-federation/node@2.7.43(@rspack/core@2.0.6)(typescript@6.0.3)(vue-tsc@3.3.3)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/runtime': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -8527,7 +8605,7 @@ snapshots:
 
   '@module-federation/node@2.7.43(typescript@6.0.3)(vue-tsc@3.3.3)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/runtime': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -8540,13 +8618,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)':
+  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
-      '@module-federation/node': 2.7.43(@rspack/core@2.0.5)(typescript@5.9.3)(vue-tsc@3.3.3)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
+      '@module-federation/node': 2.7.43(@rspack/core@2.0.6)(typescript@5.9.3)(vue-tsc@3.3.3)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8556,13 +8634,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)':
+  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
-      '@module-federation/node': 2.7.43(@rspack/core@2.0.5)(typescript@6.0.3)(vue-tsc@3.3.3)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+      '@module-federation/node': 2.7.43(@rspack/core@2.0.6)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8572,13 +8650,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.9)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)':
+  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.11)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/node': 2.7.43(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8588,7 +8666,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)':
+  '@module-federation/rspack@2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
@@ -8597,7 +8675,7 @@ snapshots:
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 5.9.3
       vue-tsc: 3.3.3(typescript@5.9.3)
@@ -8606,7 +8684,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/rspack@2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)':
+  '@module-federation/rspack@2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
@@ -8615,7 +8693,7 @@ snapshots:
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.3(typescript@6.0.3)
@@ -8650,12 +8728,12 @@ snapshots:
     optionalDependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 
-  '@module-federation/storybook-addon@6.0.12(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.12(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.5)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -9008,6 +9086,13 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
+  '@rsbuild/core@2.0.11(@module-federation/runtime-tools@2.5.0)':
+    dependencies:
+      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/core@2.0.9(@module-federation/runtime-tools@2.5.0)':
     dependencies:
       '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
@@ -9015,7 +9100,7 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.0.11)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -9024,23 +9109,23 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)':
+  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
-      less-loader: 12.3.3(@rspack/core@2.0.5)(less@4.6.4)
+      less-loader: 12.3.3(@rspack/core@2.0.6)(less@4.6.4)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.5(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-node-polyfill@1.4.5(@rsbuild/core@2.0.11)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9066,29 +9151,29 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
 
-  '@rsbuild/plugin-preact@1.7.3(@rsbuild/core@2.0.9)(preact@10.29.2)':
+  '@rsbuild/plugin-preact@1.7.3(@rsbuild/core@2.0.11)(preact@10.29.2)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.2)
       '@prefresh/utils': 1.2.1
       '@rspack/plugin-preact-refresh': 1.1.5(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh': 12.12.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.6)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.0.11)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9096,107 +9181,95 @@ snapshots:
       reduce-configs: 1.1.2
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
 
-  '@rsbuild/plugin-solid@1.2.1(@babel/core@7.29.0)(@rsbuild/core@2.0.9)(solid-js@1.9.13)':
+  '@rsbuild/plugin-solid@1.2.1(@babel/core@7.29.0)(@rsbuild/core@2.0.11)(solid-js@1.9.13)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.0.9)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.0.11)
       babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.13)
       solid-refresh: 0.7.8(solid-js@1.9.13)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)':
+  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0
-      stylus-loader: 8.1.3(@rspack/core@2.0.5)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.0.6)(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.1(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-tailwindcss@2.0.1(@rsbuild/core@2.0.11)':
     dependencies:
       '@tailwindcss/webpack': 4.3.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - webpack
 
-  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.0.11)':
     dependencies:
       toml: 4.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
 
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.5)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.6)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.3(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-typed-css-modules@1.2.3(@rsbuild/core@2.0.11)':
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
 
-  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(vue@3.5.35)':
+  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(vue@3.5.35)':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@2.0.5)(vue@3.5.35)
+      rspack-vue-loader: 17.5.0(@rspack/core@2.0.6)(vue@3.5.35)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@1.0.5(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-yaml@1.0.5(@rsbuild/core@2.0.11)':
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
 
   '@rslib/core@0.22.0(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
-      rsbuild-plugin-dts: 0.22.0(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.9)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.58.7(@types/node@25.2.0)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@typescript/native-preview'
-      - core-js
-
-  '@rslib/core@0.22.0(@microsoft/api-extractor@7.58.7)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)':
-    dependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
-      rsbuild-plugin-dts: 0.22.0(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.9)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
+      rsbuild-plugin-dts: 0.22.0(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.11)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.4)
       typescript: 6.0.3
@@ -9239,19 +9312,37 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.5':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.0.6':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.0.5':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.6':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.5':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.0.6':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.0.5':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.6':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.5':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.0.6':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.0.5':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.6':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.5':
@@ -9261,13 +9352,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.0.6':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.0.5':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.6':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.5':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.0.6':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.0.5':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.6':
     optional: true
 
   '@rspack/binding@2.0.5':
@@ -9283,9 +9390,29 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.5
       '@rspack/binding-win32-x64-msvc': 2.0.5
 
+  '@rspack/binding@2.0.6':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.6
+      '@rspack/binding-darwin-x64': 2.0.6
+      '@rspack/binding-linux-arm64-gnu': 2.0.6
+      '@rspack/binding-linux-arm64-musl': 2.0.6
+      '@rspack/binding-linux-x64-gnu': 2.0.6
+      '@rspack/binding-linux-x64-musl': 2.0.6
+      '@rspack/binding-wasm32-wasi': 2.0.6
+      '@rspack/binding-win32-arm64-msvc': 2.0.6
+      '@rspack/binding-win32-ia32-msvc': 2.0.6
+      '@rspack/binding-win32-x64-msvc': 2.0.6
+
   '@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.0.5
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
+      '@swc/helpers': 0.5.23
+
+  '@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.0.6
     optionalDependencies:
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@swc/helpers': 0.5.23
@@ -9297,18 +9424,18 @@ snapshots:
       '@prefresh/core': 1.5.10(preact@10.29.2)
       '@prefresh/utils': 1.2.1
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.6)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.15)(react@19.2.6)
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
       '@rspress/shared': 2.0.13(@module-federation/runtime-tools@2.5.0)
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -9357,7 +9484,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -9368,7 +9495,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.13(@rspress/core@2.0.13)':
     dependencies:
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       remark-mdx: 3.1.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -9379,17 +9506,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.13(@rspress/core@2.0.13)':
     dependencies:
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.13(@rspress/core@2.0.13)':
     dependencies:
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rspress/plugin-twoslash@2.0.13(@rspress/core@2.0.13)(react@19.2.6)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@shikijs/twoslash': 4.0.2(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3
       mdast-util-gfm: 3.1.0
@@ -9403,7 +9530,7 @@ snapshots:
 
   '@rspress/shared@2.0.13(@module-federation/runtime-tools@2.5.0)':
     dependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@shikijs/rehype': 4.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9412,16 +9539,16 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.3(@rspress/core@2.0.13)':
     optionalDependencies:
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rstest/adapter-rslib@0.10.3(@rslib/core@0.22.0)(@rstest/core@0.10.3)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 0.22.0(@microsoft/api-extractor@7.58.7)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)
-      '@rstest/core': 0.10.3
+      '@rslib/core': 0.22.0(@microsoft/api-extractor@7.58.7)(@module-federation/runtime-tools@2.5.0)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3)
+      '@rstest/core': 0.10.3(@module-federation/runtime-tools@2.5.0)
     optionalDependencies:
       typescript: 6.0.3
 
-  '@rstest/core@0.10.3':
+  '@rstest/core@0.10.3(@module-federation/runtime-tools@2.5.0)':
     dependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
       '@types/chai': 5.2.3
@@ -11778,11 +11905,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@rspack/core@2.0.5)(less@4.6.4):
+  less-loader@12.3.3(@rspack/core@2.0.6)(less@4.6.4):
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   less@4.6.4:
     dependencies:
@@ -13382,49 +13509,49 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.22.0(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.9)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.22.0(@microsoft/api-extractor@7.58.7)(@rsbuild/core@2.0.11)(@typescript/native-preview@7.0.0-dev.20260527.2)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@24.12.4)
       '@typescript/native-preview': 7.0.0-dev.20260527.2
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.0.9):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.0.11):
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.9):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.11):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.0.9):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.0.11):
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.0.9):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.0.11):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
 
   rslog@2.1.2: {}
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.0.5)(vue@3.5.35):
+  rspack-vue-loader@17.5.0(@rspack/core@2.0.6)(vue@3.5.35):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       vue: 3.5.35(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.13):
     dependencies:
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -13449,14 +13576,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.13):
     dependencies:
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.13)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.13):
     dependencies:
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.5)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.4)(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   run-applescript@7.1.0: {}
 
@@ -13778,18 +13905,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.0.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.0.11)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -13801,7 +13928,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.9)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.11)
       sirv: 2.0.4
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       ts-dedent: 2.2.0
@@ -13817,10 +13944,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.4)(storybook@10.4.1)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.4)(storybook@10.4.1)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@storybook/react': 10.4.1(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)
       find-up: 5.0.0
@@ -13831,7 +13958,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       resolve: 1.22.12
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -13845,12 +13972,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vue@3.5.35):
+  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vue@3.5.35):
     dependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)
+      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)
       '@storybook/vue3': 10.4.1(storybook@10.4.1)(vue@3.5.35)
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
       vue: 3.5.35(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.35)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -13970,13 +14097,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.0.5)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.0.6)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   stylus@0.64.0:
     dependencies:
@@ -14091,7 +14218,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.5)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.6)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
@@ -14099,7 +14226,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/integration/format/index.test.ts
+++ b/tests/integration/format/index.test.ts
@@ -66,8 +66,8 @@ test('import.meta.url should be preserved', async () => {
   expect(entries.esm).toMatchInlineSnapshot(`
     "import node_url from "node:url";
     const packageDirectory = node_url.fileURLToPath(new URL('.', import.meta.url));
-    var src_foo = "foo";
-    export { packageDirectory, src_foo as foo };
+    const foo = 'foo';
+    export { foo, packageDirectory };
     "
   `);
 

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@rsbuild/plugin-node-polyfill": "^1.4.5"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@rsbuild/plugin-node-polyfill": "^1.4.5"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^2.5.0",
     "@playwright/test": "1.60.0",
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@rsbuild/plugin-less": "^1.6.4",
     "@rsbuild/plugin-react": "^2.0.1",
     "@rsbuild/plugin-sass": "^1.5.3",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.0",
-    "@rsbuild/core": "~2.0.9",
+    "@rsbuild/core": "~2.0.11",
     "@rsbuild/plugin-react": "^2.0.1",
     "@rsbuild/plugin-sass": "^1.5.3",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

This PR upgrades `@rsbuild/core` to `~2.0.11` across the core package, examples, tests, website, and Storybook templates. It also refreshes the lockfile and the affected integration snapshot for the updated Rsbuild/Rspack output.

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v2.0.11

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
