### PR TITLE
chore: use pnpm staged publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,4 +60,4 @@ jobs:
 
       - name: Publish to npm
         run: |
-          pnpm -r publish --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}
+          pnpm --filter './packages/*' -r stage publish --tag ${{ github.event.inputs.npm_tag }} --no-git-checks

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "simple-git-hooks": "^2.13.1",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@11.5.0",
+  "packageManager": "pnpm@11.5.1",
   "engines": {
     "node": "^20.19.0 || >=22.12.0",
-    "pnpm": ">=11.5.0"
+    "pnpm": ">=11.5.1"
   }
 }


### PR DESCRIPTION
## Summary

This PR updates the npm release workflow to use pnpm staged publishing for workspace package releases, matching the newer npm publishing flow while keeping package selection scoped to `./packages/*`. It also upgrades the pinned pnpm version to `11.5.1` so the repository uses the latest pnpm release with the `stage` command available.

## Related Links

https://docs.npmjs.com/staged-publishing/

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).