### PR TITLE
fix(dts): correct tsgo preview peer range

### DIFF
--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "@microsoft/api-extractor": "^7",
     "@rsbuild/core": "^1.0.0 || ^2.0.0-0",
-    "@typescript/native-preview": "7.x",
+    "@typescript/native-preview": "^7.0.0-0",
     "typescript": "^5 || ^6"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6451,7 +6451,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7
       '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-      '@typescript/native-preview': 7.x
+      '@typescript/native-preview': ^7.0.0-0
       typescript: ^5 || ^6
     peerDependenciesMeta:
       '@microsoft/api-extractor':


### PR DESCRIPTION
## Summary

This PR updates the optional `@typescript/native-preview` peer range for `rsbuild-plugin-dts` from `7.x` to `^7.0.0-0`, so tsgo preview prerelease versions such as `7.0.0-dev.*` satisfy the peer dependency range.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).