### PR TITLE
perf(core): use deterministic module ids for web targets

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -482,7 +482,6 @@ export async function createConstantRsbuildConfig(): Promise<EnvironmentConfig> 
       htmlPlugin: false,
       rspack: {
         optimization: {
-          moduleIds: 'named',
           nodeEnv: false,
         },
         // TypeScript-specific behavior: if the extension is ".js" or ".jsx", try replacing it with ".ts" or ".tsx"
@@ -750,7 +749,6 @@ const composeFormatConfig = ({
               // can not set nodeEnv to false, because mf format should build shared module.
               // If nodeEnv is false, the process.env.NODE_ENV in third-party packages's will not be replaced
               nodeEnv: env === 'development' ? 'development' : 'production',
-              moduleIds: env === 'development' ? 'named' : 'deterministic',
             };
           },
         },
@@ -1705,6 +1703,25 @@ const composeTargetConfig = (
   }
 };
 
+const composeModuleIdsConfig = (
+  format: Format,
+  target: RsbuildConfigOutputTarget,
+): EnvironmentConfig => {
+  if (format === 'mf') {
+    return {};
+  }
+
+  return {
+    tools: {
+      rspack: {
+        optimization: {
+          moduleIds: target === 'web' ? 'deterministic' : 'named',
+        },
+      },
+    },
+  };
+};
+
 const composeExternalHelpersConfig = (
   externalHelpers: boolean,
   pkgJson?: PkgJson,
@@ -1792,6 +1809,7 @@ async function composeLibRsbuildConfig(
     multiCompilerIndex,
     sourceEntry: config.source?.entry,
   });
+  const moduleIdsConfig = composeModuleIdsConfig(format, target);
   const userExternals = hasExe ? undefined : config.output?.externals;
   const externalHelpersConfig = composeExternalHelpersConfig(
     hasExe ? false : externalHelpers,
@@ -1872,6 +1890,7 @@ async function composeLibRsbuildConfig(
     bundleConfig,
     formatConfig,
     // outputConfig,
+    moduleIdsConfig,
     shimsConfig,
     syntaxConfig,
     externalHelpersConfig,

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -1008,12 +1008,12 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         }
       )
     ],
-    moduleIds: 'named',
     nodeEnv: false,
     concatenateModules: false,
     sideEffects: true,
     runtimeChunk: undefined,
-    avoidEntryIife: true
+    avoidEntryIife: true,
+    moduleIds: 'named'
   },
   plugins: [
     /* config.plugin('RsbuildCorePlugin') */
@@ -1777,8 +1777,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         }
       )
     ],
-    moduleIds: 'named',
-    nodeEnv: false
+    nodeEnv: false,
+    moduleIds: 'named'
   },
   plugins: [
     /* config.plugin('RsbuildCorePlugin') */
@@ -2453,8 +2453,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         }
       )
     ],
-    moduleIds: 'named',
-    nodeEnv: 'production'
+    nodeEnv: 'production',
+    moduleIds: 'named'
   },
   plugins: [
     /* config.plugin('RsbuildCorePlugin') */
@@ -3129,8 +3129,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         }
       )
     ],
-    moduleIds: 'named',
-    nodeEnv: 'production'
+    nodeEnv: 'production',
+    moduleIds: 'named'
   },
   plugins: [
     /* config.plugin('RsbuildCorePlugin') */
@@ -3751,7 +3751,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         }
       )
     ],
-    moduleIds: 'deterministic',
     nodeEnv: 'production'
   },
   plugins: [
@@ -3951,7 +3950,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "rspack": [
         {
           "optimization": {
-            "moduleIds": "named",
             "nodeEnv": false,
           },
           "resolve": {
@@ -4000,6 +3998,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           "optimization": {
             "avoidEntryIife": true,
             "concatenateModules": false,
+            "moduleIds": "named",
             "runtimeChunk": undefined,
             "sideEffects": true,
             "splitChunks": {
@@ -4237,7 +4236,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "rspack": [
         {
           "optimization": {
-            "moduleIds": "named",
             "nodeEnv": false,
           },
           "resolve": {
@@ -4280,6 +4278,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             },
           },
           "optimization": {
+            "moduleIds": "named",
             "splitChunks": {
               "chunks": "async",
             },
@@ -4486,7 +4485,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "rspack": [
         {
           "optimization": {
-            "moduleIds": "named",
             "nodeEnv": false,
           },
           "resolve": {
@@ -4521,6 +4519,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             },
           },
           "optimization": {
+            "moduleIds": "named",
             "nodeEnv": undefined,
             "splitChunks": false,
           },
@@ -4724,7 +4723,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "rspack": [
         {
           "optimization": {
-            "moduleIds": "named",
             "nodeEnv": false,
           },
           "resolve": {
@@ -4759,6 +4757,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             },
           },
           "optimization": {
+            "moduleIds": "named",
             "nodeEnv": undefined,
             "splitChunks": false,
           },
@@ -4917,7 +4916,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "rspack": [
         {
           "optimization": {
-            "moduleIds": "named",
             "nodeEnv": false,
           },
           "resolve": {

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -737,6 +737,54 @@ describe('syntax', () => {
   });
 });
 
+describe('module ids', () => {
+  test('uses target-specific module ids by default', async () => {
+    const rslibConfig: RslibConfig = {
+      lib: [
+        {},
+        {
+          output: {
+            target: 'web',
+          },
+        },
+      ],
+    };
+
+    const rslib = await createRslib({
+      config: rslibConfig,
+    });
+    const { origin } = await rslib.inspectConfig();
+
+    expect(origin.bundlerConfigs[0]!.optimization?.moduleIds).toBe('named');
+    expect(origin.bundlerConfigs[1]!.optimization?.moduleIds).toBe(
+      'deterministic',
+    );
+  });
+
+  test('respects user configured module ids for web target', async () => {
+    const rslibConfig: RslibConfig = {
+      lib: [{}],
+      output: {
+        target: 'web',
+      },
+      tools: {
+        rspack: {
+          optimization: {
+            moduleIds: 'named',
+          },
+        },
+      },
+    };
+
+    const rslib = await createRslib({
+      config: rslibConfig,
+    });
+    const { origin } = await rslib.inspectConfig();
+
+    expect(origin.bundlerConfigs[0]!.optimization?.moduleIds).toBe('named');
+  });
+});
+
 describe('minify', () => {
   test('`minify` default value', async () => {
     const rslibConfig: RslibConfig = {

--- a/tests/integration/asset/__snapshots__/index.test.ts.snap
+++ b/tests/integration/asset/__snapshots__/index.test.ts.snap
@@ -230,7 +230,7 @@ export default logo2_namespaceObject;
 exports[`use svgr > should only contain url default export 2`] = `
 ""use strict";
 var __webpack_modules__ = {
-    "./src/assets/logo2.svg" (module) {
+    704 (module) {
         module.exports = require("../static/svg/logo2.svg");
     }
 };
@@ -244,7 +244,7 @@ function __webpack_require__(moduleId) {
     __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
     return module.exports;
 }
-var __webpack_exports__ = __webpack_require__("./src/assets/logo2.svg");
+var __webpack_exports__ = __webpack_require__(704);
 exports["default"] = __webpack_exports__["default"];
 for(var __rspack_i in __webpack_exports__)if (-1 === [
     "default"

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -57,7 +57,7 @@ test('set the size threshold to inline static assets', async () => {
   expect(logoCjs2).toMatchInlineSnapshot(`
     ""use strict";
     var __webpack_modules__ = {
-        "./src/assets/logo.svg" (module) {
+        334 (module) {
             module.exports = require("../static/svg/logo.svg");
         }
     };
@@ -71,7 +71,7 @@ test('set the size threshold to inline static assets', async () => {
         __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
         return module.exports;
     }
-    var __webpack_exports__ = __webpack_require__("./src/assets/logo.svg");
+    var __webpack_exports__ = __webpack_require__(334);
     exports["default"] = __webpack_exports__["default"];
     for(var __rspack_i in __webpack_exports__)if (-1 === [
         "default"
@@ -117,7 +117,7 @@ test('set the assets filename with hash', async () => {
   expect(imageCjs1).toMatchInlineSnapshot(`
     ""use strict";
     var __webpack_modules__ = {
-        "./src/assets/image.png" (module) {
+        369 (module) {
             module.exports = require("../static/image/image.c74653c171.png");
         }
     };
@@ -131,7 +131,7 @@ test('set the assets filename with hash', async () => {
         __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
         return module.exports;
     }
-    var __webpack_exports__ = __webpack_require__("./src/assets/image.png");
+    var __webpack_exports__ = __webpack_require__(369);
     exports["default"] = __webpack_exports__["default"];
     for(var __rspack_i in __webpack_exports__)if (-1 === [
         "default"
@@ -177,7 +177,7 @@ test('set the assets output path', async () => {
   expect(imageCjs1).toMatchInlineSnapshot(`
     ""use strict";
     var __webpack_modules__ = {
-        "./src/assets/image.png" (module) {
+        369 (module) {
             module.exports = require("../assets/bundleless/image.png");
         }
     };
@@ -191,7 +191,7 @@ test('set the assets output path', async () => {
         __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
         return module.exports;
     }
-    var __webpack_exports__ = __webpack_require__("./src/assets/image.png");
+    var __webpack_exports__ = __webpack_require__(369);
     exports["default"] = __webpack_exports__["default"];
     for(var __rspack_i in __webpack_exports__)if (-1 === [
         "default"

--- a/tests/integration/cli/mf/mf.test.ts
+++ b/tests/integration/cli/mf/mf.test.ts
@@ -27,7 +27,6 @@ describe('mf-dev', () => {
 
     const rspackConfigContent = await fse.readFile(rspackConfigFile, 'utf-8');
     expect(rspackConfigContent).toContain(`nodeEnv: 'development'`);
-    expect(rspackConfigContent).toContain(`moduleIds: 'named'`);
 
     const rsbuildConfigContent = await fse.readFile(rsbuildConfigFile, 'utf-8');
     expect(rsbuildConfigContent).toContain('writeToDisk: true');
@@ -106,6 +105,5 @@ describe('mf build', () => {
     const rspackConfigContent = await fse.readFile(rspackConfigFile, 'utf-8');
 
     expect(rspackConfigContent).toContain(`nodeEnv: 'production'`);
-    expect(rspackConfigContent).toContain(`moduleIds: 'deterministic'`);
   });
 });

--- a/tests/integration/node-polyfill/index.test.ts
+++ b/tests/integration/node-polyfill/index.test.ts
@@ -6,7 +6,7 @@ test('`Buffer` should be imported from polyfill when bundled', async () => {
   const fixturePath = join(__dirname, './bundle');
   const { entries, entryFiles } = await buildAndGetResults({ fixturePath });
   const bufferRegex =
-    /var [\w$]+ = __webpack_require__\(".*\/node_modules\/buffer\/index\.js"\)\.[\w$]+/g;
+    /var [\w$]+ = __webpack_require__\((?:"[^"]+"|\d+)\)\.[\w$]+/g;
 
   for (const format of ['esm', 'cjs'] as const) {
     expect(entries[format].match(bufferRegex)?.length).toBe(2);
@@ -31,7 +31,7 @@ test('`Buffer` should be aliased to polyfill packages when bundle is disabled', 
     import { createRequire as __rspack_createRequire } from "node:module";
     const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
     __webpack_require__.add({
-        "<PNPM_INNER>/buffer/index.js" (module) {
+        181 (module) {
             module.exports = __rspack_createRequire_require("buffer");
         }
     });

--- a/tests/integration/resolve/index.test.ts
+++ b/tests/integration/resolve/index.test.ts
@@ -62,9 +62,9 @@ test('resolve false', async () => {
         __webpack_require__.o = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
     })();
     __webpack_require__.add({
-        "?27ce" () {}
+        237 () {}
     });
-    const util_ignored_ = __webpack_require__("?27ce");
+    const util_ignored_ = __webpack_require__("237");
     var util_ignored__default = /*#__PURE__*/ __webpack_require__.n(util_ignored_);
     console.log('foo:', util_ignored__default());
     console.log('bar: ', "bar");

--- a/tests/integration/vue/index.test.ts
+++ b/tests/integration/vue/index.test.ts
@@ -40,7 +40,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
           };
       })();
       __webpack_require__.add({
-          "<PNPM_INNER>/rspack-vue-loader/dist/exportHelper.js" (__unused_rspack_module, exports) {
+          476 (__unused_rspack_module, exports) {
               exports.A = (sfc, props)=>{
                   const target = sfc.__vccOpts || sfc;
                   for (const [key, val] of props)target[key] = val;
@@ -58,7 +58,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
               return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(button.value), 1));
           }
       };
-      const exportHelper = __webpack_require__("<PNPM_INNER>/rspack-vue-loader/dist/exportHelper.js");
+      const exportHelper = __webpack_require__("476");
       const __exports__ = /*#__PURE__*/ (0, exportHelper.A)(Buttonvue_type_script_setup_true_lang_js, [
           [
               '__scopeId',
@@ -112,7 +112,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
       import "./Button.css";
       import { __webpack_require__ } from "../rslib-runtime.js";
       __webpack_require__.add({
-          "<PNPM_INNER>/rspack-vue-loader/dist/exportHelper.js" (__unused_rspack_module, exports) {
+          476 (__unused_rspack_module, exports) {
               exports.A = (sfc, props)=>{
                   const target = sfc.__vccOpts || sfc;
                   for (const [key, val] of props)target[key] = val;
@@ -130,7 +130,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
               return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(button.value), 1));
           }
       };
-      const exportHelper = __webpack_require__("<PNPM_INNER>/rspack-vue-loader/dist/exportHelper.js");
+      const exportHelper = __webpack_require__("476");
       const __exports__ = /*#__PURE__*/ (0, exportHelper.A)(Buttonvue_type_script_setup_true_lang_js, [
           [
               '__scopeId',


### PR DESCRIPTION
## Summary

This PR optimizes web-targeted bundled output by defaulting non-MF module ids to deterministic ids instead of named ids, reducing path-like module id strings in production artifacts while preserving named ids for node targets and MF dev. It also centralizes the default module id composition and keeps user `tools.rspack.optimization.moduleIds` overrides working.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
