### PR TITLE
fix(core): prefix runtime chunk in multi-compiler builds

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -835,7 +835,11 @@ export const getRuntimeChunkConfig = ({
     };
   }
 
-  if (!sourceEntry || Object.keys(sourceEntry).length <= 1) {
+  const shouldSetRuntimeChunkName =
+    typeof multiCompilerIndex === 'number' ||
+    (sourceEntry && Object.keys(sourceEntry).length > 1);
+
+  if (!shouldSetRuntimeChunkName) {
     return undefined;
   }
 

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -1018,7 +1018,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     nodeEnv: false,
     concatenateModules: false,
     sideEffects: true,
-    runtimeChunk: undefined,
+    runtimeChunk: {
+      name: '0~rslib-runtime'
+    },
     avoidEntryIife: true,
     moduleIds: 'named'
   },
@@ -4024,7 +4026,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "avoidEntryIife": true,
             "concatenateModules": false,
             "moduleIds": "named",
-            "runtimeChunk": undefined,
+            "runtimeChunk": {
+              "name": "0~rslib-runtime",
+            },
             "sideEffects": true,
             "splitChunks": {
               "chunks": "async",

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -589,22 +589,27 @@ describe('runtimeChunk', () => {
     ).toBeUndefined();
   });
 
-  test('returns runtime chunk for multiple entries without multi-compiler', async () => {
+  test('returns prefixed runtime chunk for bundled multi-compiler', async () => {
     expect(
       getRuntimeChunkConfig({
         bundle: true,
-        multiCompilerIndex: null,
+        multiCompilerIndex: 0,
+        sourceEntry: undefined,
+      }),
+    ).toEqual({
+      name: '0~rslib-runtime',
+    });
+    expect(
+      getRuntimeChunkConfig({
+        bundle: true,
+        multiCompilerIndex: 0,
         sourceEntry: {
           index: './src/index.ts',
-          cli: './src/cli/index.ts',
         },
       }),
     ).toEqual({
-      name: 'rslib-runtime',
+      name: '0~rslib-runtime',
     });
-  });
-
-  test('returns prefixed runtime chunk for multiple entries with multi-compiler', async () => {
     expect(
       getRuntimeChunkConfig({
         bundle: true,
@@ -617,17 +622,20 @@ describe('runtimeChunk', () => {
     ).toEqual({
       name: '0~rslib-runtime',
     });
+  });
+
+  test('returns runtime chunk for multiple entries without multi-compiler', async () => {
     expect(
       getRuntimeChunkConfig({
         bundle: true,
-        multiCompilerIndex: 1,
+        multiCompilerIndex: null,
         sourceEntry: {
-          foo: './src/foo.ts',
-          bar: './src/bar.ts',
+          index: './src/index.ts',
+          cli: './src/cli/index.ts',
         },
       }),
     ).toEqual({
-      name: '1~rslib-runtime',
+      name: 'rslib-runtime',
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes runtime chunk naming for bundled ESM multi-compiler builds by explicitly prefixing runtime chunk names with the compiler index even when an individual compiler has one or default entry. This prevents multiple compilers from falling back to the same default runtime chunk name while preserving single-compiler behavior.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).