### PR TITLE
chore(deps): upgrade @rsbuild/core to 2.1.0-beta.0

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.1",
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -22,7 +22,7 @@
     "@module-federation/enhanced": "^2.5.1",
     "@module-federation/rsbuild-plugin": "^2.5.1",
     "@module-federation/storybook-addon": "^6.0.13",
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.4.6",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.1",
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@rsbuild/plugin-vue": "^1.2.9",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.4.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "test": "rstest"
   },
   "dependencies": {
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -307,6 +307,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   watchOptions: {
     aggregateTimeout: 0
   },
+  experiments: {
+    sourceImport: true
+  },
   devtool: false,
   cache: {
     type: 'persistent',
@@ -1088,6 +1091,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   watchOptions: {
     aggregateTimeout: 0
   },
+  experiments: {
+    sourceImport: true
+  },
   devtool: false,
   cache: {
     type: 'persistent',
@@ -1865,6 +1871,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   watchOptions: {
     aggregateTimeout: 0
   },
+  experiments: {
+    sourceImport: true
+  },
   devtool: false,
   cache: {
     type: 'persistent',
@@ -2542,6 +2551,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   watchOptions: {
     aggregateTimeout: 0
+  },
+  experiments: {
+    sourceImport: true
   },
   devtool: false,
   cache: {
@@ -3225,6 +3237,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   watchOptions: {
     aggregateTimeout: 0
+  },
+  experiments: {
+    sourceImport: true
   },
   devtool: false,
   cache: {

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/react": "^10.4.6",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/react": "^10.4.6",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/vue3": "^10.4.6",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/vue3": "^10.4.6",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.9",
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@rslib/tsconfig": "workspace:*",
     "magic-string": "^0.30.21",
     "prebundle": "1.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,13 +80,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rsbuild/core':
-        specifier: ~2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.5.1)
+        specifier: 2.1.0-beta.0
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -101,19 +101,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.5.1
-        version: 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/storybook-addon':
         specifier: ^6.0.13
-        version: 6.0.13(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)
+        version: 6.0.13(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
-        specifier: ~2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.5.1)
+        specifier: 2.1.0-beta.0
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -140,13 +140,13 @@ importers:
         version: 19.2.7(react@19.2.7)
       storybook:
         specifier: ^10.4.6
-        version: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+        version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.15)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3)
 
   examples/module-federation/mf-remote:
     dependencies:
@@ -159,13 +159,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rsbuild/core':
-        specifier: ~2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.5.1)
+        specifier: 2.1.0-beta.0
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -287,11 +287,11 @@ importers:
   examples/vue-component-bundleless:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.5.1)
+        specifier: 2.1.0-beta.0
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(vue@3.5.38)
+        version: 1.2.9(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(vue@3.5.38)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -306,13 +306,13 @@ importers:
         version: 10.4.6(storybook@10.4.6)(vue@3.5.38)
       storybook:
         specifier: ^10.4.6
-        version: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+        version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.15)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.38)
+        version: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.38)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -326,15 +326,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.5.1)
+        specifier: 2.1.0-beta.0
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.0.15)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -361,7 +361,7 @@ importers:
         version: 1.6.5(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.0.15)
+        version: 1.0.0(@rsbuild/core@2.1.0-beta.0)
       rslib:
         specifier: npm:@rslib/core@0.23.0
         version: '@rslib/core@0.23.0(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.5.1)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)'
@@ -419,8 +419,8 @@ importers:
         specifier: ^7.58.9
         version: 7.58.9(@types/node@25.2.0)
       '@rsbuild/core':
-        specifier: ~2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.5.1)
+        specifier: 2.1.0-beta.0
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -432,7 +432,7 @@ importers:
         version: 1.6.5(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.0.15)
+        version: 1.0.0(@rsbuild/core@2.1.0-beta.0)
       rslib:
         specifier: npm:@rslib/core@0.23.0
         version: '@rslib/core@0.23.0(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.5.1)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)'
@@ -462,34 +462,34 @@ importers:
         version: 4.0.1
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.5)
       '@playwright/test':
         specifier: 1.61.0
         version: 1.61.0
       '@rsbuild/core':
-        specifier: ~2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.5.1)
+        specifier: 2.1.0-beta.0
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-less':
         specifier: ^1.6.4
-        version: 1.6.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 1.6.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.15)
+        version: 1.5.3(@rsbuild/core@2.1.0-beta.0)
       '@rsbuild/plugin-toml':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.15)
+        version: 2.0.1(@rsbuild/core@2.1.0-beta.0)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.4
-        version: 1.2.4(@rsbuild/core@2.0.15)
+        version: 1.2.4(@rsbuild/core@2.1.0-beta.0)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(vue@3.5.38)
+        version: 1.2.9(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(vue@3.5.38)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@2.0.15)
+        version: 1.0.5(@rsbuild/core@2.1.0-beta.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -972,11 +972,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.5.1)
+        specifier: 2.1.0-beta.0
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.15)
+        version: 1.4.6(@rsbuild/core@2.1.0-beta.0)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -985,11 +985,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.5.1)
+        specifier: 2.1.0-beta.0
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.0.15)
+        version: 1.4.6(@rsbuild/core@2.1.0-beta.0)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1251,16 +1251,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rsbuild/core':
-        specifier: ~2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.5.1)
+        specifier: 2.1.0-beta.0
+        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.15)
+        version: 1.5.3(@rsbuild/core@2.1.0-beta.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1308,10 +1308,10 @@ importers:
         version: 19.2.7(react@19.2.7)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.6
-        version: 1.0.6(@rsbuild/core@2.0.15)
+        version: 1.0.6(@rsbuild/core@2.1.0-beta.0)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.0.15)
+        version: 1.1.3(@rsbuild/core@2.1.0-beta.0)
       rspress-plugin-file-tree:
         specifier: ^1.0.5
         version: 1.0.5(@rspress/core@2.0.14)
@@ -1667,17 +1667,26 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -2141,6 +2150,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -2675,6 +2690,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.1.0-beta.0':
+    resolution: {integrity: sha512-uiVwiLWjrOXORRoj6FkrtqiAP2qtl1ynxs26uyS/29gaOJLiAjDT7q0lpuToxJ4JPQQ2O65H/tOt0IBFvMjGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.2.1':
     resolution: {integrity: sha512-6Zad7Ff/RUNc91AtftemJcJ1wcZRGOiwuJy349qlLJl9F++oRYwUhx+MxLSpNnVeIywWx2mKdZZBtD1hLqfj9w==}
     peerDependencies:
@@ -2882,13 +2907,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.1.0-beta.0':
+    resolution: {integrity: sha512-BE2O8aq/tzG9c3BHlsmH/cDnwr86wG68AQ/n1uaYEB5hoBJMk2eBJo/q2/CZ37ZT5ntVsCGkJpCPBT/Dh7q9PA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.0.8':
     resolution: {integrity: sha512-satPm2PD4B7jDTVlVAdvMVdUszwLvWUEnUDzLb77mvVkezKNDZmuhb+e8s+FfKs8hJpNbZ9VAejuA2rr8o985w==}
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.1.0-beta.0':
+    resolution: {integrity: sha512-9icL31+mGJRKaU1i0IVbsBcmRWpUVfTM9TuLUHZOy0fnPhoZPDT0C/BZJxjvlvSeV2NNhh/NBEzUP3taZj7Zcg==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.0.8':
     resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.0-beta.0':
+    resolution: {integrity: sha512-92OuAccIQx5AQIWdhF5GaXmW0nsW+cApQYZ1PZ2kMfCe0kq8t4R5gLL2cuJ6a3Qo66TerFsj+ii5wx0qfP7aFA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2899,8 +2940,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.1.0-beta.0':
+    resolution: {integrity: sha512-YuaHU9A+vLBYNEbjUGHlEE/K4Ctt7kp34DaKlv9iShtOz7bIc3NRfFUIZEHjExhJ+wWYInrcIAIJeviOQJnHig==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@2.0.8':
     resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.1.0-beta.0':
+    resolution: {integrity: sha512-BA2j6CS8MJfT7o7oP2UFpucf3EAv4Does/D35SfRCdBKlgMXy8kG6zJXKLW3gzKSNUez5SZ26n/mPcHcX8A6zg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -2911,12 +2964,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.1.0-beta.0':
+    resolution: {integrity: sha512-riLlSAgbyGRXclLeK0y/FN0Qd+hHlwNj0lCdgh98sADUX62gaFcWFYizC8cnfxzlIUaTjQsPCy8PjWFEbSOmuQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.0.8':
     resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.1.0-beta.0':
+    resolution: {integrity: sha512-fYEvF3QAWZm6jUf74C2TT7gpllIGEghPEdBPRmdRGROesYSu0YZxikDdVwpQXnsymA5AnkaofCs/Sj+nvKyrXQ==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.0.8':
     resolution: {integrity: sha512-8NCuiQsAhXrwRBy57QZoypqrws/zLBkaQVGiB8hksr6v++8hNigNjqpQARLbd0iyMuHsQQ++8+auGk6xlDXmzw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.0-beta.0':
+    resolution: {integrity: sha512-bRv74lkzMcloJGYwzIrabLa73L23FTYjcB/GuZkgP8qsYpM20qyMFYo6szElbc/x1NxNSW5mjR4QKaNaIxRDhA==}
     cpu: [arm64]
     os: [win32]
 
@@ -2925,16 +2993,41 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.1.0-beta.0':
+    resolution: {integrity: sha512-qvolIqHoH+KSJFi71jJde+HTIvAbVZ08VJvfzqjTQ6KktFoxAfg0FeM6zpq0aNDo14mCDzy5JFH2WGbYGxmYLQ==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.0.8':
     resolution: {integrity: sha512-7zPs8YCe/ZVJTwd+5lpB0CP0tkn2pONf/T1ycmVY76u21Nrwt8mXQGc/2yH2eWP4B7fikYBr3hGr7mpR2fajqQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.1.0-beta.0':
+    resolution: {integrity: sha512-Ge6VIpFH//LuN0ABCeHRMXuKYagRAN7rW8WIKAKO3R3WooTT8630W+dOCJ+6kiSQyTLyMrt5eg6Sufw0R6UUPg==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@2.0.8':
     resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
 
+  '@rspack/binding@2.1.0-beta.0':
+    resolution: {integrity: sha512-hSK6L966Y8l9z4ZMjRbz7lEmrk5IN+xSCQXkOL5VvtfBLvgk9AO91YEsDn5hCwNmTIdMFc2vScT2qwuIFF069w==}
+
   '@rspack/core@2.0.8':
     resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.1.0-beta.0':
+    resolution: {integrity: sha512-Trnjc1OPsAU+TamUtCoOfwFfqu0n1pClhmY6hX4hs55i8exv4muV6OR8g40j0I7fFPz1YdPArTQBeMKFlVSXsg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -7755,6 +7848,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -7766,12 +7865,22 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8247,6 +8356,56 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
+  '@module-federation/enhanced@2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+    dependencies:
+      '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/cli': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/error-codes': 2.5.1
+      '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1)
+      '@module-federation/managers': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/manifest': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/rspack': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/webpack-bundler-runtime': 2.5.1(node-fetch@2.7.0)
+      schema-utils: 4.3.0
+      tapable: 2.3.0
+      upath: 2.0.1
+    optionalDependencies:
+      typescript: 6.0.3
+      vue-tsc: 3.3.5(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - node-fetch
+      - utf-8-validate
+
+  '@module-federation/enhanced@2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+    dependencies:
+      '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/cli': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/error-codes': 2.5.1
+      '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1)
+      '@module-federation/managers': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/manifest': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/rspack': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/webpack-bundler-runtime': 2.5.1(node-fetch@2.7.0)
+      schema-utils: 4.3.0
+      tapable: 2.3.0
+      upath: 2.0.1
+    optionalDependencies:
+      typescript: 6.0.3
+      vue-tsc: 3.3.5(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - node-fetch
+      - utf-8-validate
+
   '@module-federation/error-codes@2.5.1': {}
 
   '@module-federation/inject-external-runtime-core-plugin@2.5.1(@module-federation/runtime-tools@2.5.1)':
@@ -8316,9 +8475,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.44(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/node@2.7.44(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
-      '@module-federation/enhanced': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/runtime': 2.5.1(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -8331,13 +8490,28 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.5)':
+  '@module-federation/node@2.7.44(typescript@6.0.3)(vue-tsc@3.3.5)':
+    dependencies:
+      '@module-federation/enhanced': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/runtime': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
+      encoding: 0.1.13
+      node-fetch: 2.7.0(encoding@0.1.13)
+      tapable: 2.3.0
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
+  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.5)':
     dependencies:
       '@module-federation/enhanced': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.5)
       '@module-federation/node': 2.7.44(@rspack/core@2.0.8)(typescript@5.9.3)(vue-tsc@3.3.5)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8347,13 +8521,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
       '@module-federation/enhanced': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/node': 2.7.44(@rspack/core@2.0.8)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8363,13 +8537,29 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.0.15)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
-      '@module-federation/enhanced': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/node': 2.7.44(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
+    optionalDependencies:
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - node-fetch
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - webpack
+
+  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+    dependencies:
+      '@module-federation/enhanced': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/node': 2.7.44(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8415,6 +8605,24 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
+  '@module-federation/rspack@2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+    dependencies:
+      '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1)
+      '@module-federation/managers': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/manifest': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
+      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+    optionalDependencies:
+      typescript: 6.0.3
+      vue-tsc: 3.3.5(typescript@6.0.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - node-fetch
+      - utf-8-validate
+
   '@module-federation/runtime-core@2.5.1(node-fetch@2.7.0)':
     dependencies:
       '@module-federation/error-codes': 2.5.1
@@ -8441,13 +8649,13 @@ snapshots:
     optionalDependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 
-  '@module-federation/storybook-addon@6.0.13(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.13(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
-      storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -8477,7 +8685,14 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
@@ -8548,7 +8763,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
@@ -8610,9 +8825,9 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -8806,6 +9021,13 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
+  '@rsbuild/core@2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)':
+    dependencies:
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.0.15)':
     dependencies:
       '@babel/core': 7.29.7
@@ -8844,7 +9066,19 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.0.15)':
+  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)':
+    dependencies:
+      deepmerge: 4.3.1
+      less: 4.6.4
+      less-loader: 12.3.3(@rspack/core@2.0.8)(less@4.6.4)
+      reduce-configs: 1.1.2
+    optionalDependencies:
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - webpack
+
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.0-beta.0)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -8870,7 +9104,7 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
 
   '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(preact@10.29.2)':
     dependencies:
@@ -8902,6 +9136,24 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.0.8)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.0-beta.0)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
   '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.0.15)':
     dependencies:
       deepmerge: 4.3.1
@@ -8911,6 +9163,16 @@ snapshots:
       sass-embedded: 1.100.0
     optionalDependencies:
       '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+
+  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.0-beta.0)':
+    dependencies:
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.5.15
+      reduce-configs: 1.1.2
+      sass-embedded: 1.100.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
 
   '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.0.15)(solid-js@1.9.13)':
     dependencies:
@@ -8960,27 +9222,39 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.0.15)':
+  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.0-beta.0)':
     dependencies:
       toml: 4.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
 
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
       ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.8)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.0.15)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)':
+    dependencies:
+      deepmerge: 4.3.1
+      json5: 2.2.3
+      reduce-configs: 1.1.2
+      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - typescript
+
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.0-beta.0)':
+    optionalDependencies:
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
 
   '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(vue@3.5.38)':
     dependencies:
@@ -8992,9 +9266,19 @@ snapshots:
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@1.0.5(@rsbuild/core@2.0.15)':
+  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(vue@3.5.38)':
+    dependencies:
+      rspack-vue-loader: 17.5.0(@rspack/core@2.0.8)(vue@3.5.38)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@vue/compiler-sfc'
+      - vue
+
+  '@rsbuild/plugin-yaml@1.0.5(@rsbuild/core@2.1.0-beta.0)':
+    optionalDependencies:
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
 
   '@rslib/core@0.23.0(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.5.1)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)':
     dependencies:
@@ -9049,19 +9333,37 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.8':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.1.0-beta.0':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.0.8':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.1.0-beta.0':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.8':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.1.0-beta.0':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.0.8':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.1.0-beta.0':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.8':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.1.0-beta.0':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.0.8':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.0-beta.0':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.8':
@@ -9071,13 +9373,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.1.0-beta.0':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.0.8':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.0-beta.0':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.8':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.1.0-beta.0':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.0.8':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.0-beta.0':
     optional: true
 
   '@rspack/binding@2.0.8':
@@ -9093,9 +9411,29 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.8
       '@rspack/binding-win32-x64-msvc': 2.0.8
 
+  '@rspack/binding@2.1.0-beta.0':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.0-beta.0
+      '@rspack/binding-darwin-x64': 2.1.0-beta.0
+      '@rspack/binding-linux-arm64-gnu': 2.1.0-beta.0
+      '@rspack/binding-linux-arm64-musl': 2.1.0-beta.0
+      '@rspack/binding-linux-x64-gnu': 2.1.0-beta.0
+      '@rspack/binding-linux-x64-musl': 2.1.0-beta.0
+      '@rspack/binding-wasm32-wasi': 2.1.0-beta.0
+      '@rspack/binding-win32-arm64-msvc': 2.1.0-beta.0
+      '@rspack/binding-win32-ia32-msvc': 2.1.0-beta.0
+      '@rspack/binding-win32-x64-msvc': 2.1.0-beta.0
+
   '@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.0.8
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
+      '@swc/helpers': 0.5.23
+
+  '@rspack/core@2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.0-beta.0
     optionalDependencies:
       '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
       '@swc/helpers': 0.5.23
@@ -9120,6 +9458,12 @@ snapshots:
       react-refresh: 0.18.0
     optionalDependencies:
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.0-beta.0)(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
   '@rspress/core@2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
@@ -9418,7 +9762,7 @@ snapshots:
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 19.2.17
@@ -9431,11 +9775,11 @@ snapshots:
 
   '@storybook/addon-onboarding@10.4.6(storybook@10.4.6)':
     dependencies:
-      storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
 
   '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.4)(storybook@10.4.6)':
     dependencies:
-      storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
@@ -9465,7 +9809,7 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -9478,7 +9822,7 @@ snapshots:
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -9489,7 +9833,7 @@ snapshots:
   '@storybook/vue3@10.4.6(storybook@10.4.6)(vue@3.5.38)':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       type-fest: 5.7.0
       vue: 3.5.38(typescript@6.0.3)
       vue-component-type-helpers: 3.3.1
@@ -12414,7 +12758,7 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
       '@oxc-parser/binding-win32-x64-msvc': 0.127.0
 
-  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -12432,7 +12776,7 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
@@ -13177,26 +13521,32 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260620.1
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.0.15):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.0-beta.0):
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.15):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.1.0-beta.0):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.0.15):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.0-beta.0):
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
 
   rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.0.15):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
       '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.0-beta.0):
+    dependencies:
+      publint: 0.3.21
+    optionalDependencies:
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
 
   rslog@2.1.3: {}
 
@@ -13567,18 +13917,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.0.15)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -13590,9 +13940,9 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.15)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.1.0-beta.0)
       sirv: 2.0.4
-      storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
@@ -13606,10 +13956,41 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3):
+    dependencies:
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)
+      '@vitest/mocker': 3.2.4
+      browser-assert: 1.2.1
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      cjs-module-lexer: 2.2.0
+      constants-browserify: 1.0.0
+      es-module-lexer: 1.7.0
+      fs-extra: 11.3.5
+      magic-string: 0.30.21
+      path-browserify: 1.0.1
+      picocolors: 1.1.1
+      process: 0.11.10
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.1.0-beta.0)
+      sirv: 2.0.4
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      ts-dedent: 2.2.0
+      url: 0.11.4
+      util: 0.12.5
+      util-deprecate: 1.0.2
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - msw
+      - vite
+
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)
       find-up: 5.0.0
@@ -13619,8 +14000,8 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
-      storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -13634,12 +14015,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.38):
+  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.38):
     dependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
       '@storybook/vue3': 10.4.6(storybook@10.4.6)(vue@3.5.38)
-      storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       vue: 3.5.38(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.38)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -13654,7 +14035,7 @@ snapshots:
       - vite
       - webpack
 
-  storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7):
+  storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.7)(react@19.2.7)
@@ -13666,7 +14047,7 @@ snapshots:
       esbuild: 0.28.1
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-resolver: 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       recast: 0.23.11
       semver: 7.7.4
       use-sync-external-store: 1.6.0(react@19.2.7)
@@ -13886,6 +14267,16 @@ snapshots:
       typescript: 6.0.3
     optionalDependencies:
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+
+  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.1.0-beta.0)(typescript@6.0.3):
+    dependencies:
+      '@rspack/lite-tapable': 1.1.0
+      chokidar: 3.6.0
+      memfs: 4.57.8
+      picocolors: 1.1.1
+      typescript: 6.0.3
+    optionalDependencies:
+      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
   ts-dedent@2.2.0: {}
 

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@rsbuild/plugin-node-polyfill": "^1.4.6"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@rsbuild/plugin-node-polyfill": "^1.4.6"
   }
 }

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -14,7 +14,8 @@ describe('ESM shims', async () => {
   test('__dirname', async () => {
     for (const shim of [
       'import { fileURLToPath as __rspack_fileURLToPath } from "node:url";',
-      'var src_dirname = __rspack_dirname(__rspack_fileURLToPath(import.meta.url));',
+      'import { dirname as __rspack_dirname } from "node:path";',
+      'var __rspack_import_meta_dirname__ = __rspack_dirname(__rspack_fileURLToPath(import.meta.url));',
     ]) {
       expect(entries.esm0).toContain(shim);
     }
@@ -27,7 +28,7 @@ describe('ESM shims', async () => {
   test('__filename', async () => {
     for (const shim of [
       'import { fileURLToPath as __rspack_fileURLToPath } from "node:url";',
-      'var src_filename = __rspack_fileURLToPath(import.meta.url);',
+      'var __rspack_import_meta_filename__ = __rspack_fileURLToPath(import.meta.url);',
     ]) {
       expect(entries.esm0).toContain(shim);
     }
@@ -63,8 +64,8 @@ describe('ESM shims', async () => {
     for (const shim of [
       'import { fileURLToPath as __rspack_fileURLToPath } from "node:url";',
       'import { dirname as __rspack_dirname } from "node:path";',
-      'var node_dirname = __rspack_dirname(__rspack_fileURLToPath(import.meta.url));',
-      'var node_filename = __rspack_fileURLToPath(import.meta.url);',
+      'var __rspack_import_meta_dirname__ = __rspack_dirname(__rspack_fileURLToPath(import.meta.url));',
+      'var __rspack_import_meta_filename__ = __rspack_fileURLToPath(import.meta.url);',
     ]) {
       expect(entries.esm3).toContain(shim);
     }

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^2.5.1",
     "@playwright/test": "1.61.0",
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@rsbuild/plugin-less": "^1.6.4",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-sass": "^1.5.3",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.1",
-    "@rsbuild/core": "~2.0.15",
+    "@rsbuild/core": "2.1.0-beta.0",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-sass": "^1.5.3",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

Upgrade direct `@rsbuild/core` dependencies to the fixed beta version `2.1.0-beta.0` and refresh the pnpm lockfile. This also updates the affected Rsbuild/Rspack output expectations: the inspected config now includes `experiments.sourceImport`, and ESM shim assertions now match the new `import.meta` dirname/filename shim variable names while keeping the runtime behavior checks intact.

## Related Links

https://www.npmjs.com/package/@rsbuild/core/v/2.1.0-beta.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).