### PR TITLE
chore: move build out of prepare

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -46,7 +46,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@0e65507af053729fa482e81bbdf95cb46e363aa9 # v0.3.2
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@ecca2c865c3830f56824fe7a3c6513bac77f5c8f # v0.3.4
         with:
           github-token: ${{ secrets.REPO_RSLIB_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev
@@ -63,7 +63,7 @@ jobs:
       contents: write
     steps:
       - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@0e65507af053729fa482e81bbdf95cb46e363aa9 # v0.3.2
+        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@ecca2c865c3830f56824fe7a3c6513bac77f5c8f # v0.3.4
         with:
           github-token: ${{ secrets.REPO_RSLIB_ECO_CI_GITHUB_TOKEN }}
           ecosystem-owner: web-infra-dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           run_install: true
 
+      - name: Build
+        run: pnpm run build
+
       - name: Lint
         run: pnpm run lint
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -48,6 +48,10 @@ jobs:
         with:
           run_install: true
 
+      - name: Build
+        if: steps.changes.outputs.changed == 'true'
+        run: pnpm run build
+
       - name: Publish Preview
         if: steps.changes.outputs.changed == 'true'
         run: pnpx pkg-pr-new publish --compact --pnpm ./packages/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           run_install: true
 
+      - name: Build
+        run: pnpm run build
+
       - name: Publish to npm
         run: |
           pnpm --filter './packages/*' -r stage publish --tag ${{ github.event.inputs.npm_tag }} --no-git-checks

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -56,6 +56,10 @@ jobs:
         with:
           run_install: true
 
+      - name: Build
+        if: ${{ steps.changes.outputs.changed == 'true' }}
+        run: pnpm run build
+
       - name: Unit Test
         if: ${{ steps.changes.outputs.changed == 'true' && inputs.task == 'ut' }}
         run: pnpm run test:unit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ What this will do:
 
 - Install all dependencies.
 - Create symlinks between packages in the monorepo
-- Run the prepare script to build all packages.
+- Run the prepare script to set up Git hooks and prebundle packages.
 
 ## Making changes and building
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --experimental-cli --write . && heading-case --write",
     "lint": "rslint --type-check",
     "prebundle": "pnpm --filter \"./packages/*\" run prebundle",
-    "prepare": "simple-git-hooks && pnpm prebundle && pnpm build",
+    "prepare": "simple-git-hooks && pnpm prebundle",
     "sort-package-json": "npx sort-package-json \"packages/*/package.json\"",
     "test": "pnpm run test:unit && pnpm run test:integration && pnpm run test:e2e",
     "test:benchmark": "cd ./tests && pnpm run test:benchmark",


### PR DESCRIPTION
## Summary

This PR updates ecosystem CI to rstack-ecosystem-ci v0.3.4 and removes the full workspace build from the root `prepare` lifecycle. CI jobs that need built artifacts now run `pnpm run build` explicitly after install, and the contributing guide no longer says install builds all packages.

## Related Links

- https://github.com/rstackjs/rstack-ecosystem-ci/releases/tag/v0.3.4
- https://github.com/web-infra-dev/rsbuild/pull/7979

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).