### PR TITLE
fix(plugin-dts): avoid TypeScript API in non-api backends

### DIFF
--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -38,6 +38,7 @@
     "@microsoft/api-extractor": "^7.58.9",
     "@rsbuild/core": "2.1.0-beta.0",
     "@rslib/tsconfig": "workspace:*",
+    "get-tsconfig": "5.0.0-beta.5",
     "magic-string": "^0.30.21",
     "prebundle": "1.6.5",
     "rsbuild-plugin-publint": "^1.0.0",

--- a/packages/plugin-dts/src/backend.ts
+++ b/packages/plugin-dts/src/backend.ts
@@ -1,6 +1,6 @@
 import type { PluginDtsOptions } from './index';
 
-export type DtsGenerationBackend = 'isolated' | 'tsc' | 'tsgo';
+export type DtsGenerationBackend = 'tsc-api' | 'tsgo-bin' | 'isolated';
 
 export function validateExplicitIsolatedDtsOptions(
   options: Pick<
@@ -40,8 +40,8 @@ export function resolveDtsGenerationBackend(
   }
 
   if (options.tsgo) {
-    return 'tsgo';
+    return 'tsgo-bin';
   }
 
-  return 'tsc';
+  return 'tsc-api';
 }

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -1,3 +1,4 @@
+import { logger } from '@rsbuild/core';
 import fs from 'node:fs';
 import {
   basename,
@@ -8,13 +9,14 @@ import {
   relative,
   resolve,
 } from 'node:path';
-import { logger } from '@rsbuild/core';
-import type { DtsEntry, DtsGenOptions } from './index';
+import type { DtsEntry, DtsGenOptions, DtsRedirect } from './index';
 import {
   calcLongestCommonPath,
   color,
   ensureTempDeclarationDir,
   mergeAliasWithTsConfigPaths,
+  type CompilerApiTsconfigResultForApi,
+  type GetTsconfigTsconfigResultForBin,
 } from './utils';
 
 const isObject = (obj: unknown): obj is Record<string, any> =>
@@ -130,6 +132,24 @@ export type PreparedDtsContext = {
   bundledDtsEntries: Required<DtsEntry>[];
 };
 
+export type EmitDtsOptions<
+  Tsconfig extends
+    | CompilerApiTsconfigResultForApi
+    | GetTsconfigTsconfigResultForBin,
+> = {
+  name: string;
+  cwd: string;
+  configPath: string;
+  tsConfigResult: Tsconfig;
+  declarationDir: string;
+  dtsExtension: string;
+  rootDir: string;
+  redirect: DtsRedirect;
+  paths: Record<string, string[]>;
+  banner?: string;
+  footer?: string;
+};
+
 export async function prepareDtsContext(
   data: DtsGenOptions,
 ): Promise<PreparedDtsContext> {
@@ -154,7 +174,9 @@ export async function prepareDtsContext(
     tsConfigResult.options.paths = paths;
   }
 
-  const { options: rawCompilerOptions, fileNames } = tsConfigResult;
+  const { options: rawCompilerOptions } = tsConfigResult;
+  const fileNames =
+    'fileNames' in tsConfigResult ? tsConfigResult.fileNames : [];
 
   // The longest common path of all non-declaration input files.
   // If composite is set, the default is instead the directory containing the tsconfig.json file.
@@ -307,31 +329,47 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
     }
   };
 
-  const emitDts = data.tsgo
-    ? await import('./tsgo').then((mod) => mod.emitDtsTsgo)
-    : await import('./tsc').then((mod) => mod.emitDtsTsc);
+  const emitOptions = {
+    name,
+    cwd,
+    configPath: tsconfigPath,
+    declarationDir,
+    dtsExtension,
+    redirect,
+    rootDir,
+    paths,
+    banner,
+    footer,
+  };
 
-  const hasError = await emitDts(
-    {
-      name,
-      cwd,
-      configPath: tsconfigPath,
-      tsConfigResult,
-      declarationDir,
-      dtsExtension,
-      redirect,
-      rootDir,
-      paths,
-      banner,
-      footer,
-    },
-    onComplete,
-    bundle,
-    isWatch,
-    build,
-  );
+  const useTsgoBin = data.dtsBackend === 'tsgo-bin';
+  const hasError = useTsgoBin
+    ? await import('./tsgo').then((mod) =>
+        mod.emitDtsTsgo(
+          {
+            ...emitOptions,
+            tsConfigResult: tsConfigResult as GetTsconfigTsconfigResultForBin,
+          },
+          onComplete,
+          bundle,
+          isWatch,
+          build,
+        ),
+      )
+    : await import('./tsc').then((mod) =>
+        mod.emitDtsTsc(
+          {
+            ...emitOptions,
+            tsConfigResult: tsConfigResult as CompilerApiTsconfigResultForApi,
+          },
+          onComplete,
+          bundle,
+          isWatch,
+          build,
+        ),
+      );
 
-  if (data.tsgo) {
+  if (useTsgoBin) {
     if (!hasError) {
       await bundleDtsIfNeeded(data, preparedDtsContext);
     }

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -1,31 +1,33 @@
-import { type ChildProcess, fork } from 'node:child_process';
-import { extname, join } from 'node:path';
 import {
-  type LogLevel,
   logger,
+  type LogLevel,
   type RsbuildConfig,
   type RsbuildPlugin,
 } from '@rsbuild/core';
-import type { ParsedCommandLine } from 'typescript';
+import { type ChildProcess, fork } from 'node:child_process';
+import { extname, join } from 'node:path';
 
+import {
+  type DtsGenerationBackend,
+  resolveDtsGenerationBackend,
+} from './backend';
 import {
   createIsolatedDtsContext,
   type IsolatedDtsContext,
   processIsolatedDts,
 } from './isolated';
 import {
-  resolveDtsGenerationBackend,
-  type DtsGenerationBackend,
-} from './backend';
-import {
   cleanDtsFiles,
   cleanTsBuildInfoFile,
   clearTempDeclarationDir,
   color,
+  type CompilerApiTsconfigResultForApi,
   getDtsEmitPath,
+  type GetTsconfigTsconfigResultForBin,
   loadTsconfig,
+  loadTsconfigResultForBin,
+  loadTypescript,
   processSourceEntry,
-  ts,
   warnIfOutside,
 } from './utils';
 
@@ -65,7 +67,10 @@ export type DtsEntry = {
   path: string;
 };
 
-export type DtsGenOptions = Omit<PluginDtsOptions, 'bundle' | 'isolated'> & {
+export type DtsGenOptions = Omit<
+  PluginDtsOptions,
+  'bundle' | 'isolated' | 'tsgo'
+> & {
   bundle: boolean;
   name: string;
   cwd: string;
@@ -74,10 +79,13 @@ export type DtsGenOptions = Omit<PluginDtsOptions, 'bundle' | 'isolated'> & {
   dtsEmitPath: string;
   build?: boolean;
   tsconfigPath: string;
-  tsConfigResult: ParsedCommandLine;
+  tsConfigResult:
+    | CompilerApiTsconfigResultForApi
+    | GetTsconfigTsconfigResultForBin;
   userExternals?: NonNullable<RsbuildConfig['output']>['externals'];
   apiExtractorOptions?: ApiExtractorOptions;
   loggerLevel: LogLevel;
+  dtsBackend: DtsGenerationBackend;
 };
 
 interface TaskResult {
@@ -122,6 +130,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
     let childProcesses: ChildProcess[] = [];
     const dtsBackend: DtsGenerationBackend =
       resolveDtsGenerationBackend(options);
+    const tsApi = dtsBackend === 'tsc-api' ? loadTypescript() : undefined;
     let dtsGenOptions: DtsGenOptions | undefined;
     let isolatedDtsContext: IsolatedDtsContext | undefined;
 
@@ -145,7 +154,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
 
     api.onBeforeEnvironmentCompile(
       async ({ isWatch, isFirstCompile, environment, bundlerConfig }) => {
-        if (dtsBackend === 'tsc' && !isFirstCompile) {
+        if (dtsBackend === 'tsc-api' && !isFirstCompile) {
           return;
         }
 
@@ -157,22 +166,41 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
         const dtsEntry = processSourceEntry(bundle, config.source?.entry);
 
         const cwd = api.context.rootPath;
-        const tsconfigPath = ts.findConfigFile(
-          cwd,
-          ts.sys.fileExists.bind(ts.sys),
-          config.source.tsconfigPath,
-        );
+        const configuredTsconfigPath =
+          config.source.tsconfigPath ?? 'tsconfig.json';
+        let tsconfigPath: string | undefined;
+        let tsConfigResult:
+          | CompilerApiTsconfigResultForApi
+          | GetTsconfigTsconfigResultForBin
+          | undefined;
 
-        if (!tsconfigPath) {
+        if (tsApi) {
+          tsconfigPath = tsApi.findConfigFile(
+            cwd,
+            tsApi.sys.fileExists.bind(tsApi.sys),
+            configuredTsconfigPath,
+          );
+          if (tsconfigPath) {
+            tsConfigResult = loadTsconfig(tsconfigPath, tsApi);
+          }
+        } else {
+          const loadedTsconfig = loadTsconfigResultForBin(
+            cwd,
+            configuredTsconfigPath,
+          );
+          tsconfigPath = loadedTsconfig?.path;
+          tsConfigResult = loadedTsconfig?.config;
+        }
+
+        if (!tsconfigPath || !tsConfigResult) {
           const error = new Error(
-            `Failed to resolve tsconfig file ${color.cyan(`"${config.source.tsconfigPath}"`)} from ${color.cyan(cwd)}. Please ensure that the file exists.`,
+            `Failed to resolve tsconfig file ${color.cyan(`"${configuredTsconfigPath}"`)} from ${color.cyan(cwd)}. Please ensure that the file exists.`,
           );
           error.stack = '';
           // do not log the stack trace, it is not helpful for users
           throw error;
         }
 
-        const tsConfigResult = loadTsconfig(tsconfigPath);
         const { options: rawCompilerOptions } = tsConfigResult;
         const { declarationDir, outDir, composite, incremental } =
           rawCompilerOptions;
@@ -209,8 +237,15 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
           await cleanTsBuildInfoFile(tsconfigPath, rawCompilerOptions);
         }
 
+        const {
+          bundle: _bundle,
+          isolated: _isolated,
+          tsgo: _tsgo,
+          ...rest
+        } = options;
+
         dtsGenOptions = {
-          ...options,
+          ...rest,
           bundle,
           dtsEntry,
           dtsEmitPath,
@@ -222,6 +257,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
           cwd,
           isWatch,
           loggerLevel: loggerLevel as LogLevel,
+          dtsBackend,
         };
 
         if (dtsBackend === 'isolated') {
@@ -266,7 +302,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
 
     api.onAfterBuild({
       handler: async ({ isFirstCompile, stats }) => {
-        if (dtsBackend === 'tsc' && !isFirstCompile) {
+        if (dtsBackend === 'tsc-api' && !isFirstCompile) {
           return;
         }
 
@@ -298,7 +334,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
     });
 
     api.onAfterBuild(({ isFirstCompile }) => {
-      if (dtsBackend === 'tsc' && !isFirstCompile) {
+      if (dtsBackend === 'tsc-api' && !isFirstCompile) {
         return;
       }
 

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -4,51 +4,41 @@ import type {
   CompilerOptions,
   Diagnostic,
   FormatDiagnosticsHost,
-  ParsedCommandLine,
   Program,
   System,
   WatchStatusReporter,
 } from 'typescript';
-import type { DtsRedirect } from './index';
+import type { EmitDtsOptions } from './dts';
 import {
   color,
   getTimeCost,
+  loadTypescript,
   processDtsFiles,
   renameDtsFile,
-  ts,
   updateDeclarationMapContent,
+  type CompilerApiTsconfigResultForApi,
 } from './utils';
 
 const logPrefixTsc = color.dim('[tsc]');
 
-const formatHost: FormatDiagnosticsHost = {
+const createFormatHost = (
+  ts: ReturnType<typeof loadTypescript>,
+): FormatDiagnosticsHost => ({
   getCanonicalFileName: (path) => path,
   getCurrentDirectory: ts.sys.getCurrentDirectory.bind(ts.sys),
   getNewLine: () => ts.sys.newLine,
-};
-
-export type EmitDtsOptions = {
-  name: string;
-  cwd: string;
-  configPath: string;
-  tsConfigResult: ParsedCommandLine;
-  declarationDir: string;
-  dtsExtension: string;
-  rootDir: string;
-  redirect: DtsRedirect;
-  paths: Record<string, string[]>;
-  banner?: string;
-  footer?: string;
-};
+});
 
 async function handleDiagnosticsAndProcessFiles(
+  ts: ReturnType<typeof loadTypescript>,
+  formatHost: FormatDiagnosticsHost,
   diagnostics: readonly Diagnostic[],
   configPath: string,
   bundle: boolean,
   cwd: string,
   declarationDir: string,
   dtsExtension: string,
-  redirect: DtsRedirect,
+  redirect: EmitDtsOptions<CompilerApiTsconfigResultForApi>['redirect'],
   rootDir: string,
   paths: Record<string, string[]>,
   banner?: string,
@@ -93,7 +83,7 @@ async function handleDiagnosticsAndProcessFiles(
 }
 
 export async function emitDtsTsc(
-  options: EmitDtsOptions,
+  options: EmitDtsOptions<CompilerApiTsconfigResultForApi>,
   onComplete: (isSuccess: boolean) => void,
   bundle = false,
   isWatch = false,
@@ -113,6 +103,8 @@ export async function emitDtsTsc(
     paths,
     redirect,
   } = options;
+  const ts = loadTypescript();
+  const formatHost = createFormatHost(ts);
   const {
     options: rawCompilerOptions,
     fileNames,
@@ -257,6 +249,8 @@ export async function emitDtsTsc(
         ts.sortAndDeduplicateDiagnostics(allDiagnostics);
 
       await handleDiagnosticsAndProcessFiles(
+        ts,
+        formatHost,
         sortAndDeduplicateDiagnostics,
         configPath,
         bundle,
@@ -328,6 +322,8 @@ export async function emitDtsTsc(
         ts.sortAndDeduplicateDiagnostics(allDiagnostics);
 
       await handleDiagnosticsAndProcessFiles(
+        ts,
+        formatHost,
         sortAndDeduplicateDiagnostics,
         configPath,
         bundle,

--- a/packages/plugin-dts/src/tsgo.ts
+++ b/packages/plugin-dts/src/tsgo.ts
@@ -1,16 +1,15 @@
+import { logger } from '@rsbuild/core';
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { logger } from '@rsbuild/core';
-import type ts from 'typescript';
-import type { DtsRedirect } from './index';
-import type { EmitDtsOptions } from './tsc';
+import type { EmitDtsOptions } from './dts';
 import {
   color,
   getTimeCost,
   processDtsFiles,
   rewriteDtsExtensions,
+  type GetTsconfigTsconfigResultForBin,
 } from './utils';
 
 const require = createRequire(import.meta.url);
@@ -72,15 +71,15 @@ const generateTsgoArgs = (
 async function handleDiagnosticsAndProcessFiles(
   isWatch: boolean,
   hasErrors: boolean,
-  tsConfigResult: ts.ParsedCommandLine,
+  tsConfigResult: GetTsconfigTsconfigResultForBin,
   configPath: string,
   bundle: boolean,
   cwd: string,
   declarationDir: string,
   dtsExtension: string,
-  redirect: DtsRedirect,
+  redirect: EmitDtsOptions<GetTsconfigTsconfigResultForBin>['redirect'],
   rootDir: string,
-  paths: Record<string, string[]>,
+  paths: EmitDtsOptions<GetTsconfigTsconfigResultForBin>['paths'],
   banner?: string,
   footer?: string,
   name?: string,
@@ -117,7 +116,7 @@ async function handleDiagnosticsAndProcessFiles(
 }
 
 export async function emitDtsTsgo(
-  options: EmitDtsOptions,
+  options: EmitDtsOptions<GetTsconfigTsconfigResultForBin>,
   _onComplete: (isSuccess: boolean) => void,
   bundle = false,
   isWatch = false,

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -1,3 +1,7 @@
+import type { NapiConfig } from '@ast-grep/napi';
+import { logger, type RsbuildConfig } from '@rsbuild/core';
+import { getTsconfig } from 'get-tsconfig';
+import MagicString from 'magic-string';
 import fs from 'node:fs';
 import fsP from 'node:fs/promises';
 import { createRequire } from 'node:module';
@@ -13,21 +17,15 @@ import path, {
   resolve,
 } from 'node:path';
 import { styleText } from 'node:util';
-import { logger, type RsbuildConfig } from '@rsbuild/core';
 import { convertPathToPattern, glob } from 'tinyglobby';
-import { type MatchPath, createMatchPath, loadConfig } from 'tsconfig-paths';
-import MagicString from 'magic-string';
-import type { NapiConfig } from '@ast-grep/napi';
-import type {
-  CompilerOptions,
-  Diagnostic,
-  ParsedCommandLine,
-} from 'typescript';
+import { createMatchPath, loadConfig, type MatchPath } from 'tsconfig-paths';
+import type { CompilerOptions, ParsedCommandLine } from 'typescript';
 import type { DtsEntry, DtsRedirect } from './index';
 
 const require = createRequire(import.meta.url);
 
 let astGrepNapi: typeof import('@ast-grep/napi') | undefined;
+let typescript: typeof import('typescript') | undefined;
 
 const loadAstGrepNapi = (): typeof import('@ast-grep/napi') => {
   if (!astGrepNapi) {
@@ -38,15 +36,19 @@ const loadAstGrepNapi = (): typeof import('@ast-grep/napi') => {
   return astGrepNapi;
 };
 
-/**
- * Currently, typescript only provides a CJS bundle, so we use require to load it
- * for better startup performance. If we use `import ts from 'typescript'`,
- * Node.js will use `cjs-module-lexer` to parse it, which slows down startup time.
- */
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const ts = require('typescript') as typeof import('typescript');
+export const loadTypescript = (): typeof import('typescript') => {
+  if (!typescript) {
+    /**
+     * Currently, typescript only provides a CJS bundle, so we use require to load it
+     * for better startup performance. If we use `import ts from 'typescript'`,
+     * Node.js will use `cjs-module-lexer` to parse it, which slows down startup time.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    typescript = require('typescript') as typeof import('typescript');
+  }
 
-export { ts };
+  return typescript;
+};
 
 type ColorFn = (text: string | number) => string;
 type ColorMap = Record<
@@ -86,7 +88,22 @@ export const JS_EXTENSIONS_PATTERN: RegExp = new RegExp(
   `\\.(${JS_EXTENSIONS.join('|')})$`,
 );
 
-export function loadTsconfig(tsconfigPath: string): ParsedCommandLine {
+export type CompilerApiTsconfigResultForApi = ParsedCommandLine;
+export type GetTsconfigTsconfigResultForBin = Pick<
+  CompilerApiTsconfigResultForApi,
+  'options'
+>;
+
+const resolveTsconfigPath = (
+  tsconfigDir: string,
+  value: string | undefined,
+): string | undefined =>
+  value && (isAbsolute(value) ? value : resolve(tsconfigDir, value));
+
+export function loadTsconfig(
+  tsconfigPath: string,
+  ts: typeof import('typescript') = loadTypescript(),
+): CompilerApiTsconfigResultForApi {
   const configFile = ts.readConfigFile(
     tsconfigPath,
     ts.sys.readFile.bind(ts.sys),
@@ -98,6 +115,49 @@ export function loadTsconfig(tsconfigPath: string): ParsedCommandLine {
   );
 
   return configFileContent;
+}
+
+export function loadTsconfigResultForBin(
+  cwd: string,
+  configName: string,
+): { path: string; config: GetTsconfigTsconfigResultForBin } | undefined {
+  if (isAbsolute(configName) && !fs.existsSync(configName)) {
+    return undefined;
+  }
+
+  const tsconfig = getTsconfig(isAbsolute(configName) ? configName : cwd, {
+    configName: isAbsolute(configName) ? basename(configName) : configName,
+    typescriptVersion: false,
+  });
+
+  if (!tsconfig) {
+    return undefined;
+  }
+
+  const tsconfigDir = dirname(tsconfig.path);
+  const compilerOptions = tsconfig.config.compilerOptions ?? {};
+  // get-tsconfig keeps path-like options relative to the tsconfig file.
+  // The dts post-processing code expects the TypeScript API shape.
+  const options = {
+    ...compilerOptions,
+    declarationDir: resolveTsconfigPath(
+      tsconfigDir,
+      compilerOptions.declarationDir,
+    ),
+    outDir: resolveTsconfigPath(tsconfigDir, compilerOptions.outDir),
+    rootDir: resolveTsconfigPath(tsconfigDir, compilerOptions.rootDir),
+    tsBuildInfoFile: resolveTsconfigPath(
+      tsconfigDir,
+      compilerOptions.tsBuildInfoFile,
+    ),
+  } as GetTsconfigTsconfigResultForBin['options'];
+
+  return {
+    path: tsconfig.path,
+    config: {
+      options,
+    },
+  };
 }
 
 export function mergeAliasWithTsConfigPaths(
@@ -183,18 +243,6 @@ export async function clearTempDeclarationDir(cwd: string): Promise<void> {
   const dirPath = path.join(cwd, TEMP_DTS_DIR);
 
   await emptyDir(dirPath);
-}
-
-export function getFileLoc(diagnostic: Diagnostic, configPath: string): string {
-  if (diagnostic.file) {
-    const { line, character } = ts.getLineAndCharacterOfPosition(
-      diagnostic.file,
-      diagnostic.start!,
-    );
-    return `${color.cyan(diagnostic.file.fileName)}:${color.yellow(line + 1)}:${color.yellow(character + 1)}`;
-  }
-
-  return color.cyan(configPath);
 }
 
 export const prettyTime = (seconds: number): string => {

--- a/packages/plugin-dts/tests/utils.test.ts
+++ b/packages/plugin-dts/tests/utils.test.ts
@@ -1,10 +1,10 @@
-// import { execSync } from 'node:child_process';
+import { describe, expect, test } from '@rstest/core';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { describe, expect, test } from '@rstest/core';
+import type { CompilerOptions } from 'typescript';
 import {
   cleanTsBuildInfoFile,
-  loadTsconfig,
+  loadTsconfigResultForBin,
   mergeAliasWithTsConfigPaths,
   prettyTime,
 } from '../src/utils';
@@ -112,6 +112,47 @@ describe('mergeAliasWithTsConfigPaths', () => {
   });
 });
 
+describe('loadTsconfigResultForBin', () => {
+  test('should load the options needed by the bin backend', async () => {
+    const tempDir = await fs.mkdtemp(path.join(__dirname, 'bin-tsconfig-'));
+
+    try {
+      const tsconfigPath = path.join(tempDir, 'tsconfig.json');
+      await fs.writeFile(
+        tsconfigPath,
+        JSON.stringify(
+          {
+            compilerOptions: {
+              declarationDir: 'types',
+              outDir: 'dist',
+              rootDir: 'src',
+              tsBuildInfoFile: '.cache/build.tsbuildinfo',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const loaded = loadTsconfigResultForBin(tempDir, 'tsconfig.json');
+
+      expect(path.normalize(loaded?.path ?? '')).toBe(
+        path.normalize(tsconfigPath),
+      );
+      expect(loaded?.config).toEqual({
+        options: {
+          declarationDir: path.join(tempDir, 'types'),
+          outDir: path.join(tempDir, 'dist'),
+          rootDir: path.join(tempDir, 'src'),
+          tsBuildInfoFile: path.join(tempDir, '.cache/build.tsbuildinfo'),
+        },
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('cleanTsBuildInfoFile', () => {
   const fileExists = async (filePath: string): Promise<boolean> => {
     try {
@@ -179,8 +220,7 @@ describe('cleanTsBuildInfoFile', () => {
             JSON.stringify({ compilerOptions: testCase.config }, null, 2),
           );
 
-          // execSync(`npx tsc --p ${tsconfigPath}`, { cwd: tempDir });
-          // tsc is too slow, so we directly create the file
+          // Create the file directly instead of running tsc for every case.
           await fs.mkdir(path.dirname(expectedBuildInfoPath), {
             recursive: true,
           });
@@ -191,8 +231,13 @@ describe('cleanTsBuildInfoFile', () => {
 
           expect(await fileExists(expectedBuildInfoPath)).toBe(true);
 
-          const tsconfig = loadTsconfig(tsconfigPath);
-          await cleanTsBuildInfoFile(tsconfigPath, tsconfig.options);
+          const compilerOptions = Object.fromEntries(
+            Object.entries(testCase.config).map(([key, value]) => [
+              key,
+              typeof value === 'string' ? path.join(tempDir, value) : value,
+            ]),
+          ) as CompilerOptions;
+          await cleanTsBuildInfoFile(tsconfigPath, compilerOptions);
 
           expect(await fileExists(expectedBuildInfoPath)).toBe(false);
         }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,6 +424,9 @@ importers:
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
+      get-tsconfig:
+        specifier: 5.0.0-beta.5
+        version: 5.0.0-beta.5
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
@@ -4809,6 +4812,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@5.0.0-beta.5:
+    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
+
   git-hooks-list@4.2.1:
     resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
 
@@ -6368,6 +6375,9 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -11407,6 +11417,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-tsconfig@5.0.0-beta.5:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   git-hooks-list@4.2.1: {}
 
   glob-parent@5.1.2:
@@ -13425,6 +13439,8 @@ snapshots:
       global-modules: 1.0.0
 
   resolve-from@4.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.12:
     dependencies:


### PR DESCRIPTION
## Summary

This PR keeps declaration generation from loading the TypeScript Compiler API when plugin-dts is running in non-api backends. It makes the backend selection explicit with `tsc-api`, `tsgo-bin`, and `isolated`, loads tsconfig for the bin path through `get-tsconfig`, and keeps `typescript` loading scoped to the `tsc-api` backend.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).