### PR TITLE
feat(dts): support TypeScript 7

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "@microsoft/api-extractor": "^7",
-    "typescript": "^5 || ^6"
+    "typescript": "^5 || ^6 || ^7.0.1-0"
   },
   "peerDependenciesMeta": {
     "@microsoft/api-extractor": {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -104,7 +104,7 @@ export type Dts =
       /**
        * Whether to generate declaration files with `tsgo`.
        * @experimental
-       * @defaultValue `false`
+       * @defaultValue `true` when the installed `typescript` package is version 7 or higher, otherwise `false`.
        * @see {@link https://rslib.rs/config/lib/dts#dtstsgo}
        */
       tsgo?: boolean;

--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -294,23 +294,21 @@ import { foo } from './foo.mjs'; // expected output of './dist/bar.d.mts'
 ### tsgo
 
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true` when the installed `typescript` package is version 7 or higher, otherwise `false`
 
-Whether to generate declaration files with [tsgo](https://github.com/microsoft/typescript-go).
+Whether to generate declaration files with [TypeScript Go](https://github.com/microsoft/typescript-go).
 
-> Rslib recommends enabling `tsgo` to speed up declaration file generation.
+After installing TypeScript 7 or higher, Rslib will automatically enable this option.
 
-To enable this option, you need to:
+```bash
+npm add typescript@rc -D
+```
 
-1. Install [@typescript/native-preview](https://www.npmjs.com/package/@typescript/native-preview) as a development dependency.
+You can also install [@typescript/native-preview](https://www.npmjs.com/package/@typescript/native-preview) and manually enable this option.
 
 ```bash
 npm add @typescript/native-preview -D
 ```
-
-> `@typescript/native-preview` requires Node.js 20.6.0 or higher.
-
-2. Set `tsgo` to `true`.
 
 ```js
 pluginDts({
@@ -318,7 +316,9 @@ pluginDts({
 });
 ```
 
-3. In order to ensure the consistency of local development, you need to install the corresponding [VS Code Preview Extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview) and add the following configuration in the VS Code settings:
+> The `@typescript/native-preview` usage is deprecated and kept only for compatibility. Prefer installing `typescript@rc` to use tsgo.
+
+To ensure consistency during local development, you need to install the corresponding [VS Code Preview Extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview) and add the following setting to VS Code:
 
 ```json
 {

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -51,7 +51,7 @@
     "@microsoft/api-extractor": "^7",
     "@rsbuild/core": "^1.0.0 || ^2.0.0-0",
     "@typescript/native-preview": "^7.0.0-0",
-    "typescript": "^5 || ^6"
+    "typescript": "^5 || ^6 || ^7.0.1-0"
   },
   "peerDependenciesMeta": {
     "@microsoft/api-extractor": {

--- a/packages/plugin-dts/src/backend.ts
+++ b/packages/plugin-dts/src/backend.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
-import { createRequire } from 'node:module';
-import { join } from 'node:path';
 import type { PluginDtsOptions } from './index';
+import { createRequireFromPackageJson } from './utils';
 
 export type DtsGenerationBackend =
   | 'api-old'
@@ -16,7 +15,7 @@ type ParsedTypescriptVersion = {
 
 export const readTypescriptVersion = (cwd: string): string | undefined => {
   try {
-    const currentRequire = createRequire(join(cwd, 'package.json'));
+    const currentRequire = createRequireFromPackageJson(cwd);
     const packageJsonPath = currentRequire.resolve('typescript/package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
     return typeof packageJson.version === 'string'

--- a/packages/plugin-dts/src/backend.ts
+++ b/packages/plugin-dts/src/backend.ts
@@ -5,8 +5,8 @@ import type { PluginDtsOptions } from './index';
 
 export type DtsGenerationBackend =
   | 'api-old'
-  | 'tsc-bin'
-  | 'tsgo-bin'
+  | 'tsc-executable'
+  | 'tsgo-executable'
   | 'isolated';
 
 type ParsedTypescriptVersion = {
@@ -97,11 +97,11 @@ export function resolveDtsGenerationBackend(
       );
     }
 
-    return 'tsc-bin';
+    return 'tsc-executable';
   }
 
   if (options.tsgo === true) {
-    return 'tsgo-bin';
+    return 'tsgo-executable';
   }
 
   return 'api-old';

--- a/packages/plugin-dts/src/backend.ts
+++ b/packages/plugin-dts/src/backend.ts
@@ -1,6 +1,56 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
 import type { PluginDtsOptions } from './index';
 
-export type DtsGenerationBackend = 'tsc-api' | 'tsgo-bin' | 'isolated';
+export type DtsGenerationBackend =
+  | 'api-old'
+  | 'tsc-bin'
+  | 'tsgo-bin'
+  | 'isolated';
+
+type ParsedTypescriptVersion = {
+  major: number;
+  minor: number;
+};
+
+export const readTypescriptVersion = (cwd: string): string | undefined => {
+  try {
+    const currentRequire = createRequire(join(cwd, 'package.json'));
+    const packageJsonPath = currentRequire.resolve('typescript/package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+    return typeof packageJson.version === 'string'
+      ? packageJson.version
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const parseTypescriptVersion = (
+  version: string | undefined,
+): ParsedTypescriptVersion | undefined => {
+  const match = version?.match(/^(\d+)\.(\d+)/);
+
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+  };
+};
+
+const isTypeScriptVersionAtLeast7 = (version: string | undefined): boolean => {
+  const parsedVersion = parseTypescriptVersion(version);
+
+  if (!parsedVersion) {
+    return false;
+  }
+
+  return parsedVersion.major >= 7;
+};
 
 export function validateExplicitIsolatedDtsOptions(
   options: Pick<
@@ -32,6 +82,7 @@ export function resolveDtsGenerationBackend(
     PluginDtsOptions,
     'isolated' | 'tsgo' | 'build' | 'abortOnError'
   >,
+  typescriptVersion?: string,
 ): DtsGenerationBackend {
   validateExplicitIsolatedDtsOptions(options);
 
@@ -39,9 +90,19 @@ export function resolveDtsGenerationBackend(
     return 'isolated';
   }
 
-  if (options.tsgo) {
+  if (isTypeScriptVersionAtLeast7(typescriptVersion)) {
+    if (options.tsgo === false) {
+      throw new Error(
+        'Can not set "dts.tsgo: false" when using TypeScript 7 or higher.',
+      );
+    }
+
+    return 'tsc-bin';
+  }
+
+  if (options.tsgo === true) {
     return 'tsgo-bin';
   }
 
-  return 'tsc-api';
+  return 'api-old';
 }

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -16,7 +16,7 @@ import {
   ensureTempDeclarationDir,
   mergeAliasWithTsConfigPaths,
   type CompilerApiTsconfigResultForApi,
-  type GetTsconfigTsconfigResultForBin,
+  type GetTsconfigTsconfigResultForExecutable,
 } from './utils';
 
 const isObject = (obj: unknown): obj is Record<string, any> =>
@@ -135,7 +135,7 @@ export type PreparedDtsContext = {
 export type EmitDtsOptions<
   Tsconfig extends
     | CompilerApiTsconfigResultForApi
-    | GetTsconfigTsconfigResultForBin,
+    | GetTsconfigTsconfigResultForExecutable,
 > = {
   name: string;
   cwd: string;
@@ -181,6 +181,9 @@ export async function prepareDtsContext(
   // The longest common path of all non-declaration input files.
   // If composite is set, the default is instead the directory containing the tsconfig.json file.
   // see https://www.typescriptlang.org/tsconfig/#rootDir
+  // Since TypeScript 6, rootDir defaults to the tsconfig directory. This also
+  // covers TypeScript 7+ executable backends when TypeScript API fileNames are
+  // unavailable.
   const rootDir =
     rawCompilerOptions.rootDir ??
     (rawCompilerOptions.composite
@@ -343,14 +346,16 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
   };
 
   const dtsBackend = data.dtsBackend;
-  const useTsgoBin = dtsBackend === 'tsc-bin' || dtsBackend === 'tsgo-bin';
-  const hasError = useTsgoBin
+  const useExecutable =
+    dtsBackend === 'tsc-executable' || dtsBackend === 'tsgo-executable';
+  const hasError = useExecutable
     ? await import('./tsgo').then((mod) =>
         mod.emitDtsTsgo(
           {
             ...emitOptions,
             dtsBackend,
-            tsConfigResult: tsConfigResult as GetTsconfigTsconfigResultForBin,
+            tsConfigResult:
+              tsConfigResult as GetTsconfigTsconfigResultForExecutable,
           },
           onComplete,
           bundle,
@@ -371,7 +376,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
         ),
       );
 
-  if (useTsgoBin) {
+  if (useExecutable) {
     if (!hasError) {
       await bundleDtsIfNeeded(data, preparedDtsContext);
     }

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -342,12 +342,14 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
     footer,
   };
 
-  const useTsgoBin = data.dtsBackend === 'tsgo-bin';
+  const dtsBackend = data.dtsBackend;
+  const useTsgoBin = dtsBackend === 'tsc-bin' || dtsBackend === 'tsgo-bin';
   const hasError = useTsgoBin
     ? await import('./tsgo').then((mod) =>
         mod.emitDtsTsgo(
           {
             ...emitOptions,
+            dtsBackend,
             tsConfigResult: tsConfigResult as GetTsconfigTsconfigResultForBin,
           },
           onComplete,

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -24,9 +24,9 @@ import {
   color,
   type CompilerApiTsconfigResultForApi,
   getDtsEmitPath,
-  type GetTsconfigTsconfigResultForBin,
+  type GetTsconfigTsconfigResultForExecutable,
   loadTsconfig,
-  loadTsconfigResultForBin,
+  loadTsconfigResultForExecutable,
   loadTypescript,
   processSourceEntry,
   warnIfOutside,
@@ -82,7 +82,7 @@ export type DtsGenOptions = Omit<
   tsconfigPath: string;
   tsConfigResult:
     | CompilerApiTsconfigResultForApi
-    | GetTsconfigTsconfigResultForBin;
+    | GetTsconfigTsconfigResultForExecutable;
   userExternals?: NonNullable<RsbuildConfig['output']>['externals'];
   apiExtractorOptions?: ApiExtractorOptions;
   loggerLevel: LogLevel;
@@ -174,7 +174,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
         let tsconfigPath: string | undefined;
         let tsConfigResult:
           | CompilerApiTsconfigResultForApi
-          | GetTsconfigTsconfigResultForBin
+          | GetTsconfigTsconfigResultForExecutable
           | undefined;
 
         if (tsApi) {
@@ -187,7 +187,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
             tsConfigResult = loadTsconfig(tsconfigPath, tsApi);
           }
         } else {
-          const loadedTsconfig = loadTsconfigResultForBin(
+          const loadedTsconfig = loadTsconfigResultForExecutable(
             cwd,
             configuredTsconfigPath,
           );

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -9,6 +9,7 @@ import { extname, join } from 'node:path';
 
 import {
   type DtsGenerationBackend,
+  readTypescriptVersion,
   resolveDtsGenerationBackend,
 } from './backend';
 import {
@@ -121,16 +122,18 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
     options.redirect.path = options.redirect.path ?? true;
     options.redirect.extension = options.redirect.extension ?? false;
     options.alias = options.alias ?? {};
-    options.tsgo = options.tsgo ?? false;
 
     let dtsPromise: Promise<TaskResult> = Promise.resolve({
       status: 'success',
     });
     let promiseResult: TaskResult;
     let childProcesses: ChildProcess[] = [];
-    const dtsBackend: DtsGenerationBackend =
-      resolveDtsGenerationBackend(options);
-    const tsApi = dtsBackend === 'tsc-api' ? loadTypescript() : undefined;
+    const typescriptVersion = readTypescriptVersion(api.context.rootPath);
+    const dtsBackend = resolveDtsGenerationBackend(options, typescriptVersion);
+    const tsApi =
+      dtsBackend === 'api-old'
+        ? loadTypescript(api.context.rootPath)
+        : undefined;
     let dtsGenOptions: DtsGenOptions | undefined;
     let isolatedDtsContext: IsolatedDtsContext | undefined;
 
@@ -154,7 +157,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
 
     api.onBeforeEnvironmentCompile(
       async ({ isWatch, isFirstCompile, environment, bundlerConfig }) => {
-        if (dtsBackend === 'tsc-api' && !isFirstCompile) {
+        if (dtsBackend === 'api-old' && !isFirstCompile) {
           return;
         }
 
@@ -302,7 +305,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
 
     api.onAfterBuild({
       handler: async ({ isFirstCompile, stats }) => {
-        if (dtsBackend === 'tsc-api' && !isFirstCompile) {
+        if (dtsBackend === 'api-old' && !isFirstCompile) {
           return;
         }
 
@@ -334,7 +337,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
     });
 
     api.onAfterBuild(({ isFirstCompile }) => {
-      if (dtsBackend === 'tsc-api' && !isFirstCompile) {
+      if (dtsBackend === 'api-old' && !isFirstCompile) {
         return;
       }
 

--- a/packages/plugin-dts/src/tsc.ts
+++ b/packages/plugin-dts/src/tsc.ts
@@ -103,7 +103,7 @@ export async function emitDtsTsc(
     paths,
     redirect,
   } = options;
-  const ts = loadTypescript();
+  const ts = loadTypescript(cwd);
   const formatHost = createFormatHost(ts);
   const {
     options: rawCompilerOptions,

--- a/packages/plugin-dts/src/tsgo.ts
+++ b/packages/plugin-dts/src/tsgo.ts
@@ -3,6 +3,7 @@ import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import type { DtsGenerationBackend } from './backend';
 import type { EmitDtsOptions } from './dts';
 import {
   color,
@@ -12,16 +13,52 @@ import {
   type GetTsconfigTsconfigResultForBin,
 } from './utils';
 
-const require = createRequire(import.meta.url);
-
 const logPrefixTsgo = color.dim('[tsgo]');
+const TYPESCRIPT_PACKAGE_NAME = 'typescript';
+const NATIVE_PREVIEW_PACKAGE_NAME = '@typescript/native-preview';
 
-const getTsgoBinPath = async (): Promise<string> => {
-  const tsgoPkgPath =
-    require.resolve('@typescript/native-preview/package.json');
+type BinDtsGenerationBackend = Extract<
+  DtsGenerationBackend,
+  'tsc-bin' | 'tsgo-bin'
+>;
+
+type EmitDtsBinOptions = EmitDtsOptions<GetTsconfigTsconfigResultForBin> & {
+  dtsBackend: BinDtsGenerationBackend;
+};
+
+type DtsBinCommand = {
+  command: string;
+  args: string[];
+  displayCommand: string;
+};
+
+const getRequire = (cwd: string): NodeJS.Require =>
+  createRequire(path.join(cwd, 'package.json'));
+
+const getDtsBinPath = async (
+  cwd: string,
+  packageName:
+    | typeof TYPESCRIPT_PACKAGE_NAME
+    | typeof NATIVE_PREVIEW_PACKAGE_NAME,
+): Promise<string> => {
+  let packageJsonPath: string;
+
+  try {
+    packageJsonPath = getRequire(cwd).resolve(`${packageName}/package.json`);
+  } catch {
+    if (packageName === NATIVE_PREVIEW_PACKAGE_NAME) {
+      throw new Error(
+        'Failed to resolve @typescript/native-preview. Install "typescript@rc" or "@typescript/native-preview" to use TypeScript Go.',
+      );
+    }
+
+    throw new Error(
+      'Failed to resolve typescript. Install "typescript@rc" to use TypeScript Go.',
+    );
+  }
 
   const libPath = path.resolve(
-    path.dirname(tsgoPkgPath),
+    path.dirname(packageJsonPath),
     './lib/getExePath.js',
   );
 
@@ -38,6 +75,25 @@ const getTsgoBinPath = async (): Promise<string> => {
     const getExePath = mod.default;
     return getExePath();
   });
+};
+
+const resolveDtsBinCommand = async (
+  dtsBackend: BinDtsGenerationBackend,
+  args: string[],
+  cwd: string,
+): Promise<DtsBinCommand> => {
+  const dtsBinFile = await getDtsBinPath(
+    cwd,
+    dtsBackend === 'tsc-bin'
+      ? TYPESCRIPT_PACKAGE_NAME
+      : NATIVE_PREVIEW_PACKAGE_NAME,
+  );
+
+  return {
+    command: dtsBinFile,
+    args,
+    displayCommand: `${dtsBinFile} ${args.join(' ')}`,
+  };
 };
 
 const generateTsgoArgs = (
@@ -116,7 +172,7 @@ async function handleDiagnosticsAndProcessFiles(
 }
 
 export async function emitDtsTsgo(
-  options: EmitDtsOptions<GetTsconfigTsconfigResultForBin>,
+  options: EmitDtsBinOptions,
   _onComplete: (isSuccess: boolean) => void,
   bundle = false,
   isWatch = false,
@@ -135,18 +191,19 @@ export async function emitDtsTsgo(
     paths,
     redirect,
     cwd,
+    dtsBackend,
   } = options;
 
-  const tsgoBinFile = await getTsgoBinPath();
   const args = generateTsgoArgs(configPath, declarationDir, build, isWatch);
+  const dtsBinCommand = await resolveDtsBinCommand(dtsBackend, args, cwd);
 
-  logger.debug(logPrefixTsgo, `Running: ${tsgoBinFile} ${args.join(' ')}`);
+  logger.debug(logPrefixTsgo, `Running: ${dtsBinCommand.displayCommand}`);
 
   return new Promise((resolve, reject) => {
     const childProcess = spawn(
-      tsgoBinFile,
+      dtsBinCommand.command,
       [
-        ...args,
+        ...dtsBinCommand.args,
         // Required parameter to enable colored stdout
         '--pretty',
       ],

--- a/packages/plugin-dts/src/tsgo.ts
+++ b/packages/plugin-dts/src/tsgo.ts
@@ -1,12 +1,12 @@
 import { logger } from '@rsbuild/core';
 import { spawn } from 'node:child_process';
-import { createRequire } from 'node:module';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { DtsGenerationBackend } from './backend';
 import type { EmitDtsOptions } from './dts';
 import {
   color,
+  createRequireFromPackageJson,
   getTimeCost,
   processDtsFiles,
   rewriteDtsExtensions,
@@ -33,9 +33,6 @@ type DtsExecutableCommand = {
   displayCommand: string;
 };
 
-const getRequire = (cwd: string): NodeJS.Require =>
-  createRequire(path.join(cwd, 'package.json'));
-
 const getDtsExecutablePath = async (
   cwd: string,
   packageName:
@@ -45,7 +42,9 @@ const getDtsExecutablePath = async (
   let packageJsonPath: string;
 
   try {
-    packageJsonPath = getRequire(cwd).resolve(`${packageName}/package.json`);
+    packageJsonPath = createRequireFromPackageJson(cwd).resolve(
+      `${packageName}/package.json`,
+    );
   } catch {
     if (packageName === NATIVE_PREVIEW_PACKAGE_NAME) {
       throw new Error(

--- a/packages/plugin-dts/src/tsgo.ts
+++ b/packages/plugin-dts/src/tsgo.ts
@@ -10,23 +10,24 @@ import {
   getTimeCost,
   processDtsFiles,
   rewriteDtsExtensions,
-  type GetTsconfigTsconfigResultForBin,
+  type GetTsconfigTsconfigResultForExecutable,
 } from './utils';
 
 const logPrefixTsgo = color.dim('[tsgo]');
 const TYPESCRIPT_PACKAGE_NAME = 'typescript';
 const NATIVE_PREVIEW_PACKAGE_NAME = '@typescript/native-preview';
 
-type BinDtsGenerationBackend = Extract<
+type ExecutableDtsGenerationBackend = Extract<
   DtsGenerationBackend,
-  'tsc-bin' | 'tsgo-bin'
+  'tsc-executable' | 'tsgo-executable'
 >;
 
-type EmitDtsBinOptions = EmitDtsOptions<GetTsconfigTsconfigResultForBin> & {
-  dtsBackend: BinDtsGenerationBackend;
-};
+type EmitDtsExecutableOptions =
+  EmitDtsOptions<GetTsconfigTsconfigResultForExecutable> & {
+    dtsBackend: ExecutableDtsGenerationBackend;
+  };
 
-type DtsBinCommand = {
+type DtsExecutableCommand = {
   command: string;
   args: string[];
   displayCommand: string;
@@ -35,7 +36,7 @@ type DtsBinCommand = {
 const getRequire = (cwd: string): NodeJS.Require =>
   createRequire(path.join(cwd, 'package.json'));
 
-const getDtsBinPath = async (
+const getDtsExecutablePath = async (
   cwd: string,
   packageName:
     | typeof TYPESCRIPT_PACKAGE_NAME
@@ -77,22 +78,22 @@ const getDtsBinPath = async (
   });
 };
 
-const resolveDtsBinCommand = async (
-  dtsBackend: BinDtsGenerationBackend,
+const resolveDtsExecutableCommand = async (
+  dtsBackend: ExecutableDtsGenerationBackend,
   args: string[],
   cwd: string,
-): Promise<DtsBinCommand> => {
-  const dtsBinFile = await getDtsBinPath(
+): Promise<DtsExecutableCommand> => {
+  const dtsExecutableFile = await getDtsExecutablePath(
     cwd,
-    dtsBackend === 'tsc-bin'
+    dtsBackend === 'tsc-executable'
       ? TYPESCRIPT_PACKAGE_NAME
       : NATIVE_PREVIEW_PACKAGE_NAME,
   );
 
   return {
-    command: dtsBinFile,
+    command: dtsExecutableFile,
     args,
-    displayCommand: `${dtsBinFile} ${args.join(' ')}`,
+    displayCommand: `${dtsExecutableFile} ${args.join(' ')}`,
   };
 };
 
@@ -127,15 +128,15 @@ const generateTsgoArgs = (
 async function handleDiagnosticsAndProcessFiles(
   isWatch: boolean,
   hasErrors: boolean,
-  tsConfigResult: GetTsconfigTsconfigResultForBin,
+  tsConfigResult: GetTsconfigTsconfigResultForExecutable,
   configPath: string,
   bundle: boolean,
   cwd: string,
   declarationDir: string,
   dtsExtension: string,
-  redirect: EmitDtsOptions<GetTsconfigTsconfigResultForBin>['redirect'],
+  redirect: EmitDtsOptions<GetTsconfigTsconfigResultForExecutable>['redirect'],
   rootDir: string,
-  paths: EmitDtsOptions<GetTsconfigTsconfigResultForBin>['paths'],
+  paths: EmitDtsOptions<GetTsconfigTsconfigResultForExecutable>['paths'],
   banner?: string,
   footer?: string,
   name?: string,
@@ -172,7 +173,7 @@ async function handleDiagnosticsAndProcessFiles(
 }
 
 export async function emitDtsTsgo(
-  options: EmitDtsBinOptions,
+  options: EmitDtsExecutableOptions,
   _onComplete: (isSuccess: boolean) => void,
   bundle = false,
   isWatch = false,
@@ -195,15 +196,22 @@ export async function emitDtsTsgo(
   } = options;
 
   const args = generateTsgoArgs(configPath, declarationDir, build, isWatch);
-  const dtsBinCommand = await resolveDtsBinCommand(dtsBackend, args, cwd);
+  const dtsExecutableCommand = await resolveDtsExecutableCommand(
+    dtsBackend,
+    args,
+    cwd,
+  );
 
-  logger.debug(logPrefixTsgo, `Running: ${dtsBinCommand.displayCommand}`);
+  logger.debug(
+    logPrefixTsgo,
+    `Running: ${dtsExecutableCommand.displayCommand}`,
+  );
 
   return new Promise((resolve, reject) => {
     const childProcess = spawn(
-      dtsBinCommand.command,
+      dtsExecutableCommand.command,
       [
-        ...dtsBinCommand.args,
+        ...dtsExecutableCommand.args,
         // Required parameter to enable colored stdout
         '--pretty',
       ],

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -88,7 +88,7 @@ export const JS_EXTENSIONS_PATTERN: RegExp = new RegExp(
 );
 
 export type CompilerApiTsconfigResultForApi = ParsedCommandLine;
-export type GetTsconfigTsconfigResultForBin = Pick<
+export type GetTsconfigTsconfigResultForExecutable = Pick<
   CompilerApiTsconfigResultForApi,
   'options'
 >;
@@ -116,10 +116,12 @@ export function loadTsconfig(
   return configFileContent;
 }
 
-export function loadTsconfigResultForBin(
+export function loadTsconfigResultForExecutable(
   cwd: string,
   configName: string,
-): { path: string; config: GetTsconfigTsconfigResultForBin } | undefined {
+):
+  | { path: string; config: GetTsconfigTsconfigResultForExecutable }
+  | undefined {
   if (isAbsolute(configName) && !fs.existsSync(configName)) {
     return undefined;
   }
@@ -149,7 +151,7 @@ export function loadTsconfigResultForBin(
       tsconfigDir,
       compilerOptions.tsBuildInfoFile,
     ),
-  } as GetTsconfigTsconfigResultForBin['options'];
+  } as GetTsconfigTsconfigResultForExecutable['options'];
 
   return {
     path: tsconfig.path,

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -25,6 +25,7 @@ import type { DtsEntry, DtsRedirect } from './index';
 const require = createRequire(import.meta.url);
 
 let astGrepNapi: typeof import('@ast-grep/napi') | undefined;
+const typescriptCache = new Map<string, typeof import('typescript')>();
 
 const loadAstGrepNapi = (): typeof import('@ast-grep/napi') => {
   if (!astGrepNapi) {
@@ -39,6 +40,12 @@ export const loadTypescript = (cwd?: string): typeof import('typescript') => {
   const currentRequire = cwd
     ? createRequire(join(cwd, 'package.json'))
     : require;
+  const typescriptPath = currentRequire.resolve('typescript');
+  const cachedTypescript = typescriptCache.get(typescriptPath);
+
+  if (cachedTypescript) {
+    return cachedTypescript;
+  }
 
   /**
    * Currently, typescript only provides a CJS bundle, so we use require to load it
@@ -46,7 +53,12 @@ export const loadTypescript = (cwd?: string): typeof import('typescript') => {
    * Node.js will use `cjs-module-lexer` to parse it, which slows down startup time.
    */
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  return currentRequire('typescript') as typeof import('typescript');
+  const typescript = currentRequire(
+    'typescript',
+  ) as typeof import('typescript');
+  typescriptCache.set(typescriptPath, typescript);
+
+  return typescript;
 };
 
 type ColorFn = (text: string | number) => string;

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -25,7 +25,6 @@ import type { DtsEntry, DtsRedirect } from './index';
 const require = createRequire(import.meta.url);
 
 let astGrepNapi: typeof import('@ast-grep/napi') | undefined;
-let typescript: typeof import('typescript') | undefined;
 
 const loadAstGrepNapi = (): typeof import('@ast-grep/napi') => {
   if (!astGrepNapi) {
@@ -36,18 +35,18 @@ const loadAstGrepNapi = (): typeof import('@ast-grep/napi') => {
   return astGrepNapi;
 };
 
-export const loadTypescript = (): typeof import('typescript') => {
-  if (!typescript) {
-    /**
-     * Currently, typescript only provides a CJS bundle, so we use require to load it
-     * for better startup performance. If we use `import ts from 'typescript'`,
-     * Node.js will use `cjs-module-lexer` to parse it, which slows down startup time.
-     */
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    typescript = require('typescript') as typeof import('typescript');
-  }
+export const loadTypescript = (cwd?: string): typeof import('typescript') => {
+  const currentRequire = cwd
+    ? createRequire(join(cwd, 'package.json'))
+    : require;
 
-  return typescript;
+  /**
+   * Currently, typescript only provides a CJS bundle, so we use require to load it
+   * for better startup performance. If we use `import ts from 'typescript'`,
+   * Node.js will use `cjs-module-lexer` to parse it, which slows down startup time.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return currentRequire('typescript') as typeof import('typescript');
 };
 
 type ColorFn = (text: string | number) => string;

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -27,6 +27,9 @@ const require = createRequire(import.meta.url);
 let astGrepNapi: typeof import('@ast-grep/napi') | undefined;
 const typescriptCache = new Map<string, typeof import('typescript')>();
 
+export const createRequireFromPackageJson = (cwd: string): NodeJS.Require =>
+  createRequire(join(cwd, 'package.json'));
+
 const loadAstGrepNapi = (): typeof import('@ast-grep/napi') => {
   if (!astGrepNapi) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -37,9 +40,7 @@ const loadAstGrepNapi = (): typeof import('@ast-grep/napi') => {
 };
 
 export const loadTypescript = (cwd?: string): typeof import('typescript') => {
-  const currentRequire = cwd
-    ? createRequire(join(cwd, 'package.json'))
-    : require;
+  const currentRequire = cwd ? createRequireFromPackageJson(cwd) : require;
   const typescriptPath = currentRequire.resolve('typescript');
   const cachedTypescript = typescriptCache.get(typescriptPath);
 

--- a/packages/plugin-dts/tests/backend.test.ts
+++ b/packages/plugin-dts/tests/backend.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from '@rstest/core';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  readTypescriptVersion,
+  resolveDtsGenerationBackend,
+} from '../src/backend';
+
+describe('resolveDtsGenerationBackend', () => {
+  test('should use the old compiler api backend for TypeScript 5 and 6', () => {
+    expect(resolveDtsGenerationBackend({}, '5.9.3')).toBe('api-old');
+    expect(resolveDtsGenerationBackend({}, '6.0.1')).toBe('api-old');
+  });
+
+  test('should use the TypeScript tsc bin backend for TypeScript 7.0', () => {
+    expect(resolveDtsGenerationBackend({}, '7.0.1-rc')).toBe('tsc-bin');
+    expect(resolveDtsGenerationBackend({ tsgo: true }, '7.0.1-rc')).toBe(
+      'tsc-bin',
+    );
+  });
+
+  test('should use the native-preview tsgo bin backend when tsgo is enabled without TypeScript 7.0', () => {
+    expect(resolveDtsGenerationBackend({ tsgo: true }, '6.0.1')).toBe(
+      'tsgo-bin',
+    );
+  });
+
+  test('should reject disabling tsgo with TypeScript 7.0', () => {
+    expect(() =>
+      resolveDtsGenerationBackend({ tsgo: false }, '7.0.1-rc'),
+    ).toThrow(
+      'Can not set "dts.tsgo: false" when using TypeScript 7 or higher.',
+    );
+  });
+
+  test('should use the TypeScript tsc bin backend for TypeScript 7.1 or higher', () => {
+    expect(resolveDtsGenerationBackend({}, '7.1.0')).toBe('tsc-bin');
+  });
+
+  test('should read the TypeScript version from cwd', async () => {
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'rslib-plugin-dts-'),
+    );
+
+    try {
+      const typescriptPkgDir = path.join(tempDir, 'node_modules', 'typescript');
+      const packageDir = path.join(tempDir, 'packages', 'foo');
+      await fs.mkdir(typescriptPkgDir, { recursive: true });
+      await fs.mkdir(packageDir, { recursive: true });
+      await fs.writeFile(
+        path.join(packageDir, 'package.json'),
+        JSON.stringify({ name: 'foo' }),
+      );
+      await fs.writeFile(
+        path.join(typescriptPkgDir, 'package.json'),
+        JSON.stringify({ name: 'typescript', version: '7.0.1-rc' }),
+      );
+
+      const typescriptVersion = readTypescriptVersion(packageDir);
+
+      expect(typescriptVersion).toBe('7.0.1-rc');
+      expect(resolveDtsGenerationBackend({}, typescriptVersion)).toBe(
+        'tsc-bin',
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/plugin-dts/tests/backend.test.ts
+++ b/packages/plugin-dts/tests/backend.test.ts
@@ -13,16 +13,16 @@ describe('resolveDtsGenerationBackend', () => {
     expect(resolveDtsGenerationBackend({}, '6.0.1')).toBe('api-old');
   });
 
-  test('should use the TypeScript tsc bin backend for TypeScript 7.0', () => {
-    expect(resolveDtsGenerationBackend({}, '7.0.1-rc')).toBe('tsc-bin');
+  test('should use the TypeScript executable backend for TypeScript 7.0', () => {
+    expect(resolveDtsGenerationBackend({}, '7.0.1-rc')).toBe('tsc-executable');
     expect(resolveDtsGenerationBackend({ tsgo: true }, '7.0.1-rc')).toBe(
-      'tsc-bin',
+      'tsc-executable',
     );
   });
 
-  test('should use the native-preview tsgo bin backend when tsgo is enabled without TypeScript 7.0', () => {
+  test('should use the native-preview executable backend when tsgo is enabled without TypeScript 7.0', () => {
     expect(resolveDtsGenerationBackend({ tsgo: true }, '6.0.1')).toBe(
-      'tsgo-bin',
+      'tsgo-executable',
     );
   });
 
@@ -34,8 +34,8 @@ describe('resolveDtsGenerationBackend', () => {
     );
   });
 
-  test('should use the TypeScript tsc bin backend for TypeScript 7.1 or higher', () => {
-    expect(resolveDtsGenerationBackend({}, '7.1.0')).toBe('tsc-bin');
+  test('should use the TypeScript executable backend for TypeScript 7.1 or higher', () => {
+    expect(resolveDtsGenerationBackend({}, '7.1.0')).toBe('tsc-executable');
   });
 
   test('should read the TypeScript version from cwd', async () => {
@@ -61,7 +61,7 @@ describe('resolveDtsGenerationBackend', () => {
 
       expect(typescriptVersion).toBe('7.0.1-rc');
       expect(resolveDtsGenerationBackend({}, typescriptVersion)).toBe(
-        'tsc-bin',
+        'tsc-executable',
       );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/packages/plugin-dts/tests/utils.test.ts
+++ b/packages/plugin-dts/tests/utils.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import type { CompilerOptions } from 'typescript';
 import {
   cleanTsBuildInfoFile,
-  loadTsconfigResultForBin,
+  loadTsconfigResultForExecutable,
   mergeAliasWithTsConfigPaths,
   prettyTime,
 } from '../src/utils';
@@ -112,9 +112,11 @@ describe('mergeAliasWithTsConfigPaths', () => {
   });
 });
 
-describe('loadTsconfigResultForBin', () => {
-  test('should load the options needed by the bin backend', async () => {
-    const tempDir = await fs.mkdtemp(path.join(__dirname, 'bin-tsconfig-'));
+describe('loadTsconfigResultForExecutable', () => {
+  test('should load the options needed by the executable backend', async () => {
+    const tempDir = await fs.mkdtemp(
+      path.join(__dirname, 'executable-tsconfig-'),
+    );
 
     try {
       const tsconfigPath = path.join(tempDir, 'tsconfig.json');
@@ -134,7 +136,7 @@ describe('loadTsconfigResultForBin', () => {
         ),
       );
 
-      const loaded = loadTsconfigResultForBin(tempDir, 'tsconfig.json');
+      const loaded = loadTsconfigResultForExecutable(tempDir, 'tsconfig.json');
 
       expect(path.normalize(loaded?.path ?? '')).toBe(
         path.normalize(tsconfigPath),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -754,6 +754,12 @@ importers:
 
   tests/integration/dts-tsgo/bundle-false/dist-path: {}
 
+  tests/integration/dts-tsgo/bundle-false/ts7-basic:
+    devDependencies:
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
+
   tests/integration/dts-tsgo/bundle-false/tsconfig-path: {}
 
   tests/integration/dts-tsgo/bundle/abort-on-error: {}
@@ -3704,6 +3710,126 @@ packages:
     resolution: {integrity: sha512-W5XiTTbIGZSAJUMJqynchbfcjPcoNn29U8dnd+FK+x+Mj9VT9NNTymZ0YAIf+hU2uYAxx3AGe6/U/2OF2TpQwg==}
     engines: {node: '>=16.20.0'}
     hasBin: true
+
+  '@typescript/typescript-aix-ppc64@7.0.1-rc':
+    resolution: {integrity: sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.1-rc':
+    resolution: {integrity: sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-DE+ppd8Ix2c6OMuRkKY4PJ4hngMGJ9M95OQUP17p9xL/1IKXof7npIeuusMN/bgL5o5JzMfSGh+N+5scTYRg0Q==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-ST1ozHMw0u+CLOnWkcTyWDMV4Qn9osZ6fd1V1lnKDM1t0hZIp81mdGpdHxyHJjd7jdGrb6Gb/QXcZ1uqZ0t5zw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.1-rc':
+    resolution: {integrity: sha512-gHmHwT5Naq5CKM8g9bbaGeEpnwQEvWCLn3fwP4K2m61VQdDKkPk0Dhab/OoZ4LV2SrMddmclYXTzpyg23YGt5g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.1-rc':
+    resolution: {integrity: sha512-G17Sao312rgiPBTh2F4nOpLpa3CcnBSaNhqNghZk2LNhnsp1RaMO5HMq2me21gqu9xLpc6CIgHtOzU6JBgNlfg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.1-rc':
+    resolution: {integrity: sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.1-rc':
+    resolution: {integrity: sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.1-rc':
+    resolution: {integrity: sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.1-rc':
+    resolution: {integrity: sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.1-rc':
+    resolution: {integrity: sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-PQGhlxfNig+0YQ9Wwzd0USPBkt6w/ZqkBQWsU7G/0JkTzunJel+jSWwhKw4947pak/m7hGSeYiI04xReDLGZww==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.1-rc':
+    resolution: {integrity: sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.1-rc':
+    resolution: {integrity: sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@typescript/vfs@1.6.4':
     resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
@@ -7177,6 +7303,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.1-rc:
+    resolution: {integrity: sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -10215,6 +10346,66 @@ snapshots:
       '@typescript/native-preview-linux-x64': 7.0.0-dev.20260620.1
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260620.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260620.1
+
+  '@typescript/typescript-aix-ppc64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.1-rc':
+    optional: true
 
   '@typescript/vfs@1.6.4(typescript@6.0.3)':
     dependencies:
@@ -14352,6 +14543,29 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.1-rc:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.1-rc
+      '@typescript/typescript-darwin-arm64': 7.0.1-rc
+      '@typescript/typescript-darwin-x64': 7.0.1-rc
+      '@typescript/typescript-freebsd-arm64': 7.0.1-rc
+      '@typescript/typescript-freebsd-x64': 7.0.1-rc
+      '@typescript/typescript-linux-arm': 7.0.1-rc
+      '@typescript/typescript-linux-arm64': 7.0.1-rc
+      '@typescript/typescript-linux-loong64': 7.0.1-rc
+      '@typescript/typescript-linux-mips64el': 7.0.1-rc
+      '@typescript/typescript-linux-ppc64': 7.0.1-rc
+      '@typescript/typescript-linux-riscv64': 7.0.1-rc
+      '@typescript/typescript-linux-s390x': 7.0.1-rc
+      '@typescript/typescript-linux-x64': 7.0.1-rc
+      '@typescript/typescript-netbsd-arm64': 7.0.1-rc
+      '@typescript/typescript-netbsd-x64': 7.0.1-rc
+      '@typescript/typescript-openbsd-arm64': 7.0.1-rc
+      '@typescript/typescript-openbsd-x64': 7.0.1-rc
+      '@typescript/typescript-sunos-x64': 7.0.1-rc
+      '@typescript/typescript-win32-arm64': 7.0.1-rc
+      '@typescript/typescript-win32-x64': 7.0.1-rc
 
   undici-types@7.16.0: {}
 

--- a/tests/integration/dts-tsgo/bundle-false/index.test.ts
+++ b/tests/integration/dts-tsgo/bundle-false/index.test.ts
@@ -47,8 +47,23 @@ describe('dts with tsgo when bundle: false', () => {
       type: 'dts',
     });
 
-    expect(files.esm).toContain(join(fixturePath, 'dist/esm/index.d.ts'));
-    expect(files.cjs).toContain(join(fixturePath, 'dist/cjs/index.d.ts'));
+    expect(files.esm).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts-tsgo/bundle-false/ts7-basic/dist/esm/index.d.ts",
+        "<ROOT>/tests/integration/dts-tsgo/bundle-false/ts7-basic/dist/esm/sum.d.ts",
+        "<ROOT>/tests/integration/dts-tsgo/bundle-false/ts7-basic/dist/esm/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts-tsgo/bundle-false/ts7-basic/dist/esm/utils/strings.d.ts",
+      ]
+    `);
+
+    expect(files.cjs).toMatchInlineSnapshot(`
+      [
+        "<ROOT>/tests/integration/dts-tsgo/bundle-false/ts7-basic/dist/cjs/index.d.ts",
+        "<ROOT>/tests/integration/dts-tsgo/bundle-false/ts7-basic/dist/cjs/sum.d.ts",
+        "<ROOT>/tests/integration/dts-tsgo/bundle-false/ts7-basic/dist/cjs/utils/numbers.d.ts",
+        "<ROOT>/tests/integration/dts-tsgo/bundle-false/ts7-basic/dist/cjs/utils/strings.d.ts",
+      ]
+    `);
   });
 
   test('distPath', async () => {

--- a/tests/integration/dts-tsgo/bundle-false/index.test.ts
+++ b/tests/integration/dts-tsgo/bundle-false/index.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, test } from '@rstest/core';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { describe, expect, test } from '@rstest/core';
 import {
   buildAndGetResults,
   createTempFiles,
@@ -37,6 +37,18 @@ describe('dts with tsgo when bundle: false', () => {
     `);
 
     expect(contents.esm).toMatchSnapshot();
+  });
+
+  test('ts7 basic', async () => {
+    const fixturePath = join(__dirname, 'ts7-basic');
+
+    const { files } = await buildAndGetResults({
+      fixturePath,
+      type: 'dts',
+    });
+
+    expect(files.esm).toContain(join(fixturePath, 'dist/esm/index.d.ts'));
+    expect(files.cjs).toContain(join(fixturePath, 'dist/cjs/index.d.ts'));
   });
 
   test('distPath', async () => {

--- a/tests/integration/dts-tsgo/bundle-false/ts7-basic/package.json
+++ b/tests/integration/dts-tsgo/bundle-false/ts7-basic/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dts-tsgo-bundle-false-ts7-basic-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "typescript": "7.0.1-rc"
+  }
+}

--- a/tests/integration/dts-tsgo/bundle-false/ts7-basic/rslib.config.ts
+++ b/tests/integration/dts-tsgo/bundle-false/ts7-basic/rslib.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+      },
+    }),
+    generateBundleCjsConfig({
+      bundle: false,
+      dts: {
+        bundle: false,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['../__fixtures__/src/**'],
+    },
+    tsconfigPath: '../__fixtures__/tsconfig.json',
+  },
+});

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -273,23 +273,17 @@ At this time, when [redirect.dts.path](/config/lib/redirect#redirectdtspath) is 
 ### dts.tsgo
 
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true` when the installed `typescript` package is version 7 or higher, otherwise `false`
 
-Whether to generate declaration files with [tsgo](https://github.com/microsoft/typescript-go).
+Whether to generate declaration files with [TypeScript Go](https://github.com/microsoft/typescript-go).
 
-To enable this option, you need to:
+After installing TypeScript 7 or higher, Rslib will automatically enable this option.
 
-1. Install [@typescript/native-preview](https://www.npmjs.com/package/@typescript/native-preview) as a development dependency.
+<PackageManagerTabs command="add typescript@rc -D" />
+
+You can also install [@typescript/native-preview](https://www.npmjs.com/package/@typescript/native-preview) and manually enable this option.
 
 <PackageManagerTabs command="add @typescript/native-preview -D" />
-
-::: tip Version requirements
-
-`@typescript/native-preview` requires Node.js 20.6.0 or higher.
-
-:::
-
-2. Configure in the Rslib config file:
 
 ```ts title="rslib.config.ts"
 export default {
@@ -303,7 +297,13 @@ export default {
 };
 ```
 
-3. In order to ensure the consistency of local development, you need to install the corresponding [VS Code Preview Extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview) and add the following configuration in the VS Code settings:
+:::note
+
+The `@typescript/native-preview` usage is deprecated and kept only for compatibility. Prefer installing `typescript@rc` to use tsgo.
+
+:::
+
+To ensure consistency during local development, you need to install the corresponding [VS Code Preview Extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview) and add the following setting to VS Code:
 
 ```json title=".vscode/settings.json"
 {

--- a/website/docs/en/guide/advanced/dts.mdx
+++ b/website/docs/en/guide/advanced/dts.mdx
@@ -85,19 +85,15 @@ export default {
 
 #### tsgo
 
-Enabling [dts.tsgo](/config/lib/dts#dtstsgo) uses [tsgo](https://github.com/microsoft/typescript-go) to generate declaration files. It keeps type checking while significantly improving the speed of declaration generation.
+Using [TypeScript Go](https://github.com/microsoft/typescript-go) to generate declaration files can preserve type checking while significantly improving the speed of declaration generation.
 
-1. Install `@typescript/native-preview` as a development dependency:
+After installing TypeScript 7 or higher, Rslib will automatically enable [dts.tsgo](/config/lib/dts#dtstsgo).
+
+<PackageManagerTabs command="add typescript@rc -D" />
+
+You can also install `@typescript/native-preview` and enable `dts.tsgo` in the Rslib config file.
 
 <PackageManagerTabs command="add @typescript/native-preview -D" />
-
-::: tip Version requirements
-
-`@typescript/native-preview` requires Node.js 20.6.0 or higher.
-
-:::
-
-2. Configure in the Rslib config file:
 
 ```ts title="rslib.config.ts"
 export default {
@@ -111,7 +107,13 @@ export default {
 };
 ```
 
-3. In order to ensure the consistency of local development, you need to install the corresponding [VS Code Preview Extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview) and add the following configuration in the VS Code settings:
+:::note
+
+The `@typescript/native-preview` usage is deprecated and kept only for compatibility. Prefer installing `typescript@rc` to use tsgo.
+
+:::
+
+To ensure consistency during local development, you need to install the corresponding [VS Code Preview Extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview) and add the following setting to VS Code:
 
 ```json title=".vscode/settings.json"
 {

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -273,23 +273,17 @@ export default {
 ### dts.tsgo
 
 - **类型：** `boolean`
-- **默认值：** `false`
+- **默认值：** 当安装的 `typescript` 包版本为 7 或更高时为 `true`，否则为 `false`
 
-是否使用 [tsgo](https://github.com/microsoft/typescript-go) 生成类型声明文件。
+是否使用 [TypeScript Go](https://github.com/microsoft/typescript-go) 生成类型声明文件。
 
-启用该选项，你需要：
+安装 TypeScript 7 或更高版本后，Rslib 会自动开启该选项。
 
-1. 安装 [@typescript/native-preview](https://www.npmjs.com/package/@typescript/native-preview) 作为开发依赖。
+<PackageManagerTabs command="add typescript@rc -D" />
+
+你也可以安装 [@typescript/native-preview](https://www.npmjs.com/package/@typescript/native-preview)，并手动开启该选项。
 
 <PackageManagerTabs command="add @typescript/native-preview -D" />
-
-::: tip 版本要求
-
-`@typescript/native-preview` 要求 Node.js 20.6.0 或更高版本。
-
-:::
-
-2. 在 Rslib 配置文件中设置：
 
 ```ts title="rslib.config.ts"
 export default {
@@ -303,7 +297,11 @@ export default {
 };
 ```
 
-3. 为了保证本地开发的一致性，你需要安装对应的 [VS Code 预览版扩展](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview)，并在 VS Code 设置中添加如下配置：
+:::note
+`@typescript/native-preview` 的用法已废弃，仅作为兼容方式保留，推荐安装 `typescript@rc` 使用 tsgo。
+:::
+
+为了保证本地开发的一致性，你需要安装对应的 [VS Code 预览版扩展](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview)，并在 VS Code 设置中添加如下配置：
 
 ```json title=".vscode/settings.json"
 {

--- a/website/docs/zh/guide/advanced/dts.mdx
+++ b/website/docs/zh/guide/advanced/dts.mdx
@@ -85,19 +85,15 @@ export default {
 
 #### tsgo
 
-开启 [dts.tsgo](/config/lib/dts#dtstsgo) 会使用 [tsgo](https://github.com/microsoft/typescript-go) 生成类型声明文件，在保留类型检查的同时，能够显著加快类型生成的速度。
+使用 [TypeScript Go](https://github.com/microsoft/typescript-go) 生成类型声明文件，可以在保留类型检查的同时，显著加快类型生成的速度。
 
-1. 安装 `@typescript/native-preview` 作为开发依赖：
+安装 TypeScript 7 或更高版本后，Rslib 会自动开启 [dts.tsgo](/config/lib/dts#dtstsgo)。
+
+<PackageManagerTabs command="add typescript@rc -D" />
+
+你也可以安装 `@typescript/native-preview`，并在 Rslib 配置文件中开启 `dts.tsgo`。
 
 <PackageManagerTabs command="add @typescript/native-preview -D" />
-
-::: tip 版本要求
-
-`@typescript/native-preview` 要求 Node.js 20.6.0 或更高版本。
-
-:::
-
-2. 在 Rslib 配置文件中设置：
 
 ```ts title="rslib.config.ts"
 export default {
@@ -111,7 +107,11 @@ export default {
 };
 ```
 
-3. 为了保证本地开发的一致性，你需要安装对应的 [VS Code 预览版扩展](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview)，并在 VS Code 设置中添加如下配置：
+:::note
+`@typescript/native-preview` 的用法已废弃，仅作为兼容方式保留，推荐安装 `typescript@rc` 使用 tsgo。
+:::
+
+为了保证本地开发的一致性，你需要安装对应的 [VS Code 预览版扩展](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview)，并在 VS Code 设置中添加如下配置：
 
 ```json title=".vscode/settings.json"
 {


### PR DESCRIPTION
## Summary

This PR adds TypeScript 7 RC support for declaration generation by auto-selecting the TypeScript Go binary path when the project resolves TypeScript 7 or higher, while keeping TypeScript 5/6 on the existing Compiler API path and retaining `@typescript/native-preview` as a compatibility path for explicit `dts.tsgo` usage. It also updates peer ranges, documentation, and focused backend/integration coverage.

## Related Links

https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-rc/

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).