### PR TITLE
fix(dts): clean executable watch processes

### DIFF
--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -392,6 +392,11 @@ process.on('disconnect', () => {
   process.exit();
 });
 
+const shouldExitAfterGenerate = (data: DtsGenOptions): boolean =>
+  !data.isWatch ||
+  data.dtsBackend === 'tsc-executable' ||
+  data.dtsBackend === 'tsgo-executable';
+
 process.on('message', async (data: DtsGenOptions) => {
   if (!data.cwd) {
     return;
@@ -407,7 +412,7 @@ process.on('message', async (data: DtsGenOptions) => {
 
   process.send!('success');
 
-  if (!data.isWatch) {
+  if (shouldExitAfterGenerate(data)) {
     process.exit();
   }
 });

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -24,6 +24,16 @@ const isObject = (obj: unknown): obj is Record<string, any> =>
 
 export const DEFAULT_EXCLUDED_PACKAGES: string[] = ['@types/react'];
 
+type ExecutableDtsGenerationBackend = Extract<
+  DtsGenOptions['dtsBackend'],
+  'tsc-executable' | 'tsgo-executable'
+>;
+
+const isExecutableBackend = (
+  dtsBackend: DtsGenOptions['dtsBackend'],
+): dtsBackend is ExecutableDtsGenerationBackend =>
+  dtsBackend === 'tsc-executable' || dtsBackend === 'tsgo-executable';
+
 type CalculateBundledPackagesOptions = {
   cwd: string;
   autoExternal: DtsGenOptions['autoExternal'];
@@ -346,8 +356,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
   };
 
   const dtsBackend = data.dtsBackend;
-  const useExecutable =
-    dtsBackend === 'tsc-executable' || dtsBackend === 'tsgo-executable';
+  const useExecutable = isExecutableBackend(dtsBackend);
   const hasError = useExecutable
     ? await import('./tsgo').then((mod) =>
         mod.emitDtsTsgo(
@@ -393,9 +402,7 @@ process.on('disconnect', () => {
 });
 
 const shouldExitAfterGenerate = (data: DtsGenOptions): boolean =>
-  !data.isWatch ||
-  data.dtsBackend === 'tsc-executable' ||
-  data.dtsBackend === 'tsgo-executable';
+  !data.isWatch || isExecutableBackend(data.dtsBackend);
 
 process.on('message', async (data: DtsGenOptions) => {
   if (!data.cwd) {

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -284,6 +284,11 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
         );
 
         childProcesses.push(childProcess);
+        childProcess.once('close', () => {
+          childProcesses = childProcesses.filter(
+            (item) => item !== childProcess,
+          );
+        });
         childProcess.send(dtsGenOptions);
 
         dtsPromise = new Promise<TaskResult>((resolve) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7769,7 +7769,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 8.0.0
       '@babel/helper-validator-option': 8.0.0
-      browserslist: 4.28.1
+      browserslist: 4.28.4
       lru-cache: 11.5.1
       semver: 7.7.4
 


### PR DESCRIPTION
## Summary

- Fix executable dts backends so one-shot watch rebuilds exit after reporting success, preventing TypeScript 7 and native-preview watch sessions from accumulating idle dts child processes.
- Remove closed dts child processes from the parent tracking list.
- Align the browserslist snapshot in `pnpm-lock.yaml` with the existing lockfile entry so frozen installs remain valid.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).