### PR TITLE
fix(website): provide TypeScript peer for Rspress docs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1327,6 +1327,9 @@ importers:
       rspress-plugin-font-open-sans:
         specifier: 1.0.4
         version: 1.0.4(@rspress/core@2.0.14)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 

--- a/website/package.json
+++ b/website/package.json
@@ -32,6 +32,7 @@
     "rsbuild-plugin-google-analytics": "1.0.6",
     "rsbuild-plugin-open-graph": "^1.1.3",
     "rspress-plugin-file-tree": "^1.0.5",
-    "rspress-plugin-font-open-sans": "1.0.4"
+    "rspress-plugin-font-open-sans": "1.0.4",
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes an Rspress ecosystem CI failure where the website build can resolve `@rspress/plugin-twoslash`'s TypeScript peer to a TS 7 fixture dependency after local Rspress packages are overridden into the workspace. The website now explicitly provides its expected TypeScript 6 peer so twoslash continues to load a compatible TypeScript entry during docs builds.

## Related Links

https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/28167329042/job/83422471829

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
