### PR TITLE
chore(deps): bump rsbuild to 2.1.0

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.1",
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -22,7 +22,7 @@
     "@module-federation/enhanced": "^2.5.1",
     "@module-federation/rsbuild-plugin": "^2.5.1",
     "@module-federation/storybook-addon": "^6.0.13",
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.4.6",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.1",
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@rsbuild/plugin-vue": "^2.0.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.4.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "test": "rstest"
   },
   "dependencies": {
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/react": "^10.4.6",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/react": "^10.4.6",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/vue3": "^10.4.6",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/vue3": "^10.4.6",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.9",
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@rslib/tsconfig": "workspace:*",
     "get-tsconfig": "5.0.0-beta.5",
     "magic-string": "^0.30.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,13 +80,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rsbuild/core':
-        specifier: 2.1.0-beta.0
-        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+        specifier: ~2.1.0
+        version: 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -101,19 +101,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.5.1
-        version: 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/storybook-addon':
         specifier: ^6.0.13
-        version: 6.0.13(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)
+        version: 6.0.13(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
-        specifier: 2.1.0-beta.0
-        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+        specifier: ~2.1.0
+        version: 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -143,10 +143,10 @@ importers:
         version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -162,13 +162,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rsbuild/core':
-        specifier: 2.1.0-beta.0
-        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+        specifier: ~2.1.0
+        version: 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -183,10 +183,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(preact@10.29.2)
+        version: 2.0.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(preact@10.29.2)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)
+        version: 2.0.0(@rsbuild/core@2.1.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -198,10 +198,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)
+        version: 2.0.0(@rsbuild/core@2.1.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -216,10 +216,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)
+        version: 2.0.0(@rsbuild/core@2.1.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -234,10 +234,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)
+        version: 2.0.0(@rsbuild/core@2.1.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -252,13 +252,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)
+        version: 2.0.0(@rsbuild/core@2.1.0)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)
+        version: 2.0.0(@rsbuild/core@2.1.0)
       '@rsbuild/plugin-solid':
         specifier: ^1.2.2
-        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.0.15)(solid-js@1.9.13)
+        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.0)(solid-js@1.9.13)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -273,7 +273,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(vue@3.5.38)
+        version: 2.0.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(vue@3.5.38)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -290,11 +290,11 @@ importers:
   examples/vue-component-bundleless:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.0-beta.0
-        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+        specifier: ~2.1.0
+        version: 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(vue@3.5.38)
+        version: 2.0.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(vue@3.5.38)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -312,10 +312,10 @@ importers:
         version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.38)
+        version: 3.3.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.38)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -329,15 +329,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: 2.1.0-beta.0
-        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+        specifier: ~2.1.0
+        version: 2.1.0(@module-federation/runtime-tools@2.5.1)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -364,7 +364,7 @@ importers:
         version: 1.6.5(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.0-beta.0)
+        version: 1.0.0(@rsbuild/core@2.1.0)
       rslib:
         specifier: npm:@rslib/core@0.23.0
         version: '@rslib/core@0.23.0(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.5.1)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)'
@@ -401,7 +401,7 @@ importers:
         version: 11.3.5
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.0.15)
+        version: 1.0.0(@rsbuild/core@2.1.0)
       rslib:
         specifier: npm:@rslib/core@0.23.0
         version: '@rslib/core@0.23.0(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.5.1)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)'
@@ -422,8 +422,8 @@ importers:
         specifier: ^7.58.9
         version: 7.58.9(@types/node@25.2.0)
       '@rsbuild/core':
-        specifier: 2.1.0-beta.0
-        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+        specifier: ~2.1.0
+        version: 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -438,7 +438,7 @@ importers:
         version: 1.6.5(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.0-beta.0)
+        version: 1.0.0(@rsbuild/core@2.1.0)
       rslib:
         specifier: npm:@rslib/core@0.23.0
         version: '@rslib/core@0.23.0(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.5.1)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)'
@@ -468,34 +468,34 @@ importers:
         version: 4.0.1
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@playwright/test':
         specifier: 1.61.0
         version: 1.61.0
       '@rsbuild/core':
-        specifier: 2.1.0-beta.0
-        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+        specifier: ~2.1.0
+        version: 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-less':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)
+        version: 2.0.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.0-beta.0)
+        version: 2.0.0(@rsbuild/core@2.1.0)
       '@rsbuild/plugin-toml':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.0-beta.0)
+        version: 2.0.1(@rsbuild/core@2.1.0)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.4
-        version: 1.2.4(@rsbuild/core@2.1.0-beta.0)
+        version: 1.2.4(@rsbuild/core@2.1.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(vue@3.5.38)
+        version: 2.0.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(vue@3.5.38)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@2.1.0-beta.0)
+        version: 1.0.5(@rsbuild/core@2.1.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -572,7 +572,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
 
   tests/integration/asset/json: {}
 
@@ -588,10 +588,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.4
-        version: 2.0.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(typescript@6.0.3)
+        version: 2.0.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(typescript@6.0.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -685,10 +685,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.4
-        version: 2.0.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(typescript@6.0.3)
+        version: 2.0.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(typescript@6.0.3)
 
   tests/integration/cli/build: {}
 
@@ -987,11 +987,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.0-beta.0
-        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+        specifier: ~2.1.0
+        version: 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.1.0-beta.0)
+        version: 1.4.6(@rsbuild/core@2.1.0)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -1000,11 +1000,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.0-beta.0
-        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+        specifier: ~2.1.0
+        version: 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.1.0-beta.0)
+        version: 1.4.6(@rsbuild/core@2.1.0)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1038,7 +1038,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)
+        version: 2.0.0(@rsbuild/core@2.1.0)
       babel-plugin-polyfill-corejs3:
         specifier: ^1.0.0
         version: 1.0.0(@babel/core@7.29.7)
@@ -1051,7 +1051,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1177,19 +1177,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.0.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.0.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.0.3(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1198,7 +1198,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.0.3(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1246,10 +1246,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+        version: 2.0.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(vue@3.5.38)
+        version: 2.0.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(vue@3.5.38)
       vue:
         specifier: ^3.5.38
         version: 3.5.38(typescript@6.0.3)
@@ -1266,16 +1266,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.1
-        version: 2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.5.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rsbuild/core':
-        specifier: 2.1.0-beta.0
-        version: 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+        specifier: ~2.1.0
+        version: 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)
+        version: 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.0-beta.0)
+        version: 2.0.0(@rsbuild/core@2.1.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1284,7 +1284,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 2.0.14
-        version: 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 2.0.14
         version: 2.0.14(@rspress/core@2.0.14)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
@@ -1323,10 +1323,10 @@ importers:
         version: 19.2.7(react@19.2.7)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.6
-        version: 1.0.6(@rsbuild/core@2.1.0-beta.0)
+        version: 1.0.6(@rsbuild/core@2.1.0)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.1.0-beta.0)
+        version: 1.1.3(@rsbuild/core@2.1.0)
       rspress-plugin-file-tree:
         specifier: ^1.0.5
         version: 1.0.5(@rspress/core@2.0.14)
@@ -2727,8 +2727,8 @@ packages:
       core-js:
         optional: true
 
-  '@rsbuild/core@2.1.0-beta.0':
-    resolution: {integrity: sha512-uiVwiLWjrOXORRoj6FkrtqiAP2qtl1ynxs26uyS/29gaOJLiAjDT7q0lpuToxJ4JPQQ2O65H/tOt0IBFvMjGOg==}
+  '@rsbuild/core@2.1.0':
+    resolution: {integrity: sha512-BNOp22xLGA+L8zvZ12Qg/3zhFhWFZCvZ7OcQRoGLSTw1pB9q/XDLK+WGey9SFPOtsRD3CRPXheXApxwvneH6uA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2947,8 +2947,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@2.1.0-beta.0':
-    resolution: {integrity: sha512-BE2O8aq/tzG9c3BHlsmH/cDnwr86wG68AQ/n1uaYEB5hoBJMk2eBJo/q2/CZ37ZT5ntVsCGkJpCPBT/Dh7q9PA==}
+  '@rspack/binding-darwin-arm64@2.1.0':
+    resolution: {integrity: sha512-1DdnXLCl4/7BydtxvFyJbqOyvo3dgeKIdukr5BrM7UUA5rJnpin0qZIq/C0Y+ZwTx7ML4zdYaJeR+WOujRQH1Q==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2957,8 +2957,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.1.0-beta.0':
-    resolution: {integrity: sha512-9icL31+mGJRKaU1i0IVbsBcmRWpUVfTM9TuLUHZOy0fnPhoZPDT0C/BZJxjvlvSeV2NNhh/NBEzUP3taZj7Zcg==}
+  '@rspack/binding-darwin-x64@2.1.0':
+    resolution: {integrity: sha512-PJB6n/BaupvfLaErsfvC7q9W07WozkPe2Xw7sQqX6fblK+4tooBp0ZdAtKi76L+U2fR8t8/nQb0Jokco0co7Fg==}
     cpu: [x64]
     os: [darwin]
 
@@ -2968,8 +2968,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-gnu@2.1.0-beta.0':
-    resolution: {integrity: sha512-92OuAccIQx5AQIWdhF5GaXmW0nsW+cApQYZ1PZ2kMfCe0kq8t4R5gLL2cuJ6a3Qo66TerFsj+ii5wx0qfP7aFA==}
+  '@rspack/binding-linux-arm64-gnu@2.1.0':
+    resolution: {integrity: sha512-TCmWIeI03ZZi8GjpIS2yl9JpaazsaA4F84zbX6a4kdZnFkrmFKRdvczZrquTNQvmggAEaJiPxkSrS8OC1LSAwA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2980,9 +2980,21 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-arm64-musl@2.1.0-beta.0':
-    resolution: {integrity: sha512-YuaHU9A+vLBYNEbjUGHlEE/K4Ctt7kp34DaKlv9iShtOz7bIc3NRfFUIZEHjExhJ+wWYInrcIAIJeviOQJnHig==}
+  '@rspack/binding-linux-arm64-musl@2.1.0':
+    resolution: {integrity: sha512-HJzw5gG62qjj9fRQgj948naLucwE1Vg1bfcYHAxOr1/bVVIm4I4QvWGuqvd3XOu0MfLXPWvEyMAvJL+rtgamsw==}
     cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.0':
+    resolution: {integrity: sha512-B3ENZHIBi5u1Apt6RJ62QSCabCijI5l86Sm2AEDYpQnqqBj3vIc+Br9HJHvNjK8PNWs1WfmD//UTUmQqZbYpKQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-musl@2.1.0':
+    resolution: {integrity: sha512-Qho1S8bW2BKRsJjl/f39GoyPRznF8ZarIgxZdVCIkn4k+3veggKWxqR1WWKoMj/LfykQd1uG3FF6n7zy5IfxWw==}
+    cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
@@ -2992,8 +3004,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-gnu@2.1.0-beta.0':
-    resolution: {integrity: sha512-BA2j6CS8MJfT7o7oP2UFpucf3EAv4Does/D35SfRCdBKlgMXy8kG6zJXKLW3gzKSNUez5SZ26n/mPcHcX8A6zg==}
+  '@rspack/binding-linux-x64-gnu@2.1.0':
+    resolution: {integrity: sha512-oE2CMALLdV3QNiA3YYDZ46tDGf+WRlqu/tQ+B79JYKVwt3sI0fpzvgwPNpx/gfRKUyA0phaeYS4kyOEnpltjpA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3004,8 +3016,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-musl@2.1.0-beta.0':
-    resolution: {integrity: sha512-riLlSAgbyGRXclLeK0y/FN0Qd+hHlwNj0lCdgh98sADUX62gaFcWFYizC8cnfxzlIUaTjQsPCy8PjWFEbSOmuQ==}
+  '@rspack/binding-linux-x64-musl@2.1.0':
+    resolution: {integrity: sha512-lxTFZgsfPPyyIt/DpOH5TK2u1ZROMB+gLp/LWvYBc8FSOtmR0Gl4L/AWmJdM2yqwPfy0hgSkVicf/7k80jHuVQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -3014,8 +3026,8 @@ packages:
     resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@2.1.0-beta.0':
-    resolution: {integrity: sha512-fYEvF3QAWZm6jUf74C2TT7gpllIGEghPEdBPRmdRGROesYSu0YZxikDdVwpQXnsymA5AnkaofCs/Sj+nvKyrXQ==}
+  '@rspack/binding-wasm32-wasi@2.1.0':
+    resolution: {integrity: sha512-ZsDDduXaEF1SpyGz2OFuEU9Tzm0pKtbtCYviymiNtQS+3lx6rXyv+FaK0oIWn+gWL+gVNamplxKnNNR2jZsp5w==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@2.0.8':
@@ -3023,8 +3035,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@2.1.0-beta.0':
-    resolution: {integrity: sha512-bRv74lkzMcloJGYwzIrabLa73L23FTYjcB/GuZkgP8qsYpM20qyMFYo6szElbc/x1NxNSW5mjR4QKaNaIxRDhA==}
+  '@rspack/binding-win32-arm64-msvc@2.1.0':
+    resolution: {integrity: sha512-0uMWAZYgwdkk0ocE4X85w/0BNWT5GaKJTEZDVYxfSYcfVAxJvIsuM0VH/cjRjsQtEeE1rcY7JvJyd0rQ6j0DqA==}
     cpu: [arm64]
     os: [win32]
 
@@ -3033,8 +3045,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.1.0-beta.0':
-    resolution: {integrity: sha512-qvolIqHoH+KSJFi71jJde+HTIvAbVZ08VJvfzqjTQ6KktFoxAfg0FeM6zpq0aNDo14mCDzy5JFH2WGbYGxmYLQ==}
+  '@rspack/binding-win32-ia32-msvc@2.1.0':
+    resolution: {integrity: sha512-MRuIZwF6w1tGyZgoJZ5dnpLaD/oMx8zAYSYQfNS7l0f7qjxbnp42625wkeNB8kPqrmDfqaWUWLwiOaRqFPmumA==}
     cpu: [ia32]
     os: [win32]
 
@@ -3043,16 +3055,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.1.0-beta.0':
-    resolution: {integrity: sha512-Ge6VIpFH//LuN0ABCeHRMXuKYagRAN7rW8WIKAKO3R3WooTT8630W+dOCJ+6kiSQyTLyMrt5eg6Sufw0R6UUPg==}
+  '@rspack/binding-win32-x64-msvc@2.1.0':
+    resolution: {integrity: sha512-Fme2Ifa647CtD7N6we9xvK+COzfzVJREtUayxdG+VArPdijURZyRQVUKKlYSBW+2qMg+G+kF1xo7gf7svG3sNA==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@2.0.8':
     resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
 
-  '@rspack/binding@2.1.0-beta.0':
-    resolution: {integrity: sha512-hSK6L966Y8l9z4ZMjRbz7lEmrk5IN+xSCQXkOL5VvtfBLvgk9AO91YEsDn5hCwNmTIdMFc2vScT2qwuIFF069w==}
+  '@rspack/binding@2.1.0':
+    resolution: {integrity: sha512-LsXFIOOYDutHk44SAOcVQa5iA7lhYwEbD+nZhgmCiGJvKKh0UIpBj6EAsBsB6omEK5GEXvjDeLFieKgbYW08QQ==}
 
   '@rspack/core@2.0.8':
     resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
@@ -3066,8 +3078,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@2.1.0-beta.0':
-    resolution: {integrity: sha512-Trnjc1OPsAU+TamUtCoOfwFfqu0n1pClhmY6hX4hs55i8exv4muV6OR8g40j0I7fFPz1YdPArTQBeMKFlVSXsg==}
+  '@rspack/core@2.1.0':
+    resolution: {integrity: sha512-dlZRzWQi90HzLYErGh0/xnEWAEMEAtDKXvNxERCEj5uIVIOVu9+uYwpNyAkKc9cK5sPhOz05kk9MIb1EaUJ5gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8480,7 +8492,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/enhanced@2.5.1(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0)
       '@module-federation/cli': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
@@ -8489,57 +8501,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1)
       '@module-federation/managers': 2.5.1(node-fetch@2.7.0)
       '@module-federation/manifest': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/rspack': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/webpack-bundler-runtime': 2.5.1(node-fetch@2.7.0)
-      schema-utils: 4.3.0
-      tapable: 2.3.0
-      upath: 2.0.1
-    optionalDependencies:
-      typescript: 6.0.3
-      vue-tsc: 3.3.5(typescript@6.0.3)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - node-fetch
-      - utf-8-validate
-
-  '@module-federation/enhanced@2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
-    dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/cli': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/error-codes': 2.5.1
-      '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1)
-      '@module-federation/managers': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/manifest': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/rspack': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/webpack-bundler-runtime': 2.5.1(node-fetch@2.7.0)
-      schema-utils: 4.3.0
-      tapable: 2.3.0
-      upath: 2.0.1
-    optionalDependencies:
-      typescript: 6.0.3
-      vue-tsc: 3.3.5(typescript@6.0.3)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - node-fetch
-      - utf-8-validate
-
-  '@module-federation/enhanced@2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
-    dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/cli': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/error-codes': 2.5.1
-      '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1)
-      '@module-federation/managers': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/manifest': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/rspack': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/rspack': 2.5.1(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.5.1(node-fetch@2.7.0)
@@ -8581,9 +8543,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.44(@rspack/core@2.0.8)(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/node@2.7.44(@rspack/core@2.1.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
-      '@module-federation/enhanced': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/runtime': 2.5.1(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -8596,43 +8558,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.44(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
-      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/runtime': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
-      encoding: 0.1.13
-      node-fetch: 2.7.0(encoding@0.1.13)
-      tapable: 2.3.0
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-
-  '@module-federation/node@2.7.44(typescript@6.0.3)(vue-tsc@3.3.5)':
-    dependencies:
-      '@module-federation/enhanced': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/runtime': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
-      encoding: 0.1.13
-      node-fetch: 2.7.0(encoding@0.1.13)
-      tapable: 2.3.0
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-
-  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
-    dependencies:
-      '@module-federation/enhanced': 2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/node': 2.7.44(@rspack/core@2.0.8)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/node': 2.7.44(@rspack/core@2.1.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8642,39 +8574,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
-    dependencies:
-      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/node': 2.7.44(@rspack/core@2.1.0-beta.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - node-fetch
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-      - webpack
-
-  '@module-federation/rsbuild-plugin@2.5.1(@rsbuild/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
-    dependencies:
-      '@module-federation/enhanced': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/node': 2.7.44(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - node-fetch
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-      - webpack
-
-  '@module-federation/rspack@2.5.1(@rspack/core@2.0.8)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/rspack@2.5.1(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
@@ -8683,25 +8583,7 @@ snapshots:
       '@module-federation/manifest': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
-    optionalDependencies:
-      typescript: 6.0.3
-      vue-tsc: 3.3.5(typescript@6.0.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - node-fetch
-      - utf-8-validate
-
-  '@module-federation/rspack@2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
-    dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1)
-      '@module-federation/managers': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/manifest': 2.5.1(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
-      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
-      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.5(typescript@6.0.3)
@@ -8736,12 +8618,12 @@ snapshots:
     optionalDependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 
-  '@module-federation/storybook-addon@6.0.13(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.13(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0-beta.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/enhanced': 2.5.1(@rspack/core@2.1.0)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -9108,14 +8990,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)':
+  '@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.5.1)':
     dependencies:
-      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.0.15)':
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.0)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
@@ -9124,11 +9006,11 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.0(@rsbuild/core@2.0.15)':
+  '@rsbuild/plugin-babel@2.0.0(@rsbuild/core@2.1.0)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
@@ -9137,35 +9019,23 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@2.0.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)':
+  '@rsbuild/plugin-less@2.0.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.0.8)(less@4.6.7)
+      less-loader: 12.3.3(@rspack/core@2.1.0)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-less@2.0.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)':
-    dependencies:
-      deepmerge: 4.3.1
-      less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.0.8)(less@4.6.7)
-      reduce-configs: 2.0.1
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - webpack
-
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.0-beta.0)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.0)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9191,57 +9061,39 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
 
-  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(preact@10.29.2)':
+  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(preact@10.29.2)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.2)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.0.8)
+      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.0)
       '@swc/plugin-prefresh': 12.12.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - preact
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.8)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.0)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.0.8)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.0)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.0.8)(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-    transitivePeerDependencies:
-      - '@rspack/core'
-
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.0-beta.0)(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-    transitivePeerDependencies:
-      - '@rspack/core'
-
-  '@rsbuild/plugin-sass@2.0.0(@rsbuild/core@2.0.15)':
+  '@rsbuild/plugin-sass@2.0.0(@rsbuild/core@2.1.0)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9249,125 +9101,92 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
 
-  '@rsbuild/plugin-sass@2.0.0(@rsbuild/core@2.1.0-beta.0)':
+  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.0)(solid-js@1.9.13)':
     dependencies:
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.15
-      reduce-configs: 2.0.1
-      sass-embedded: 1.100.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-
-  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.0.15)(solid-js@1.9.13)':
-    dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.0.15)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.0)
       babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.13)
       solid-refresh: 0.6.3(solid-js@1.9.13)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)':
+  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0
-      stylus-loader: 8.1.3(@rspack/core@2.0.8)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.1.0)(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.4(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.0.8)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.0-beta.0)':
+  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.0)':
     dependencies:
       toml: 4.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
 
-  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@typescript/native-preview': 7.0.0-dev.20260620.1
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)':
-    dependencies:
-      deepmerge: 4.3.1
-      json5: 2.2.3
-      reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.0-beta.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.0)':
     optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-      '@typescript/native-preview': 7.0.0-dev.20260620.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - typescript
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
 
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.0-beta.0)':
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-
-  '@rsbuild/plugin-vue@2.0.0(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)(vue@3.5.38)':
+  '@rsbuild/plugin-vue@2.0.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(vue@3.5.38)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.0.8)(vue@3.5.38)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.0)(vue@3.5.38)
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-vue@2.0.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(vue@3.5.38)':
-    dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.0.8)(vue@3.5.38)
+  '@rsbuild/plugin-yaml@1.0.5(@rsbuild/core@2.1.0)':
     optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@vue/compiler-sfc'
-      - vue
-
-  '@rsbuild/plugin-yaml@1.0.5(@rsbuild/core@2.1.0-beta.0)':
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
 
   '@rslib/core@0.23.0(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.5.1)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)':
     dependencies:
@@ -9422,37 +9241,43 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.8':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.1.0-beta.0':
+  '@rspack/binding-darwin-arm64@2.1.0':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.8':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.1.0-beta.0':
+  '@rspack/binding-darwin-x64@2.1.0':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.0-beta.0':
+  '@rspack/binding-linux-arm64-gnu@2.1.0':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.0-beta.0':
+  '@rspack/binding-linux-arm64-musl@2.1.0':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.0':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.0':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.1.0-beta.0':
+  '@rspack/binding-linux-x64-gnu@2.1.0':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.1.0-beta.0':
+  '@rspack/binding-linux-x64-musl@2.1.0':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.8':
@@ -9462,7 +9287,7 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.1.0-beta.0':
+  '@rspack/binding-wasm32-wasi@2.1.0':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
@@ -9472,19 +9297,19 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.0-beta.0':
+  '@rspack/binding-win32-arm64-msvc@2.1.0':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.1.0-beta.0':
+  '@rspack/binding-win32-ia32-msvc@2.1.0':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.1.0-beta.0':
+  '@rspack/binding-win32-x64-msvc@2.1.0':
     optional: true
 
   '@rspack/binding@2.0.8':
@@ -9500,18 +9325,20 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.8
       '@rspack/binding-win32-x64-msvc': 2.0.8
 
-  '@rspack/binding@2.1.0-beta.0':
+  '@rspack/binding@2.1.0':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.0-beta.0
-      '@rspack/binding-darwin-x64': 2.1.0-beta.0
-      '@rspack/binding-linux-arm64-gnu': 2.1.0-beta.0
-      '@rspack/binding-linux-arm64-musl': 2.1.0-beta.0
-      '@rspack/binding-linux-x64-gnu': 2.1.0-beta.0
-      '@rspack/binding-linux-x64-musl': 2.1.0-beta.0
-      '@rspack/binding-wasm32-wasi': 2.1.0-beta.0
-      '@rspack/binding-win32-arm64-msvc': 2.1.0-beta.0
-      '@rspack/binding-win32-ia32-msvc': 2.1.0-beta.0
-      '@rspack/binding-win32-x64-msvc': 2.1.0-beta.0
+      '@rspack/binding-darwin-arm64': 2.1.0
+      '@rspack/binding-darwin-x64': 2.1.0
+      '@rspack/binding-linux-arm64-gnu': 2.1.0
+      '@rspack/binding-linux-arm64-musl': 2.1.0
+      '@rspack/binding-linux-riscv64-gnu': 2.1.0
+      '@rspack/binding-linux-riscv64-musl': 2.1.0
+      '@rspack/binding-linux-x64-gnu': 2.1.0
+      '@rspack/binding-linux-x64-musl': 2.1.0
+      '@rspack/binding-wasm32-wasi': 2.1.0
+      '@rspack/binding-win32-arm64-msvc': 2.1.0
+      '@rspack/binding-win32-ia32-msvc': 2.1.0
+      '@rspack/binding-win32-x64-msvc': 2.1.0
 
   '@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)':
     dependencies:
@@ -9520,46 +9347,40 @@ snapshots:
       '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
       '@swc/helpers': 0.5.23
 
-  '@rspack/core@2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)':
+  '@rspack/core@2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': 2.1.0-beta.0
+      '@rspack/binding': 2.1.0
     optionalDependencies:
       '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0)
       '@swc/helpers': 0.5.23
 
   '@rspack/lite-tapable@1.1.2': {}
 
-  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.0.8)':
+  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.0)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.2)
       '@prefresh/utils': 1.2.1
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.8)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.0)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.0.8)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.0)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.0-beta.0)(react-refresh@0.18.0)':
-    dependencies:
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
-
-  '@rspress/core@2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.15)(@rspack/core@2.0.8)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)
       '@rspress/shared': 2.0.14(@module-federation/runtime-tools@2.5.1)
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -9608,7 +9429,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
-      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -9619,7 +9440,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.14(@rspress/core@2.0.14)':
     dependencies:
-      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       remark-mdx: 3.1.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -9630,17 +9451,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.14(@rspress/core@2.0.14)':
     dependencies:
-      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.14(@rspress/core@2.0.14)':
     dependencies:
-      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rspress/plugin-twoslash@2.0.14(@rspress/core@2.0.14)(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@shikijs/twoslash': 4.0.2(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3
       mdast-util-gfm: 3.1.0
@@ -9654,7 +9475,7 @@ snapshots:
 
   '@rspress/shared@2.0.14(@module-federation/runtime-tools@2.5.1)':
     dependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@shikijs/rehype': 4.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9663,7 +9484,7 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.4(@rspress/core@2.0.14)':
     optionalDependencies:
-      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rstest/adapter-rslib@0.10.6(@rslib/core@0.23.0)(@rstest/core@0.10.6)(typescript@6.0.3)':
     dependencies:
@@ -10077,14 +9898,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.0.8)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.0)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
   '@testing-library/jest-dom@6.9.1':
     dependencies:
@@ -12064,11 +11885,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@rspack/core@2.0.8)(less@4.6.7):
+  less-loader@12.3.3(@rspack/core@2.1.0)(less@4.6.7):
     dependencies:
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
   less@4.6.7:
     dependencies:
@@ -13686,46 +13507,40 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260620.1
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.0-beta.0):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.0):
     optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
 
-  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.0-beta.0):
+  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.0):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.0-beta.0):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.0):
     optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.0.15):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.0):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.0.15(@module-federation/runtime-tools@2.5.1)
-
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.0-beta.0):
-    dependencies:
-      publint: 0.3.21
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
 
   rslog@2.1.3: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.0.8)(vue@3.5.38):
+  rspack-vue-loader@17.5.1(@rspack/core@2.1.0)(vue@3.5.38):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
       vue: 3.5.38(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.14):
     dependencies:
-      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -13750,14 +13565,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.14):
     dependencies:
-      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.14)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.14):
     dependencies:
-      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.0.8)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.14(@module-federation/runtime-tools@2.5.1)(@rspack/core@2.1.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   run-applescript@7.1.0: {}
 
@@ -14088,18 +13903,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.0-beta.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14111,7 +13926,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.0-beta.0)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.0)
       sirv: 2.0.4
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.3.0
@@ -14128,42 +13943,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3):
-    dependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
-      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3)
-      '@vitest/mocker': 3.2.4
-      browser-assert: 1.2.1
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      cjs-module-lexer: 2.2.0
-      constants-browserify: 1.0.0
-      es-module-lexer: 1.7.0
-      fs-extra: 11.3.5
-      magic-string: 0.30.21
-      path-browserify: 1.0.1
-      picocolors: 1.1.1
-      process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.0-beta.0)
-      sirv: 2.0.4
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
-      ts-dedent: 2.3.0
-      url: 0.11.4
-      util: 0.12.5
-      util-deprecate: 1.0.2
-    optionalDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@typescript/native-preview'
-      - msw
-      - vite
-
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)
       find-up: 5.0.0
@@ -14174,7 +13957,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.1.0-beta.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14189,12 +13972,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.38):
+  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.38):
     dependencies:
-      '@rsbuild/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.5.1)
       '@storybook/vue3': 10.4.6(storybook@10.4.6)(vue@3.5.38)
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.0-beta.0)(@rspack/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.0)(@rspack/core@2.1.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       vue: 3.5.38(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.38)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -14315,13 +14098,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.0.8)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.1.0)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
 
   stylus@0.64.0:
     dependencies:
@@ -14433,7 +14216,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.0.8)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
@@ -14441,18 +14224,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
-      '@typescript/native-preview': 7.0.0-dev.20260620.1
-
-  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.0-beta.0)(@typescript/native-preview@7.0.0-dev.20260620.1)(typescript@6.0.3):
-    dependencies:
-      '@rspack/lite-tapable': 1.1.2
-      chokidar: 3.6.0
-      memfs: 4.57.8
-      picocolors: 1.1.1
-      typescript: 6.0.3
-    optionalDependencies:
-      '@rspack/core': 2.1.0-beta.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23)
       '@typescript/native-preview': 7.0.0-dev.20260620.1
 
   ts-dedent@2.3.0: {}

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@rsbuild/plugin-node-polyfill": "^1.4.6"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@rsbuild/plugin-node-polyfill": "^1.4.6"
   }
 }

--- a/tests/integration/vue/index.test.ts
+++ b/tests/integration/vue/index.test.ts
@@ -40,7 +40,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
           };
       })();
       __webpack_require__.add({
-          933 (__unused_rspack_module, exports) {
+          246 (__unused_rspack_module, exports) {
               exports.A = (sfc, props)=>{
                   const target = sfc.__vccOpts || sfc;
                   for (const [key, val] of props)target[key] = val;
@@ -58,7 +58,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
               return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(button.value), 1));
           }
       };
-      const exportHelper = __webpack_require__("933");
+      const exportHelper = __webpack_require__("246");
       const __exports__ = /*#__PURE__*/ (0, exportHelper.A)(Buttonvue_type_script_setup_true_lang_js, [
           [
               '__scopeId',
@@ -112,7 +112,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
       import "./Button.css";
       import { __webpack_require__ } from "../rslib-runtime.js";
       __webpack_require__.add({
-          933 (__unused_rspack_module, exports) {
+          246 (__unused_rspack_module, exports) {
               exports.A = (sfc, props)=>{
                   const target = sfc.__vccOpts || sfc;
                   for (const [key, val] of props)target[key] = val;
@@ -130,7 +130,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
               return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(button.value), 1));
           }
       };
-      const exportHelper = __webpack_require__("933");
+      const exportHelper = __webpack_require__("246");
       const __exports__ = /*#__PURE__*/ (0, exportHelper.A)(Buttonvue_type_script_setup_true_lang_js, [
           [
               '__scopeId',

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^2.5.1",
     "@playwright/test": "1.61.0",
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@rsbuild/plugin-less": "^2.0.0",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-sass": "^2.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.1",
-    "@rsbuild/core": "2.1.0-beta.0",
+    "@rsbuild/core": "~2.1.0",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-sass": "^2.0.0",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

Bump `@rsbuild/core` to `~2.1.0` and update related snapshots.

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v2.1.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
