### PR TITLE
docs: add Rslib 1.0 development notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 
 English | [简体中文](./README.zh-CN.md)
 
+> [!NOTE]
+> The `main` branch is under active development for **Rslib 1.0**.  
+> The stable **0.x** releases are maintained in the [v0.x](https://github.com/web-infra-dev/rslib/tree/v0.x) branch.
+
 Rslib is a library development tool that leverages the well-designed configurations and plugins of [Rsbuild](https://rsbuild.rs), empowering library developers to take advantage of the extensive knowledge and ecosystem of webpack and Rspack.
 
 Rslib aims to provide library developers with:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 English | [简体中文](./README.zh-CN.md)
 
 > [!NOTE]
-> The `main` branch is under active development for **Rslib 1.0**.  
+> The `main` branch is under active development for **Rslib 1.0**.
+>
 > The stable **0.x** releases are maintained in the [v0.x](https://github.com/web-infra-dev/rslib/tree/v0.x) branch.
 
 Rslib is a library development tool that leverages the well-designed configurations and plugins of [Rsbuild](https://rsbuild.rs), empowering library developers to take advantage of the extensive knowledge and ecosystem of webpack and Rspack.


### PR DESCRIPTION
## Summary

This PR adds a README notice that the `main` branch is under active development for Rslib 1.0 and points users of the stable 0.x releases to the `v0.x` branch.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).