### PR TITLE
docs: enable Rspress anchor checks

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
   logoText: 'Rslib',
   root: path.join(__dirname, 'docs'),
   markdown: {
+    link: {
+      checkAnchors: true,
+    },
     shiki: {
       transformers: [transformerNotationHighlight(), transformerNotationDiff()],
     },


### PR DESCRIPTION
## Summary

This PR enables Rspress anchor validation in the website markdown link checker so broken local URL fragments are caught during docs builds.

## Related Links

https://github.com/web-infra-dev/rspress/releases/tag/v2.0.15

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).