### PR TITLE
refactor(create-rslib): simplify svelte rstest config

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,3 @@
-import fs from 'node:fs';
-import path, { dirname, extname, join } from 'node:path';
 import {
   defineConfig as defineRsbuildConfig,
   type EnvironmentConfig,
@@ -12,6 +10,8 @@ import {
   rspack,
   type ToolsConfig,
 } from '@rsbuild/core';
+import fs from 'node:fs';
+import path, { dirname, extname, join } from 'node:path';
 import { composeAssetConfig } from './asset/assetConfig';
 import {
   DTS_EXTENSIONS_PATTERN,

--- a/packages/create-rslib/template-svelte-js/rstest.config.js
+++ b/packages/create-rslib/template-svelte-js/rstest.config.js
@@ -3,5 +3,4 @@ import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   extends: withRslibConfig(),
-  testEnvironment: 'happy-dom',
 });

--- a/packages/create-rslib/template-svelte-ts/rstest.config.ts
+++ b/packages/create-rslib/template-svelte-ts/rstest.config.ts
@@ -3,5 +3,4 @@ import { defineConfig } from '@rstest/core';
 
 export default defineConfig({
   extends: withRslibConfig(),
-  testEnvironment: 'happy-dom',
 });


### PR DESCRIPTION
## Summary

This PR removes redundant `happy-dom` test environment declarations from the Svelte create-rslib templates because the Rstest adapter already provides that environment by default.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).