### PR TITLE
fix(core): reset Rspack const environment

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.6.0",
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -22,7 +22,7 @@
     "@module-federation/enhanced": "^2.6.0",
     "@module-federation/rsbuild-plugin": "^2.6.0",
     "@module-federation/storybook-addon": "^6.0.14",
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.4.6",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.6.0",
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@rsbuild/plugin-vue": "^2.0.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.4.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "test": "rstest"
   },
   "dependencies": {
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -761,26 +761,36 @@ const composeFormatConfig = ({
   }
 };
 
-const disableUrlParseRsbuildPlugin = (): RsbuildPlugin => ({
-  name: 'rsbuild:disable-url-parse',
+const modifyRsbuildDefaultPlugin = ({
+  disableUrlParse,
+}: {
+  disableUrlParse?: boolean;
+} = {}): RsbuildPlugin => ({
+  name: 'rslib:modify-rsbuild-default',
   setup(api) {
-    api.modifyBundlerChain((config, { CHAIN_ID }) => {
+    api.modifyBundlerChain((chain, { CHAIN_ID, target }) => {
+      // Part 1: disable URL parsing for library output.
       // Fix for https://github.com/web-infra-dev/rslib/issues/499.
-      // Prevent parsing and try bundling `new URL()` in ESM format.
-      config.module
+      // Prevent parsing and try bundling `new URL()` in ESM/CJS format.
+      if (disableUrlParse) {
+        chain.module
+          .rule(CHAIN_ID.RULE.JS)
+          .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
+          .parser({
+            url: false,
+          });
+      }
+
+      // Part 2: remove Rsbuild's default JS module type.
+      // Port https://github.com/web-infra-dev/rsbuild/pull/5955 before it merged into Rsbuild.
+      chain.module
         .rule(CHAIN_ID.RULE.JS)
         .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
-        .parser({
-          url: false,
-        });
-    });
-  },
-});
+        .delete('type');
 
-const resetEnvConstPlugin = (): RsbuildPlugin => ({
-  name: 'rsbuild:reset-env-const',
-  setup(api) {
-    api.modifyBundlerChain((chain, { target }) => {
+      // Part 3: reset Rsbuild's const environment override.
+      // Rsbuild disables `const` for web-like app runtimes. Rslib should
+      // leave this to Rspack's target inference for library output.
       if (target !== 'web' && target !== 'web-worker') {
         return;
       }
@@ -791,26 +801,11 @@ const resetEnvConstPlugin = (): RsbuildPlugin => ({
         return;
       }
 
-      // Rsbuild disables `const` for web-like app runtimes. Rslib should
-      // leave this to Rspack's target inference for library output.
       delete environment.const;
 
       if (Object.keys(environment).length === 0) {
         chain.output.delete('environment');
       }
-    });
-  },
-});
-
-// Port https://github.com/web-infra-dev/rsbuild/pull/5955 before it merged into Rsbuild.
-const fixJsModuleTypePlugin = (): RsbuildPlugin => ({
-  name: 'rsbuild:fix-js-module-type',
-  setup(api) {
-    api.modifyBundlerChain((config, { CHAIN_ID }) => {
-      config.module
-        .rule(CHAIN_ID.RULE.JS)
-        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
-        .delete('type');
     });
   },
 });
@@ -934,9 +929,7 @@ const composeShimsConfig = (
         },
         plugins: [
           resolvedShims.esm.require && pluginEsmRequireShim(),
-          disableUrlParseRsbuildPlugin(),
-          fixJsModuleTypePlugin(),
-          resetEnvConstPlugin(),
+          modifyRsbuildDefaultPlugin({ disableUrlParse: true }),
         ].filter(Boolean),
       };
       break;
@@ -945,9 +938,7 @@ const composeShimsConfig = (
       rsbuildConfig = {
         plugins: [
           pluginCjsShims(resolvedShims.cjs),
-          disableUrlParseRsbuildPlugin(),
-          fixJsModuleTypePlugin(),
-          resetEnvConstPlugin(),
+          modifyRsbuildDefaultPlugin({ disableUrlParse: true }),
         ].filter(Boolean),
       };
       break;
@@ -955,7 +946,7 @@ const composeShimsConfig = (
     case 'iife':
     case 'mf':
       rsbuildConfig = {
-        plugins: [fixJsModuleTypePlugin(), resetEnvConstPlugin()],
+        plugins: [modifyRsbuildDefaultPlugin()],
       };
       break;
     default:

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -778,7 +778,7 @@ const disableUrlParseRsbuildPlugin = (): RsbuildPlugin => ({
 });
 
 const resetEnvConstPlugin = (): RsbuildPlugin => ({
-  name: 'rslib:reset-env-const',
+  name: 'rsbuild:reset-env-const',
   setup(api) {
     api.modifyBundlerChain((chain, { target }) => {
       if (target !== 'web' && target !== 'web-worker') {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -547,7 +547,7 @@ const composeFormatConfig = ({
 
   // The built-in Rslib plugin will apply to all formats except the `mf` format.
   // The `mf` format functions more like an application than a library and requires additional webpack runtime.
-  const plugins = [
+  const rspackPlugins = [
     new rspack.experiments.RslibPlugin({
       interceptApiPlugin: true,
       forceNodeShims: enabledShims.esm.__dirname || enabledShims.esm.__filename,
@@ -558,6 +558,7 @@ const composeFormatConfig = ({
   switch (format) {
     case 'esm':
       return {
+        plugins: [modifyRsbuildDefaultPlugin({ disableUrlParse: true })],
         output: {
           filenameHash: false,
         },
@@ -595,12 +596,13 @@ const composeFormatConfig = ({
               chunkLoading: 'import',
               workerChunkLoading: 'import',
             },
-            plugins,
+            plugins: rspackPlugins,
           },
         },
       };
     case 'cjs':
       return {
+        plugins: [modifyRsbuildDefaultPlugin({ disableUrlParse: true })],
         output: {
           module: false,
           filenameHash: false,
@@ -631,7 +633,7 @@ const composeFormatConfig = ({
               chunkLoading: 'require',
               workerChunkLoading: 'async-node',
             },
-            plugins,
+            plugins: rspackPlugins,
           },
         },
       };
@@ -643,6 +645,7 @@ const composeFormatConfig = ({
       }
 
       const config: EnvironmentConfig = {
+        plugins: [modifyRsbuildDefaultPlugin()],
         output: {
           module: false,
           filenameHash: false,
@@ -671,7 +674,7 @@ const composeFormatConfig = ({
               nodeEnv: process.env.NODE_ENV,
               splitChunks: false,
             },
-            plugins,
+            plugins: rspackPlugins,
           },
         },
       };
@@ -686,6 +689,7 @@ const composeFormatConfig = ({
       }
 
       const config: EnvironmentConfig = {
+        plugins: [modifyRsbuildDefaultPlugin()],
         output: {
           module: false,
           filenameHash: false,
@@ -719,7 +723,7 @@ const composeFormatConfig = ({
               nodeEnv: process.env.NODE_ENV,
               splitChunks: false,
             },
-            plugins,
+            plugins: rspackPlugins,
           },
         },
       };
@@ -734,6 +738,7 @@ const composeFormatConfig = ({
       }
 
       return {
+        plugins: [modifyRsbuildDefaultPlugin()],
         dev: {
           writeToDisk: true,
         },
@@ -781,8 +786,9 @@ const modifyRsbuildDefaultPlugin = ({
           });
       }
 
-      // Part 2: remove Rsbuild's default JS module type.
-      // Port https://github.com/web-infra-dev/rsbuild/pull/5955 before it merged into Rsbuild.
+      // Part 2: remove Rsbuild's `type: 'javascript/auto'` override.
+      // Rslib follows Rspack's original module type inference, so ESM-like
+      // modules are treated as strict ESM (`javascript/esm`).
       chain.module
         .rule(CHAIN_ID.RULE.JS)
         .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
@@ -927,27 +933,21 @@ const composeShimsConfig = (
             },
           },
         },
-        plugins: [
-          resolvedShims.esm.require && pluginEsmRequireShim(),
-          modifyRsbuildDefaultPlugin({ disableUrlParse: true }),
-        ].filter(Boolean),
+        plugins: [resolvedShims.esm.require && pluginEsmRequireShim()].filter(
+          Boolean,
+        ),
       };
       break;
     }
     case 'cjs':
       rsbuildConfig = {
-        plugins: [
-          pluginCjsShims(resolvedShims.cjs),
-          modifyRsbuildDefaultPlugin({ disableUrlParse: true }),
-        ].filter(Boolean),
+        plugins: [pluginCjsShims(resolvedShims.cjs)],
       };
       break;
     case 'umd':
     case 'iife':
     case 'mf':
-      rsbuildConfig = {
-        plugins: [modifyRsbuildDefaultPlugin()],
-      };
+      rsbuildConfig = {};
       break;
     default:
       throw new Error(`Unsupported format: ${format}`);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -777,6 +777,31 @@ const disableUrlParseRsbuildPlugin = (): RsbuildPlugin => ({
   },
 });
 
+const resetEnvConstPlugin = (): RsbuildPlugin => ({
+  name: 'rslib:reset-env-const',
+  setup(api) {
+    api.modifyBundlerChain((chain, { target }) => {
+      if (target !== 'web' && target !== 'web-worker') {
+        return;
+      }
+
+      const environment = chain.output.get('environment');
+
+      if (!environment || environment.const !== false) {
+        return;
+      }
+
+      // Rsbuild disables `const` for web-like app runtimes. Rslib should
+      // leave this to Rspack's target inference for library output.
+      delete environment.const;
+
+      if (Object.keys(environment).length === 0) {
+        chain.output.delete('environment');
+      }
+    });
+  },
+});
+
 // Port https://github.com/web-infra-dev/rsbuild/pull/5955 before it merged into Rsbuild.
 const fixJsModuleTypePlugin = (): RsbuildPlugin => ({
   name: 'rsbuild:fix-js-module-type',
@@ -911,6 +936,7 @@ const composeShimsConfig = (
           resolvedShims.esm.require && pluginEsmRequireShim(),
           disableUrlParseRsbuildPlugin(),
           fixJsModuleTypePlugin(),
+          resetEnvConstPlugin(),
         ].filter(Boolean),
       };
       break;
@@ -921,6 +947,7 @@ const composeShimsConfig = (
           pluginCjsShims(resolvedShims.cjs),
           disableUrlParseRsbuildPlugin(),
           fixJsModuleTypePlugin(),
+          resetEnvConstPlugin(),
         ].filter(Boolean),
       };
       break;
@@ -928,7 +955,7 @@ const composeShimsConfig = (
     case 'iife':
     case 'mf':
       rsbuildConfig = {
-        plugins: [fixJsModuleTypePlugin()],
+        plugins: [fixJsModuleTypePlugin(), resetEnvConstPlugin()],
       };
       break;
     default:

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -3968,6 +3968,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
+        "name": "rslib:reset-env-const",
+        "setup": [Function],
+      },
+      {
         "name": "rsbuild:lib-asset",
         "pre": [
           "rsbuild:svgr",
@@ -4250,6 +4254,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
+        "name": "rslib:reset-env-const",
+        "setup": [Function],
+      },
+      {
         "name": "rsbuild:lib-asset",
         "pre": [
           "rsbuild:svgr",
@@ -4509,6 +4517,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "name": "rsbuild:fix-js-module-type",
         "setup": [Function],
       },
+      {
+        "name": "rslib:reset-env-const",
+        "setup": [Function],
+      },
     ],
     "resolve": {
       "alias": {
@@ -4747,6 +4759,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "name": "rsbuild:fix-js-module-type",
         "setup": [Function],
       },
+      {
+        "name": "rslib:reset-env-const",
+        "setup": [Function],
+      },
     ],
     "resolve": {
       "alias": {
@@ -4934,6 +4950,10 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       },
       {
         "name": "rsbuild:fix-js-module-type",
+        "setup": [Function],
+      },
+      {
+        "name": "rslib:reset-env-const",
         "setup": [Function],
       },
       {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -3968,7 +3968,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rslib:reset-env-const",
+        "name": "rsbuild:reset-env-const",
         "setup": [Function],
       },
       {
@@ -4254,7 +4254,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rslib:reset-env-const",
+        "name": "rsbuild:reset-env-const",
         "setup": [Function],
       },
       {
@@ -4518,7 +4518,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rslib:reset-env-const",
+        "name": "rsbuild:reset-env-const",
         "setup": [Function],
       },
     ],
@@ -4760,7 +4760,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rslib:reset-env-const",
+        "name": "rsbuild:reset-env-const",
         "setup": [Function],
       },
     ],
@@ -4953,7 +4953,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rslib:reset-env-const",
+        "name": "rsbuild:reset-env-const",
         "setup": [Function],
       },
       {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -3960,15 +3960,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rsbuild:disable-url-parse",
-        "setup": [Function],
-      },
-      {
-        "name": "rsbuild:fix-js-module-type",
-        "setup": [Function],
-      },
-      {
-        "name": "rsbuild:reset-env-const",
+        "name": "rslib:modify-rsbuild-default",
         "setup": [Function],
       },
       {
@@ -4246,15 +4238,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rsbuild:disable-url-parse",
-        "setup": [Function],
-      },
-      {
-        "name": "rsbuild:fix-js-module-type",
-        "setup": [Function],
-      },
-      {
-        "name": "rsbuild:reset-env-const",
+        "name": "rslib:modify-rsbuild-default",
         "setup": [Function],
       },
       {
@@ -4514,11 +4498,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rsbuild:fix-js-module-type",
-        "setup": [Function],
-      },
-      {
-        "name": "rsbuild:reset-env-const",
+        "name": "rslib:modify-rsbuild-default",
         "setup": [Function],
       },
     ],
@@ -4756,11 +4736,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rsbuild:fix-js-module-type",
-        "setup": [Function],
-      },
-      {
-        "name": "rsbuild:reset-env-const",
+        "name": "rslib:modify-rsbuild-default",
         "setup": [Function],
       },
     ],
@@ -4949,11 +4925,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rsbuild:fix-js-module-type",
-        "setup": [Function],
-      },
-      {
-        "name": "rsbuild:reset-env-const",
+        "name": "rslib:modify-rsbuild-default",
         "setup": [Function],
       },
       {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -4234,11 +4234,11 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "setup": [Function],
       },
       {
-        "name": "rsbuild:cjs-shims",
+        "name": "rslib:modify-rsbuild-default",
         "setup": [Function],
       },
       {
-        "name": "rslib:modify-rsbuild-default",
+        "name": "rsbuild:cjs-shims",
         "setup": [Function],
       },
       {

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { describe, expect, rs, test } from '@rstest/core';
 import type { BuildOptions } from '../src/cli/commands';
 import { init } from '../src/cli/init';
@@ -782,6 +783,57 @@ describe('module ids', () => {
     const { origin } = await rslib.inspectConfig();
 
     expect(origin.bundlerConfigs[0]!.optimization?.moduleIds).toBe('named');
+  });
+});
+
+describe('output environment', () => {
+  test('resets Rsbuild default const environment for web target', async () => {
+    const rslibConfig: RslibConfig = {
+      lib: [
+        {},
+        {
+          tools: {
+            rspack: {
+              output: {
+                environment: {
+                  const: false,
+                },
+              },
+            },
+          },
+        },
+        {
+          plugins: [
+            {
+              name: 'test:set-lib-output-environment-const',
+              setup(api) {
+                api.modifyBundlerChain((chain) => {
+                  chain.output.merge({
+                    environment: {
+                      const: false,
+                    },
+                  });
+                });
+              },
+            } satisfies RsbuildPlugin,
+          ],
+        },
+      ],
+      output: {
+        target: 'web',
+      },
+    };
+
+    const rslib = await createRslib({
+      config: rslibConfig,
+    });
+    const { origin } = await rslib.inspectConfig();
+
+    expect(
+      origin.bundlerConfigs[0]!.output?.environment?.const,
+    ).toBeUndefined();
+    expect(origin.bundlerConfigs[1]!.output?.environment?.const).toBe(false);
+    expect(origin.bundlerConfigs[2]!.output?.environment?.const).toBe(false);
   });
 });
 

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/react": "^10.4.6",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/react": "^10.4.6",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/vue3": "^10.4.6",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
     "@storybook/vue3": "^10.4.6",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.9",
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@rslib/tsconfig": "workspace:*",
     "get-tsconfig": "5.0.0-beta.5",
     "magic-string": "^0.30.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2191,12 +2191,6 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -2733,16 +2727,6 @@ packages:
       core-js:
         optional: true
 
-  '@rsbuild/core@2.1.1':
-    resolution: {integrity: sha512-s6Cc+pHCJK9RP6Yk4LwsQWHxxxasrk5kmo9nkZK7j1iObp4w2PLivsUdP6HtkeoXuxcnK3QKH8/r49plNBjaQw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
   '@rsbuild/core@2.1.2':
     resolution: {integrity: sha512-EP24Oj01bdwtw/Xl3LiaLe/WG6PBQV2yWbbCh+2TkMDc9dNHiyBTnR+/JZvGxI8RdO5qU0rH4YgMOJ6nVXIQSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2963,11 +2947,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@2.1.1':
-    resolution: {integrity: sha512-6K8jA3pZphBwLt5DU78wl0IzY1myHrqNSvFVCd9CHa+szlOwv2iMQpZdYdpupIBxwiZ39rrDyQKtoZw7lsAG8w==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@2.1.2':
     resolution: {integrity: sha512-IYcxareUOYJZz+uNMSIwn+iDRiVyjZNOjoxO/zL4OFaPK8Ncrw0ka/9DqL9Gd7OpnAXN1zK3uS8yD0O1yIYI3Q==}
     cpu: [arm64]
@@ -2978,11 +2957,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.1.1':
-    resolution: {integrity: sha512-RdqtEfIbSe5ucLNVvMac1k88UwmL4Gil8uXqlEFcSZ3VC2jTOkecadd+B0RYqJ+PirSInrRmKm1cr0740zppOA==}
-    cpu: [x64]
-    os: [darwin]
-
   '@rspack/binding-darwin-x64@2.1.2':
     resolution: {integrity: sha512-aoifkILvx/XEHyvg8yW57xu95nx7f9f/3ah1+RguHSNKcJMcoCep9VX1Ct1N0ftqg8MC0JUObc7xWL5W14hmjA==}
     cpu: [x64]
@@ -2990,12 +2964,6 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@2.0.8':
     resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-arm64-gnu@2.1.1':
-    resolution: {integrity: sha512-ROKtqXoLpbZO1vYEcNxQg6COvRhdlJcoib1Z4pzG1nIyctEAUuFmnD7pIvJiVe6M7YuJNXW+1p0BhpptT2XEUQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3012,35 +2980,17 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-arm64-musl@2.1.1':
-    resolution: {integrity: sha512-QdQpG9dK0GfPASjBd/8rUwDNW0ShfFfYJfcoGLNTM6A8EqmgvWwklXDiCVF5dXALbZIksAuRznIKnLDsUoXi9Q==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rspack/binding-linux-arm64-musl@2.1.2':
     resolution: {integrity: sha512-yt+GGWUH7WPE8K97cRc8OpZhH7Pbj1vU+lkvKbDtF/rR8X9a/bJsA/nBqyUV2oBKOVbrp5I8rFZlnDskMqgvKw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.1':
-    resolution: {integrity: sha512-LGdYCAvblZp2qtHk9UseYftIRyaBzSWqEzd1toaS08sYESXERm+YBbrYKKiyq1yXiU1L7BkhMUxiWc3GCYmKcA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-riscv64-gnu@2.1.2':
     resolution: {integrity: sha512-uys8Jyw8Z3ralvICbN/L/nZfy5qELIwpOY72rhIqhoDYwFcL4fmMaY7WsvUcJOjCB2rqOcWPaWKuF2oPvo9iDQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rspack/binding-linux-riscv64-musl@2.1.1':
-    resolution: {integrity: sha512-87phiiPGFT1p4gy3Oz6YdNijCPXdjJy43LFdE8AFiZsV4ChFXQPqnVCF2aMRLybYa51A+9wGYlTvxt09yUQUww==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-riscv64-musl@2.1.2':
     resolution: {integrity: sha512-JYNVQwqCaRGQWvjHQYzZkIzQiwllMaJwh4Rdu3ww6W2OJcJUqT08sL1pkOtU0iCxT4VUYiRRcp93VGTGpHr8fg==}
@@ -3050,12 +3000,6 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@2.0.8':
     resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-x64-gnu@2.1.1':
-    resolution: {integrity: sha512-om0/PvZzxISsnyz3hdmI3xBi3Qsn6faRGrfp6WJpGHa5JYYaRVWz1MJ9fe+/cQE9ON9r32HpMOeuataCLv+Owg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3072,12 +3016,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-musl@2.1.1':
-    resolution: {integrity: sha512-YgAyTOM5ZWvWT0Exwcg7QkGUv9PsHT4yIsEyJbH+a99uAKliGMwkHIOP/aJgrCF8G+lTfigY2wyl9cWo4TA4aw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rspack/binding-linux-x64-musl@2.1.2':
     resolution: {integrity: sha512-66hWmIGvn4zCKAYXJE9Bp5SNSLYnLFq2Ke/efE+ZtWy43Dd5vk9AAOmThVGBwdwmIxmGtHGCp+cAuS4G0wu0TA==}
     cpu: [x64]
@@ -3088,21 +3026,12 @@ packages:
     resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@2.1.1':
-    resolution: {integrity: sha512-OicgaB3Dcd+KXsH/I3DkJG7XQyREJScg/jLkCtycFn9BhT0IVJvgi37F8QNJKl8Bp9YZIGehsqK9HpQWav6SLw==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@2.1.2':
     resolution: {integrity: sha512-EB4SqH8DW/E/OmqssNQvnIVGQiVUyYNlA/pcc6Ia4MlTNwu6eNDppcNLrToH+kSZpL4CpHSFfSM3eIsSuar2Rw==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@2.0.8':
     resolution: {integrity: sha512-8NCuiQsAhXrwRBy57QZoypqrws/zLBkaQVGiB8hksr6v++8hNigNjqpQARLbd0iyMuHsQQ++8+auGk6xlDXmzw==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@2.1.1':
-    resolution: {integrity: sha512-fwL4P3SsC0r/vVGgnmexnc4vkvf+9vWMcGw5fdlPBJNR/zWlZRSXR5V6eXcHrpYVLhBsLYvZYE3NZa9paIUGxw==}
     cpu: [arm64]
     os: [win32]
 
@@ -3116,11 +3045,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.1.1':
-    resolution: {integrity: sha512-j3BISXbjPyI57HeHxW9Jx+UP7RebNQ4t62uCbRP29caf9aghYJP+ZA5nJ2X7pol7N5Je2/V6WNahuNd0zQFDOA==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rspack/binding-win32-ia32-msvc@2.1.2':
     resolution: {integrity: sha512-OtxkFVz14mVL4QK8QriSELn9B6PaYGHw1jGJwVDEzpu2ZxSHCTQPz9dVE1ekYtREEqZUkRU7Fp7VfhJSmjTt2Q==}
     cpu: [ia32]
@@ -3128,11 +3052,6 @@ packages:
 
   '@rspack/binding-win32-x64-msvc@2.0.8':
     resolution: {integrity: sha512-7zPs8YCe/ZVJTwd+5lpB0CP0tkn2pONf/T1ycmVY76u21Nrwt8mXQGc/2yH2eWP4B7fikYBr3hGr7mpR2fajqQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@2.1.1':
-    resolution: {integrity: sha512-aPNNFuZT5iBM8+S9J4P5ywJbf3tUvZN3Ppe6mXJ8/jTVDUDhe0YVj3AgD/AuxnUvl+yHrLfQkN1nNwUfIcomfA==}
     cpu: [x64]
     os: [win32]
 
@@ -3144,26 +3063,11 @@ packages:
   '@rspack/binding@2.0.8':
     resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
 
-  '@rspack/binding@2.1.1':
-    resolution: {integrity: sha512-6062hZP33fn1w51ClpQnum19GGXl/3eS754xrRYbQ7wwBNZk94HVwfSyiqcNCtY/pB1lsFjnaTKiW/Q+jv0axQ==}
-
   '@rspack/binding@2.1.2':
     resolution: {integrity: sha512-/mFcRSUW7Pl19KeaBIujJvZYNJQu0wD5D3aa5h+Qcph26v7nmLYlX7eajIHGi8tt2qTZX1lXifw2KLIXKwYaRQ==}
 
   '@rspack/core@2.0.8':
     resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@2.1.1':
-    resolution: {integrity: sha512-Rgz6xZcD0rm7ejZhYNi13qvW2dSnIQQt/7D3xbYoT5hOU838JbkF0P3SAMFGKE+FyLZswnyRpxGfnYHZQqDmJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8756,24 +8660,17 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
-    dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -8841,7 +8738,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
@@ -8905,7 +8802,7 @@ snapshots:
 
   '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9095,13 +8992,6 @@ snapshots:
   '@rsbuild/core@2.0.15(@module-federation/runtime-tools@2.6.0)':
     dependencies:
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
-  '@rsbuild/core@2.1.1(@module-federation/runtime-tools@2.6.0)':
-    dependencies:
-      '@rspack/core': 2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -9306,8 +9196,8 @@ snapshots:
 
   '@rslib/core@0.23.1(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.6.0)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
-      rsbuild-plugin-dts: 0.23.1(@microsoft/api-extractor@7.58.9)(@rsbuild/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
+      rsbuild-plugin-dts: 0.23.1(@microsoft/api-extractor@7.58.9)(@rsbuild/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.9(@types/node@24.13.2)
       typescript: 6.0.3
@@ -9357,16 +9247,10 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.8':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.1.1':
-    optional: true
-
   '@rspack/binding-darwin-arm64@2.1.2':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.8':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.1.1':
     optional: true
 
   '@rspack/binding-darwin-x64@2.1.2':
@@ -9375,28 +9259,16 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.1':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@2.1.2':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.1':
-    optional: true
-
   '@rspack/binding-linux-arm64-musl@2.1.2':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.1':
-    optional: true
-
   '@rspack/binding-linux-riscv64-gnu@2.1.2':
-    optional: true
-
-  '@rspack/binding-linux-riscv64-musl@2.1.1':
     optional: true
 
   '@rspack/binding-linux-riscv64-musl@2.1.2':
@@ -9405,16 +9277,10 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.1.1':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@2.1.2':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.8':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@2.1.1':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.1.2':
@@ -9427,13 +9293,6 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.1.1':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-    optional: true
-
   '@rspack/binding-wasm32-wasi@2.1.2':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -9444,25 +9303,16 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.1':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@2.1.2':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.1.1':
-    optional: true
-
   '@rspack/binding-win32-ia32-msvc@2.1.2':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.8':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@2.1.1':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.1.2':
@@ -9480,21 +9330,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 2.0.8
       '@rspack/binding-win32-ia32-msvc': 2.0.8
       '@rspack/binding-win32-x64-msvc': 2.0.8
-
-  '@rspack/binding@2.1.1':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.1
-      '@rspack/binding-darwin-x64': 2.1.1
-      '@rspack/binding-linux-arm64-gnu': 2.1.1
-      '@rspack/binding-linux-arm64-musl': 2.1.1
-      '@rspack/binding-linux-riscv64-gnu': 2.1.1
-      '@rspack/binding-linux-riscv64-musl': 2.1.1
-      '@rspack/binding-linux-x64-gnu': 2.1.1
-      '@rspack/binding-linux-x64-musl': 2.1.1
-      '@rspack/binding-wasm32-wasi': 2.1.1
-      '@rspack/binding-win32-arm64-msvc': 2.1.1
-      '@rspack/binding-win32-ia32-msvc': 2.1.1
-      '@rspack/binding-win32-x64-msvc': 2.1.1
 
   '@rspack/binding@2.1.2':
     optionalDependencies:
@@ -9514,13 +9349,6 @@ snapshots:
   '@rspack/core@2.0.8(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.0.8
-    optionalDependencies:
-      '@module-federation/runtime-tools': 2.6.0(node-fetch@2.7.0)
-      '@swc/helpers': 0.5.23
-
-  '@rspack/core@2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)':
-    dependencies:
-      '@rspack/binding': 2.1.1
     optionalDependencies:
       '@module-federation/runtime-tools': 2.6.0(node-fetch@2.7.0)
       '@swc/helpers': 0.5.23
@@ -13682,10 +13510,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.23.1(@microsoft/api-extractor@7.58.9)(@rsbuild/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.23.1(@microsoft/api-extractor@7.58.9)(@rsbuild/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.9(@types/node@24.13.2)
       '@typescript/native-preview': 7.0.0-dev.20260627.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,13 +80,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.6.0
-        version: 2.6.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.6.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rsbuild/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@module-federation/runtime-tools@2.6.0)
+        specifier: ~2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -101,19 +101,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.6.0
-        version: 2.6.0(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.6.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.6.0
-        version: 2.6.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.6.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/storybook-addon':
         specifier: ^6.0.14
-        version: 6.0.14(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)
+        version: 6.0.14(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@module-federation/runtime-tools@2.6.0)
+        specifier: ~2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -143,10 +143,10 @@ importers:
         version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.1)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -162,13 +162,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.6.0
-        version: 2.6.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.6.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rsbuild/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@module-federation/runtime-tools@2.6.0)
+        specifier: ~2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -183,10 +183,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(preact@10.29.3)
+        version: 2.0.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(preact@10.29.3)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -198,10 +198,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -216,10 +216,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -234,10 +234,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -252,13 +252,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)
       '@rsbuild/plugin-solid':
         specifier: ^1.2.2
-        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.1)(solid-js@1.9.13)
+        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.2)(solid-js@1.9.13)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -273,7 +273,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(vue@3.5.39)
+        version: 2.0.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(vue@3.5.39)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -290,11 +290,11 @@ importers:
   examples/vue-component-bundleless:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@module-federation/runtime-tools@2.6.0)
+        specifier: ~2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(vue@3.5.39)
+        version: 2.0.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(vue@3.5.39)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -312,10 +312,10 @@ importers:
         version: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.1)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.39)
+        version: 3.3.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.39)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -329,15 +329,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@module-federation/runtime-tools@2.6.0)
+        specifier: ~2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.6.0
-        version: 2.6.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.6.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -364,7 +364,7 @@ importers:
         version: 1.6.5(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.1)
+        version: 1.0.0(@rsbuild/core@2.1.2)
       rslib:
         specifier: npm:@rslib/core@0.23.1
         version: '@rslib/core@0.23.1(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.6.0)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)'
@@ -401,7 +401,7 @@ importers:
         version: 11.3.5
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.1)
+        version: 1.0.0(@rsbuild/core@2.1.2)
       rslib:
         specifier: npm:@rslib/core@0.23.1
         version: '@rslib/core@0.23.1(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.6.0)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)'
@@ -422,8 +422,8 @@ importers:
         specifier: ^7.58.9
         version: 7.58.9(@types/node@25.2.0)
       '@rsbuild/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@module-federation/runtime-tools@2.6.0)
+        specifier: ~2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -438,7 +438,7 @@ importers:
         version: 1.6.5(typescript@6.0.3)
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.1)
+        version: 1.0.0(@rsbuild/core@2.1.2)
       rslib:
         specifier: npm:@rslib/core@0.23.1
         version: '@rslib/core@0.23.1(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.6.0)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)'
@@ -468,34 +468,34 @@ importers:
         version: 4.0.1
       '@module-federation/rsbuild-plugin':
         specifier: ^2.6.0
-        version: 2.6.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.6.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@playwright/test':
         specifier: 1.61.1
         version: 1.61.1
       '@rsbuild/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@module-federation/runtime-tools@2.6.0)
+        specifier: ~2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@rsbuild/plugin-less':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)
       '@rsbuild/plugin-toml':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.1)
+        version: 2.0.1(@rsbuild/core@2.1.2)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.4
-        version: 1.2.4(@rsbuild/core@2.1.1)
+        version: 1.2.4(@rsbuild/core@2.1.2)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(vue@3.5.39)
+        version: 2.0.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(vue@3.5.39)
       '@rsbuild/plugin-yaml':
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@2.1.1)
+        version: 1.0.5(@rsbuild/core@2.1.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -572,7 +572,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
 
   tests/integration/asset/json: {}
 
@@ -588,10 +588,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.4
-        version: 2.0.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(typescript@6.0.3)
+        version: 2.0.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(typescript@6.0.3)
 
   tests/integration/async-chunks/default: {}
 
@@ -685,10 +685,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.4
-        version: 2.0.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(typescript@6.0.3)
+        version: 2.0.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(typescript@6.0.3)
 
   tests/integration/cli/build: {}
 
@@ -987,11 +987,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@module-federation/runtime-tools@2.6.0)
+        specifier: ~2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.1.1)
+        version: 1.4.6(@rsbuild/core@2.1.2)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -1000,11 +1000,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@module-federation/runtime-tools@2.6.0)
+        specifier: ~2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.1.1)
+        version: 1.4.6(@rsbuild/core@2.1.2)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1038,7 +1038,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)
       babel-plugin-polyfill-corejs3:
         specifier: ^1.0.0
         version: 1.0.0(@babel/core@7.29.7)
@@ -1051,7 +1051,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1177,19 +1177,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.0.1(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.0.1(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.0.3(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1198,7 +1198,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.0.3(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1246,10 +1246,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(vue@3.5.39)
+        version: 2.0.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(vue@3.5.39)
       vue:
         specifier: ^3.5.39
         version: 3.5.39(typescript@6.0.3)
@@ -1266,16 +1266,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.6.0
-        version: 2.6.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+        version: 2.6.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@rsbuild/core':
-        specifier: ~2.1.1
-        version: 2.1.1(@module-federation/runtime-tools@2.6.0)
+        specifier: ~2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+        version: 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)
+        version: 2.0.0(@rsbuild/core@2.1.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1284,7 +1284,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 2.0.15
-        version: 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 2.0.15
         version: 2.0.15(@rspress/core@2.0.15)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
@@ -1323,10 +1323,10 @@ importers:
         version: 19.2.7(react@19.2.7)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.6
-        version: 1.0.6(@rsbuild/core@2.1.1)
+        version: 1.0.6(@rsbuild/core@2.1.2)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.1.1)
+        version: 1.1.3(@rsbuild/core@2.1.2)
       rspress-plugin-file-tree:
         specifier: ^1.0.5
         version: 1.0.5(@rspress/core@2.0.15)
@@ -2197,6 +2197,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2737,6 +2743,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.1.2':
+    resolution: {integrity: sha512-EP24Oj01bdwtw/Xl3LiaLe/WG6PBQV2yWbbCh+2TkMDc9dNHiyBTnR+/JZvGxI8RdO5qU0rH4YgMOJ6nVXIQSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.2.1':
     resolution: {integrity: sha512-6Zad7Ff/RUNc91AtftemJcJ1wcZRGOiwuJy349qlLJl9F++oRYwUhx+MxLSpNnVeIywWx2mKdZZBtD1hLqfj9w==}
     peerDependencies:
@@ -2952,6 +2968,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.1.2':
+    resolution: {integrity: sha512-IYcxareUOYJZz+uNMSIwn+iDRiVyjZNOjoxO/zL4OFaPK8Ncrw0ka/9DqL9Gd7OpnAXN1zK3uS8yD0O1yIYI3Q==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.0.8':
     resolution: {integrity: sha512-satPm2PD4B7jDTVlVAdvMVdUszwLvWUEnUDzLb77mvVkezKNDZmuhb+e8s+FfKs8hJpNbZ9VAejuA2rr8o985w==}
     cpu: [x64]
@@ -2959,6 +2980,11 @@ packages:
 
   '@rspack/binding-darwin-x64@2.1.1':
     resolution: {integrity: sha512-RdqtEfIbSe5ucLNVvMac1k88UwmL4Gil8uXqlEFcSZ3VC2jTOkecadd+B0RYqJ+PirSInrRmKm1cr0740zppOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.1.2':
+    resolution: {integrity: sha512-aoifkILvx/XEHyvg8yW57xu95nx7f9f/3ah1+RguHSNKcJMcoCep9VX1Ct1N0ftqg8MC0JUObc7xWL5W14hmjA==}
     cpu: [x64]
     os: [darwin]
 
@@ -2970,6 +2996,12 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@2.1.1':
     resolution: {integrity: sha512-ROKtqXoLpbZO1vYEcNxQg6COvRhdlJcoib1Z4pzG1nIyctEAUuFmnD7pIvJiVe6M7YuJNXW+1p0BhpptT2XEUQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.2':
+    resolution: {integrity: sha512-My4m40tyJSgiCEf3bB2KIEX710q3nZg99LIjy+8Zxgi3oZTkg1bFmFRusFU5U4eN5408zfSqDDGvjDE3Yv7o4w==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2986,14 +3018,32 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.1.2':
+    resolution: {integrity: sha512-yt+GGWUH7WPE8K97cRc8OpZhH7Pbj1vU+lkvKbDtF/rR8X9a/bJsA/nBqyUV2oBKOVbrp5I8rFZlnDskMqgvKw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-riscv64-gnu@2.1.1':
     resolution: {integrity: sha512-LGdYCAvblZp2qtHk9UseYftIRyaBzSWqEzd1toaS08sYESXERm+YBbrYKKiyq1yXiU1L7BkhMUxiWc3GCYmKcA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
+  '@rspack/binding-linux-riscv64-gnu@2.1.2':
+    resolution: {integrity: sha512-uys8Jyw8Z3ralvICbN/L/nZfy5qELIwpOY72rhIqhoDYwFcL4fmMaY7WsvUcJOjCB2rqOcWPaWKuF2oPvo9iDQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-riscv64-musl@2.1.1':
     resolution: {integrity: sha512-87phiiPGFT1p4gy3Oz6YdNijCPXdjJy43LFdE8AFiZsV4ChFXQPqnVCF2aMRLybYa51A+9wGYlTvxt09yUQUww==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-musl@2.1.2':
+    resolution: {integrity: sha512-JYNVQwqCaRGQWvjHQYzZkIzQiwllMaJwh4Rdu3ww6W2OJcJUqT08sL1pkOtU0iCxT4VUYiRRcp93VGTGpHr8fg==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -3010,6 +3060,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rspack/binding-linux-x64-gnu@2.1.2':
+    resolution: {integrity: sha512-KDoPy0Msf/JLhxgPPrJQzZeB4Qpqd32em8AP5lSW2s6jR5I35dHgAe9xc2A++EQtnSrU4GTn6DBvFC7q84SihQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-x64-musl@2.0.8':
     resolution: {integrity: sha512-6CtDaGZjNDvJd9TBp7a9zABbrPORO21W96+3ZcGBn0YNUPUk4ARxIxrTTpeJ/1F41QDM8AYIkGDdqEYMqTYBsA==}
     cpu: [x64]
@@ -3022,12 +3078,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.1.2':
+    resolution: {integrity: sha512-66hWmIGvn4zCKAYXJE9Bp5SNSLYnLFq2Ke/efE+ZtWy43Dd5vk9AAOmThVGBwdwmIxmGtHGCp+cAuS4G0wu0TA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.0.8':
     resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
     cpu: [wasm32]
 
   '@rspack/binding-wasm32-wasi@2.1.1':
     resolution: {integrity: sha512-OicgaB3Dcd+KXsH/I3DkJG7XQyREJScg/jLkCtycFn9BhT0IVJvgi37F8QNJKl8Bp9YZIGehsqK9HpQWav6SLw==}
+    cpu: [wasm32]
+
+  '@rspack/binding-wasm32-wasi@2.1.2':
+    resolution: {integrity: sha512-EB4SqH8DW/E/OmqssNQvnIVGQiVUyYNlA/pcc6Ia4MlTNwu6eNDppcNLrToH+kSZpL4CpHSFfSM3eIsSuar2Rw==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@2.0.8':
@@ -3037,6 +3103,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@2.1.1':
     resolution: {integrity: sha512-fwL4P3SsC0r/vVGgnmexnc4vkvf+9vWMcGw5fdlPBJNR/zWlZRSXR5V6eXcHrpYVLhBsLYvZYE3NZa9paIUGxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.2':
+    resolution: {integrity: sha512-T6Fs/g32MRja/UpCq4AdyPRj8tA0cOkcEa4PrAcn/ztUgK8b/qMVxj5mhMI+n7k+kHZQnpeB1Q4HqdSJi6OocA==}
     cpu: [arm64]
     os: [win32]
 
@@ -3050,6 +3121,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.1.2':
+    resolution: {integrity: sha512-OtxkFVz14mVL4QK8QriSELn9B6PaYGHw1jGJwVDEzpu2ZxSHCTQPz9dVE1ekYtREEqZUkRU7Fp7VfhJSmjTt2Q==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.0.8':
     resolution: {integrity: sha512-7zPs8YCe/ZVJTwd+5lpB0CP0tkn2pONf/T1ycmVY76u21Nrwt8mXQGc/2yH2eWP4B7fikYBr3hGr7mpR2fajqQ==}
     cpu: [x64]
@@ -3060,11 +3136,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.1.2':
+    resolution: {integrity: sha512-Am+nx9fLF3nzgD/K05Bs1Bb+WO8SFLWAYRbXkymaL1r+RQxjRj7jd5ap2PhGOCcfaNA4yVWkAFvmFP92eRu7bQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@2.0.8':
     resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
 
   '@rspack/binding@2.1.1':
     resolution: {integrity: sha512-6062hZP33fn1w51ClpQnum19GGXl/3eS754xrRYbQ7wwBNZk94HVwfSyiqcNCtY/pB1lsFjnaTKiW/Q+jv0axQ==}
+
+  '@rspack/binding@2.1.2':
+    resolution: {integrity: sha512-/mFcRSUW7Pl19KeaBIujJvZYNJQu0wD5D3aa5h+Qcph26v7nmLYlX7eajIHGi8tt2qTZX1lXifw2KLIXKwYaRQ==}
 
   '@rspack/core@2.0.8':
     resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
@@ -3080,6 +3164,18 @@ packages:
 
   '@rspack/core@2.1.1':
     resolution: {integrity: sha512-Rgz6xZcD0rm7ejZhYNi13qvW2dSnIQQt/7D3xbYoT5hOU838JbkF0P3SAMFGKE+FyLZswnyRpxGfnYHZQqDmJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.1.2':
+    resolution: {integrity: sha512-crpNQKhHfnzrIl4Sa4fjH30Ho5aAPgyqpmJZ41SkUFOzyKHdZKYfE5LF3CMh7MiFQFPPxiiKf5BcpxmtZZx4MQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8498,7 +8594,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.6.0(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/enhanced@2.6.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.6.0(node-fetch@2.7.0)
       '@module-federation/cli': 2.6.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
@@ -8507,7 +8603,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.6.0(@module-federation/runtime-tools@2.6.0)
       '@module-federation/managers': 2.6.0(node-fetch@2.7.0)
       '@module-federation/manifest': 2.6.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/rspack': 2.6.0(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/rspack': 2.6.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/runtime-tools': 2.6.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.6.0(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.6.0(node-fetch@2.7.0)
@@ -8549,9 +8645,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.45(@rspack/core@2.1.1)(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/node@2.7.45(@rspack/core@2.1.2)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
-      '@module-federation/enhanced': 2.6.0(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/enhanced': 2.6.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/runtime': 2.6.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.6.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -8564,13 +8660,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.6.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/rsbuild-plugin@2.6.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
-      '@module-federation/enhanced': 2.6.0(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
-      '@module-federation/node': 2.7.45(@rspack/core@2.1.1)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/enhanced': 2.6.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/node': 2.7.45(@rspack/core@2.1.2)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/sdk': 2.6.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8580,7 +8676,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.6.0(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
+  '@module-federation/rspack@2.6.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.6.0(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.6.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
@@ -8589,7 +8685,7 @@ snapshots:
       '@module-federation/manifest': 2.6.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/runtime-tools': 2.6.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.6.0(node-fetch@2.7.0)
-      '@rspack/core': 2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.5(typescript@6.0.3)
@@ -8624,12 +8720,12 @@ snapshots:
     optionalDependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 
-  '@module-federation/storybook-addon@6.0.14(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.14(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(node-fetch@2.7.0)(storybook@10.4.6)(typescript@6.0.3)(vue-tsc@3.3.5)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.6.0(@rspack/core@2.1.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
+      '@module-federation/enhanced': 2.6.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.5)
       '@module-federation/sdk': 2.6.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.1)(react-dom@19.2.7)(react@19.2.7)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -8671,6 +8767,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -9003,7 +9106,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.1)':
+  '@rsbuild/core@2.1.2(@module-federation/runtime-tools@2.6.0)':
+    dependencies:
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.2)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
@@ -9012,11 +9122,11 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.0(@rsbuild/core@2.1.1)':
+  '@rsbuild/plugin-babel@2.0.0(@rsbuild/core@2.1.2)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
@@ -9025,23 +9135,23 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-less@2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)':
+  '@rsbuild/plugin-less@2.0.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.1)(less@4.6.7)
+      less-loader: 12.3.3(@rspack/core@2.1.2)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.1)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.2)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9067,39 +9177,39 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
 
-  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(preact@10.29.3)':
+  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(preact@10.29.3)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.3)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.1)
+      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.2)
       '@swc/plugin-prefresh': 12.12.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - preact
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.1)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.2)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.1)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.2)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@2.0.0(@rsbuild/core@2.1.1)':
+  '@rsbuild/plugin-sass@2.0.0(@rsbuild/core@2.1.2)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9107,92 +9217,92 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
 
-  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.1)(solid-js@1.9.13)':
+  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.2)(solid-js@1.9.13)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.1)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.2)
       babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.13)
       solid-refresh: 0.6.3(solid-js@1.9.13)
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)':
+  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0
-      stylus-loader: 8.1.3(@rspack/core@2.1.1)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.1.2)(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.1)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.2)
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.1)':
+  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.2)':
     dependencies:
       toml: 4.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
 
-  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@typescript/native-preview': 7.0.0-dev.20260627.2
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.1)':
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.2)':
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
 
-  '@rsbuild/plugin-vue@2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(vue@3.5.39)':
+  '@rsbuild/plugin-vue@2.0.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(vue@3.5.39)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.1)(vue@3.5.39)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.2)(vue@3.5.39)
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@1.0.5(@rsbuild/core@2.1.1)':
+  '@rsbuild/plugin-yaml@1.0.5(@rsbuild/core@2.1.2)':
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
 
   '@rslib/core@0.23.1(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.6.0)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)':
     dependencies:
@@ -9250,10 +9360,16 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.1.1':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.1.2':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.0.8':
     optional: true
 
   '@rspack/binding-darwin-x64@2.1.1':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.1.2':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.8':
@@ -9262,16 +9378,28 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.1.1':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.1.2':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.0.8':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.1.1':
     optional: true
 
+  '@rspack/binding-linux-arm64-musl@2.1.2':
+    optional: true
+
   '@rspack/binding-linux-riscv64-gnu@2.1.1':
     optional: true
 
+  '@rspack/binding-linux-riscv64-gnu@2.1.2':
+    optional: true
+
   '@rspack/binding-linux-riscv64-musl@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.2':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.8':
@@ -9280,10 +9408,16 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.1.1':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.1.2':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.0.8':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.1.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.2':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.8':
@@ -9300,10 +9434,20 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.1.2':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.0.8':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.1.1':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.2':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.8':
@@ -9312,10 +9456,16 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@2.1.1':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.1.2':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.0.8':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.1.1':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.2':
     optional: true
 
   '@rspack/binding@2.0.8':
@@ -9346,6 +9496,21 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.1.1
       '@rspack/binding-win32-x64-msvc': 2.1.1
 
+  '@rspack/binding@2.1.2':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.2
+      '@rspack/binding-darwin-x64': 2.1.2
+      '@rspack/binding-linux-arm64-gnu': 2.1.2
+      '@rspack/binding-linux-arm64-musl': 2.1.2
+      '@rspack/binding-linux-riscv64-gnu': 2.1.2
+      '@rspack/binding-linux-riscv64-musl': 2.1.2
+      '@rspack/binding-linux-x64-gnu': 2.1.2
+      '@rspack/binding-linux-x64-musl': 2.1.2
+      '@rspack/binding-wasm32-wasi': 2.1.2
+      '@rspack/binding-win32-arm64-msvc': 2.1.2
+      '@rspack/binding-win32-ia32-msvc': 2.1.2
+      '@rspack/binding-win32-x64-msvc': 2.1.2
+
   '@rspack/core@2.0.8(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.0.8
@@ -9360,33 +9525,40 @@ snapshots:
       '@module-federation/runtime-tools': 2.6.0(node-fetch@2.7.0)
       '@swc/helpers': 0.5.23
 
+  '@rspack/core@2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.2
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.6.0(node-fetch@2.7.0)
+      '@swc/helpers': 0.5.23
+
   '@rspack/lite-tapable@1.1.2': {}
 
-  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.1)':
+  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.2)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.3)
       '@prefresh/utils': 1.2.1
     optionalDependencies:
-      '@rspack/core': 2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.1)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.2)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.1)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.2)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)
       '@rspress/shared': 2.0.15(@module-federation/runtime-tools@2.6.0)
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -9435,7 +9607,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
-      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -9446,7 +9618,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.15(@rspress/core@2.0.15)':
     dependencies:
-      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       remark-mdx: 3.1.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -9457,17 +9629,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.15(@rspress/core@2.0.15)':
     dependencies:
-      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.15(@rspress/core@2.0.15)':
     dependencies:
-      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rspress/plugin-twoslash@2.0.15(@rspress/core@2.0.15)(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@shikijs/twoslash': 4.3.0(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3
       mdast-util-gfm: 3.1.0
@@ -9481,7 +9653,7 @@ snapshots:
 
   '@rspress/shared@2.0.15(@module-federation/runtime-tools@2.6.0)':
     dependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@shikijs/rehype': 4.3.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9490,7 +9662,7 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.5(@rspress/core@2.0.15)':
     optionalDependencies:
-      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rstest/adapter-rslib@0.10.6(@rslib/core@0.23.1)(@rstest/core@0.10.6)(typescript@6.0.3)':
     dependencies:
@@ -9885,14 +10057,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.1)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.2)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
     optionalDependencies:
-      '@rspack/core': 2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
 
   '@testing-library/jest-dom@6.9.1':
     dependencies:
@@ -11872,11 +12044,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@rspack/core@2.1.1)(less@4.6.7):
+  less-loader@12.3.3(@rspack/core@2.1.2)(less@4.6.7):
     dependencies:
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
 
   less@4.6.7:
     dependencies:
@@ -13519,40 +13691,40 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260627.2
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.1):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.2):
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
 
-  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.1):
+  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.2):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.1):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.2):
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.1):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.2):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
 
   rslog@2.1.3: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.1)(vue@3.5.39):
+  rspack-vue-loader@17.5.1(@rspack/core@2.1.2)(vue@3.5.39):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
       vue: 3.5.39(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.15):
     dependencies:
-      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -13577,14 +13749,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.15):
     dependencies:
-      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.15)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.15):
     dependencies:
-      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.1)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.15(@module-federation/runtime-tools@2.6.0)(@rspack/core@2.1.2)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   run-applescript@7.1.0: {}
 
@@ -13915,18 +14087,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
-      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -13938,7 +14110,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.1)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.2)
       sirv: 2.0.4
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.1)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.3.0
@@ -13955,10 +14127,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.4)(storybook@10.4.6)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)
       find-up: 5.0.0
@@ -13969,7 +14141,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.1)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -13984,12 +14156,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.39):
+  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)(vue@3.5.39):
     dependencies:
-      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.6.0)
+      '@rsbuild/core': 2.1.2(@module-federation/runtime-tools@2.6.0)
       '@storybook/vue3': 10.4.6(storybook@10.4.6)(vue@3.5.39)
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.1)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.2)(@rspack/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.6)(typescript@6.0.3)
       vue: 3.5.39(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.39)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -14110,13 +14282,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.1.1)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.1.2)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
 
   stylus@0.64.0:
     dependencies:
@@ -14228,7 +14400,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.1)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260627.2)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
@@ -14236,7 +14408,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.1.1(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.6.0)(@swc/helpers@0.5.23)
       '@typescript/native-preview': 7.0.0-dev.20260627.2
 
   ts-dedent@2.3.0: {}

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@rsbuild/plugin-node-polyfill": "^1.4.6"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@rsbuild/plugin-node-polyfill": "^1.4.6"
   }
 }

--- a/tests/integration/vue/index.test.ts
+++ b/tests/integration/vue/index.test.ts
@@ -40,7 +40,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
           };
       })();
       __webpack_require__.add({
-          288 (__unused_rspack_module, exports) {
+          265 (__unused_rspack_module, exports) {
               exports.A = (sfc, props)=>{
                   const target = sfc.__vccOpts || sfc;
                   for (const [key, val] of props)target[key] = val;
@@ -58,7 +58,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
               return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(button.value), 1));
           }
       };
-      const exportHelper = __webpack_require__("288");
+      const exportHelper = __webpack_require__("265");
       const __exports__ = /*#__PURE__*/ (0, exportHelper.A)(Buttonvue_type_script_setup_true_lang_js, [
           [
               '__scopeId',
@@ -112,7 +112,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
       import "./Button.css";
       import { __webpack_require__ } from "../rslib-runtime.js";
       __webpack_require__.add({
-          288 (__unused_rspack_module, exports) {
+          265 (__unused_rspack_module, exports) {
               exports.A = (sfc, props)=>{
                   const target = sfc.__vccOpts || sfc;
                   for (const [key, val] of props)target[key] = val;
@@ -130,7 +130,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
               return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(button.value), 1));
           }
       };
-      const exportHelper = __webpack_require__("288");
+      const exportHelper = __webpack_require__("265");
       const __exports__ = /*#__PURE__*/ (0, exportHelper.A)(Buttonvue_type_script_setup_true_lang_js, [
           [
               '__scopeId',

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^2.6.0",
     "@playwright/test": "1.61.1",
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@rsbuild/plugin-less": "^2.0.0",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-sass": "^2.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.6.0",
-    "@rsbuild/core": "~2.1.1",
+    "@rsbuild/core": "~2.1.2",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-sass": "^2.0.0",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

This PR upgrades Rsbuild to 2.1.2 and resets Rsbuild's web-like output `environment.const` default for Rslib library builds. Rslib now removes the app-runtime `const: false` override so Rspack can infer `const` support from the configured target, while explicit user overrides through `tools.rspack` and lib-level plugins remain supported.

It also consolidates Rslib's format-level Rsbuild default adjustments into `rslib:modify-rsbuild-default`, registered from `composeFormatConfig`:

- disables `new URL()` parsing for ESM/CJS library output
- removes Rsbuild's `type: 'javascript/auto'` override so ESM-like modules follow Rspack's original inference and are treated as strict ESM (`javascript/esm`)
- resets the web/web-worker `environment.const` override

## Related Links

https://github.com/web-infra-dev/rspack/releases/tag/v2.1.2
https://github.com/web-infra-dev/rsbuild/pull/8020

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
