### PR TITLE
feat(core): support custom argv in runCLI

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -86,7 +86,7 @@ const applyCommonOptions = (cli: CAC) => {
     .option('--no-env', 'Disable loading of `.env` files');
 };
 
-export function setupCommands(): void {
+export function setupCommands(argv: string[]): void {
   const cli = cac('rslib');
 
   cli.version(RSLIB_VERSION);
@@ -253,5 +253,5 @@ export function setupCommands(): void {
     }
   });
 
-  cli.parse();
+  cli.parse(argv);
 }

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -2,10 +2,18 @@ import type { LogLevel } from '@rsbuild/core';
 import { isDebug, logger } from '../utils/logger';
 import { setupCommands } from './commands';
 
-function initNodeEnv() {
+export type RunCLIOptions = {
+  /**
+   * The command-line arguments to parse, matching the shape of Node.js `process.argv`
+   * @default process.argv
+   */
+  argv?: string[];
+};
+
+function initNodeEnv(argv: string[]) {
   if (!process.env.NODE_ENV) {
     // defaults to build mode
-    const command = process.argv[2] ?? 'build';
+    const command = argv[2] ?? 'build';
     process.env.NODE_ENV = ['build', 'inspect'].includes(command)
       ? 'production'
       : 'development';
@@ -26,25 +34,25 @@ function showGreeting() {
 }
 
 // ensure log level is set before any log is printed
-function setupLogLevel() {
-  const logLevelIndex = process.argv.findIndex(
+function setupLogLevel(argv: string[]) {
+  const logLevelIndex = argv.findIndex(
     (item) => item === '--log-level' || item === '--logLevel',
   );
   if (logLevelIndex !== -1) {
-    const level = process.argv[logLevelIndex + 1];
+    const level = argv[logLevelIndex + 1];
     if (level && ['warn', 'error', 'silent'].includes(level) && !isDebug()) {
       logger.level = level as LogLevel;
     }
   }
 }
 
-export function runCLI(): void {
-  initNodeEnv();
-  setupLogLevel();
+export function runCLI({ argv = process.argv }: RunCLIOptions = {}): void {
+  initNodeEnv(argv);
+  setupLogLevel(argv);
   showGreeting();
 
   try {
-    setupCommands();
+    setupCommands(argv);
   } catch (err) {
     logger.error('Failed to start Rslib CLI.');
     logger.error(err);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  * the public API of @rslib/core.
  */
 
-export { runCLI } from './cli';
+export { type RunCLIOptions, runCLI } from './cli';
 export { createRslib } from './createRslib';
 export {
   type ConfigParams,


### PR DESCRIPTION
## Summary

Adds a `RunCLIOptions` API so `runCLI` can parse a custom Node-style `argv`, matching Rsbuild behavior. The argv value now flows through NODE_ENV initialization, log-level setup, and CAC command parsing.

## Checklist

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
