### PR TITLE
fix(core): replace deprecated circular dependency plugin

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   },
   tools: {
     rspack: {
-      plugins: [new rspack.CircularDependencyRspackPlugin({})],
+      plugins: [new rspack.CircularCheckRspackPlugin()],
     },
   },
 });


### PR DESCRIPTION
## Summary

Use Rspack's new `CircularCheckRspackPlugin` in the core build config to replace the deprecated `CircularDependencyRspackPlugin`.

## Related Links

https://github.com/web-infra-dev/rspack/pull/14319