### PR TITLE
feat(create-rslib): bump default Node syntax to 22 and add public publishConfig

### DIFF
--- a/packages/create-rslib/template-node-dual-js/package.json
+++ b/packages/create-rslib/template-node-dual-js/package.json
@@ -12,6 +12,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",

--- a/packages/create-rslib/template-node-dual-js/rslib.config.js
+++ b/packages/create-rslib/template-node-dual-js/rslib.config.js
@@ -4,11 +4,11 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: ['node 18'],
+      syntax: ['node 22'],
     },
     {
       format: 'cjs',
-      syntax: ['node 18'],
+      syntax: ['node 22'],
     },
   ],
 });

--- a/packages/create-rslib/template-node-dual-ts/package.json
+++ b/packages/create-rslib/template-node-dual-ts/package.json
@@ -14,6 +14,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",

--- a/packages/create-rslib/template-node-dual-ts/rslib.config.ts
+++ b/packages/create-rslib/template-node-dual-ts/rslib.config.ts
@@ -4,12 +4,12 @@ export default defineConfig({
   lib: [
     {
       format: 'esm',
-      syntax: ['node 18'],
+      syntax: ['node 22'],
       dts: true,
     },
     {
       format: 'cjs',
-      syntax: ['node 18'],
+      syntax: ['node 22'],
     },
   ],
 });

--- a/packages/create-rslib/template-node-esm-js/package.json
+++ b/packages/create-rslib/template-node-esm-js/package.json
@@ -10,6 +10,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",

--- a/packages/create-rslib/template-node-esm-js/rslib.config.js
+++ b/packages/create-rslib/template-node-esm-js/rslib.config.js
@@ -3,8 +3,7 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     {
-      format: 'esm',
-      syntax: ['node 18'],
+      syntax: ['node 22'],
     },
   ],
 });

--- a/packages/create-rslib/template-node-esm-ts/package.json
+++ b/packages/create-rslib/template-node-esm-ts/package.json
@@ -12,6 +12,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",

--- a/packages/create-rslib/template-node-esm-ts/rslib.config.ts
+++ b/packages/create-rslib/template-node-esm-ts/rslib.config.ts
@@ -3,8 +3,7 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   lib: [
     {
-      format: 'esm',
-      syntax: ['node 18'],
+      syntax: ['node 22'],
       dts: true,
     },
   ],

--- a/packages/create-rslib/template-react-compiler/react-js/rslib.config.js
+++ b/packages/create-rslib/template-react-compiler/react-js/rslib.config.js
@@ -10,7 +10,6 @@ export default defineConfig({
   lib: [
     {
       bundle: false,
-      format: 'esm',
     },
   ],
   output: {

--- a/packages/create-rslib/template-react-compiler/react-ts/rslib.config.ts
+++ b/packages/create-rslib/template-react-compiler/react-ts/rslib.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
     {
       bundle: false,
       dts: true,
-      format: 'esm',
     },
   ],
   output: {

--- a/packages/create-rslib/template-react-js/package.json
+++ b/packages/create-rslib/template-react-js/package.json
@@ -10,6 +10,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",

--- a/packages/create-rslib/template-react-js/rslib.config.js
+++ b/packages/create-rslib/template-react-js/rslib.config.js
@@ -10,7 +10,6 @@ export default defineConfig({
   lib: [
     {
       bundle: false,
-      format: 'esm',
     },
   ],
   output: {

--- a/packages/create-rslib/template-react-ts/package.json
+++ b/packages/create-rslib/template-react-ts/package.json
@@ -12,6 +12,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",

--- a/packages/create-rslib/template-react-ts/rslib.config.ts
+++ b/packages/create-rslib/template-react-ts/rslib.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
     {
       bundle: false,
       dts: true,
-      format: 'esm',
     },
   ],
   output: {

--- a/packages/create-rslib/template-svelte-js/package.json
+++ b/packages/create-rslib/template-svelte-js/package.json
@@ -11,6 +11,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",

--- a/packages/create-rslib/template-svelte-ts/package.json
+++ b/packages/create-rslib/template-svelte-ts/package.json
@@ -13,6 +13,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rslib",
     "check": "svelte-check",

--- a/packages/create-rslib/template-vue-js/package.json
+++ b/packages/create-rslib/template-vue-js/package.json
@@ -12,6 +12,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",

--- a/packages/create-rslib/template-vue-js/rslib.config.ts
+++ b/packages/create-rslib/template-vue-js/rslib.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   lib: [
     {
       bundle: false,
-      format: 'esm',
     },
   ],
   output: {

--- a/packages/create-rslib/template-vue-ts/package.json
+++ b/packages/create-rslib/template-vue-ts/package.json
@@ -12,6 +12,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rslib && vue-tsc",
     "dev": "rslib --watch",

--- a/packages/create-rslib/template-vue-ts/rslib.config.ts
+++ b/packages/create-rslib/template-vue-ts/rslib.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   lib: [
     {
       bundle: false,
-      format: 'esm',
     },
   ],
   output: {

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -24,6 +24,7 @@ export const expectPackageJson = (
   expect(pkgJson.scripts['test:watch']).toBe('rstest --watch');
   expect(pkgJson.devDependencies['@rstest/adapter-rslib']).toBeTruthy();
   expect(pkgJson.devDependencies['@rstest/core']).toBeTruthy();
+  expect(pkgJson.publishConfig?.access).toBe('public');
 };
 
 export interface TemplateCase {


### PR DESCRIPTION
## Summary

- **Bump the default Node syntax from `node 18` to `node 22`** (Node 18/20 are EOL) in the `node-esm` and `node-dual` templates.
- **Drop redundant `format: 'esm'`** since Rslib defaults `lib.format` to `'esm'`. `node-dual` keeps `esm` + `cjs` to show the dual-output intent, and `svelte` keeps it because its `lib` entry has no other fields.
- **Add `publishConfig.access: "public"` to every base template** so scoped packages can be published without extra setup (with a matching assertion in `test/helper.ts`).