### PR TITLE
fix(core): pass cli command to config loading

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -9,7 +9,7 @@ import {
 import type { Format, Syntax } from '../types';
 import { color } from '../utils/color';
 import { logger } from '../utils/logger';
-import { init } from './init';
+import { init, initCliAction } from './init';
 
 const RSPACK_BUILD_ERROR = 'Rspack build failed.';
 
@@ -142,9 +142,10 @@ export function setupCommands(argv: string[]): void {
       'use specific tsconfig (relative to project root)',
     )
     .action(async (options: BuildOptions) => {
+      initCliAction('build', options);
       try {
         const cliBuild = async () => {
-          const rslib = await init(options);
+          const rslib = await init();
 
           if (options.watch) {
             watchFilesForRestart(getWatchFilesForRestart(rslib), async () => {
@@ -185,8 +186,9 @@ export function setupCommands(argv: string[]): void {
     })
     .option('--verbose', 'show full function definitions in output')
     .action(async (options: InspectOptions) => {
+      initCliAction('inspect', options);
       try {
-        const rslib = await init(options);
+        const rslib = await init();
         await rslib.inspectConfig({
           lib: options.lib,
           mode: options.mode,
@@ -202,9 +204,10 @@ export function setupCommands(argv: string[]): void {
     });
 
   mfDevCommand.action(async (options: MfDevOptions) => {
+    initCliAction('mf-dev', options);
     try {
       const cliMfDev = async () => {
-        const rslib = await init(options);
+        const rslib = await init();
         await rslib.startMFDevServer({
           lib: options.lib,
         });

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -10,16 +10,6 @@ export type RunCLIOptions = {
   argv?: string[];
 };
 
-function initNodeEnv(argv: string[]) {
-  if (!process.env.NODE_ENV) {
-    // defaults to build mode
-    const command = argv[2] ?? 'build';
-    process.env.NODE_ENV = ['build', 'inspect'].includes(command)
-      ? 'production'
-      : 'development';
-  }
-}
-
 function showGreeting() {
   // Ensure consistent spacing before the greeting message.
   // Different package managers handle output formatting differently - some automatically
@@ -47,7 +37,6 @@ function setupLogLevel(argv: string[]) {
 }
 
 export function runCLI({ argv = process.argv }: RunCLIOptions = {}): void {
-  initNodeEnv(argv);
   setupLogLevel(argv);
   showGreeting();
 

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -12,6 +12,27 @@ import { ensureAbsolutePath } from '../utils/helper';
 import { logger } from '../utils/logger';
 import type { BuildOptions, CommonOptions } from './commands';
 
+export type CommandName = 'build' | 'inspect' | 'mf-dev';
+
+const cliState: {
+  command?: CommandName;
+  options: CommonOptions;
+} = {
+  options: {} as CommonOptions,
+};
+
+export const initCliAction = (
+  command: CommandName,
+  options: CommonOptions,
+): void => {
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = command === 'mf-dev' ? 'development' : 'production';
+  }
+
+  cliState.command = command;
+  cliState.options = options;
+};
+
 const getEnvDir = (cwd: string, envDir?: string) => {
   if (envDir) {
     return path.isAbsolute(envDir) ? envDir : path.resolve(cwd, envDir);
@@ -110,12 +131,17 @@ export const applyCliOptions = (
   }
 };
 
-const loadConfig = async (options: CommonOptions, root: string) => {
+const loadConfig = async (
+  options: CommonOptions,
+  root: string,
+  command?: CommandName,
+) => {
   const { content: config, filePath: configFilePath } = await baseLoadConfig({
     cwd: root,
     path: options.config,
     envMode: options.envMode,
     loader: options.configLoader,
+    command,
   });
 
   if (configFilePath === null) {
@@ -128,13 +154,14 @@ const loadConfig = async (options: CommonOptions, root: string) => {
   return config;
 };
 
-export async function init(options: CommonOptions): Promise<RslibInstance> {
+export async function init(): Promise<RslibInstance> {
+  const { options, command } = cliState;
   const cwd = process.cwd();
   const root = options.root ? ensureAbsolutePath(cwd, options.root) : cwd;
 
   const rslib = await createRslib({
     cwd: root,
-    config: () => loadConfig(options, root),
+    config: () => loadConfig(options, root, command),
     loadEnv:
       options.env === false
         ? false

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -20,13 +20,11 @@ export type RslibConfigSyncFn = (env: ConfigParams) => RslibConfig;
 export type RslibConfigAsyncFn = (env: ConfigParams) => Promise<RslibConfig>;
 
 export type RslibConfigExport =
-  | RslibConfig
-  | RslibConfigSyncFn
-  | RslibConfigAsyncFn;
+  RslibConfig | RslibConfigSyncFn | RslibConfigAsyncFn;
 
 export type LoadConfigOptions = Pick<
   RsbuildLoadConfigOptions,
-  'cwd' | 'path' | 'envMode' | 'meta' | 'loader'
+  'cwd' | 'path' | 'envMode' | 'meta' | 'loader' | 'command'
 >;
 
 export type ConfigLoader = RsbuildLoadConfigOptions['loader'];
@@ -101,6 +99,7 @@ export async function loadConfig({
   envMode,
   meta,
   loader,
+  command,
 }: LoadConfigOptions): Promise<LoadConfigResult> {
   const configFilePath = resolveConfigPath(cwd, path);
 
@@ -118,6 +117,7 @@ export async function loadConfig({
     envMode,
     meta,
     loader,
+    command,
   });
 
   return { content: content as RslibConfig, filePath: configFilePath };

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -3,7 +3,7 @@ import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { describe, expect, rs, test } from '@rstest/core';
 import type { BuildOptions } from '../src/cli/commands';
-import { init } from '../src/cli/init';
+import { init, initCliAction } from '../src/cli/init';
 import {
   composeCreateRsbuildConfig,
   composeRsbuildEnvironments,
@@ -153,6 +153,18 @@ describe('Should load config file correctly', () => {
       _privateMeta: {
         configFilePath,
       },
+    });
+  });
+
+  test('passes command to config function', async () => {
+    const fixtureDir = join(__dirname, 'fixtures/config/command');
+    const { content: config } = await loadConfig({
+      cwd: fixtureDir,
+      command: 'build',
+    });
+
+    expect(config.source?.define).toEqual({
+      COMMAND: JSON.stringify('build'),
     });
   });
 });
@@ -387,9 +399,12 @@ describe('CLI options', () => {
       tsconfig: 'tsconfig.build.json',
     };
 
-    const rslib = await init(options);
-    const config = rslib.getRslibConfig();
-    expect(config).toMatchInlineSnapshot(`
+    const originalNodeEnv = process.env.NODE_ENV;
+    try {
+      initCliAction('build', options);
+      const rslib = await init();
+      const config = rslib.getRslibConfig();
+      expect(config).toMatchInlineSnapshot(`
       {
         "_privateMeta": {
           "configFilePath": "<WORKSPACE>/tests/fixtures/config/cli-options/rslib.config.ts",
@@ -429,6 +444,13 @@ describe('CLI options', () => {
         },
       }
     `);
+    } finally {
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    }
   });
 });
 

--- a/packages/core/tests/fixtures/config/command/rslib.config.ts
+++ b/packages/core/tests/fixtures/config/command/rslib.config.ts
@@ -1,0 +1,10 @@
+import type { ConfigParams, RslibConfig } from '@rslib/core';
+
+export default ({ command }: ConfigParams): RslibConfig => ({
+  lib: [],
+  source: {
+    define: {
+      COMMAND: JSON.stringify(command),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,8 @@ importers:
 
   tests/integration/cli/env: {}
 
+  tests/integration/cli/function-config: {}
+
   tests/integration/cli/inspect: {}
 
   tests/integration/cli/log-level: {}

--- a/tests/integration/cli/function-config/index.test.ts
+++ b/tests/integration/cli/function-config/index.test.ts
@@ -1,0 +1,19 @@
+import { join } from 'node:path';
+import { expect, test } from '@rstest/core';
+import fse from 'fs-extra';
+import { globContentJSON, runCliSync } from 'test-helper';
+
+test('should parse build command after global option values', async () => {
+  await fse.remove(join(__dirname, 'dist'));
+
+  runCliSync('--env-mode inspect build', {
+    cwd: __dirname,
+  });
+
+  const files = await globContentJSON(join(__dirname, 'dist'));
+  expect(Object.keys(files).sort()).toMatchInlineSnapshot(`
+    [
+      "<ROOT>/tests/integration/cli/function-config/dist/production-inspect-build/index.js",
+    ]
+  `);
+});

--- a/tests/integration/cli/function-config/package.json
+++ b/tests/integration/cli/function-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cli-function-config-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/cli/function-config/rslib.config.ts
+++ b/tests/integration/cli/function-config/rslib.config.ts
@@ -1,0 +1,17 @@
+import type { ConfigParams, RslibConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default ({ command, env, envMode }: ConfigParams): RslibConfig => ({
+  lib: [
+    generateBundleEsmConfig({
+      output: {
+        distPath: `dist/${env}-${envMode}-${command}`,
+      },
+    }),
+  ],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+});

--- a/tests/integration/cli/function-config/src/index.ts
+++ b/tests/integration/cli/function-config/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -101,6 +101,7 @@ function loadConfig(params?: {
   path?: string;
   meta?: Record<string, unknown>;
   envMode?: string;
+  command?: string;
   loader?: 'auto' | 'jiti' | 'native';
 }): Promise<{
   content: RslibConfig;
@@ -159,6 +160,18 @@ In the `defineConfig` configuration function, you can access the `foo` variable 
 export default defineConfig(({ meta }) => {
   console.log(meta.foo); // bar
   return config;
+});
+```
+
+### Passing command
+
+By default, `loadConfig` passes `process.argv[2]` as the `command` value to the config function. Use the `command` option to explicitly set this value.
+
+```ts
+import { loadConfig } from '@rslib/core';
+
+const { content } = await loadConfig({
+  command: 'build',
 });
 ```
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -101,6 +101,7 @@ function loadConfig(params?: {
   path?: string;
   meta?: Record<string, unknown>;
   envMode?: string;
+  command?: string;
   loader?: 'auto' | 'jiti' | 'native';
 }): Promise<{
   content: RslibConfig;
@@ -159,6 +160,18 @@ const { content } = await loadConfig({
 export default defineConfig(({ meta }) => {
   console.log(meta.foo); // bar
   return config;
+});
+```
+
+### 传入 command
+
+默认情况下，`loadConfig` 会将 `process.argv[2]` 作为 `command` 传给配置函数。你可以通过 `command` 选项显式设置该值。
+
+```ts
+import { loadConfig } from '@rslib/core';
+
+const { content } = await loadConfig({
+  command: 'build',
 });
 ```
 


### PR DESCRIPTION
## Summary

Fixes Rslib CLI command detection when global option values appear before the subcommand, matching Rsbuild behavior. CLI actions now store the resolved command/options before init, `loadConfig` forwards the explicit `command`, and the JavaScript API docs cover the new option.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8033
- https://github.com/web-infra-dev/rsbuild/pull/8035

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).