### PR TITLE
feat(core): export config definition types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,9 @@ export {
   type LoadConfigResult,
   type LoadEnvOptions,
   type LoadEnvResult,
+  type RslibConfigAsyncFn,
+  type RslibConfigDefinition,
+  type RslibConfigSyncFn,
   loadConfig,
   loadEnv,
 } from './loadConfig';

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -19,7 +19,7 @@ export type RslibConfigSyncFn = (env: ConfigParams) => RslibConfig;
 
 export type RslibConfigAsyncFn = (env: ConfigParams) => Promise<RslibConfig>;
 
-export type RslibConfigExport =
+export type RslibConfigDefinition =
   RslibConfig | RslibConfigSyncFn | RslibConfigAsyncFn;
 
 export type LoadConfigOptions = Pick<
@@ -48,8 +48,10 @@ export type LoadConfigResult = {
 export function defineConfig(config: RslibConfig): RslibConfig;
 export function defineConfig(config: RslibConfigSyncFn): RslibConfigSyncFn;
 export function defineConfig(config: RslibConfigAsyncFn): RslibConfigAsyncFn;
-export function defineConfig(config: RslibConfigExport): RslibConfigExport;
-export function defineConfig(config: RslibConfigExport) {
+export function defineConfig(
+  config: RslibConfigDefinition,
+): RslibConfigDefinition;
+export function defineConfig(config: RslibConfigDefinition) {
   return config;
 }
 


### PR DESCRIPTION
## Summary

This PR aligns Rslib's config definition type naming with Rsbuild by renaming the config union to `RslibConfigDefinition` and exporting it from `@rslib/core` alongside `RslibConfigSyncFn` and `RslibConfigAsyncFn`. This makes the public type usable for both config-file exports and values passed to `defineConfig`.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/8036

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).