### PR TITLE
docs(create-rslib): update template guidance

### DIFF
--- a/packages/create-rslib/AGENTS.md
+++ b/packages/create-rslib/AGENTS.md
@@ -6,19 +6,18 @@ This guide extends the repository instructions in `../../AGENTS.md`. Refer there
 
 - `create-rslib` provides the `pnpm create rslib` scaffolding CLI shipped from `dist/`.
 - Author source changes under `src/`; treat `dist/` as build output regenerated via `pnpm -C packages/create-rslib build`.
-- Template inputs live in `fragments/`; generated scaffolding blueprints are the `template-*` directories.
+- Template inputs are the checked-in `template-*` directories. They are copied directly by `create-rstack` and published with this package.
 - Tests in `test/` use `@rstest/core` to exercise CLI flows and validate generated projects.
 
 ## Common commands
 
 - Build once before testing locally: `pnpm -C packages/create-rslib build`.
 - Watch rebuild during development: `pnpm -C packages/create-rslib dev`.
-- Regenerate template directories after touching fragments or generators: `pnpm -C packages/create-rslib generate-templates`.
 - Run package tests: `pnpm -C packages/create-rslib test`; the repo-level `pnpm test:unit` also covers this package.
 
 ## Working on templates
 
-- Add or update base files in `fragments/base/*` and tool overlays in `fragments/tools/*`; keep naming aligned with `src/helpers.ts`.
-- Update `TEMPLATES` in `src/helpers.ts` whenever you introduce a new template combination so the CLI prompts and tests remain exhaustive.
-- Treat `template-*` directories as generated output from `pnpm -C packages/create-rslib generate-templates`, don't directly edit them; keep changes reproducible by updating generators in `src/` or fragments under `fragments/` instead of editing the generated files directly.
-- Keep dependency versions aligned across all `template-*` directories; when one template upgrades a shared dependency, update the others via fragments or generators to match.
+- Add or update base template files in directories such as `template-react-ts/`, `template-vue-js/`, and shared files in `template-common/`.
+- Add or update tool overlays in directories such as `template-storybook/`, `template-rspress/`, and `template-react-compiler/`; these overlays are merged into the selected base template by `src/index.ts`.
+- Update `TEMPLATES` and `extraTools` in `src/index.ts` whenever you introduce a new template or tool combination so the CLI prompts and tests remain exhaustive.
+- Keep dependency versions aligned across sibling template package files. For example, a Storybook dependency change should update every relevant `template-storybook/*/package.json` file together.


### PR DESCRIPTION
## Summary

This PR updates the create-rslib package guidelines to match the current template flow: the checked-in `template-*` directories are the source templates copied by `create-rstack`, not generated output from a removed fragments/generate-templates flow. It also clarifies that sibling tool overlay package files, such as Storybook templates, should keep shared dependency versions aligned.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).