### PR TITLE
fix(create-rslib): move reference types into tsconfig

### DIFF
--- a/packages/create-rslib/template-node-dual-ts/tsconfig.json
+++ b/packages/create-rslib/template-node-dual-ts/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "bundler",
     "useDefineForClassFields": true,
     "allowImportingTsExtensions": true,
+    "types": ["node"],
     "rootDir": "src"
   },
   "include": ["src"]

--- a/packages/create-rslib/template-node-esm-ts/tsconfig.json
+++ b/packages/create-rslib/template-node-esm-ts/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "bundler",
     "useDefineForClassFields": true,
     "allowImportingTsExtensions": true,
+    "types": ["node"],
     "rootDir": "src"
   },
   "include": ["src"]

--- a/packages/create-rslib/template-react-ts/src/env.d.ts
+++ b/packages/create-rslib/template-react-ts/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@rslib/core/types" />

--- a/packages/create-rslib/template-react-ts/tests/test.d.ts
+++ b/packages/create-rslib/template-react-ts/tests/test.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@testing-library/jest-dom" />

--- a/packages/create-rslib/template-react-ts/tests/tsconfig.json
+++ b/packages/create-rslib/template-react-ts/tests/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["@rslib/core/types", "@testing-library/jest-dom"]
+  },
   "include": [".", "../rstest.setup.ts"]
 }

--- a/packages/create-rslib/template-react-ts/tsconfig.json
+++ b/packages/create-rslib/template-react-ts/tsconfig.json
@@ -7,6 +7,7 @@
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "useDefineForClassFields": true,
+    "types": ["@rslib/core/types"],
     "rootDir": "src"
   },
   "include": ["src"]

--- a/packages/create-rslib/template-rspress/react-ts/tsconfig.json
+++ b/packages/create-rslib/template-rspress/react-ts/tsconfig.json
@@ -7,6 +7,7 @@
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "useDefineForClassFields": true,
+    "types": ["@rslib/core/types", "node"],
     "paths": {
       "{{ packageName }}": ["."]
     }

--- a/packages/create-rslib/template-vue-ts/src/env.d.ts
+++ b/packages/create-rslib/template-vue-ts/src/env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@rslib/core/types" />

--- a/packages/create-rslib/template-vue-ts/tests/test.d.ts
+++ b/packages/create-rslib/template-vue-ts/tests/test.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@testing-library/jest-dom" />

--- a/packages/create-rslib/template-vue-ts/tests/tsconfig.json
+++ b/packages/create-rslib/template-vue-ts/tests/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["@rslib/core/types", "@testing-library/jest-dom"]
+  },
   "include": [".", "../rstest.setup.ts"]
 }

--- a/packages/create-rslib/template-vue-ts/tsconfig.json
+++ b/packages/create-rslib/template-vue-ts/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
+    "types": ["@rslib/core/types"],
 
     /* type checking */
     "noUnusedLocals": true,

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -111,13 +111,9 @@ export const createAndValidate = (
     templateCase.lang === 'ts' &&
     (templateCase.template === 'react' || templateCase.template === 'vue')
   ) {
-    const envDtsPath = path.join(dir, 'src/env.d.ts');
-    const testDtsPath = path.join(dir, 'tests/test.d.ts');
     const testsTsconfig = readTsconfig(path.join(dir, 'tests/tsconfig.json'));
     const testsTypes = testsTsconfig.compilerOptions?.types;
 
-    expect(existsSync(envDtsPath)).toBe(false);
-    expect(existsSync(testDtsPath)).toBe(false);
     expect(
       tsconfig?.compilerOptions?.types?.includes('@rslib/core/types'),
     ).toBe(true);

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -1,13 +1,9 @@
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { createRequire } from 'node:module';
 import path from 'node:path';
 import { expect } from '@rstest/core';
 import fse from 'fs-extra';
 import type { Lang } from '../src/index';
-
-const require = createRequire(import.meta.url);
-const ts = require('typescript') as typeof import('typescript');
 
 export const expectPackageJson = (
   pkgJson: Record<string, any>,
@@ -37,21 +33,6 @@ export interface TemplateCase {
   tools: string[];
   label: string;
 }
-
-const readTsconfig = (tsconfigPath: string): Record<string, any> => {
-  const result = ts.parseConfigFileTextToJson(
-    tsconfigPath,
-    fse.readFileSync(tsconfigPath, 'utf-8'),
-  );
-
-  if (result.error) {
-    throw new Error(
-      ts.flattenDiagnosticMessageText(result.error.messageText, '\n'),
-    );
-  }
-
-  return result.config;
-};
 
 export const createAndValidate = (
   cwd: string,
@@ -96,29 +77,9 @@ export const createAndValidate = (
   );
 
   // tsconfig
-  let tsconfig: Record<string, any> | undefined;
   if (templateCase.lang === 'ts') {
     expect(pkgJson.devDependencies.typescript).toBeTruthy();
     expect(existsSync(path.join(dir, 'tsconfig.json'))).toBeTruthy();
-    tsconfig = readTsconfig(path.join(dir, 'tsconfig.json'));
-
-    if (pkgJson.devDependencies['@types/node']) {
-      expect(tsconfig?.compilerOptions?.types?.includes('node')).toBe(true);
-    }
-  }
-
-  if (
-    templateCase.lang === 'ts' &&
-    (templateCase.template === 'react' || templateCase.template === 'vue')
-  ) {
-    const testsTsconfig = readTsconfig(path.join(dir, 'tests/tsconfig.json'));
-    const testsTypes = testsTsconfig.compilerOptions?.types;
-
-    expect(
-      tsconfig?.compilerOptions?.types?.includes('@rslib/core/types'),
-    ).toBe(true);
-    expect(testsTypes.includes('@rslib/core/types')).toBe(true);
-    expect(testsTypes.includes('@testing-library/jest-dom')).toBe(true);
   }
 
   expect(

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -1,9 +1,13 @@
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { expect } from '@rstest/core';
 import fse from 'fs-extra';
 import type { Lang } from '../src/index';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript') as typeof import('typescript');
 
 export const expectPackageJson = (
   pkgJson: Record<string, any>,
@@ -33,6 +37,21 @@ export interface TemplateCase {
   tools: string[];
   label: string;
 }
+
+const readTsconfig = (tsconfigPath: string): Record<string, any> => {
+  const result = ts.parseConfigFileTextToJson(
+    tsconfigPath,
+    fse.readFileSync(tsconfigPath, 'utf-8'),
+  );
+
+  if (result.error) {
+    throw new Error(
+      ts.flattenDiagnosticMessageText(result.error.messageText, '\n'),
+    );
+  }
+
+  return result.config;
+};
 
 export const createAndValidate = (
   cwd: string,
@@ -77,9 +96,15 @@ export const createAndValidate = (
   );
 
   // tsconfig
+  let tsconfig: Record<string, any> | undefined;
   if (templateCase.lang === 'ts') {
     expect(pkgJson.devDependencies.typescript).toBeTruthy();
     expect(existsSync(path.join(dir, 'tsconfig.json'))).toBeTruthy();
+    tsconfig = readTsconfig(path.join(dir, 'tsconfig.json'));
+
+    if (pkgJson.devDependencies['@types/node']) {
+      expect(tsconfig?.compilerOptions?.types?.includes('node')).toBe(true);
+    }
   }
 
   if (
@@ -87,10 +112,17 @@ export const createAndValidate = (
     (templateCase.template === 'react' || templateCase.template === 'vue')
   ) {
     const envDtsPath = path.join(dir, 'src/env.d.ts');
-    expect(existsSync(envDtsPath)).toBeTruthy();
-    expect(fse.readFileSync(envDtsPath, 'utf-8').trimEnd()).toBe(
-      '/// <reference types="@rslib/core/types" />',
-    );
+    const testDtsPath = path.join(dir, 'tests/test.d.ts');
+    const testsTsconfig = readTsconfig(path.join(dir, 'tests/tsconfig.json'));
+    const testsTypes = testsTsconfig.compilerOptions?.types;
+
+    expect(existsSync(envDtsPath)).toBe(false);
+    expect(existsSync(testDtsPath)).toBe(false);
+    expect(
+      tsconfig?.compilerOptions?.types?.includes('@rslib/core/types'),
+    ).toBe(true);
+    expect(testsTypes.includes('@rslib/core/types')).toBe(true);
+    expect(testsTypes.includes('@testing-library/jest-dom')).toBe(true);
   }
 
   expect(


### PR DESCRIPTION
## Summary

This PR moves create-rslib template type references from triple-slash `.d.ts` files into `compilerOptions.types` in generated `tsconfig.json` files.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
