### PR TITLE
docs: fix static assets examples

### DIFF
--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -28,7 +28,7 @@ import logo from './assets/logo.png';
 
 console.log(logo); // "/static/image/logo.png"
 
-export default = () => <img src={logo} />;
+export default () => <img src={logo} />;
 ```
 
 Import with **alias** is also available:
@@ -38,7 +38,7 @@ import logo from '@/assets/logo.png';
 
 console.log(logo); // "/static/image/logo.png"
 
-export default = () => <img src={logo} />;
+export default () => <img src={logo} />;
 ```
 
 When the [format](/config/lib/format) is set to `cjs` or `esm`, Rslib treats the output as an mid-level artifact that will be consumed by other build tools again and transforms the source file into a JavaScript file and a static asset file that is emitted according to [output.distPath](/config/rsbuild/output#outputdistpath) by default with preserving the `import` or `require` statements for static assets.

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -28,7 +28,7 @@ import logo from './assets/logo.png';
 
 console.log(logo); // "/static/image/logo.png"
 
-export default = () => <img src={logo} />;
+export default () => <img src={logo} />;
 ```
 
 也可以使用**路径别名**来引用：
@@ -38,7 +38,7 @@ import logo from '@/assets/logo.png';
 
 console.log(logo); // "/static/image/logo.png"
 
-export default = () => <img src={logo} />;
+export default () => <img src={logo} />;
 ```
 
 在 [format](/config/lib/format) 为 `cjs` 或 `esm` 时，Rslib 将产物视为会被其他打包工具再次消费的中间产物，默认会在代码转换时将源文件转化为一个 JavaScript 文件和一个根据 [output.distPath](/config/rsbuild/output#outputdistpath) 输出的静态资源文件，并保留引用静态资源的 `import` 或 `require` 语句。


### PR DESCRIPTION
## Summary

This PR fixes the static assets guide examples so the React component snippets use valid `export default () => ...` syntax in both English and Chinese docs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).