### PR TITLE
docs: update preset type configuration

### DIFF
--- a/website/docs/en/guide/advanced/json-files.mdx
+++ b/website/docs/en/guide/advanced/json-files.mdx
@@ -212,12 +212,16 @@ bar = "baz"
 
 ## Type declaration
 
-When you import YAML or TOML files in TypeScript code, please create a `src/env.d.ts` file in your project and add the corresponding type declarations.
+When you import YAML or TOML files in TypeScript code, use one of the following methods to add type declarations:
 
-- Method 1: If the `@rslib/core` package is installed, you can reference the [preset types](/guide/basic/typescript#preset-types) provided by `@rslib/core`:
+- Method 1: If the `@rslib/core` package is installed, you can add the [preset types](/guide/basic/typescript#preset-types) provided by `@rslib/core` to `tsconfig.json`:
 
-```ts title="src/env.d.ts"
-/// <reference types="@rslib/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rslib/core/types"]
+  }
+}
 ```
 
 - Method 2: Manually add the required type declarations:

--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -257,12 +257,16 @@ When you import static assets in TypeScript code, TypeScript may prompt that the
 TS2307: Cannot find module './logo.png' or its corresponding type declarations.
 ```
 
-To fix this, you need to add a type declaration file for the static assets, please create a `src/env.d.ts` file, and add the corresponding type declaration.
+To fix this, use one of the following methods:
 
-- Method 1: If the `@rslib/core` package is installed, you can reference the [preset types](/guide/basic/typescript#preset-types) provided by `@rslib/core`:
+- Method 1: If the `@rslib/core` package is installed, you can add the [preset types](/guide/basic/typescript#preset-types) provided by `@rslib/core` to `tsconfig.json`:
 
-```ts
-/// <reference types="@rslib/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rslib/core/types"]
+  }
+}
 ```
 
 - Method 2: Manually add the required type declarations:

--- a/website/docs/en/guide/basic/typescript.mdx
+++ b/website/docs/en/guide/basic/typescript.mdx
@@ -38,11 +38,19 @@ export type { SomeType } from './types';
 
 `@rslib/core` provides some preset type definitions, including CSS Modules, static assets, `import.meta` and other types.
 
-You can create a `src/env.d.ts` file to reference it:
+Add the preset types to [`compilerOptions.types`](https://www.typescriptlang.org/tsconfig/#types) in `tsconfig.json`:
 
-```ts title="src/env.d.ts"
-/// <reference types="@rslib/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rslib/core/types"]
+  }
+}
 ```
+
+If your project already has `compilerOptions.types`, append `@rslib/core/types` to the existing list.
+
+> Rslib's preset types are the same as Rsbuild's preset types. See Rsbuild's [types.d.ts](https://github.com/web-infra-dev/rsbuild/blob/main/packages/core/types.d.ts) for the complete type definitions.
 
 ## Type checking
 

--- a/website/docs/en/guide/migration/modernjs-module.mdx
+++ b/website/docs/en/guide/migration/modernjs-module.mdx
@@ -159,10 +159,14 @@ declare module '*.scss' {
 }
 ```
 
-or
+or add the [preset types](/guide/basic/typescript#preset-types) provided by `@rslib/core` to `tsconfig.json`:
 
-```ts title="src/env.d.ts"
-/// <reference types="@rslib/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rslib/core/types"]
+  }
+}
 ```
 
 ## CSS Modules

--- a/website/docs/zh/guide/advanced/json-files.mdx
+++ b/website/docs/zh/guide/advanced/json-files.mdx
@@ -209,12 +209,16 @@ bar = "baz"
 
 ## 类型声明
 
-当你在 TypeScript 代码中引用 YAML 或 TOML 文件时，请在项目中创建 `src/env.d.ts` 文件，并添加相应的类型声明。
+当你在 TypeScript 代码中引用 YAML 或 TOML 文件时，可以使用以下任一方法添加类型声明：
 
-- 方法一：如果项目里安装了 `@rslib/core` 包，你可以直接引用 `@rslib/core` 提供的 [预设类型](/guide/basic/typescript#预设类型)：
+- 方法一：如果项目里安装了 `@rslib/core` 包，你可以在 `tsconfig.json` 中添加 `@rslib/core` 提供的 [预设类型](/guide/basic/typescript#预设类型)：
 
-```ts title="src/env.d.ts"
-/// <reference types="@rslib/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rslib/core/types"]
+  }
+}
 ```
 
 - 方法二：手动添加需要的类型声明：

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -257,12 +257,16 @@ export default {
 TS2307: Cannot find module './logo.png' or its corresponding type declarations.
 ```
 
-此时你需要为静态资源添加类型声明文件，请在项目中创建 `src/env.d.ts` 文件，并添加相应的类型声明。
+此时你可以使用以下任一方法添加类型声明：
 
-- 方法一：如果项目里安装了 `@rslib/core` 包，你可以直接引用 `@rslib/core` 提供的 [预设类型](/guide/basic/typescript#预设类型)：
+- 方法一：如果项目里安装了 `@rslib/core` 包，你可以在 `tsconfig.json` 中添加 `@rslib/core` 提供的 [预设类型](/guide/basic/typescript#预设类型)：
 
-```ts
-/// <reference types="@rslib/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rslib/core/types"]
+  }
+}
 ```
 
 - 方法二：手动添加需要的类型声明：

--- a/website/docs/zh/guide/basic/typescript.mdx
+++ b/website/docs/zh/guide/basic/typescript.mdx
@@ -38,11 +38,19 @@ export type { SomeType } from './types';
 
 `@rslib/core` 提供了一些预设的类型定义，包含 CSS Modules、静态资源、`import.meta` 等类型。
 
-你可以创建一个 `src/env.d.ts` 文件来引用：
+你可以在 `tsconfig.json` 的 [`compilerOptions.types`](https://www.typescriptlang.org/tsconfig/#types) 中添加这些预设类型：
 
-```ts title="src/env.d.ts"
-/// <reference types="@rslib/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rslib/core/types"]
+  }
+}
 ```
+
+如果你的项目中已经配置了 `compilerOptions.types`，请将 `@rslib/core/types` 追加到已有列表中。
+
+> Rslib 的预设类型与 Rsbuild 的预设类型相同。参考 Rsbuild 的 [types.d.ts](https://github.com/web-infra-dev/rsbuild/blob/main/packages/core/types.d.ts) 来了解完整类型定义。
 
 ## 类型检查
 

--- a/website/docs/zh/guide/migration/modernjs-module.mdx
+++ b/website/docs/zh/guide/migration/modernjs-module.mdx
@@ -159,10 +159,14 @@ declare module '*.scss' {
 }
 ```
 
-或者
+或者在 `tsconfig.json` 中添加 `@rslib/core` 提供的 [预设类型](/guide/basic/typescript#预设类型)：
 
-```ts title="src/env.d.ts"
-/// <reference types="@rslib/core/types" />
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rslib/core/types"]
+  }
+}
 ```
 
 ## CSS Modules


### PR DESCRIPTION
## Summary

This PR updates the preset type documentation after `@rslib/core/types` is configured through `compilerOptions.types`. It replaces `src/env.d.ts` triple-slash reference examples with `tsconfig.json` snippets, clarifies that Rslib's preset types match Rsbuild's preset types, and updates the related YAML/TOML, static asset, and Modern.js migration docs in English and Chinese.

## Links

https://github.com/web-infra-dev/rslib/pull/1750

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).