### PR TITLE
refactor(core)!: remove advancedEsm experiment

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -357,13 +357,6 @@ export type Redirect = {
 
 export type LibExperiments = {
   /**
-   * Whether to enable Rspack advanced ESM output.
-   * @deprecated The advanced ESM output is now the default output for ESM format and this option has no effect. It will be removed in a future major version.
-   * @defaultValue `true`
-   * @see {@link https://rslib.rs/config/lib/experiments#experimentsadvancedesm}
-   */
-  advancedEsm?: boolean;
-  /**
    * Generate a Node.js single executable application alongside the JavaScript output.
    *
    * This option is only available for Node.js `esm` and `cjs` builds in bundle mode,

--- a/website/docs/en/config/lib/experiments.mdx
+++ b/website/docs/en/config/lib/experiments.mdx
@@ -6,47 +6,6 @@ description: 'Configure lib.experiments to enable experimental features and try 
 
 Used to enable some Rslib experimental features.
 
-## experiments.advancedEsm
-
-::: tip
-
-`experiments.advancedEsm` is deprecated since Rslib v0.20 and will be removed in v1. Advanced ESM output is now the default for ESM format, so this option has no effect.
-
-:::
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-Controls whether to enable Rspack experimental ESM output. When enabled, it emits ESM output that is high-quality, more friendly to static analysis, and supports code splitting.
-
-:::info
-Currently this option only takes effect in bundle mode when format is `'esm'`.
-:::
-
-If you need to disable this feature, you can set it to `false`:
-
-```js title="rslib.config.ts"
-export default {
-  lib: [
-    {
-      format: 'esm',
-      bundle: true,
-      experiments: {
-        advancedEsm: false,
-      },
-    },
-  ],
-};
-```
-
-### Version history
-
-| Version | Changes                                          |
-| ------- | ------------------------------------------------ |
-| v0.17.0 | Added this option                                |
-| v0.19.0 | Changed default value from `false` to `true`     |
-| v0.20.0 | Deprecated this option, no longer has any effect |
-
 ## experiments.exe
 
 Use [Node.js Single Executable Application](https://nodejs.org/api/single-executable-applications.html) to package the generated JavaScript output into an executable file.

--- a/website/docs/en/config/lib/index.mdx
+++ b/website/docs/en/config/lib/index.mdx
@@ -13,7 +13,7 @@ interface LibConfig extends EnvironmentConfig {
   banner?: BannerAndFooter;
   bundle?: boolean;
   dts?: Dts;
-  experiments?: { advancedEsm?: boolean };
+  experiments?: { exe?: ExeOptions };
   externalHelpers?: boolean;
   footer?: BannerAndFooter;
   format?: Format;

--- a/website/docs/zh/config/lib/experiments.mdx
+++ b/website/docs/zh/config/lib/experiments.mdx
@@ -6,47 +6,6 @@ description: '配置 lib.experiments，启用实验性特性并提前试用 Rsli
 
 用于开启 Rslib 的一些实验性的功能。
 
-## experiments.advancedEsm
-
-::: tip
-
-自 Rslib v0.20 版本起，`experiments.advancedEsm` 已被弃用，并将在 v1 版本中移除。高级 ESM 输出现已作为 ESM 格式的默认行为，因此该配置项已无实际效果。
-
-:::
-
-- **类型：** `boolean`
-- **默认值：** `true`
-
-控制是否启用 Rspack 实验性的 ESM 输出。开启后会生成高质量、对静态分析更友好并且支持代码分割的 ESM 输出。
-
-:::info
-目前该选项仅在 bundle 模式下且 format 为 `'esm'` 时生效。
-:::
-
-如果需要禁用该功能，可以将其设置为 `false`：
-
-```js title="rslib.config.ts"
-export default {
-  lib: [
-    {
-      format: 'esm',
-      bundle: true,
-      experiments: {
-        advancedEsm: false,
-      },
-    },
-  ],
-};
-```
-
-### 版本历史
-
-| 版本    | 变更内容                     |
-| ------- | ---------------------------- |
-| v0.17.0 | 新增该选项                   |
-| v0.19.0 | 默认值由 `false` 改为 `true` |
-| v0.20.0 | 弃用该选项，已无实际效果     |
-
 ## experiments.exe
 
 使用 [Node.js Single Executable Application](https://nodejs.org/api/single-executable-applications.html) 将生成的 JavaScript 产物打包为一个可执行文件。

--- a/website/docs/zh/config/lib/index.mdx
+++ b/website/docs/zh/config/lib/index.mdx
@@ -13,7 +13,7 @@ interface LibConfig extends EnvironmentConfig {
   banner?: BannerAndFooter;
   bundle?: boolean;
   dts?: Dts;
-  experiments?: { advancedEsm?: boolean };
+  experiments?: { exe?: ExeOptions };
   externalHelpers?: boolean;
   format?: Format;
   id?: string;


### PR DESCRIPTION
## Summary

This PR removes the deprecated `experiments.advancedEsm` public config from Rslib's core types as a v1 breaking change. Advanced ESM output is already the default behavior for ESM builds, so the docs now remove the obsolete option and show `experiments.exe` as the remaining `lib.experiments` setting.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).