### PR TITLE
refactor(core): replace tsconfck with get-tsconfig

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "cac": "^7.0.0",
     "chokidar": "^5.0.0",
     "fs-extra": "^11.3.6",
+    "get-tsconfig": "5.0.0-beta.5",
     "memfs": "^4.57.8",
     "path-serializer": "0.6.0",
     "prebundle": "1.6.5",
@@ -61,7 +62,6 @@
     "rslog": "^2.1.3",
     "semver": "^7.8.5",
     "tinyglobby": "^0.2.17",
-    "tsconfck": "3.1.6",
     "typescript": "^6.0.3"
   },
   "peerDependencies": {

--- a/packages/core/src/utils/tsconfig.ts
+++ b/packages/core/src/utils/tsconfig.ts
@@ -1,5 +1,13 @@
-import { basename, join } from 'node:path';
-import { find, parse } from 'tsconfck';
+import { statSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+
+const isFileSync = (filePath: string): boolean | undefined => {
+  try {
+    return statSync(filePath, { throwIfNoEntry: false })?.isFile();
+  } catch {
+    return false;
+  }
+};
 
 export async function loadTsconfig(
   root: string,
@@ -7,14 +15,16 @@ export async function loadTsconfig(
 ): Promise<{
   compilerOptions?: Record<string, any>;
 }> {
-  const tsconfigFileName = await find(join(root, tsconfigPath), {
-    root,
-    configName: basename(tsconfigPath),
-  });
+  const resolvedTsconfigPath = isAbsolute(tsconfigPath)
+    ? tsconfigPath
+    : join(root, tsconfigPath);
 
-  if (tsconfigFileName) {
-    const { tsconfig } = await parse(tsconfigFileName);
-    return tsconfig;
+  if (isFileSync(resolvedTsconfigPath)) {
+    const { readTsconfig } = await import('get-tsconfig');
+
+    return readTsconfig(resolvedTsconfigPath, {
+      typescriptVersion: false,
+    }).config;
   }
 
   return {};

--- a/packages/core/tests/fixtures/tsconfig/exist/tsconfig.custom.json
+++ b/packages/core/tests/fixtures/tsconfig/exist/tsconfig.custom.json
@@ -1,5 +1,5 @@
 {
   "compilerOptions": {
-    "rootDir": "custom"
+    "rootDir": "./custom"
   }
 }

--- a/packages/core/tests/tsconfig.test.ts
+++ b/packages/core/tests/tsconfig.test.ts
@@ -8,20 +8,16 @@ describe('loadTsconfig', () => {
     const result1 = await loadTsconfig(fixtureDir);
     const result2 = await loadTsconfig(fixtureDir, './tsconfig.custom.json');
 
-    expect(result1).toMatchInlineSnapshot(`
-      {
-        "compilerOptions": {
-          "rootDir": "./",
-        },
-      }
-    `);
-    expect(result2).toMatchInlineSnapshot(`
-      {
-        "compilerOptions": {
-          "rootDir": "custom",
-        },
-      }
-    `);
+    expect(result1).toEqual({
+      compilerOptions: {
+        rootDir: './',
+      },
+    });
+    expect(result2).toEqual({
+      compilerOptions: {
+        rootDir: './custom',
+      },
+    });
   });
 
   it('should return an empty object when no tsconfig file is found', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       fs-extra:
         specifier: ^11.3.6
         version: 11.3.6
+      get-tsconfig:
+        specifier: 5.0.0-beta.5
+        version: 5.0.0-beta.5
       memfs:
         specifier: ^4.57.8
         version: 4.57.8
@@ -380,9 +383,6 @@ importers:
       tinyglobby:
         specifier: ^0.2.17
         version: 0.2.17
-      tsconfck:
-        specifier: 3.1.6
-        version: 3.1.6(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -7363,17 +7363,6 @@ packages:
   ts-morph@27.0.2:
     resolution: {integrity: sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -14326,10 +14315,6 @@ snapshots:
     dependencies:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
-
-  tsconfck@3.1.6(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
 
   tsconfig-paths@4.2.0:
     dependencies:

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -147,7 +147,6 @@ tinyglobby
 transpiling
 treeshaking
 tsbuildinfo
-tsconfck
 tsdoc
 tsdown
 tsgo


### PR DESCRIPTION
## Summary

Replace `tsconfck` in `@rslib/core` with `get-tsconfig` because `tsconfck` is unmaintained. Rslib now resolves `source.tsconfigPath` the same way Rsbuild does, loads `get-tsconfig` dynamically only when a tsconfig file exists, and opts out of TypeScript-version defaults to preserve the existing compiler options behavior.

## Related Links

https://github.com/dominikg/tsconfck/issues/240

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).