### PR TITLE
chore(plugin-dts): require Rsbuild 2 peer

### DIFF
--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "@microsoft/api-extractor": "^7",
-    "@rsbuild/core": "^1.0.0 || ^2.0.0-0",
+    "@rsbuild/core": "^2.0.0",
     "@typescript/native-preview": "^7.0.0-0",
     "typescript": "^5 || ^6 || ^7.0.1-0"
   },


### PR DESCRIPTION
## Summary

This PR updates `rsbuild-plugin-dts` to declare `@rsbuild/core` `^2.0.0` as its peer dependency. The package is typically used together with Rslib, and Rslib already uses Rsbuild v2 by default, so this aligns the peer range with the default Rslib setup.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
