### PR TITLE
docs: use latest TypeScript for tsgo

### DIFF
--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -301,7 +301,7 @@ Whether to generate declaration files with [TypeScript Go](https://github.com/mi
 After installing TypeScript 7 or higher, Rslib will automatically enable this option.
 
 ```bash
-npm add typescript@rc -D
+npm add typescript@latest -D
 ```
 
 You can also install [@typescript/native-preview](https://www.npmjs.com/package/@typescript/native-preview) and manually enable this option.
@@ -316,7 +316,7 @@ pluginDts({
 });
 ```
 
-> The `@typescript/native-preview` usage is deprecated and kept only for compatibility. Prefer installing `typescript@rc` to use tsgo.
+> The `@typescript/native-preview` usage is deprecated and kept only for compatibility. Prefer installing `typescript@latest` to use tsgo.
 
 To ensure consistency during local development, you need to install the corresponding [VS Code Preview Extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview) and add the following setting to VS Code:
 

--- a/packages/plugin-dts/src/tsgo.ts
+++ b/packages/plugin-dts/src/tsgo.ts
@@ -36,8 +36,7 @@ type DtsExecutableCommand = {
 const getDtsExecutablePath = async (
   cwd: string,
   packageName:
-    | typeof TYPESCRIPT_PACKAGE_NAME
-    | typeof NATIVE_PREVIEW_PACKAGE_NAME,
+    typeof TYPESCRIPT_PACKAGE_NAME | typeof NATIVE_PREVIEW_PACKAGE_NAME,
 ): Promise<string> => {
   let packageJsonPath: string;
 
@@ -48,12 +47,12 @@ const getDtsExecutablePath = async (
   } catch {
     if (packageName === NATIVE_PREVIEW_PACKAGE_NAME) {
       throw new Error(
-        'Failed to resolve @typescript/native-preview. Install "typescript@rc" or "@typescript/native-preview" to use TypeScript Go.',
+        'Failed to resolve @typescript/native-preview. Install "typescript@latest" or "@typescript/native-preview" to use TypeScript Go.',
       );
     }
 
     throw new Error(
-      'Failed to resolve typescript. Install "typescript@rc" to use TypeScript Go.',
+      'Failed to resolve typescript. Install "typescript@latest" to use TypeScript Go.',
     );
   }
 

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -279,7 +279,7 @@ Whether to generate declaration files with [TypeScript Go](https://github.com/mi
 
 After installing TypeScript 7 or higher, Rslib will automatically enable this option.
 
-<PackageManagerTabs command="add typescript@rc -D" />
+<PackageManagerTabs command="add typescript@latest -D" />
 
 You can also install [@typescript/native-preview](https://www.npmjs.com/package/@typescript/native-preview) and manually enable this option.
 
@@ -299,7 +299,7 @@ export default {
 
 :::note
 
-The `@typescript/native-preview` usage is deprecated and kept only for compatibility. Prefer installing `typescript@rc` to use tsgo.
+The `@typescript/native-preview` usage is deprecated and kept only for compatibility. Prefer installing `typescript@latest` to use tsgo.
 
 :::
 

--- a/website/docs/en/guide/advanced/dts.mdx
+++ b/website/docs/en/guide/advanced/dts.mdx
@@ -89,7 +89,7 @@ Using [TypeScript Go](https://github.com/microsoft/typescript-go) to generate de
 
 After installing TypeScript 7 or higher, Rslib will automatically enable [dts.tsgo](/config/lib/dts#dtstsgo).
 
-<PackageManagerTabs command="add typescript@rc -D" />
+<PackageManagerTabs command="add typescript@latest -D" />
 
 You can also install `@typescript/native-preview` and enable `dts.tsgo` in the Rslib config file.
 
@@ -109,7 +109,7 @@ export default {
 
 :::note
 
-The `@typescript/native-preview` usage is deprecated and kept only for compatibility. Prefer installing `typescript@rc` to use tsgo.
+The `@typescript/native-preview` usage is deprecated and kept only for compatibility. Prefer installing `typescript@latest` to use tsgo.
 
 :::
 

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -279,7 +279,7 @@ export default {
 
 安装 TypeScript 7 或更高版本后，Rslib 会自动开启该选项。
 
-<PackageManagerTabs command="add typescript@rc -D" />
+<PackageManagerTabs command="add typescript@latest -D" />
 
 你也可以安装 [@typescript/native-preview](https://www.npmjs.com/package/@typescript/native-preview)，并手动开启该选项。
 
@@ -298,7 +298,7 @@ export default {
 ```
 
 :::note
-`@typescript/native-preview` 的用法已废弃，仅作为兼容方式保留，推荐安装 `typescript@rc` 使用 tsgo。
+`@typescript/native-preview` 的用法已废弃，仅作为兼容方式保留，推荐安装 `typescript@latest` 使用 tsgo。
 :::
 
 为了保证本地开发的一致性，你需要安装对应的 [VS Code 预览版扩展](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview)，并在 VS Code 设置中添加如下配置：

--- a/website/docs/zh/guide/advanced/dts.mdx
+++ b/website/docs/zh/guide/advanced/dts.mdx
@@ -89,7 +89,7 @@ export default {
 
 安装 TypeScript 7 或更高版本后，Rslib 会自动开启 [dts.tsgo](/config/lib/dts#dtstsgo)。
 
-<PackageManagerTabs command="add typescript@rc -D" />
+<PackageManagerTabs command="add typescript@latest -D" />
 
 你也可以安装 `@typescript/native-preview`，并在 Rslib 配置文件中开启 `dts.tsgo`。
 
@@ -108,7 +108,7 @@ export default {
 ```
 
 :::note
-`@typescript/native-preview` 的用法已废弃，仅作为兼容方式保留，推荐安装 `typescript@rc` 使用 tsgo。
+`@typescript/native-preview` 的用法已废弃，仅作为兼容方式保留，推荐安装 `typescript@latest` 使用 tsgo。
 :::
 
 为了保证本地开发的一致性，你需要安装对应的 [VS Code 预览版扩展](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview)，并在 VS Code 设置中添加如下配置：


### PR DESCRIPTION
## Summary

This PR updates the TypeScript Go installation guidance for v0.x docs, the plugin README, and tsgo missing-package messages now that TypeScript 7 has been announced. It replaces `typescript@rc` with `typescript@latest` while keeping `@typescript/native-preview` as the deprecated compatibility fallback.

## Related Links

https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).