### PR TITLE
refactor(types): simplify mergeRslibConfig types

### DIFF
--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -1,10 +1,6 @@
 import { mergeRsbuildConfig } from '@rsbuild/core';
 import type { LibConfig, RslibConfig } from './types';
 
-export type RslibConfigWithOptionalLib = Omit<RslibConfig, 'lib'> & {
-  lib?: RslibConfig['lib'];
-};
-
 /**
  * Merge multiple lib arrays, merging items with the same id.
  * Items without id are appended to the result.
@@ -53,10 +49,10 @@ function mergeLibConfigs(
  * Other configuration fields are merged using `mergeRsbuildConfig`.
  */
 export function mergeRslibConfig(
-  ...originalConfigs: (RslibConfigWithOptionalLib | undefined)[]
-): RslibConfigWithOptionalLib {
+  ...originalConfigs: (RslibConfig | undefined)[]
+): RslibConfig {
   const definedConfigs = originalConfigs.filter(
-    (config): config is RslibConfigWithOptionalLib => config !== undefined,
+    (config): config is RslibConfig => config !== undefined,
   );
 
   if (definedConfigs.length === 0) {
@@ -73,9 +69,7 @@ export function mergeRslibConfig(
   });
 
   // Merge non-lib parts using mergeRsbuildConfig
-  const mergedConfig = mergeRsbuildConfig(
-    ...configsWithoutLib,
-  ) as RslibConfigWithOptionalLib;
+  const mergedConfig = mergeRsbuildConfig(...configsWithoutLib) as RslibConfig;
 
   // Merge lib arrays with id-based merging
   const mergedLib = mergeLibConfigs(...libArrays);

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -13,10 +13,7 @@ import {
 } from '../src/config';
 import { createRslib } from '../src/createRslib';
 import { loadConfig } from '../src/loadConfig';
-import {
-  mergeRslibConfig,
-  type RslibConfigWithOptionalLib,
-} from '../src/mergeConfig';
+import { mergeRslibConfig } from '../src/mergeConfig';
 import type { RslibConfig } from '../src/types/config';
 
 rs.mock('rslog');
@@ -273,7 +270,7 @@ describe('Should merge Rslib config correctly', () => {
       },
     };
 
-    const config2: RslibConfigWithOptionalLib = {
+    const config2: RslibConfig = {
       output: {
         target: 'web',
       },

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -181,9 +181,7 @@ The `mergeRslibConfig` function takes multiple configuration objects as paramete
 - **Type:**
 
 ```ts
-function mergeRslibConfig(
-  ...configs: (RslibConfigWithOptionalLib | undefined)[]
-): RslibConfigWithOptionalLib;
+function mergeRslibConfig(...configs: (RslibConfig | undefined)[]): RslibConfig;
 ```
 
 ### Basic example

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -181,9 +181,7 @@ Rslib 的 `loadConfig` 与 Rsbuild 的用法基本一致，区别在于默认查
 - **类型：**
 
 ```ts
-function mergeRslibConfig(
-  ...configs: (RslibConfigWithOptionalLib | undefined)[]
-): RslibConfigWithOptionalLib;
+function mergeRslibConfig(...configs: (RslibConfig | undefined)[]): RslibConfig;
 ```
 
 ### 基础示例


### PR DESCRIPTION
## Summary

`RslibConfig` now allows `lib` to be omitted after #1756, making the internal `RslibConfigWithOptionalLib` type redundant. This PR updates `mergeRslibConfig` to use the public `RslibConfig` type directly and synchronizes the English and Chinese API documentation. There is no runtime behavior change.

## Related Links

- #1756

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).