### PR TITLE
fix(core): correct CLI subcommand help

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -229,13 +229,17 @@ export function setupCommands(argv: string[]): void {
     // remove the default version log as we already log it in greeting
     sections.shift();
 
+    const commandName = cli.matchedCommandName;
+    sections = sections.filter(
+      ({ title }) =>
+        !commandName ||
+        (title !== 'Commands' && !title?.startsWith('For more info')),
+    );
+
     for (const section of sections) {
       // Fix the command usage
       if (section.title === 'Usage') {
-        section.body = section.body.replace(
-          '$ rslib',
-          color.yellow('$ rslib [command] [options]'),
-        );
+        section.body = `  ${color.yellow(`$ rslib ${commandName || '[command]'} [options]`)}`;
       }
 
       // Fix the build command name
@@ -246,7 +250,7 @@ export function setupCommands(argv: string[]): void {
         );
       }
 
-      // Simplify the help output for sub-commands
+      // Simplify the root help instructions for sub-commands
       if (section.title?.startsWith('For more info')) {
         section.title = color.dim('  For details on a sub-command, run');
         section.body = color.dim('  $ rslib <command> -h');
@@ -254,6 +258,8 @@ export function setupCommands(argv: string[]): void {
         section.title = color.cyan(section.title);
       }
     }
+
+    return sections;
   });
 
   cli.parse(argv);

--- a/tests/integration/cli/help/__snapshots__/index.test.ts.snap
+++ b/tests/integration/cli/help/__snapshots__/index.test.ts.snap
@@ -1,0 +1,113 @@
+// Rstest Snapshot v1
+
+exports[`should show build help 1`] = `
+"Rslib v<version>
+
+Usage:
+  $ rslib build [options]
+
+Options:
+  -w, --watch               turn on watch mode, watch for changes and rebuild
+  --entry <entry>           set entry file or pattern (repeatable) (default: )
+  --dist-path <dir>         set output directory
+  --bundle                  enable bundle mode (use --no-bundle to disable)
+  --format <format>         specify the output format (esm | cjs | umd | mf | iife)
+  --syntax <syntax>         set build syntax target (repeatable)
+  --target <target>         set runtime target (web | node)
+  --dts                     emit declaration files (use --no-dts to disable)
+  --externals <pkg>         add package to externals (repeatable) (default: )
+  --minify                  minify output (use --no-minify to disable)
+  --clean                   clean output directory before build (use --no-clean to disable)
+  --auto-extension          control automatic extension redirect (use --no-auto-extension to disable)
+  --auto-external           control automatic dependency externalization (use --no-auto-external to disable)
+  --tsconfig <path>         use specific tsconfig (relative to project root)
+  -v, --version             Display version number
+  -c, --config <config>     specify the configuration file, can be a relative or absolute path
+  --config-loader <loader>  Set the config file loader (auto | jiti | native) (default: auto)
+  -r, --root <root>         specify the project root directory, can be an absolute path or a path relative to cwd
+  --env-mode <mode>         specify the env mode to load the \`.env.[mode]\` file
+  --env-dir <dir>           specify the directory to load \`.env\` files
+  --log-level <level>       set the log level (info | warn | error | silent)
+  --lib <id>                specify the library (repeatable, e.g. --lib esm --lib cjs) (default: )
+  --no-env                  Disable loading of \`.env\` files (default: true)
+  -h, --help                Display this message"
+`;
+
+exports[`should show inspect help 1`] = `
+"Rslib v<version>
+
+Usage:
+  $ rslib inspect [options]
+
+Options:
+  --output <output>         specify inspect content output path (default: .rsbuild)
+  --verbose                 show full function definitions in output
+  -c, --config <config>     specify the configuration file, can be a relative or absolute path
+  --config-loader <loader>  Set the config file loader (auto | jiti | native) (default: auto)
+  -r, --root <root>         specify the project root directory, can be an absolute path or a path relative to cwd
+  --env-mode <mode>         specify the env mode to load the \`.env.[mode]\` file
+  --env-dir <dir>           specify the directory to load \`.env\` files
+  --log-level <level>       set the log level (info | warn | error | silent)
+  --lib <id>                specify the library (repeatable, e.g. --lib esm --lib cjs) (default: )
+  --no-env                  Disable loading of \`.env\` files (default: true)
+  -h, --help                Display this message"
+`;
+
+exports[`should show mf-dev help 1`] = `
+"Rslib v<version>
+
+Usage:
+  $ rslib mf-dev [options]
+
+Options:
+  -c, --config <config>     specify the configuration file, can be a relative or absolute path
+  --config-loader <loader>  Set the config file loader (auto | jiti | native) (default: auto)
+  -r, --root <root>         specify the project root directory, can be an absolute path or a path relative to cwd
+  --env-mode <mode>         specify the env mode to load the \`.env.[mode]\` file
+  --env-dir <dir>           specify the directory to load \`.env\` files
+  --log-level <level>       set the log level (info | warn | error | silent)
+  --lib <id>                specify the library (repeatable, e.g. --lib esm --lib cjs) (default: )
+  --no-env                  Disable loading of \`.env\` files (default: true)
+  -h, --help                Display this message"
+`;
+
+exports[`should show root help 1`] = `
+"Rslib v<version>
+
+Usage:
+  $ rslib [command] [options]
+
+Commands:
+  build    build the library for production (default if no command is given)
+  inspect  inspect the Rsbuild / Rspack configs of Rslib projects
+  mf-dev   start Rsbuild dev server of Module Federation format
+
+  For details on a sub-command, run:
+  $ rslib <command> -h
+
+Options:
+  -w, --watch               turn on watch mode, watch for changes and rebuild
+  --entry <entry>           set entry file or pattern (repeatable) (default: )
+  --dist-path <dir>         set output directory
+  --bundle                  enable bundle mode (use --no-bundle to disable)
+  --format <format>         specify the output format (esm | cjs | umd | mf | iife)
+  --syntax <syntax>         set build syntax target (repeatable)
+  --target <target>         set runtime target (web | node)
+  --dts                     emit declaration files (use --no-dts to disable)
+  --externals <pkg>         add package to externals (repeatable) (default: )
+  --minify                  minify output (use --no-minify to disable)
+  --clean                   clean output directory before build (use --no-clean to disable)
+  --auto-extension          control automatic extension redirect (use --no-auto-extension to disable)
+  --auto-external           control automatic dependency externalization (use --no-auto-external to disable)
+  --tsconfig <path>         use specific tsconfig (relative to project root)
+  -v, --version             Display version number
+  -c, --config <config>     specify the configuration file, can be a relative or absolute path
+  --config-loader <loader>  Set the config file loader (auto | jiti | native) (default: auto)
+  -r, --root <root>         specify the project root directory, can be an absolute path or a path relative to cwd
+  --env-mode <mode>         specify the env mode to load the \`.env.[mode]\` file
+  --env-dir <dir>           specify the directory to load \`.env\` files
+  --log-level <level>       set the log level (info | warn | error | silent)
+  --lib <id>                specify the library (repeatable, e.g. --lib esm --lib cjs) (default: )
+  --no-env                  Disable loading of \`.env\` files (default: true)
+  -h, --help                Display this message"
+`;

--- a/tests/integration/cli/help/index.test.ts
+++ b/tests/integration/cli/help/index.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@rstest/core';
+import { runCliSync } from 'test-helper';
+
+const normalizeHelp = (output: string) =>
+  output
+    .replace(/^Rslib v.+$/m, 'Rslib v<version>')
+    .replace(/[ \t]+$/gm, '')
+    .trim();
+
+for (const [name, command] of [
+  ['root', '-h'],
+  ['build', 'build -h'],
+  ['inspect', 'inspect -h'],
+  ['mf-dev', 'mf-dev -h'],
+] as const) {
+  test(`should show ${name} help`, () => {
+    const { status, stdout } = runCliSync(command);
+
+    expect(status).toBe(0);
+    expect(normalizeHelp(stdout)).toMatchSnapshot();
+  });
+}


### PR DESCRIPTION
## Summary

`rslib build -h` currently renders the root command list because `build` is also registered as the default command. This PR makes help output command-aware so each subcommand displays the correct usage and adds snapshot coverage for the CLI help output.

## Before / After

`rslib build -h`:

```diff
 Usage:
-  $ rslib [command] [options]
-
-Commands:
-  build    build the library for production (default if no command is given)
-  inspect  inspect the Rsbuild / Rspack configs of Rslib projects
-  mf-dev   start Rsbuild dev server of Module Federation format
-
-  For details on a sub-command, run:
-  $ rslib <command> -h
+  $ rslib build [options]
```

Other subcommands now use the standard command-first syntax:

```diff
-  $ rslib [command] [options] inspect
+  $ rslib inspect [options]

-  $ rslib [command] [options] mf-dev
+  $ rslib mf-dev [options]
```

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).