### PR TITLE
feat(core): support reload-server watch files

### DIFF
--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -5,11 +5,31 @@ import { debounce, isTTY } from './utils/helper';
 import { logger } from './utils/logger';
 
 export function getWatchFilesForRestart(rslib: RslibInstance): string[] {
-  const meta = rslib.getRslibConfig()._privateMeta;
-  if (!meta) {
-    return [];
+  const { _privateMeta: meta, dev } = rslib.getRslibConfig();
+  const files: string[] = [];
+
+  if (meta) {
+    files.push(meta.configFilePath, ...(meta.envFilePaths || []));
   }
-  return [meta.configFilePath, ...(meta.envFilePaths || [])].filter(Boolean);
+
+  const watchConfig = dev?.watchFiles;
+  if (!watchConfig) {
+    return files;
+  }
+
+  const configs = Array.isArray(watchConfig) ? watchConfig : [watchConfig];
+  for (const { paths, type } of configs) {
+    if (type !== 'reload-server') {
+      continue;
+    }
+    if (Array.isArray(paths)) {
+      files.push(...paths);
+    } else {
+      files.push(paths);
+    }
+  }
+
+  return files;
 }
 
 export async function watchFilesForRestart(

--- a/packages/core/tests/restart.test.ts
+++ b/packages/core/tests/restart.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@rstest/core';
+import { getWatchFilesForRestart } from '../src/restart';
+import type { RslibInstance } from '../src/types';
+
+test('should get files for restart', () => {
+  const rslib = {
+    getRslibConfig: () => ({
+      _privateMeta: {
+        configFilePath: 'rslib.config.ts',
+        envFilePaths: ['.env'],
+      },
+      dev: {
+        watchFiles: [
+          {
+            paths: 'rstack.config.ts',
+            type: 'reload-server',
+          },
+          {
+            paths: ['shared.ts', 'constants.ts'],
+            type: 'reload-server',
+          },
+          {
+            paths: 'index.html',
+            type: 'reload-page',
+          },
+        ],
+      },
+    }),
+  } as RslibInstance;
+
+  expect(getWatchFilesForRestart(rslib)).toEqual([
+    'rslib.config.ts',
+    '.env',
+    'rstack.config.ts',
+    'shared.ts',
+    'constants.ts',
+  ]);
+});


### PR DESCRIPTION
## Summary

This PR makes the Rslib CLI restart its watch process when `dev.watchFiles` entries use `type: 'reload-server'`, allowing tools such as Rstack to reload after `rstack.config.*` changes. Existing Rslib config and env file restart behavior is preserved.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).