### PR TITLE
feat(deps): upgrade rsbuild to 2.1.6

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.7.0",
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -22,7 +22,7 @@
     "@module-federation/enhanced": "^2.7.0",
     "@module-federation/rsbuild-plugin": "^2.7.0",
     "@module-federation/storybook-addon": "^6.0.15",
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.5.0",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.7.0",
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "test": "rstest"
   },
   "dependencies": {
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@storybook/addon-docs": "^10.5.0",
     "@storybook/addon-onboarding": "^10.5.0",
     "@storybook/react": "^10.5.0",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@storybook/addon-docs": "^10.5.0",
     "@storybook/addon-onboarding": "^10.5.0",
     "@storybook/react": "^10.5.0",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@storybook/addon-docs": "^10.5.0",
     "@storybook/addon-onboarding": "^10.5.0",
     "@storybook/vue3": "^10.5.0",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@storybook/addon-docs": "^10.5.0",
     "@storybook/addon-onboarding": "^10.5.0",
     "@storybook/vue3": "^10.5.0",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.9",
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@rslib/tsconfig": "workspace:*",
     "get-tsconfig": "5.0.0-beta.5",
     "magic-string": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 0.11.1(@rslib/core@1.0.0-beta.0)(@rstest/core@0.11.1)(typescript@6.0.3)
       '@rstest/core':
         specifier: ^0.11.1
-        version: 0.11.1
+        version: 0.11.1(@module-federation/runtime-tools@2.7.0)
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -77,13 +77,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.7.0
-        version: 2.7.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)
+        version: 2.7.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@rsbuild/core':
-        specifier: ~2.1.5
-        version: 2.1.5(@module-federation/runtime-tools@2.7.0)
+        specifier: ~2.1.6
+        version: 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -98,19 +98,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.7.0
-        version: 2.7.0(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)
+        version: 2.7.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.7.0
-        version: 2.7.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)
+        version: 2.7.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/storybook-addon':
         specifier: ^6.0.15
-        version: 6.0.15(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(storybook@10.5.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)
+        version: 6.0.15(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(storybook@10.5.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
-        specifier: ~2.1.5
-        version: 2.1.5(@module-federation/runtime-tools@2.7.0)
+        specifier: ~2.1.6
+        version: 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -137,13 +137,13 @@ importers:
         version: 19.2.7(react@19.2.7)
       storybook:
         specifier: ^10.5.0
-        version: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+        version: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.6)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -159,13 +159,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.7.0
-        version: 2.7.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)
+        version: 2.7.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@rsbuild/core':
-        specifier: ~2.1.5
-        version: 2.1.5(@module-federation/runtime-tools@2.7.0)
+        specifier: ~2.1.6
+        version: 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -180,10 +180,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(preact@10.29.7)
+        version: 2.0.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(preact@10.29.7)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)
+        version: 2.0.1(@rsbuild/core@2.1.6)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -195,10 +195,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)
+        version: 2.0.1(@rsbuild/core@2.1.6)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -213,10 +213,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)
+        version: 2.0.1(@rsbuild/core@2.1.6)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -231,10 +231,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)
+        version: 2.0.1(@rsbuild/core@2.1.6)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -249,13 +249,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)
+        version: 2.0.1(@rsbuild/core@2.1.6)
       '@rsbuild/plugin-solid':
         specifier: ^1.2.2
-        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.5)(solid-js@1.9.14)
+        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.6)(solid-js@1.9.14)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -270,7 +270,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(vue@3.5.39)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.39)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -287,11 +287,11 @@ importers:
   examples/vue-component-bundleless:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.5
-        version: 2.1.5(@module-federation/runtime-tools@2.7.0)
+        specifier: ~2.1.6
+        version: 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(vue@3.5.39)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.39)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -306,13 +306,13 @@ importers:
         version: 10.5.0(storybook@10.5.0)(vue@3.5.39)
       storybook:
         specifier: ^10.5.0
-        version: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+        version: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.6)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)(vue@3.5.39)
+        version: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)(vue@3.5.39)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -326,15 +326,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~2.1.5
-        version: 2.1.5(@module-federation/runtime-tools@2.7.0)
+        specifier: ~2.1.6
+        version: 2.1.6(@module-federation/runtime-tools@2.7.0)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.7.0
-        version: 2.7.0(@rsbuild/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)
+        version: 2.7.0(@rsbuild/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -364,7 +364,7 @@ importers:
         version: 0.6.0
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.5)
+        version: 1.0.0(@rsbuild/core@2.1.6)
       rslib:
         specifier: npm:@rslib/core@0.23.2
         version: '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.7.0)(typescript@7.0.2)'
@@ -401,7 +401,7 @@ importers:
         version: 11.3.6
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.5)
+        version: 1.0.0(@rsbuild/core@2.1.6)
       rslib:
         specifier: npm:@rslib/core@0.23.2
         version: '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.7.0)(typescript@7.0.2)'
@@ -422,8 +422,8 @@ importers:
         specifier: ^7.58.9
         version: 7.58.9(@types/node@25.2.0)
       '@rsbuild/core':
-        specifier: ~2.1.5
-        version: 2.1.5(@module-federation/runtime-tools@2.7.0)
+        specifier: ~2.1.6
+        version: 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -435,7 +435,7 @@ importers:
         version: 1.0.0
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.5)
+        version: 1.0.0(@rsbuild/core@2.1.6)
       rslib:
         specifier: npm:@rslib/core@0.23.2
         version: '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.7.0)(typescript@7.0.2)'
@@ -468,34 +468,34 @@ importers:
         version: 4.0.1
       '@module-federation/rsbuild-plugin':
         specifier: ^2.7.0
-        version: 2.7.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)
+        version: 2.7.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@playwright/test':
         specifier: 1.61.1
         version: 1.61.1
       '@rsbuild/core':
-        specifier: ~2.1.5
-        version: 2.1.5(@module-federation/runtime-tools@2.7.0)
+        specifier: ~2.1.6
+        version: 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@rsbuild/plugin-less':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)
+        version: 2.0.1(@rsbuild/core@2.1.6)
       '@rsbuild/plugin-toml':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)
+        version: 2.0.1(@rsbuild/core@2.1.6)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.4
-        version: 1.2.4(@rsbuild/core@2.1.5)
+        version: 1.2.4(@rsbuild/core@2.1.6)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(vue@3.5.39)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.39)
       '@rsbuild/plugin-yaml':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.5)
+        version: 2.0.0(@rsbuild/core@2.1.6)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -572,7 +572,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
 
   tests/integration/asset/json: {}
 
@@ -588,10 +588,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.5
-        version: 2.0.5(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@7.0.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -685,10 +685,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.5
-        version: 2.0.5(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@7.0.2)
 
   tests/integration/cli/build: {}
 
@@ -995,11 +995,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.5
-        version: 2.1.5(@module-federation/runtime-tools@2.7.0)
+        specifier: ~2.1.6
+        version: 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.1.5)
+        version: 1.4.6(@rsbuild/core@2.1.6)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -1008,11 +1008,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.5
-        version: 2.1.5(@module-federation/runtime-tools@2.7.0)
+        specifier: ~2.1.6
+        version: 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.1.5)
+        version: 1.4.6(@rsbuild/core@2.1.6)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1049,7 +1049,7 @@ importers:
         version: 8.0.1
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       babel-plugin-polyfill-corejs3:
         specifier: ^1.0.0
         version: 1.0.0(@babel/core@8.0.1)
@@ -1062,7 +1062,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1203,19 +1203,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.0.3(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -1224,7 +1224,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.0.3(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -1272,10 +1272,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(vue@3.5.39)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.39)
       vue:
         specifier: ^3.5.39
         version: 3.5.39(typescript@7.0.2)
@@ -1292,16 +1292,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.7.0
-        version: 2.7.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)
+        version: 2.7.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@rsbuild/core':
-        specifier: ~2.1.5
-        version: 2.1.5(@module-federation/runtime-tools@2.7.0)
+        specifier: ~2.1.6
+        version: 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.5)
+        version: 2.0.1(@rsbuild/core@2.1.6)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1310,7 +1310,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 2.0.17
-        version: 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 2.0.17
         version: 2.0.17(@rspress/core@2.0.17)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
@@ -1349,10 +1349,10 @@ importers:
         version: 19.2.7(react@19.2.7)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.6
-        version: 1.0.6(@rsbuild/core@2.1.5)
+        version: 1.0.6(@rsbuild/core@2.1.6)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.1.5)
+        version: 1.1.3(@rsbuild/core@2.1.6)
       rspress-plugin-file-tree:
         specifier: ^1.0.5
         version: 1.0.5(@rspress/core@2.0.17)
@@ -1775,11 +1775,17 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -2643,6 +2649,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.1.6':
+    resolution: {integrity: sha512-w2WxblstOgHnDElkqJZVO/jM/EqPaEhg7zqQhON3Xu3Mj9FlVOJx+SgimOtghFzxLt8x7atX4oMUtMTNSZGf0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.2.1':
     resolution: {integrity: sha512-6Zad7Ff/RUNc91AtftemJcJ1wcZRGOiwuJy349qlLJl9F++oRYwUhx+MxLSpNnVeIywWx2mKdZZBtD1hLqfj9w==}
     peerDependencies:
@@ -2858,13 +2874,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.1.4':
+    resolution: {integrity: sha512-3Xcs01iw48F4WeE4SHga6bCNb/UEFvtQX4P4eMIaJfGPjTQuxfabGE8yCPm9e3tpLZ5uo+IBnJ6nh5r6tIDOXQ==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.1.3':
     resolution: {integrity: sha512-sVqWXNiFTMXAyN362y6IA+eJc8LXZKfHdhEJ/zDuMmRp+u2IvhgaF8tk3vX/OmeB9jydVjySijuiqk8No/FoCA==}
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.1.4':
+    resolution: {integrity: sha512-bz/AsCplLs+3fXULPQU9d4r8H4PdeljgHFyItvVIrA/NKZqzQ8sX0topf/zJVZAOtPH7GNnrKjq0/F0U2DHikQ==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.1.3':
     resolution: {integrity: sha512-aCy9Zli/2Qf+Ee5otXfFQ6mhv5fEyn0wIoBVmouqtJoqOO21et6UTtJ+LHLsMDolwGLyHERAljeSFSmYX3/O5A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.4':
+    resolution: {integrity: sha512-x0HQTLU1MusCtNamuXxf3ayEPkvh9uuaq4wVyBqveRkn4FznSOoHUsxTAKMnjGARX+vdLV/y/SwWJRDp2RI4zw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2875,8 +2907,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.1.4':
+    resolution: {integrity: sha512-SEYCQD9UflKJMkYGnG5nt2gcsqdkgJsQmryBC/jxo+bOuY9gUSReU99FqCt7WRQrsHLbGeAFeTWs1QzItWG/Bw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-riscv64-gnu@2.1.3':
     resolution: {integrity: sha512-yojg8elye1nhsNeGncw0NrZ4pMGF7NVebR80CLg72TXyzfYwFJlFTdU5yUYb1Gy+JXIvrSCwzQt2QkyiEvmkfg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.4':
+    resolution: {integrity: sha512-jYtQKtnDRaVfyasvTGY04Z7m+xDWZYVwAIEOB4hP7czM7FVLOMgHlMlvw/EgF0DNHrBthqbPfBIS2tP50CzpEA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -2887,8 +2931,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-riscv64-musl@2.1.4':
+    resolution: {integrity: sha512-ZgxKjQAm9pidq2kChQO2PqKI9OQpLuGD7iPBuyT0gQg3m1+7vvbbkArLBPzJ12CQHVZvqua7n/QGx8pQjJI2Zw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@2.1.3':
     resolution: {integrity: sha512-lMXjoGKf0SnviH596fmTszgtnXLHmWOoE90G8grG9MvKVa3pelRmfps5ewZL9s8ENf3NXRfOxIhIf/M9as6MqA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.1.4':
+    resolution: {integrity: sha512-C53B3e6M4yzlYn4hDxR9cHZV+HqkfFGR0zuhH8QCfdBfN5KyGsmXmujiFU85ANEvBgf9CF8VreBQeJ20lyto/g==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -2899,12 +2955,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.1.4':
+    resolution: {integrity: sha512-UaeG3FRo7e5RameQvWRNQ6KeXF29LEk67U/ohb9tF4U38mKH1OGqhmwCf5yLkqiOSgOi7Ff3ireOZD83Fso1iw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.1.3':
     resolution: {integrity: sha512-UsrDjD59UEP0mhfN/Z+uTc3vLgiUvIr+mn92WC1sbQi9gtZohTYvaQYFhWuMkBqsACGcmZp704JAbbSrVrVYCA==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.1.4':
+    resolution: {integrity: sha512-0P1WZEfu7JOPzD/jQfk9U/6gnRFc7RpvYCQaYZVVYZNJ2gU6O0/yLegRGKNK/2L0zjYwiD0ynhOIBVUUERf5Pw==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.1.3':
     resolution: {integrity: sha512-42RS/SwKBTkNvXIPZXqTn0yEFN8zwGRfRe/ly0GDvPp/KxpLMFWxJmLxgtoLompU+0UCGvV4KpcBENt3oWs6BA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.4':
+    resolution: {integrity: sha512-+aStQipk1EakLRPfD+/aQbtmTXfxqSWetcRRDWV3cAsD4ebv1tF8FLKYY1PCaFpQbX1FxzCBGF0KHxkAsi9cxA==}
     cpu: [arm64]
     os: [win32]
 
@@ -2913,16 +2984,41 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.1.4':
+    resolution: {integrity: sha512-7nyrLRQ07j6i6omZuwiwwTI6rpjdy/Su3niLDAG7WsLL21u3/UQQrw6Fvm8SH3XYteghoHLSM3dhgaisuUhdJg==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.1.3':
     resolution: {integrity: sha512-ObaUcj+BHo/aBL1weyM3orApaHyAR5Phr3YNEpQEifxjZbNKM1iO5X5prN4OqEv3H+7o5e/Wh9Fy3N7Vvd+psA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.1.4':
+    resolution: {integrity: sha512-Z4je7JBaDpO9vvNMgCxlycycRJq+GQwwuXSXagW2xvvGM10Ij63YVtIehSMG9xaW8PED41oc9nWndoEsiD60pA==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@2.1.3':
     resolution: {integrity: sha512-4UGXJqUHmm36tWG1GgFZz3p8sQ5JuSgWI+gq1xPPoihS41uYJL3cXuJnirTeWsmVrusmYZTQhgU3tl3VYGcJYg==}
 
+  '@rspack/binding@2.1.4':
+    resolution: {integrity: sha512-iye4BaTYtTt0qa39avWwEsUobVxFNhQHr6B8reFeKU7sdaZsC9LUoDR8JAt5gOnbnzFMPdKgrdU/VzkC6rXbIg==}
+
   '@rspack/core@2.1.3':
     resolution: {integrity: sha512-1iGnxLrP+iyY0ZSjLZeQTaxrISpQz4yLyqJPmaF/l4uw27/dBcrloszAeLOJQ9jiv7EJtU0T5zB+LOFPpivIxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.1.4':
+    resolution: {integrity: sha512-lpJgtr+JAXuDAMBJfRJ1LHyWVuYJyhZu6L6aj9t4lipUU03qwakHnzn3vwSCr68PsVvVPzR6NbJE1gJienSV0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -7959,6 +8055,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -7966,6 +8068,11 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8399,7 +8506,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.7.0(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)':
+  '@module-federation/enhanced@2.7.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.7.0
       '@module-federation/cli': 2.7.0(typescript@6.0.3)(vue-tsc@3.3.7)
@@ -8408,7 +8515,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.7.0(@module-federation/runtime-tools@2.7.0)
       '@module-federation/managers': 2.7.0
       '@module-federation/manifest': 2.7.0(typescript@6.0.3)(vue-tsc@3.3.7)
-      '@module-federation/rspack': 2.7.0(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/rspack': 2.7.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/runtime-tools': 2.7.0
       '@module-federation/sdk': 2.7.0
       '@module-federation/webpack-bundler-runtime': 2.7.0
@@ -8423,7 +8530,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.7.0(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)':
+  '@module-federation/enhanced@2.7.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.7.0
       '@module-federation/cli': 2.7.0(typescript@7.0.2)(vue-tsc@3.3.7)
@@ -8432,7 +8539,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.7.0(@module-federation/runtime-tools@2.7.0)
       '@module-federation/managers': 2.7.0
       '@module-federation/manifest': 2.7.0(typescript@7.0.2)(vue-tsc@3.3.7)
-      '@module-federation/rspack': 2.7.0(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)
+      '@module-federation/rspack': 2.7.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/runtime-tools': 2.7.0
       '@module-federation/sdk': 2.7.0
       '@module-federation/webpack-bundler-runtime': 2.7.0
@@ -8480,9 +8587,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.46(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)':
+  '@module-federation/node@2.7.46(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)':
     dependencies:
-      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/runtime': 2.7.0
       '@module-federation/sdk': 2.7.0
       encoding: 0.1.13
@@ -8495,9 +8602,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.46(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)':
+  '@module-federation/node@2.7.46(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)':
     dependencies:
-      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/runtime': 2.7.0
       '@module-federation/sdk': 2.7.0
       encoding: 0.1.13
@@ -8512,7 +8619,7 @@ snapshots:
 
   '@module-federation/node@2.7.46(typescript@7.0.2)(vue-tsc@3.3.7)':
     dependencies:
-      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/runtime': 2.7.0
       '@module-federation/sdk': 2.7.0
       encoding: 0.1.13
@@ -8525,13 +8632,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.7.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)':
+  '@module-federation/rsbuild-plugin@2.7.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)':
     dependencies:
-      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)
-      '@module-federation/node': 2.7.46(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/node': 2.7.46(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/sdk': 2.7.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8540,13 +8647,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.7.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)':
+  '@module-federation/rsbuild-plugin@2.7.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)':
     dependencies:
-      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)
-      '@module-federation/node': 2.7.46(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
+      '@module-federation/node': 2.7.46(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/sdk': 2.7.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8555,13 +8662,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.7.0(@rsbuild/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)':
+  '@module-federation/rsbuild-plugin@2.7.0(@rsbuild/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.7)':
     dependencies:
-      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/node': 2.7.46(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/sdk': 2.7.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8570,7 +8677,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.7.0(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)':
+  '@module-federation/rspack@2.7.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.7.0
       '@module-federation/dts-plugin': 2.7.0(typescript@6.0.3)(vue-tsc@3.3.7)
@@ -8579,7 +8686,7 @@ snapshots:
       '@module-federation/manifest': 2.7.0(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/runtime-tools': 2.7.0
       '@module-federation/sdk': 2.7.0
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.7(typescript@6.0.3)
@@ -8587,7 +8694,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rspack@2.7.0(@rspack/core@2.1.3)(typescript@7.0.2)(vue-tsc@3.3.7)':
+  '@module-federation/rspack@2.7.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.7.0
       '@module-federation/dts-plugin': 2.7.0(typescript@7.0.2)(vue-tsc@3.3.7)
@@ -8596,7 +8703,7 @@ snapshots:
       '@module-federation/manifest': 2.7.0(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/runtime-tools': 2.7.0
       '@module-federation/sdk': 2.7.0
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 7.0.2
       vue-tsc: 3.3.7(typescript@7.0.2)
@@ -8622,13 +8729,13 @@ snapshots:
 
   '@module-federation/sdk@2.7.0': {}
 
-  '@module-federation/storybook-addon@6.0.15(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(storybook@10.5.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.15(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(storybook@10.5.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.3)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.7.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/sdk': 2.7.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
-      storybook: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
+      storybook: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -8652,6 +8759,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -8788,9 +8902,9 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -8907,7 +9021,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.5)':
+  '@rsbuild/core@2.1.6(@module-federation/runtime-tools@2.7.0)':
+    dependencies:
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.6)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
@@ -8916,39 +9037,39 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)':
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.3)
+      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.3)(less@4.6.7)
+      less-loader: 12.3.3(@rspack/core@2.1.4)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.5)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.6)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -8974,30 +9095,30 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
 
-  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(preact@10.29.7)':
+  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(preact@10.29.7)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.7)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.3)
+      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.4)
       '@swc/plugin-prefresh': 12.12.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - preact
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.3)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.5)':
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.6)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9005,98 +9126,98 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
 
-  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.5)(solid-js@1.9.14)':
+  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.6)(solid-js@1.9.14)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.5)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.6)
       babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.14)
       solid-refresh: 0.6.3(solid-js@1.9.14)
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)':
+  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0
-      stylus-loader: 8.1.3(@rspack/core@2.1.3)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.1.4)(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@7.0.2)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@svgr/core': 8.1.0(typescript@7.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.3)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.4)
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.5)':
+  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.6)':
     dependencies:
       toml: 4.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
 
-  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.3)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.4)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.5)':
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.6)':
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(vue@3.5.39)':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.39)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.3)(vue@3.5.39)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.4)(vue@3.5.39)
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.1.5)':
+  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.1.6)':
     dependencies:
       yaml: 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
 
   '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.7.0)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
-      rsbuild-plugin-dts: 0.23.2(@microsoft/api-extractor@7.58.9)(@rsbuild/core@2.1.5)(typescript@7.0.2)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
+      rsbuild-plugin-dts: 0.23.2(@microsoft/api-extractor@7.58.9)(@rsbuild/core@2.1.6)(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.9(@types/node@25.2.0)
       typescript: 7.0.2
@@ -9105,7 +9226,7 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rslib/core@1.0.0-beta.0(@microsoft/api-extractor@7.58.9)(typescript@6.0.3)':
+  '@rslib/core@1.0.0-beta.0(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.7.0)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
       rsbuild-plugin-dts: 1.0.0-beta.0(@microsoft/api-extractor@7.58.9)(@rsbuild/core@2.1.5)(typescript@6.0.3)
@@ -9157,25 +9278,49 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.1.3':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.1.4':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.1.3':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.1.4':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.1.3':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.1.4':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.1.3':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.1.4':
     optional: true
 
   '@rspack/binding-linux-riscv64-gnu@2.1.3':
     optional: true
 
+  '@rspack/binding-linux-riscv64-gnu@2.1.4':
+    optional: true
+
   '@rspack/binding-linux-riscv64-musl@2.1.3':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.4':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.1.3':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.1.4':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.1.3':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.4':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.1.3':
@@ -9185,13 +9330,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.1.4':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.1.3':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.4':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.1.3':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.1.4':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.1.3':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.4':
     optional: true
 
   '@rspack/binding@2.1.3':
@@ -9209,6 +9370,21 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.1.3
       '@rspack/binding-win32-x64-msvc': 2.1.3
 
+  '@rspack/binding@2.1.4':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.4
+      '@rspack/binding-darwin-x64': 2.1.4
+      '@rspack/binding-linux-arm64-gnu': 2.1.4
+      '@rspack/binding-linux-arm64-musl': 2.1.4
+      '@rspack/binding-linux-riscv64-gnu': 2.1.4
+      '@rspack/binding-linux-riscv64-musl': 2.1.4
+      '@rspack/binding-linux-x64-gnu': 2.1.4
+      '@rspack/binding-linux-x64-musl': 2.1.4
+      '@rspack/binding-wasm32-wasi': 2.1.4
+      '@rspack/binding-win32-arm64-msvc': 2.1.4
+      '@rspack/binding-win32-ia32-msvc': 2.1.4
+      '@rspack/binding-win32-x64-msvc': 2.1.4
+
   '@rspack/core@2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.1.3
@@ -9216,27 +9392,34 @@ snapshots:
       '@module-federation/runtime-tools': 2.7.0
       '@swc/helpers': 0.5.23
 
+  '@rspack/core@2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.4
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.7.0
+      '@swc/helpers': 0.5.23
+
   '@rspack/lite-tapable@1.1.2': {}
 
-  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.3)':
+  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.4)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.7)
       '@prefresh/utils': 1.2.1
     optionalDependencies:
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.3)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
       '@rspress/shared': 2.0.17(@module-federation/runtime-tools@2.7.0)
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -9285,7 +9468,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
-      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -9296,7 +9479,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.17(@rspress/core@2.0.17)':
     dependencies:
-      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       remark-mdx: 3.1.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -9307,17 +9490,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.17(@rspress/core@2.0.17)':
     dependencies:
-      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.17(@rspress/core@2.0.17)':
     dependencies:
-      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rspress/plugin-twoslash@2.0.17(@rspress/core@2.0.17)(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@shikijs/twoslash': 4.3.0(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3
       mdast-util-gfm: 3.1.0
@@ -9331,7 +9514,7 @@ snapshots:
 
   '@rspress/shared@2.0.17(@module-federation/runtime-tools@2.7.0)':
     dependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@shikijs/rehype': 4.3.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9340,16 +9523,16 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.5(@rspress/core@2.0.17)':
     optionalDependencies:
-      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rstest/adapter-rslib@0.11.1(@rslib/core@1.0.0-beta.0)(@rstest/core@0.11.1)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 1.0.0-beta.0(@microsoft/api-extractor@7.58.9)(typescript@6.0.3)
-      '@rstest/core': 0.11.1
+      '@rslib/core': 1.0.0-beta.0(@microsoft/api-extractor@7.58.9)(@module-federation/runtime-tools@2.7.0)(typescript@6.0.3)
+      '@rstest/core': 0.11.1(@module-federation/runtime-tools@2.7.0)
     optionalDependencies:
       typescript: 6.0.3
 
-  '@rstest/core@0.11.1':
+  '@rstest/core@0.11.1(@module-federation/runtime-tools@2.7.0)':
     dependencies:
       '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
       '@types/chai': 5.2.3
@@ -9528,7 +9711,7 @@ snapshots:
       '@storybook/react-dom-shim': 10.5.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.3.0
     optionalDependencies:
       '@types/react': 19.2.17
@@ -9541,11 +9724,11 @@ snapshots:
 
   '@storybook/addon-onboarding@10.5.0(storybook@10.5.0)':
     dependencies:
-      storybook: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
 
   '@storybook/csf-plugin@10.5.0(esbuild@0.28.1)(storybook@10.5.0)':
     dependencies:
-      storybook: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
@@ -9574,7 +9757,7 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -9587,7 +9770,7 @@ snapshots:
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -9598,7 +9781,7 @@ snapshots:
   '@storybook/vue3@10.5.0(storybook@10.5.0)(vue@3.5.39)':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       type-fest: 5.7.0
       vue: 3.5.39(typescript@6.0.3)
       vue-component-type-helpers: 3.3.1
@@ -9753,14 +9936,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.3)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.4)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
     optionalDependencies:
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10267,12 +10450,12 @@ snapshots:
 
   b-validate@1.5.3: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.3):
+  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4):
     dependencies:
       '@babel/core': 7.29.7
       find-up: 5.0.0
     optionalDependencies:
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
 
   babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
     dependencies:
@@ -11717,11 +11900,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@rspack/core@2.1.3)(less@4.6.7):
+  less-loader@12.3.3(@rspack/core@2.1.4)(less@4.6.7):
     dependencies:
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
 
   less@4.6.7:
     dependencies:
@@ -12602,7 +12785,7 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
       '@oxc-parser/binding-win32-x64-msvc': 0.127.0
 
-  oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
+  oxc-resolver@11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -12620,7 +12803,7 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
@@ -13310,10 +13493,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.23.2(@microsoft/api-extractor@7.58.9)(@rsbuild/core@2.1.5)(typescript@7.0.2):
+  rsbuild-plugin-dts@0.23.2(@microsoft/api-extractor@7.58.9)(@rsbuild/core@2.1.6)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.9(@types/node@25.2.0)
       typescript: 7.0.2
@@ -13326,40 +13509,40 @@ snapshots:
       '@microsoft/api-extractor': 7.58.9(@types/node@24.13.3)
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.5):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.6):
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
 
-  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.5):
+  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.6):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.5):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.6):
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.5):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.6):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
 
   rslog@2.2.0: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.3)(vue@3.5.39):
+  rspack-vue-loader@17.5.1(@rspack/core@2.1.4)(vue@3.5.39):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
       vue: 3.5.39(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.17):
     dependencies:
-      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -13384,14 +13567,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.17):
     dependencies:
-      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.17)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.17):
     dependencies:
-      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.3)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.17(@module-federation/runtime-tools@2.7.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   run-applescript@7.1.0: {}
 
@@ -13724,18 +13907,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.5)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.6)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
-      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -13747,9 +13930,9 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.5)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.6)
       sirv: 2.0.4
-      storybook: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.3.0
       url: 0.11.4
       util: 0.12.5
@@ -13764,10 +13947,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@storybook/react': 10.5.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)
       find-up: 5.0.0
@@ -13777,8 +13960,8 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
-      storybook: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)
+      storybook: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -13793,12 +13976,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)(vue@3.5.39):
+  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)(vue@3.5.39):
     dependencies:
-      '@rsbuild/core': 2.1.5(@module-federation/runtime-tools@2.7.0)
+      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.7.0)
       '@storybook/vue3': 10.5.0(storybook@10.5.0)(vue@3.5.39)
-      storybook: 10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.5)(@rspack/core@2.1.3)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)
+      storybook: 10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.0)(typescript@6.0.3)
       vue: 3.5.39(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.39)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -13814,7 +13997,7 @@ snapshots:
       - vite
       - webpack
 
-  storybook@10.5.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7):
+  storybook@10.5.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.7)(react@19.2.7)
@@ -13828,7 +14011,7 @@ snapshots:
       jsonc-parser: 3.3.1
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      oxc-resolver: 11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       recast: 0.23.11
       semver: 7.8.5
       use-sync-external-store: 1.6.0(react@19.2.7)
@@ -13920,13 +14103,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.1.3)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.1.4)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
 
   stylus@0.64.0:
     dependencies:
@@ -14040,7 +14223,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.3)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.4)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
@@ -14048,7 +14231,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.1.3(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.7.0)(@swc/helpers@0.5.23)
 
   ts-dedent@2.3.0: {}
 

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -67,7 +67,7 @@ describe('minify config (mf)', () => {
     expect(mfExposeEntry).toBeDefined();
     expect(normalizeMfExposeEntry(mfExposeEntry!)).toMatchInlineSnapshot(`
       "/*! LICENSE: __federation_expose_default_export.<HASH>.js.LICENSE.txt */
-      "use strict";(globalThis["default_minify"]=globalThis["default_minify"]||[]).push([[525],{<MODULE_ID>(__unused_rspack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);var react_jsx_runtime__rspack_import_0=__webpack_require__(491);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__rspack_import_0.jsx)("button",{});__webpack_require__.d(__webpack_exports__,{},{Button:Button,foo:foo})}}]);"
+      "use strict";(globalThis["default_minify"]||=[]).push([[525],{<MODULE_ID>(__unused_rspack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);var react_jsx_runtime__rspack_import_0=__webpack_require__(491);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__rspack_import_0.jsx)("button",{});__webpack_require__.d(__webpack_exports__,{},{Button:Button,foo:foo})}}]);"
     `);
   });
 
@@ -78,7 +78,7 @@ describe('minify config (mf)', () => {
     expect(mfExposeEntry).toBeDefined();
     expect(normalizeMfExposeEntry(mfExposeEntry!)).toMatchInlineSnapshot(`
       ""use strict";
-      (globalThis["disable_minify"] = globalThis["disable_minify"] || []).push([[525], {
+      (globalThis["disable_minify"] ||= []).push([[525], {
       <MODULE_ID>(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
       __webpack_require__.r(__webpack_exports__);
       /* import */ var react_jsx_runtime__rspack_import_0 = __webpack_require__(491);

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@rsbuild/plugin-node-polyfill": "^1.4.6"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@rsbuild/plugin-node-polyfill": "^1.4.6"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^2.7.0",
     "@playwright/test": "1.61.1",
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@rsbuild/plugin-less": "^2.0.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-sass": "^2.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.7.0",
-    "@rsbuild/core": "~2.1.5",
+    "@rsbuild/core": "~2.1.6",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-sass": "^2.0.1",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

This PR upgrades Rsbuild to v2.1.6 across Rslib packages, examples, tests, and the website. It refreshes the lockfile for the bundled Rspack v2.1.4 update and updates Module Federation minify snapshots for the generated logical-assignment output.

## Related Links

https://github.com/web-infra-dev/rsbuild/releases/tag/v2.1.6

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).