### PR TITLE
fix(dts): refine TypeScript path handling

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -104,7 +104,7 @@ export type Dts =
        */
       isolated?: boolean;
       /**
-       * A custom absolute path used to resolve TypeScript.
+       * A custom absolute path to the TypeScript module entry.
        * @defaultValue The resolved path of `typescript` from the project root.
        * @see {@link https://rslib.rs/config/lib/dts#dtstypescriptpath}
        */

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -104,8 +104,8 @@ export type Dts =
        */
       isolated?: boolean;
       /**
-       * The absolute path to the TypeScript module entry.
-       * @defaultValue The absolute path to the module entry of the project's `typescript` dependency.
+       * A custom absolute path used to resolve TypeScript.
+       * @defaultValue The resolved path of `typescript` from the project root.
        * @see {@link https://rslib.rs/config/lib/dts#dtstypescriptpath}
        */
       typescriptPath?: string;

--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -294,13 +294,22 @@ import { foo } from './foo.mjs'; // expected output of './dist/bar.d.mts'
 ### typescriptPath
 
 - **Type:** `string`
-- **Default:** The absolute path to the module entry of the project's `typescript` dependency
+- **Default:** The resolved path of `typescript` from the project root
 
-Specifies the TypeScript installation used to generate declaration files. Set it to the absolute path of that TypeScript's module entry.
+Specifies a custom absolute path used to resolve TypeScript.
 
-When this option is unset, the plugin uses the project's `typescript` dependency. When set, it uses the configured TypeScript instead.
+If a project uses TypeScript 6 and you want to try TypeScript 7 for declaration generation, install both versions with [npm aliases](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0):
 
-The plugin selects the declaration generation backend from the selected TypeScript's version: TypeScript 5 and 6 use the Compiler API, while TypeScript 7 and later use the native executable.
+```json
+{
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  }
+}
+```
+
+Then, configure the plugin to use TypeScript 7 through the `@typescript/native` alias:
 
 ```ts
 import { fileURLToPath } from 'node:url';
@@ -314,8 +323,6 @@ export default {
   ],
 };
 ```
-
-The path must be absolute and point to a TypeScript module entry.
 
 ### tsgo
 

--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -296,7 +296,7 @@ import { foo } from './foo.mjs'; // expected output of './dist/bar.d.mts'
 - **Type:** `string`
 - **Default:** The resolved path of `typescript` from the project root
 
-Specifies a custom absolute path used to resolve TypeScript.
+Specifies a custom absolute path to the TypeScript module entry.
 
 If a project uses TypeScript 6 and you want to try TypeScript 7 for declaration generation, install both versions with [npm aliases](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0):
 

--- a/packages/plugin-dts/src/backend.ts
+++ b/packages/plugin-dts/src/backend.ts
@@ -23,9 +23,9 @@ export const resolveTypescriptPath = (
       );
     }
 
-    if (!fs.existsSync(configuredPath)) {
+    if (!fs.statSync(configuredPath, { throwIfNoEntry: false })?.isFile()) {
       throw new Error(
-        `The path specified by "dts.typescriptPath" does not exist: ${JSON.stringify(configuredPath)}.`,
+        `The path specified by "dts.typescriptPath" must point to an existing TypeScript module entry file: ${JSON.stringify(configuredPath)}.`,
       );
     }
 

--- a/packages/plugin-dts/src/backend.ts
+++ b/packages/plugin-dts/src/backend.ts
@@ -15,17 +15,17 @@ type ParsedTypescriptVersion = {
 export const resolveTypescriptPath = (
   cwd: string,
   configuredPath?: string,
-): string | undefined => {
+): string => {
   if (configuredPath !== undefined) {
     if (!path.isAbsolute(configuredPath)) {
       throw new Error(
-        `The "dts.typescriptPath" option must be an absolute path to a TypeScript module entry, received ${JSON.stringify(configuredPath)}.`,
+        `The "dts.typescriptPath" option must be an absolute path where TypeScript can be resolved, received ${JSON.stringify(configuredPath)}.`,
       );
     }
 
     if (!fs.existsSync(configuredPath)) {
       throw new Error(
-        `Failed to resolve TypeScript from "dts.typescriptPath": ${JSON.stringify(configuredPath)} does not exist.`,
+        `The path specified by "dts.typescriptPath" does not exist: ${JSON.stringify(configuredPath)}.`,
       );
     }
 
@@ -36,7 +36,9 @@ export const resolveTypescriptPath = (
     const currentRequire = createRequireFromPackageJson(cwd);
     return currentRequire.resolve('typescript');
   } catch {
-    return undefined;
+    throw new Error(
+      'Failed to resolve TypeScript from the project root. Please install TypeScript or set "dts.typescriptPath".',
+    );
   }
 };
 

--- a/packages/plugin-dts/src/tsgo.ts
+++ b/packages/plugin-dts/src/tsgo.ts
@@ -155,16 +155,10 @@ export async function emitDtsTsgo(
     typescriptPath,
   } = options;
 
-  if (!typescriptPath) {
-    throw new Error(
-      'Failed to resolve the native TypeScript executable because no TypeScript module entry was found.',
-    );
-  }
-
   const args = generateTsgoArgs(configPath, declarationDir, build, isWatch);
   const dtsExecutableCommand = await resolveDtsExecutableCommand(
     args,
-    typescriptPath,
+    typescriptPath!,
   );
 
   logger.debug(

--- a/packages/plugin-dts/tests/backend.test.ts
+++ b/packages/plugin-dts/tests/backend.test.ts
@@ -131,9 +131,14 @@ describe('resolveDtsGenerationBackend', () => {
     expect(() => resolveTypescriptPath('/project', './typescript.js')).toThrow(
       'must be an absolute path',
     );
-    expect(() =>
-      resolveTypescriptPath('/project', '/path/not-found/typescript.js'),
-    ).toThrow('does not exist');
+    for (const configuredPath of [
+      '/path/not-found/typescript.js',
+      os.tmpdir(),
+    ]) {
+      expect(() => resolveTypescriptPath('/project', configuredPath)).toThrow(
+        'must point to an existing TypeScript module entry file',
+      );
+    }
   });
 
   test('should reject when TypeScript cannot be resolved from cwd', async () => {

--- a/packages/plugin-dts/tests/backend.test.ts
+++ b/packages/plugin-dts/tests/backend.test.ts
@@ -97,7 +97,7 @@ describe('resolveDtsGenerationBackend', () => {
       const typescriptPath = resolveTypescriptPath(packageDir);
       const typescriptVersion = readTypescriptVersion(typescriptPath);
 
-      expect(await fs.realpath(typescriptPath!)).toBe(
+      expect(await fs.realpath(typescriptPath)).toBe(
         await fs.realpath(path.join(typescriptPkgDir, 'lib', 'version.cjs')),
       );
       expect(typescriptVersion).toBe('7.0.2');
@@ -109,7 +109,7 @@ describe('resolveDtsGenerationBackend', () => {
     }
   });
 
-  test('should use the configured TypeScript module entry', async () => {
+  test('should use the configured TypeScript path', async () => {
     const tempDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'rslib-plugin-dts-custom-'),
     );
@@ -134,6 +134,20 @@ describe('resolveDtsGenerationBackend', () => {
     expect(() =>
       resolveTypescriptPath('/project', '/path/not-found/typescript.js'),
     ).toThrow('does not exist');
+  });
+
+  test('should reject when TypeScript cannot be resolved from cwd', async () => {
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'rslib-plugin-dts-missing-'),
+    );
+
+    try {
+      expect(() => resolveTypescriptPath(tempDir)).toThrow(
+        'Failed to resolve TypeScript from the project root',
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   test('should reject typescriptPath with isolated declarations', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,12 +723,9 @@ importers:
 
   tests/integration/dts:
     devDependencies:
-      '@typescript/native':
-        specifier: npm:typescript@^7.0.2
-        version: typescript@7.0.2
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.2
-        version: '@typescript/typescript6@6.0.2'
+        specifier: ^6.0.3
+        version: 6.0.3
 
   tests/integration/dts-tsgo:
     devDependencies:
@@ -838,7 +835,14 @@ importers:
 
   tests/integration/dts/bundle-false/tsconfig-path: {}
 
-  tests/integration/dts/bundle-false/typescript-path: {}
+  tests/integration/dts/bundle-false/typescript-path:
+    devDependencies:
+      '@typescript/native':
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
+      typescript:
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
 
   tests/integration/dts/bundle/abort-on-error: {}
 

--- a/tests/integration/dts/bundle-false/typescript-path/package.json
+++ b/tests/integration/dts/bundle-false/typescript-path/package.json
@@ -2,5 +2,9 @@
   "name": "dts-typescript-path-test",
   "version": "1.0.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  }
 }

--- a/tests/integration/dts/bundle-false/typescript-path/rslib.config.ts
+++ b/tests/integration/dts/bundle-false/typescript-path/rslib.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from '@rslib/core';
 import { generateBundleEsmConfig } from 'test-helper';
 
 export default defineConfig({
+  // Explicit `tsgo` values make the test fail if `typescriptPath` resolves
+  // to an unexpected TypeScript major version.
   lib: [
     generateBundleEsmConfig({
       bundle: false,

--- a/tests/integration/dts/bundle-false/typescript-path/rslib.config.ts
+++ b/tests/integration/dts/bundle-false/typescript-path/rslib.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       },
       dts: {
         bundle: false,
+        tsgo: false,
         typescriptPath: fileURLToPath(import.meta.resolve('typescript')),
       },
     }),
@@ -21,6 +22,7 @@ export default defineConfig({
       },
       dts: {
         bundle: false,
+        tsgo: true,
         typescriptPath: fileURLToPath(
           import.meta.resolve('@typescript/native'),
         ),

--- a/tests/integration/dts/package.json
+++ b/tests/integration/dts/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@typescript/native": "npm:typescript@^7.0.2",
-    "typescript": "npm:@typescript/typescript6@^6.0.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -276,7 +276,7 @@ At this time, when [redirect.dts.path](/config/lib/redirect#redirectdtspath) is 
 - **Type:** `string`
 - **Default:** The resolved path of `typescript` from the project root
 
-Specifies a custom absolute path used to resolve TypeScript.
+Specifies a custom absolute path to the TypeScript module entry.
 
 If a project uses TypeScript 6 and you want to try TypeScript 7 for declaration generation, install both versions with [npm aliases](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0):
 

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -274,15 +274,11 @@ At this time, when [redirect.dts.path](/config/lib/redirect#redirectdtspath) is 
 ### dts.typescriptPath
 
 - **Type:** `string`
-- **Default:** The absolute path to the module entry of the project's `typescript` dependency
+- **Default:** The resolved path of `typescript` from the project root
 
-Specifies the TypeScript installation used to generate declaration files. Set it to the absolute path of that TypeScript's module entry.
+Specifies a custom absolute path used to resolve TypeScript.
 
-When this option is unset, Rslib uses the project's `typescript` dependency. When set, Rslib uses the configured TypeScript instead.
-
-Rslib selects the declaration generation backend from the selected TypeScript's version: TypeScript 5 and 6 use the Compiler API, while TypeScript 7 and later use the native executable.
-
-For example, a project can use TypeScript 6 for development while using TypeScript 7 to generate declaration files. Install both versions with [npm aliases](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-60):
+If a project uses TypeScript 6 and you want to try TypeScript 7 for declaration generation, install both versions with [npm aliases](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0):
 
 ```json title="package.json"
 {
@@ -293,7 +289,7 @@ For example, a project can use TypeScript 6 for development while using TypeScri
 }
 ```
 
-Then select the TypeScript 7 installation provided by `@typescript/native` in the Rslib config:
+Then, configure Rslib to use TypeScript 7 through the `@typescript/native` alias:
 
 ```ts title="rslib.config.ts"
 import { fileURLToPath } from 'node:url';
@@ -319,7 +315,7 @@ export default defineConfig({
 
 Whether to generate declaration files using [native TypeScript](https://github.com/microsoft/typescript-go).
 
-When unset, Rslib enables this option automatically when TypeScript 7+ is detected. If [dts.typescriptPath](#dtstypescriptpath) is set, Rslib uses that TypeScript version.
+When unset, Rslib enables this option automatically when TypeScript 7+ is detected. When [dts.typescriptPath](#dtstypescriptpath) is configured, Rslib determines whether to enable `tsgo` automatically based on the resolved TypeScript version.
 
 <PackageManagerTabs command="add typescript@latest -D" />
 

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -276,7 +276,7 @@ export default {
 - **类型：** `string`
 - **默认值：** 从项目根目录解析到的 `typescript` 路径
 
-指定用于解析 TypeScript 的自定义绝对路径。
+指定 TypeScript 模块入口的自定义绝对路径。
 
 如果项目使用 TypeScript 6，并希望尝试用 TypeScript 7 生成类型声明，可以通过 [npm alias](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0) 安装这两个版本：
 

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -274,15 +274,11 @@ export default {
 ### dts.typescriptPath
 
 - **类型：** `string`
-- **默认值：** 项目的 `typescript` 依赖模块入口的绝对路径
+- **默认值：** 从项目根目录解析到的 `typescript` 路径
 
-指定用于生成类型声明文件的 TypeScript。配置值必须是这个 TypeScript 模块入口的绝对路径。
+指定用于解析 TypeScript 的自定义绝对路径。
 
-未设置此项时，Rslib 使用项目的 `typescript` 依赖；设置此项后，Rslib 使用配置的 TypeScript。
-
-Rslib 根据所使用 TypeScript 的版本选择类型声明生成后端：TypeScript 5 和 6 使用 Compiler API，TypeScript 7 及以上版本使用 native executable。
-
-例如，项目使用 TypeScript 6 开发，但希望通过 TypeScript 7 生成类型声明。可以通过 [npm alias](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-60) 同时安装两个版本：
+如果项目使用 TypeScript 6，并希望尝试用 TypeScript 7 生成类型声明，可以通过 [npm alias](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0) 安装这两个版本：
 
 ```json title="package.json"
 {
@@ -293,7 +289,7 @@ Rslib 根据所使用 TypeScript 的版本选择类型声明生成后端：TypeS
 }
 ```
 
-然后在 Rslib 配置中，选择 `@typescript/native` 对应的 TypeScript 7：
+然后在 Rslib 配置中，将 `dts.typescriptPath` 指向 `@typescript/native` 提供的 TypeScript 7：
 
 ```ts title="rslib.config.ts"
 import { fileURLToPath } from 'node:url';
@@ -319,7 +315,7 @@ export default defineConfig({
 
 是否通过 [native TypeScript](https://github.com/microsoft/typescript-go) 生成类型声明文件。
 
-如果没有显式设置该选项，Rslib 会在检测到 TypeScript 7+ 时自动开启。设置 [dts.typescriptPath](#dtstypescriptpath) 后，Rslib 会以这个 TypeScript 的版本为准。
+如果没有显式设置该选项，Rslib 会在检测到 TypeScript 7+ 时自动开启。配置 [dts.typescriptPath](#dtstypescriptpath) 后，Rslib 会根据解析到的 TypeScript 版本决定是否自动启用 `tsgo`。
 
 <PackageManagerTabs command="add typescript@latest -D" />
 


### PR DESCRIPTION
## Summary

This is a follow-up to #1767 that makes `dts.typescriptPath` failures earlier and easier to understand while aligning the documentation and integration fixture with the supported TypeScript 6/7 side-by-side setup.

- fail early when TypeScript cannot be resolved from the project root and remove the redundant tsgo path guard
- clarify the option documentation and the `@typescript/native` alias example
- scope the TypeScript aliases to the dedicated fixture and make its backend assertions version-sensitive

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1767
- https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).