### PR TITLE
fix(core): avoid chunk filename conflicts in multi-compiler builds

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -362,7 +362,6 @@ const composeFormatConfig = ({
   umdName,
   pkgJson,
   enabledShims,
-  multiCompilerIndex,
   sourceEntry,
 }: {
   format: Format;
@@ -370,7 +369,6 @@ const composeFormatConfig = ({
   bundle?: boolean;
   umdName?: Rspack.LibraryName;
   enabledShims: DeepRequired<Shims>;
-  multiCompilerIndex: number | null;
   sourceEntry?: RsbuildConfigEntry;
 }): EnvironmentConfig => {
   const jsParserOptions: Record<string, Rspack.JavascriptParserOptions> = {
@@ -401,7 +399,12 @@ const composeFormatConfig = ({
   ].filter(Boolean);
 
   switch (format) {
-    case 'esm':
+    case 'esm': {
+      // Bundleless builds can expand a single source pattern into many entries.
+      // Bundled builds only need a shared runtime for multiple declared entries.
+      const shouldExtractRuntimeChunk =
+        bundle === false || Object.keys(sourceEntry ?? {}).length > 1;
+
       return {
         plugins: [modifyRsbuildDefaultPlugin({ disableUrlParse: true })],
         output: {
@@ -421,11 +424,9 @@ const composeFormatConfig = ({
             optimization: {
               concatenateModules: false,
               sideEffects: true,
-              runtimeChunk: getRuntimeChunkConfig({
-                bundle,
-                multiCompilerIndex,
-                sourceEntry,
-              }),
+              ...(shouldExtractRuntimeChunk
+                ? { runtimeChunk: { name: 'rslib-runtime' } }
+                : {}),
               avoidEntryIife: true,
               splitChunks: {
                 // Splitted "sync" chunks will make entry modules can't be inlined.
@@ -445,6 +446,7 @@ const composeFormatConfig = ({
           },
         },
       };
+    }
     case 'cjs':
       return {
         plugins: [modifyRsbuildDefaultPlugin({ disableUrlParse: true })],
@@ -682,39 +684,6 @@ const BundlePlugin = (): RsbuildPlugin => ({
   },
 });
 
-const RSLIB_RUNTIME_CHUNK_NAME = 'rslib-runtime';
-
-const getMultiCompilerRuntimeChunkName = (
-  multiCompilerIndex: number | null,
-): string =>
-  typeof multiCompilerIndex === 'number'
-    ? `${multiCompilerIndex}~${RSLIB_RUNTIME_CHUNK_NAME}`
-    : RSLIB_RUNTIME_CHUNK_NAME;
-
-export const getRuntimeChunkConfig = ({
-  bundle,
-  multiCompilerIndex,
-  sourceEntry,
-}: {
-  bundle: boolean;
-  multiCompilerIndex: number | null;
-  sourceEntry?: RsbuildConfigEntry;
-}): NonNullable<Rspack.Configuration['optimization']>['runtimeChunk'] => {
-  if (!bundle) {
-    return {
-      name: RSLIB_RUNTIME_CHUNK_NAME,
-    };
-  }
-
-  if (!sourceEntry || Object.keys(sourceEntry).length <= 1) {
-    return undefined;
-  }
-
-  return {
-    name: getMultiCompilerRuntimeChunkName(multiCompilerIndex),
-  };
-};
-
 const composeBundleConfig = (
   bundle: LibConfig['bundle'],
 ): { rsbuildConfig: EnvironmentConfig } => {
@@ -858,6 +827,16 @@ const composeExternalsConfig = (
   };
 };
 
+const isEntryChunk = (chunk: Rspack.PathData['chunk']): boolean => {
+  if (!chunk || !('groupsIterable' in chunk)) {
+    return false;
+  }
+
+  return [...chunk.groupsIterable].some(
+    (group) => group.isInitial() && group.getEntrypointChunk() === chunk,
+  );
+};
+
 const composeOutputFilenameConfig = (
   config: LibConfig,
   format: Format,
@@ -884,38 +863,99 @@ const composeOutputFilenameConfig = (
     return filenameHash ? '.[contenthash:10]' : '';
   };
 
-  // Copied from https://github.com/web-infra-dev/rspack/blob/2efea8673f86a562559e26a9351680e8df4d9ae9/packages/rspack/src/config/defaults.ts#L667-L680.
-  const inferChunkFilename = (filename: string): string | undefined => {
-    if (typeof filename !== 'function') {
-      const hasName = filename.includes('[name]');
-      const hasId = filename.includes('[id]');
-      const hasChunkHash = filename.includes('[chunkhash]');
-      const hasContentHash = filename.includes('[contenthash]');
-      const multiCompilerPrefix =
-        typeof multiCompilerIndex === 'number' ? `${multiCompilerIndex}~` : '';
-      // Anything changing depending on chunk is fine
+  const chunkFilenamePlaceholders = [
+    '[name]',
+    '[id]',
+    '[chunkhash]',
+    '[contenthash]',
+  ];
 
-      if (hasChunkHash || hasContentHash || hasName || hasId)
-        return filename.replace(
-          /(^|\/)([^/]*(?:\?|$))/,
-          `$1${multiCompilerPrefix}$2`,
-        );
-      // Otherwise prefix "[id]." in front of the basename to make it changing
-      return filename.replace(
-        /(^|\/)([^/]*(?:\?|$))/,
-        `$1${multiCompilerIndex}[id].$2`,
-      );
+  // Keep filename inference in sync with Rspack's default `chunkFilename`
+  // inference for strings:
+  // https://github.com/web-infra-dev/rspack/blob/e8a7bce74b5261220f0f351ebe581d5d99df54d6/packages/rspack/src/config/defaults.ts#L813-L826
+  const inferChunkFilename = (
+    filename: Rspack.Filename,
+  ): string | undefined => {
+    if (typeof filename === 'function') {
+      return undefined;
     }
 
-    return undefined;
+    const hasName = filename.includes('[name]');
+    const hasId = filename.includes('[id]');
+    const hasChunkHash = filename.includes('[chunkhash]');
+    const hasContentHash = filename.includes('[contenthash]');
+    // Anything changing depending on chunk is fine
+    if (hasChunkHash || hasContentHash || hasName || hasId) return filename;
+    // Otherwise prefix "[id]." in front of the basename to make it changing
+    return filename.replace(/(^|\/)([^/]*(?:\?|$))/, '$1[id].$2');
+  };
+
+  /**
+   * Appends a multi-compiler suffix to a Rspack filename template without
+   * resolving its placeholders. The suffix is placed after a chunk-specific
+   * placeholder in the basename when possible, or before the file extension
+   * otherwise, while preserving directories and query strings.
+   *
+   * For example, `assets/[name].[contenthash].js?raw` with `~1` becomes
+   * `assets/[name]~1.[contenthash].js?raw`, and `assets/chunk.js` becomes
+   * `assets/chunk~1.js`. This keeps `filename` for non-entry initial chunks and
+   * `chunkFilename` for async chunks in the same multi-compiler namespace.
+   */
+  const appendMultiCompilerSuffix = (
+    filename: string,
+    suffix: string,
+  ): string => {
+    const queryIndex = filename.indexOf('?');
+    const pathname =
+      queryIndex === -1 ? filename : filename.slice(0, queryIndex);
+    const query = queryIndex === -1 ? '' : filename.slice(queryIndex);
+    const basenameIndex = pathname.lastIndexOf('/') + 1;
+    const dirname = pathname.slice(0, basenameIndex);
+    const basename = pathname.slice(basenameIndex);
+    const placeholder = chunkFilenamePlaceholders.find((item) =>
+      basename.includes(item),
+    );
+    if (placeholder) {
+      return `${dirname}${basename.replace(placeholder, `${placeholder}${suffix}`)}${query}`;
+    }
+
+    const extension = extname(basename);
+    const stem = extension ? basename.slice(0, -extension.length) : basename;
+    return `${dirname}${stem}${suffix}${extension}${query}`;
   };
 
   const hash = getHash();
-  const defaultJsFilename = `[name]${hash}${jsExtension}`;
+  const multiCompilerSuffix =
+    typeof multiCompilerIndex === 'number' && multiCompilerIndex > 0
+      ? `~${multiCompilerIndex}`
+      : '';
+  const defaultJsFilenameTemplate = `[name]${hash}${jsExtension}`;
   const userJsFilename = config.output?.filename?.js;
-  const defaultJsChunkFilename = inferChunkFilename(
-    (userJsFilename as string) ?? defaultJsFilename,
+  // A custom filename function owns the naming contract. Leave
+  // `chunkFilename` unset so Rsbuild applies it to async chunks as well; users
+  // are responsible for avoiding collisions across compilers.
+  const inferredJsChunkFilename = inferChunkFilename(
+    userJsFilename ?? defaultJsFilenameTemplate,
   );
+  const defaultJsChunkFilename =
+    multiCompilerSuffix && inferredJsChunkFilename !== undefined
+      ? appendMultiCompilerSuffix(inferredJsChunkFilename, multiCompilerSuffix)
+      : inferredJsChunkFilename;
+  // With the default filename, runtime and other initial chunks use `filename`
+  // instead of `chunkFilename`. Keep entry filenames stable while isolating the
+  // other chunks by compiler. The first compiler keeps the original filename,
+  // and later compilers append a stable suffix based on their `lib` order.
+  // Do not infer whether compiler output paths actually overlap here.
+  const shouldSuffixInitialChunk = Boolean(multiCompilerSuffix);
+  const defaultInitialChunkFilename = shouldSuffixInitialChunk
+    ? appendMultiCompilerSuffix(defaultJsFilenameTemplate, multiCompilerSuffix)
+    : defaultJsFilenameTemplate;
+  const defaultJsFilename: Rspack.Filename = shouldSuffixInitialChunk
+    ? ({ chunk }) =>
+        isEntryChunk(chunk)
+          ? defaultJsFilenameTemplate
+          : defaultInitialChunkFilename
+    : defaultJsFilenameTemplate;
 
   // will be returned to use in redirect feature
   // only support string type for now since we can not get the return value of function
@@ -924,15 +964,18 @@ const composeOutputFilenameConfig = (
       ? extname(userJsFilename)
       : jsExtension;
 
-  const chunkFilename: RsbuildConfig = {
-    tools: {
-      rspack: {
-        output: {
-          chunkFilename: defaultJsChunkFilename,
-        },
-      },
-    },
-  };
+  const chunkFilename: RsbuildConfig =
+    defaultJsChunkFilename === undefined
+      ? {}
+      : {
+          tools: {
+            rspack: {
+              output: {
+                chunkFilename: defaultJsChunkFilename,
+              },
+            },
+          },
+        };
 
   const finalConfig: RsbuildConfig = userJsFilename
     ? chunkFilename
@@ -1676,7 +1719,6 @@ async function composeLibRsbuildConfig(
     bundle,
     umdName,
     enabledShims,
-    multiCompilerIndex,
     sourceEntry: config.source?.entry,
   });
   const moduleIdsConfig = composeModuleIdsConfig(format, target);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -937,25 +937,6 @@ const composeOutputFilenameConfig = (
   const inferredJsChunkFilename = inferChunkFilename(
     userJsFilename ?? defaultJsFilenameTemplate,
   );
-  const defaultJsChunkFilename =
-    multiCompilerSuffix && inferredJsChunkFilename !== undefined
-      ? appendMultiCompilerSuffix(inferredJsChunkFilename, multiCompilerSuffix)
-      : inferredJsChunkFilename;
-  // With the default filename, runtime and other initial chunks use `filename`
-  // instead of `chunkFilename`. Keep entry filenames stable while isolating the
-  // other chunks by compiler. The first compiler keeps the original filename,
-  // and later compilers append a stable suffix based on their `lib` order.
-  // Do not infer whether compiler output paths actually overlap here.
-  const shouldSuffixInitialChunk = Boolean(multiCompilerSuffix);
-  const defaultInitialChunkFilename = shouldSuffixInitialChunk
-    ? appendMultiCompilerSuffix(defaultJsFilenameTemplate, multiCompilerSuffix)
-    : defaultJsFilenameTemplate;
-  const defaultJsFilename: Rspack.Filename = shouldSuffixInitialChunk
-    ? ({ chunk }) =>
-        isEntryChunk(chunk)
-          ? defaultJsFilenameTemplate
-          : defaultInitialChunkFilename
-    : defaultJsFilenameTemplate;
 
   // will be returned to use in redirect feature
   // only support string type for now since we can not get the return value of function
@@ -964,28 +945,60 @@ const composeOutputFilenameConfig = (
       ? extname(userJsFilename)
       : jsExtension;
 
-  const chunkFilename: RsbuildConfig =
-    defaultJsChunkFilename === undefined
-      ? {}
-      : {
-          tools: {
-            rspack: {
-              output: {
-                chunkFilename: defaultJsChunkFilename,
-              },
-            },
-          },
-        };
+  if (inferredJsChunkFilename === undefined) {
+    return {
+      config: {},
+      jsExtension: finalJsExtension,
+      dtsExtension,
+    };
+  }
 
-  const finalConfig: RsbuildConfig = userJsFilename
-    ? chunkFilename
-    : mergeRsbuildConfig(chunkFilename, {
-        output: {
-          filename: {
-            js: defaultJsFilename,
-          },
-        },
-      });
+  // Runtime and other initial chunks use `filename` instead of `chunkFilename`.
+  // For default and string filename templates, keep entry filenames stable
+  // while isolating the other chunks by compiler. The first compiler keeps the
+  // original filename, and later compilers append a stable suffix based on
+  // their `lib` order.
+  // Do not infer whether compiler output paths actually overlap here.
+  const jsFilenameTemplate =
+    typeof userJsFilename === 'string'
+      ? userJsFilename
+      : defaultJsFilenameTemplate;
+  let jsFilename: Rspack.Filename = jsFilenameTemplate;
+  let jsChunkFilename = inferredJsChunkFilename;
+
+  if (multiCompilerSuffix) {
+    const nonEntryFilename = appendMultiCompilerSuffix(
+      jsFilenameTemplate,
+      multiCompilerSuffix,
+    );
+    jsFilename = ({ chunk }) =>
+      isEntryChunk(chunk) ? jsFilenameTemplate : nonEntryFilename;
+    jsChunkFilename = appendMultiCompilerSuffix(
+      inferredJsChunkFilename,
+      multiCompilerSuffix,
+    );
+  }
+
+  const rspackOutput: NonNullable<Rspack.Configuration['output']> = {
+    chunkFilename: jsChunkFilename,
+  };
+  const finalConfig: RsbuildConfig = {
+    tools: {
+      rspack: {
+        output: rspackOutput,
+      },
+    },
+  };
+
+  if (userJsFilename === undefined) {
+    finalConfig.output = {
+      filename: {
+        js: jsFilename,
+      },
+    };
+  } else if (multiCompilerSuffix) {
+    rspackOutput.filename = jsFilename;
+  }
 
   return {
     // Do not modify MF's output hash configuration.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -926,9 +926,7 @@ const composeOutputFilenameConfig = (
 
   const hash = getHash();
   const multiCompilerSuffix =
-    typeof multiCompilerIndex === 'number' && multiCompilerIndex > 0
-      ? `~${multiCompilerIndex}`
-      : '';
+    typeof multiCompilerIndex === 'number' ? `~${multiCompilerIndex}` : '';
   const defaultJsFilenameTemplate = `[name]${hash}${jsExtension}`;
   const userJsFilename = config.output?.filename?.js;
   // A custom filename function owns the naming contract. Leave
@@ -955,9 +953,8 @@ const composeOutputFilenameConfig = (
 
   // Runtime and other initial chunks use `filename` instead of `chunkFilename`.
   // For default and string filename templates, keep entry filenames stable
-  // while isolating the other chunks by compiler. The first compiler keeps the
-  // original filename, and later compilers append a stable suffix based on
-  // their `lib` order.
+  // while isolating the other chunks by compiler. Multi-compiler builds append
+  // a stable suffix based on each compiler's `lib` index, starting from `~0`.
   // Do not infer whether compiler output paths actually overlap here.
   const jsFilenameTemplate =
     typeof userJsFilename === 'string'

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -398,7 +398,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     devtoolFallbackModuleFilenameTemplate: '[relative-resource-path]?[hash]',
     path: '<WORKSPACE>/dist',
     filename: '[name].js',
-    chunkFilename: '0~[name].js',
+    chunkFilename: '[name].js',
     publicPath: 'auto',
     library: {
       type: 'modern-module'
@@ -1112,7 +1112,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     nodeEnv: false,
     concatenateModules: false,
     sideEffects: true,
-    runtimeChunk: undefined,
     avoidEntryIife: true,
     moduleIds: 'named'
   },
@@ -1267,8 +1266,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     devtoolModuleFilenameTemplate: '[relative-resource-path]',
     devtoolFallbackModuleFilenameTemplate: '[relative-resource-path]?[hash]',
     path: '<WORKSPACE>/dist',
-    filename: '[name].cjs',
-    chunkFilename: '1~[name].cjs',
+    filename: function () { /* omitted long function */ },
+    chunkFilename: '[name]~1.cjs',
     publicPath: 'auto',
     library: {
       type: 'commonjs-static'
@@ -2130,8 +2129,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     devtoolModuleFilenameTemplate: '[relative-resource-path]',
     devtoolFallbackModuleFilenameTemplate: '[relative-resource-path]?[hash]',
     path: '<WORKSPACE>/dist',
-    filename: '[name].js',
-    chunkFilename: '2~[name].js',
+    filename: function () { /* omitted long function */ },
+    chunkFilename: '[name]~2.js',
     publicPath: '/',
     library: {
       type: 'umd'
@@ -2902,8 +2901,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     devtoolModuleFilenameTemplate: '[relative-resource-path]',
     devtoolFallbackModuleFilenameTemplate: '[relative-resource-path]?[hash]',
     path: '<WORKSPACE>/dist',
-    filename: '[name].js',
-    chunkFilename: '3~[name].js',
+    filename: function () { /* omitted long function */ },
+    chunkFilename: '[name]~3.js',
     publicPath: '/',
     library: {
       type: 'module'
@@ -4489,7 +4488,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             "avoidEntryIife": true,
             "concatenateModules": false,
             "moduleIds": "named",
-            "runtimeChunk": undefined,
             "sideEffects": true,
             "splitChunks": {
               "chunks": "async",
@@ -4520,7 +4518,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         [Function],
         {
           "output": {
-            "chunkFilename": "0~[name].js",
+            "chunkFilename": "[name].js",
           },
         },
         {
@@ -4644,7 +4642,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "pnpapi",
       ],
       "filename": {
-        "js": "[name].cjs",
+        "js": [Function],
       },
       "filenameHash": false,
       "minify": {
@@ -4793,7 +4791,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         [Function],
         {
           "output": {
-            "chunkFilename": "1~[name].cjs",
+            "chunkFilename": "[name]~1.cjs",
           },
         },
         {
@@ -4907,7 +4905,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "pnpapi",
       ],
       "filename": {
-        "js": "[name].js",
+        "js": [Function],
       },
       "filenameHash": false,
       "minify": {
@@ -5029,7 +5027,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         [Function],
         {
           "output": {
-            "chunkFilename": "2~[name].js",
+            "chunkFilename": "[name]~2.js",
           },
         },
         {
@@ -5143,7 +5141,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "pnpapi",
       ],
       "filename": {
-        "js": "[name].js",
+        "js": [Function],
       },
       "filenameHash": false,
       "minify": {
@@ -5269,7 +5267,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         [Function],
         {
           "output": {
-            "chunkFilename": "3~[name].js",
+            "chunkFilename": "[name]~3.js",
           },
         },
         {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -397,8 +397,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     devtoolModuleFilenameTemplate: '[relative-resource-path]',
     devtoolFallbackModuleFilenameTemplate: '[relative-resource-path]?[hash]',
     path: '<WORKSPACE>/dist',
-    filename: '[name].js',
-    chunkFilename: '[name].js',
+    filename: function () { /* omitted long function */ },
+    chunkFilename: '[name]~0.js',
     publicPath: 'auto',
     library: {
       type: 'modern-module'
@@ -4371,7 +4371,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "pnpapi",
       ],
       "filename": {
-        "js": "[name].js",
+        "js": [Function],
       },
       "filenameHash": false,
       "minify": {
@@ -4518,7 +4518,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         [Function],
         {
           "output": {
-            "chunkFilename": "[name].js",
+            "chunkFilename": "[name]~0.js",
           },
         },
         {

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -1,15 +1,14 @@
-import { mkdtemp, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { describe, expect, rs, test } from '@rstest/core';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { BuildOptions } from '../src/cli/commands';
 import { init, initCliAction } from '../src/cli/init';
 import {
   composeCreateRsbuildConfig,
   composeRsbuildEnvironments,
-  getRuntimeChunkConfig,
 } from '../src/config';
 import { createRslib } from '../src/createRslib';
 import { loadConfig } from '../src/loadConfig';
@@ -572,6 +571,87 @@ describe('Should compose create Rsbuild config correctly', () => {
     });
   });
 
+  test('infers and suffixes chunkFilename from string filenames', async () => {
+    const rslib = await createRslib({
+      config: {
+        root: join(__dirname, '..'),
+        source: {
+          entry: {
+            index: './src/index.ts',
+          },
+        },
+        lib: [
+          { output: { filename: { js: '[name].js' } } },
+          { output: { filename: { js: '[name].js' } } },
+          { output: { filename: { js: 'assets/file.js?asset=/x' } } },
+          { output: { filename: { js: '[contenthash:10].js' } } },
+        ],
+      },
+    });
+    const {
+      origin: { bundlerConfigs },
+    } = await rslib.inspectConfig({ verbose: true });
+
+    expect(
+      bundlerConfigs.map((config) => config.output?.chunkFilename),
+    ).toEqual([
+      '[name].js',
+      '[name]~1.js',
+      'assets/[id]~2.file.js?asset=/x',
+      '[id]~3.[contenthash:10].js',
+    ]);
+  });
+
+  test('does not override chunkFilename for filename functions', async () => {
+    const filename = () => '[name].js';
+    const rslibConfig: RslibConfig = {
+      root: join(__dirname, '..'),
+      source: {
+        entry: {
+          index: './src/index.ts',
+        },
+      },
+      lib: [
+        { output: { filename: { js: filename } } },
+        { output: { filename: { js: filename } } },
+      ],
+    };
+
+    const composedRsbuildConfigs =
+      await composeCreateRsbuildConfig(rslibConfig);
+    expect(
+      composedRsbuildConfigs.map(({ config }) => config.output?.filename?.js),
+    ).toEqual([filename, filename]);
+    for (const { config } of composedRsbuildConfigs) {
+      const rspackConfigs = Array.isArray(config.tools?.rspack)
+        ? config.tools.rspack
+        : [config.tools?.rspack];
+      expect(
+        rspackConfigs.some(
+          (rspackConfig) =>
+            typeof rspackConfig === 'object' &&
+            rspackConfig.output !== undefined &&
+            Object.prototype.hasOwnProperty.call(
+              rspackConfig.output,
+              'chunkFilename',
+            ),
+        ),
+      ).toBe(false);
+    }
+
+    const rslib = await createRslib({ config: rslibConfig });
+    const {
+      origin: { bundlerConfigs },
+    } = await rslib.inspectConfig({ verbose: true });
+
+    expect(
+      bundlerConfigs.map((config) => typeof config.output?.filename),
+    ).toEqual(['function', 'function']);
+    expect(
+      bundlerConfigs.map((config) => config.output?.chunkFilename),
+    ).toEqual([expect.any(Function), expect.any(Function)]);
+  });
+
   test('Merge output.distPath correctly', async () => {
     const rslibConfig: RslibConfig = {
       lib: [
@@ -613,83 +693,6 @@ describe('Should compose create Rsbuild config correctly', () => {
         "root": "dist/cjs",
       }
     `);
-  });
-});
-
-describe('runtimeChunk', () => {
-  test('defaults to rslib-runtime for bundleless esm', async () => {
-    expect(
-      getRuntimeChunkConfig({
-        bundle: false,
-        multiCompilerIndex: null,
-      }),
-    ).toEqual({
-      name: 'rslib-runtime',
-    });
-  });
-
-  test('defaults to undefined for single-entry bundled esm', async () => {
-    expect(
-      getRuntimeChunkConfig({
-        bundle: true,
-        multiCompilerIndex: null,
-        sourceEntry: {
-          index: './src/index.ts',
-        },
-      }),
-    ).toBeUndefined();
-  });
-
-  test('returns runtime chunk for multiple entries without multi-compiler', async () => {
-    expect(
-      getRuntimeChunkConfig({
-        bundle: true,
-        multiCompilerIndex: null,
-        sourceEntry: {
-          index: './src/index.ts',
-          cli: './src/cli/index.ts',
-        },
-      }),
-    ).toEqual({
-      name: 'rslib-runtime',
-    });
-  });
-
-  test('returns prefixed runtime chunk for multiple entries with multi-compiler', async () => {
-    expect(
-      getRuntimeChunkConfig({
-        bundle: true,
-        multiCompilerIndex: 0,
-        sourceEntry: {
-          foo: './src/foo.ts',
-          bar: './src/bar.ts',
-        },
-      }),
-    ).toEqual({
-      name: '0~rslib-runtime',
-    });
-    expect(
-      getRuntimeChunkConfig({
-        bundle: true,
-        multiCompilerIndex: 1,
-        sourceEntry: {
-          foo: './src/foo.ts',
-          bar: './src/bar.ts',
-        },
-      }),
-    ).toEqual({
-      name: '1~rslib-runtime',
-    });
-  });
-
-  test('returns undefined when source.entry is not provided', async () => {
-    expect(
-      getRuntimeChunkConfig({
-        bundle: true,
-        multiCompilerIndex: null,
-        sourceEntry: undefined,
-      }),
-    ).toBeUndefined();
   });
 });
 
@@ -789,9 +792,9 @@ describe('syntax', () => {
 
     const composedRsbuildConfig = await composeCreateRsbuildConfig(rslibConfig);
 
-    expect(composedRsbuildConfig[0]!.config.output?.overrideBrowserslist).toEqual(
-      ['node >= 20.19.0'],
-    );
+    expect(
+      composedRsbuildConfig[0]!.config.output?.overrideBrowserslist,
+    ).toEqual(['node >= 20.19.0']);
   });
 
   test('explicit `syntax` should take precedence over engines.node', async () => {

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -595,7 +595,7 @@ describe('Should compose create Rsbuild config correctly', () => {
     expect(
       bundlerConfigs.map((config) => config.output?.chunkFilename),
     ).toEqual([
-      '[name].js',
+      '[name]~0.js',
       '[name]~1.js',
       'assets/[id]~2.file.js?asset=/x',
       '[id]~3.[contenthash:10].js',

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -236,7 +236,7 @@ test('set the assets public path', async () => {
     /assets\/image\.js/,
   );
   expect(imageJs).toMatchInlineSnapshot(`
-    "import { __webpack_require__ } from "../rslib-runtime.js";
+    "import { __webpack_require__ } from "../rslib-runtime~2.js";
     const image_namespaceObject = __webpack_require__.p + "static/image/image.png";
     export default image_namespaceObject;
     "

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -227,10 +227,10 @@ test('bundleless user externals false should preserve shared dependency behavior
 
   expect(files.esm1).toMatchInlineSnapshot(`
     [
-      "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/esm-shared/504.js",
+      "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/esm-shared/504~2.js",
       "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/esm-shared/a.js",
       "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/esm-shared/b.js",
-      "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/esm-shared/rslib-runtime.js",
+      "<ROOT>/tests/integration/externals/bundleless-user-external-false/dist/esm-shared/rslib-runtime~2.js",
     ]
   `);
   expect(files.cjs1).toMatchInlineSnapshot(`
@@ -244,12 +244,12 @@ test('bundleless user externals false should preserve shared dependency behavior
   // so this case only verifies the shared behavior for JS dependency modules.
   expect(
     queryContent(contents.esm1!, 'a.js', { basename: true }).content,
-  ).toContain('import "./504.js";');
+  ).toContain('import "./504~2.js";');
   expect(
     queryContent(contents.esm1!, 'b.js', { basename: true }).content,
-  ).toContain('import "./504.js";');
+  ).toContain('import "./504~2.js";');
   expect(
-    queryContent(contents.esm1!, '504.js', { basename: true }).content,
+    queryContent(contents.esm1!, '504~2.js', { basename: true }).content,
   ).toContain('./node_modules/foo/index.js');
   expect(
     queryContent(contents.cjs1!, 'a.cjs', { basename: true }).content,

--- a/tests/integration/output/chunkFileName-multi/rslib4.config.ts
+++ b/tests/integration/output/chunkFileName-multi/rslib4.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          runtime1: './src/runtime1.js',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          runtime2: './src/runtime2.js',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          multi1: './src/runtime1.js',
+          multi2: './src/runtime2.js',
+        },
+      },
+    }),
+    generateBundleEsmConfig({
+      source: {
+        entry: {
+          manual: './src/runtime1.js',
+        },
+      },
+      tools: {
+        rspack: {
+          optimization: {
+            runtimeChunk: {
+              name: 'manual-runtime',
+            },
+          },
+        },
+      },
+    }),
+  ],
+});

--- a/tests/integration/output/chunkFileName-multi/rslib4.config.ts
+++ b/tests/integration/output/chunkFileName-multi/rslib4.config.ts
@@ -24,6 +24,11 @@ export default defineConfig({
           multi2: './src/runtime2.js',
         },
       },
+      output: {
+        filename: {
+          js: 'custom/[name].js',
+        },
+      },
     }),
     generateBundleEsmConfig({
       source: {

--- a/tests/integration/output/chunkFileName-multi/src/runtime-dep.cjs
+++ b/tests/integration/output/chunkFileName-multi/src/runtime-dep.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  value: 'runtime',
+};

--- a/tests/integration/output/chunkFileName-multi/src/runtime1.js
+++ b/tests/integration/output/chunkFileName-multi/src/runtime1.js
@@ -1,0 +1,4 @@
+import dep from './runtime-dep.cjs';
+
+export const value = dep.value;
+export const loadShared = () => import('./shared.js');

--- a/tests/integration/output/chunkFileName-multi/src/runtime2.js
+++ b/tests/integration/output/chunkFileName-multi/src/runtime2.js
@@ -1,0 +1,4 @@
+import dep from './runtime-dep.cjs';
+
+export const value = dep.value;
+export const loadShared = () => import('./shared.js');

--- a/tests/integration/output/index.test.ts
+++ b/tests/integration/output/index.test.ts
@@ -1,10 +1,10 @@
-import { basename, join } from 'node:path';
 import { describe, expect, test } from '@rstest/core';
+import { basename, join } from 'node:path';
 import { buildAndGetResults } from 'test-helper';
 
 describe('output config', () => {
   describe('chunkFileName', () => {
-    test('should prefix index for multi-compiler builds', async () => {
+    test('should suffix index for multi-compiler builds', async () => {
       const fixturePath = join(__dirname, 'chunkFileName-multi');
       const { files, rspackConfig } = await buildAndGetResults({
         fixturePath,
@@ -12,17 +12,25 @@ describe('output config', () => {
       });
 
       expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
-      expect(rspackConfig[0]!.output?.chunkFilename).toBe('0~[name].js');
-      expect(rspackConfig[1]!.output?.chunkFilename).toBe('1~[name].js');
+      expect(rspackConfig[0]!.optimization?.runtimeChunk).toBeUndefined();
+      expect(rspackConfig[1]!.optimization?.runtimeChunk).toBeUndefined();
+      expect(rspackConfig[0]!.output?.chunkFilename).toBe('[name].js');
+      expect(rspackConfig[1]!.output?.chunkFilename).toBe('[name]~1.js');
 
       const esm0BaseNames = (files.esm0 ?? []).map((p) => basename(p));
       const esm1BaseNames = (files.esm1 ?? []).map((p) => basename(p));
 
-      expect(esm0BaseNames.some((n) => n === '0~shared.js')).toBeTruthy();
-      expect(esm1BaseNames.some((n) => n === '1~shared.js')).toBeTruthy();
+      expect(esm0BaseNames).toContain('lib1.js');
+      expect(esm1BaseNames).toContain('lib2.js');
+      expect(esm0BaseNames.some((name) => /^\d+\.js$/.test(name))).toBe(false);
+      expect(esm1BaseNames.some((name) => /^\d+~1\.js$/.test(name))).toBe(
+        false,
+      );
+      expect(esm0BaseNames.some((n) => n === 'shared.js')).toBeTruthy();
+      expect(esm1BaseNames.some((n) => n === 'shared~1.js')).toBeTruthy();
     });
 
-    test('should prefix index for multi-compiler builds (with filename)', async () => {
+    test('should suffix index for multi-compiler builds (with filename)', async () => {
       const fixturePath = join(__dirname, 'chunkFileName-multi');
       const { files, rspackConfig } = await buildAndGetResults({
         fixturePath,
@@ -30,25 +38,31 @@ describe('output config', () => {
       });
 
       expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
+      expect(
+        rspackConfig.slice(0, 2).map((config) => config.output?.filename),
+      ).toEqual([
+        'static/js/[name].[contenthash:10].js',
+        'static/js/[name].[contenthash:10].js',
+      ]);
       expect(rspackConfig[0]!.output?.chunkFilename).toBe(
-        'static/js/0~[name].[contenthash:10].js',
+        'static/js/[name].[contenthash:10].js',
       );
       expect(rspackConfig[1]!.output?.chunkFilename).toBe(
-        'static/js/1~[name].[contenthash:10].js',
+        'static/js/[name]~1.[contenthash:10].js',
       );
 
       const esm0BaseNames = (files.esm0 ?? []).map((p) => basename(p));
       const esm1BaseNames = (files.esm1 ?? []).map((p) => basename(p));
 
       expect(
-        esm0BaseNames.some((n) => /^0~shared\.[a-f0-9]+\.js$/.test(n)),
+        esm0BaseNames.some((n) => /^shared\.[a-f0-9]+\.js$/.test(n)),
       ).toBeTruthy();
       expect(
-        esm1BaseNames.some((n) => /^1~shared\.[a-f0-9]+\.js$/.test(n)),
+        esm1BaseNames.some((n) => /^shared~1\.[a-f0-9]+\.js$/.test(n)),
       ).toBeTruthy();
     });
 
-    test('should prefix index for multi-compiler builds (with chunkFilename)', async () => {
+    test('should suffix index for multi-compiler builds (with chunkFilename)', async () => {
       const fixturePath = join(__dirname, 'chunkFileName-multi');
       const { files, rspackConfig } = await buildAndGetResults({
         fixturePath,
@@ -56,22 +70,28 @@ describe('output config', () => {
       });
 
       expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
+      expect(
+        rspackConfig.slice(0, 2).map((config) => config.output?.filename),
+      ).toEqual([
+        'static1/js/[name].js',
+        'static2/js/[name].[contenthash:10].js',
+      ]);
       expect(rspackConfig[0]!.output?.chunkFilename).toBe(
-        'static1/js/0~[name].js',
+        'static1/js/[name].js',
       );
       expect(rspackConfig[1]!.output?.chunkFilename).toBe(
-        'static2/js/1~[name].[contenthash:10].js',
+        'static2/js/[name]~1.[contenthash:10].js',
       );
 
       expect(
-        files.esm0!.some((n) => /static1\/js\/0~shared\.js$/.test(n)),
+        files.esm0!.some((n) => /static1\/js\/shared\.js$/.test(n)),
       ).toBeTruthy();
       expect(
         files.esm0!.some((n) => /static1\/js\/lib1\.js$/.test(n)),
       ).toBeTruthy();
       expect(
         files.esm0!.some((n) =>
-          /static2\/js\/1~shared\.[a-f0-9]+\.js$/.test(n),
+          /static2\/js\/shared~1\.[a-f0-9]+\.js$/.test(n),
         ),
       ).toBeTruthy();
       expect(
@@ -79,12 +99,54 @@ describe('output config', () => {
       ).toBeTruthy();
     });
 
-    test('should not prefix index for single-compiler builds', async () => {
+    test('should suffix non-entry initial chunks for later compilers', async () => {
+      const fixturePath = join(__dirname, 'chunkFileName-multi');
+      const { files, rspackConfig } = await buildAndGetResults({
+        fixturePath,
+        configPath: 'rslib4.config.ts',
+      });
+
+      expect(rspackConfig.length).toBeGreaterThanOrEqual(4);
+      expect(rspackConfig[0]!.output?.filename).toBe('[name].js');
+      expect(typeof rspackConfig[1]!.output?.filename).toBe('function');
+      expect(typeof rspackConfig[2]!.output?.filename).toBe('function');
+      expect(typeof rspackConfig[3]!.output?.filename).toBe('function');
+      expect(rspackConfig[0]!.optimization?.runtimeChunk).toBeUndefined();
+      expect(rspackConfig[1]!.optimization?.runtimeChunk).toBeUndefined();
+      expect(rspackConfig[2]!.optimization?.runtimeChunk).toEqual({
+        name: 'rslib-runtime',
+      });
+      expect(rspackConfig[3]!.optimization?.runtimeChunk).toEqual({
+        name: 'manual-runtime',
+      });
+
+      const getBaseNames = (paths: string[] | undefined) =>
+        (paths ?? []).map((p) => basename(p));
+      const esm0BaseNames = getBaseNames(files.esm0);
+      const esm1BaseNames = getBaseNames(files.esm1);
+      const esm2BaseNames = getBaseNames(files.esm2);
+      const esm3BaseNames = getBaseNames(files.esm3);
+
+      expect(esm0BaseNames).toContain('runtime1.js');
+      expect(esm1BaseNames).toContain('runtime2.js');
+      expect(esm2BaseNames).toEqual(
+        expect.arrayContaining(['multi1.js', 'multi2.js']),
+      );
+      expect(esm3BaseNames).toContain('manual.js');
+      expect(esm0BaseNames.some((name) => /^\d+\.js$/.test(name))).toBe(true);
+      expect(esm1BaseNames.some((name) => /^\d+~1\.js$/.test(name))).toBe(true);
+      expect(esm2BaseNames).toContain('rslib-runtime~2.js');
+      expect(esm3BaseNames).toContain('manual-runtime~3.js');
+      expect(esm2BaseNames).toContain('shared~2.js');
+      expect(esm3BaseNames).toContain('shared~3.js');
+    });
+
+    test('should not suffix index for single-compiler builds', async () => {
       const fixturePath = join(__dirname, 'chunkFileName-single');
       const { files } = await buildAndGetResults({ fixturePath });
 
       const esmBaseNames = (files.esm ?? []).map((p) => basename(p));
-      expect(esmBaseNames.some((n) => /^\d+~.+\.js$/.test(n))).toBeFalsy();
+      expect(esmBaseNames.some((n) => /~\d+\.js$/.test(n))).toBeFalsy();
       expect(
         esmBaseNames.some(
           (n) => /^\d+\.js$/.test(n) || /shared.*\.js$/.test(n),

--- a/tests/integration/output/index.test.ts
+++ b/tests/integration/output/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@rstest/core';
-import { basename, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { buildAndGetResults } from 'test-helper';
 
 describe('output config', () => {
@@ -38,12 +38,9 @@ describe('output config', () => {
       });
 
       expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
-      expect(
-        rspackConfig.slice(0, 2).map((config) => config.output?.filename),
-      ).toEqual([
+      expect(rspackConfig[0]!.output?.filename).toBe(
         'static/js/[name].[contenthash:10].js',
-        'static/js/[name].[contenthash:10].js',
-      ]);
+      );
       expect(rspackConfig[0]!.output?.chunkFilename).toBe(
         'static/js/[name].[contenthash:10].js',
       );
@@ -60,6 +57,12 @@ describe('output config', () => {
       expect(
         esm1BaseNames.some((n) => /^shared~1\.[a-f0-9]+\.js$/.test(n)),
       ).toBeTruthy();
+      expect(
+        esm0BaseNames.some((n) => /^lib1\.[a-f0-9]+\.js$/.test(n)),
+      ).toBeTruthy();
+      expect(
+        esm1BaseNames.some((n) => /^lib2\.[a-f0-9]+\.js$/.test(n)),
+      ).toBeTruthy();
     });
 
     test('should suffix index for multi-compiler builds (with chunkFilename)', async () => {
@@ -70,12 +73,7 @@ describe('output config', () => {
       });
 
       expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
-      expect(
-        rspackConfig.slice(0, 2).map((config) => config.output?.filename),
-      ).toEqual([
-        'static1/js/[name].js',
-        'static2/js/[name].[contenthash:10].js',
-      ]);
+      expect(rspackConfig[0]!.output?.filename).toBe('static1/js/[name].js');
       expect(rspackConfig[0]!.output?.chunkFilename).toBe(
         'static1/js/[name].js',
       );
@@ -107,10 +105,6 @@ describe('output config', () => {
       });
 
       expect(rspackConfig.length).toBeGreaterThanOrEqual(4);
-      expect(rspackConfig[0]!.output?.filename).toBe('[name].js');
-      expect(typeof rspackConfig[1]!.output?.filename).toBe('function');
-      expect(typeof rspackConfig[2]!.output?.filename).toBe('function');
-      expect(typeof rspackConfig[3]!.output?.filename).toBe('function');
       expect(rspackConfig[0]!.optimization?.runtimeChunk).toBeUndefined();
       expect(rspackConfig[1]!.optimization?.runtimeChunk).toBeUndefined();
       expect(rspackConfig[2]!.optimization?.runtimeChunk).toEqual({
@@ -124,21 +118,26 @@ describe('output config', () => {
         (paths ?? []).map((p) => basename(p));
       const esm0BaseNames = getBaseNames(files.esm0);
       const esm1BaseNames = getBaseNames(files.esm1);
-      const esm2BaseNames = getBaseNames(files.esm2);
       const esm3BaseNames = getBaseNames(files.esm3);
+      const esm2OutputFiles = (files.esm2 ?? []).map((path) =>
+        join(basename(dirname(path)), basename(path)),
+      );
 
       expect(esm0BaseNames).toContain('runtime1.js');
       expect(esm1BaseNames).toContain('runtime2.js');
-      expect(esm2BaseNames).toEqual(
-        expect.arrayContaining(['multi1.js', 'multi2.js']),
-      );
       expect(esm3BaseNames).toContain('manual.js');
       expect(esm0BaseNames.some((name) => /^\d+\.js$/.test(name))).toBe(true);
       expect(esm1BaseNames.some((name) => /^\d+~1\.js$/.test(name))).toBe(true);
-      expect(esm2BaseNames).toContain('rslib-runtime~2.js');
       expect(esm3BaseNames).toContain('manual-runtime~3.js');
-      expect(esm2BaseNames).toContain('shared~2.js');
       expect(esm3BaseNames).toContain('shared~3.js');
+      expect(esm2OutputFiles).toEqual(
+        expect.arrayContaining([
+          join('custom', 'multi1.js'),
+          join('custom', 'multi2.js'),
+          join('custom', 'rslib-runtime~2.js'),
+          join('custom', 'shared~2.js'),
+        ]),
+      );
     });
 
     test('should not suffix index for single-compiler builds', async () => {

--- a/tests/integration/output/index.test.ts
+++ b/tests/integration/output/index.test.ts
@@ -14,7 +14,7 @@ describe('output config', () => {
       expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
       expect(rspackConfig[0]!.optimization?.runtimeChunk).toBeUndefined();
       expect(rspackConfig[1]!.optimization?.runtimeChunk).toBeUndefined();
-      expect(rspackConfig[0]!.output?.chunkFilename).toBe('[name].js');
+      expect(rspackConfig[0]!.output?.chunkFilename).toBe('[name]~0.js');
       expect(rspackConfig[1]!.output?.chunkFilename).toBe('[name]~1.js');
 
       const esm0BaseNames = (files.esm0 ?? []).map((p) => basename(p));
@@ -22,11 +22,13 @@ describe('output config', () => {
 
       expect(esm0BaseNames).toContain('lib1.js');
       expect(esm1BaseNames).toContain('lib2.js');
-      expect(esm0BaseNames.some((name) => /^\d+\.js$/.test(name))).toBe(false);
+      expect(esm0BaseNames.some((name) => /^\d+~0\.js$/.test(name))).toBe(
+        false,
+      );
       expect(esm1BaseNames.some((name) => /^\d+~1\.js$/.test(name))).toBe(
         false,
       );
-      expect(esm0BaseNames.some((n) => n === 'shared.js')).toBeTruthy();
+      expect(esm0BaseNames.some((n) => n === 'shared~0.js')).toBeTruthy();
       expect(esm1BaseNames.some((n) => n === 'shared~1.js')).toBeTruthy();
     });
 
@@ -38,11 +40,8 @@ describe('output config', () => {
       });
 
       expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
-      expect(rspackConfig[0]!.output?.filename).toBe(
-        'static/js/[name].[contenthash:10].js',
-      );
       expect(rspackConfig[0]!.output?.chunkFilename).toBe(
-        'static/js/[name].[contenthash:10].js',
+        'static/js/[name]~0.[contenthash:10].js',
       );
       expect(rspackConfig[1]!.output?.chunkFilename).toBe(
         'static/js/[name]~1.[contenthash:10].js',
@@ -52,7 +51,7 @@ describe('output config', () => {
       const esm1BaseNames = (files.esm1 ?? []).map((p) => basename(p));
 
       expect(
-        esm0BaseNames.some((n) => /^shared\.[a-f0-9]+\.js$/.test(n)),
+        esm0BaseNames.some((n) => /^shared~0\.[a-f0-9]+\.js$/.test(n)),
       ).toBeTruthy();
       expect(
         esm1BaseNames.some((n) => /^shared~1\.[a-f0-9]+\.js$/.test(n)),
@@ -73,16 +72,15 @@ describe('output config', () => {
       });
 
       expect(rspackConfig.length).toBeGreaterThanOrEqual(2);
-      expect(rspackConfig[0]!.output?.filename).toBe('static1/js/[name].js');
       expect(rspackConfig[0]!.output?.chunkFilename).toBe(
-        'static1/js/[name].js',
+        'static1/js/[name]~0.js',
       );
       expect(rspackConfig[1]!.output?.chunkFilename).toBe(
         'static2/js/[name]~1.[contenthash:10].js',
       );
 
       expect(
-        files.esm0!.some((n) => /static1\/js\/shared\.js$/.test(n)),
+        files.esm0!.some((n) => /static1\/js\/shared~0\.js$/.test(n)),
       ).toBeTruthy();
       expect(
         files.esm0!.some((n) => /static1\/js\/lib1\.js$/.test(n)),
@@ -97,7 +95,7 @@ describe('output config', () => {
       ).toBeTruthy();
     });
 
-    test('should suffix non-entry initial chunks for later compilers', async () => {
+    test('should suffix non-entry initial chunks for all compilers', async () => {
       const fixturePath = join(__dirname, 'chunkFileName-multi');
       const { files, rspackConfig } = await buildAndGetResults({
         fixturePath,
@@ -126,8 +124,9 @@ describe('output config', () => {
       expect(esm0BaseNames).toContain('runtime1.js');
       expect(esm1BaseNames).toContain('runtime2.js');
       expect(esm3BaseNames).toContain('manual.js');
-      expect(esm0BaseNames.some((name) => /^\d+\.js$/.test(name))).toBe(true);
+      expect(esm0BaseNames.some((name) => /^\d+~0\.js$/.test(name))).toBe(true);
       expect(esm1BaseNames.some((name) => /^\d+~1\.js$/.test(name))).toBe(true);
+      expect(esm0BaseNames).toContain('shared~0.js');
       expect(esm3BaseNames).toContain('manual-runtime~3.js');
       expect(esm3BaseNames).toContain('shared~3.js');
       expect(esm2OutputFiles).toEqual(

--- a/tests/integration/resolve/index.test.ts
+++ b/tests/integration/resolve/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { expect, test } from '@rstest/core';
-import { buildAndGetResults } from 'test-helper';
+import { buildAndGetResults, queryContent } from 'test-helper';
 
 test('resolve data url', async () => {
   const fixturePath = join(__dirname, 'data-url');
@@ -89,20 +89,25 @@ test('resolve with condition exports', async () => {
   const fixturePath = join(__dirname, 'with-condition-exports');
   const { contents, isSuccess } = await buildAndGetResults({ fixturePath });
 
-  const nodeResults = Object.values(contents.esm0!);
-  const browserResults = Object.values(contents.esm1!);
+  const entryFiles = ['entry1.js', 'entry2.js', 'entry3.js', 'entry4.js'];
+  const getEntryContents = (output: Record<string, string>) =>
+    entryFiles.map(
+      (filename) => queryContent(output, filename, { basename: true }).content,
+    );
+  const nodeResults = getEntryContents(contents.esm0!);
+  const browserResults = getEntryContents(contents.esm1!);
 
   expect(isSuccess).toBeTruthy();
 
-  expect(nodeResults[1]).toContain('lib1 mjs');
-  expect(nodeResults[2]).toContain('lib2 module');
-  expect(nodeResults[3]).toContain('node');
-  expect(nodeResults[4]).toContain('lib1 cjs');
+  expect(nodeResults[0]).toContain('lib1 mjs');
+  expect(nodeResults[1]).toContain('lib2 module');
+  expect(nodeResults[2]).toContain('node');
+  expect(nodeResults[3]).toContain('lib1 cjs');
 
-  expect(browserResults[1]).toContain('lib1 mjs');
-  expect(browserResults[2]).toContain('lib2 module');
-  expect(browserResults[3]).toContain('browser');
-  expect(browserResults[4]).toContain('lib1 cjs');
+  expect(browserResults[0]).toContain('lib1 mjs');
+  expect(browserResults[1]).toContain('lib2 module');
+  expect(browserResults[2]).toContain('browser');
+  expect(browserResults[3]).toContain('lib1 cjs');
 });
 
 test('resolve with js extensions', async () => {

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -134,7 +134,7 @@ describe('CJS shims', () => {
     const dynamicUrl = await dynamicImportMetaUrl();
     const { path: dynamicPath, content: dynamicContent } = queryContent(
       contents.cjs!,
-      /1~\d+\.cjs/,
+      /\d+~1\.cjs/,
     );
 
     expect(importMetaUrl).toBe(fileUrl);

--- a/tests/integration/vue/index.test.ts
+++ b/tests/integration/vue/index.test.ts
@@ -128,7 +128,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
         "<ROOT>/tests/integration/vue/dist/bundleless/Button/Button.js": "import { createElementBlock, openBlock, ref, toDisplayString } from "vue";
       import "./style.css";
       import "./Button.css";
-      import { __webpack_require__ } from "../rslib-runtime.js";
+      import { __webpack_require__ } from "../rslib-runtime~0.js";
       __webpack_require__.add({
           <MODULE_ID> (__unused_rspack_module, exports) {
               exports.A = (sfc, props)=>{
@@ -179,7 +179,7 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
         "<ROOT>/tests/integration/vue/dist/bundleless/index.js": "export { default as Button } from "./Button/index.js";
       export { default as Card } from "./Card.js";
       ",
-        "<ROOT>/tests/integration/vue/dist/bundleless/rslib-runtime.js": "var __webpack_modules__ = {};
+        "<ROOT>/tests/integration/vue/dist/bundleless/rslib-runtime~0.js": "var __webpack_modules__ = {};
       var __webpack_module_cache__ = {};
       function __webpack_require__(moduleId) {
           var cachedModule = __webpack_module_cache__[moduleId];


### PR DESCRIPTION
## Summary

Multi-compiler builds can emit runtime and other initial chunks through `output.filename`, while async chunks use `output.chunkFilename`. Without a compiler-specific namespace, non-entry chunks can collide with chunks or entries emitted by another library config into the same directory.

- Preserve entry filenames while suffixing every non-entry initial/runtime and async chunk in multi-compiler builds with `~<index>`, starting from `~0`.
- Apply collision protection to the default filename and string `output.filename.js` templates. Filename functions remain user-owned, and explicit `tools.rspack.output.filename/chunkFilename` overrides remain authoritative.
- Extract the default ESM runtime only for bundleless or multi-entry builds, preserving the bundled single-entry single-file expectation.

| Build and `output.filename.js` | Entry | Runtime / other initial | Async |
| --- | --- | --- | --- |
| Single compiler, omitted or string | Keep the original template | Keep the original template | Infer from the original template |
| Multi-compiler, omitted or string (compiler `i`) | Keep the original template | Append `~i` | Infer from the template and append `~i` |
| Function | User-owned | User-owned | User-owned; Rslib does not infer or suffix `chunkFilename` |

## Related Links

- https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/rslib.config.ts#L82

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).