### PR TITLE
fix(core): remove deprecated autoExternal from shared lib config

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -493,7 +493,6 @@ export type SharedLibConfig = Pick<
   LibConfig,
   | 'bundle'
   | 'autoExtension'
-  | 'autoExternal'
   | 'redirect'
   | 'syntax'
   | 'externalHelpers'

--- a/tests/type-tests/resolution-bundler/index.ts
+++ b/tests/type-tests/resolution-bundler/index.ts
@@ -10,7 +10,6 @@ defineConfig({
   lib: [{}],
   bundle: false,
   autoExtension: false,
-  autoExternal: false,
   redirect: {
     js: {
       extension: false,

--- a/tests/type-tests/resolution-nodenext/index.ts
+++ b/tests/type-tests/resolution-nodenext/index.ts
@@ -10,7 +10,6 @@ defineConfig({
   lib: [{}],
   bundle: false,
   autoExtension: false,
-  autoExternal: false,
   redirect: {
     js: {
       extension: false,

--- a/website/docs/en/config/lib/auto-external.mdx
+++ b/website/docs/en/config/lib/auto-external.mdx
@@ -32,7 +32,6 @@ type AutoExternal =
   - `true` when [format](/config/lib/format) is `cjs` or `esm`
   - `false` when [format](/config/lib/format) is `umd` or `mf`
 - **CLI:** `--auto-external` / `--no-auto-external`
-- **Top-level config:** Supported
 
 Whether to automatically externalize dependencies of different dependency types and do not bundle them.
 

--- a/website/docs/en/config/lib/index.mdx
+++ b/website/docs/en/config/lib/index.mdx
@@ -32,7 +32,6 @@ export default {
 The following lib configurations can be placed outside the `lib` field as shared configuration for all outputs or inside a `lib` item to configure a specific output:
 
 - [`autoExtension`](/config/lib/auto-extension)
-- [`autoExternal`](/config/lib/auto-external)
 - [`banner`](/config/lib/banner)
 - [`bundle`](/config/lib/bundle)
 - [`externalHelpers`](/config/lib/external-helpers)

--- a/website/docs/zh/config/lib/auto-external.mdx
+++ b/website/docs/zh/config/lib/auto-external.mdx
@@ -32,7 +32,6 @@ type AutoExternal =
   - 当 [format](/config/lib/format) 为 `cjs` 或 `esm` 时为 `true`
   - 当 [format](/config/lib/format) 为 `umd` 或 `mf` 时为 `false`
 - **命令行：** `--auto-external` / `--no-auto-external`
-- **顶层配置：** 支持
 
 是否自动对不同依赖类型的依赖进行外部化处理，不将其打包。
 

--- a/website/docs/zh/config/lib/index.mdx
+++ b/website/docs/zh/config/lib/index.mdx
@@ -32,7 +32,6 @@ export default {
 以下 lib 配置可以写在 `lib` 字段外，作为所有产物的共享配置，也可以写在 `lib` 项中，用于单独配置对应产物：
 
 - [`autoExtension`](/config/lib/auto-extension)
-- [`autoExternal`](/config/lib/auto-external)
 - [`banner`](/config/lib/banner)
 - [`bundle`](/config/lib/bundle)
 - [`externalHelpers`](/config/lib/external-helpers)


### PR DESCRIPTION
`autoExternal` is deprecated in favor of `output.autoExternal`, so it shouldn't be exposed at the top level via the newly added `SharedLibConfig`. This removes it and drops the now-invalid top-level usage in the type tests.