### PR TITLE
feat(deps): upgrade rsbuild to 2.1.7

### DIFF
--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.8.0",
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -22,7 +22,7 @@
     "@module-federation/enhanced": "^2.8.0",
     "@module-federation/rsbuild-plugin": "^2.8.0",
     "@module-federation/storybook-addon": "^6.0.16",
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.5.2",

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.8.0",
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@rslib/core": "workspace:*",
     "@storybook/addon-docs": "^10.5.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "test": "rstest"
   },
   "dependencies": {
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "rsbuild-plugin-dts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -13,7 +13,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         paths: [
           '<WORKSPACE>/tsconfig.json'
         ],
-        type: 'reload-server'
+        type: 'restart'
       }
     ],
     assetPrefix: '/',

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -31,6 +31,7 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
+        configFileDependencies: [],
         configFilePath,
       },
     });
@@ -48,6 +49,7 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
+        configFileDependencies: [],
         configFilePath,
       },
     });
@@ -65,6 +67,7 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
+        configFileDependencies: [],
         configFilePath,
       },
     });
@@ -82,6 +85,7 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
+        configFileDependencies: [],
         configFilePath,
       },
     });
@@ -99,6 +103,7 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
+        configFileDependencies: [],
         configFilePath,
       },
     });
@@ -116,6 +121,7 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
+        configFileDependencies: [],
         configFilePath,
       },
     });
@@ -133,6 +139,7 @@ describe('Should load config file correctly', () => {
         },
       },
       _privateMeta: {
+        configFileDependencies: [],
         configFilePath,
       },
     });
@@ -406,6 +413,7 @@ describe('CLI options', () => {
       expect(config).toMatchInlineSnapshot(`
       {
         "_privateMeta": {
+          "configFileDependencies": [],
           "configFilePath": "<WORKSPACE>/tests/fixtures/config/cli-options/rslib.config.ts",
           "envFilePaths": [],
         },
@@ -826,9 +834,9 @@ describe('syntax', () => {
 
     const composedRsbuildConfig = await composeCreateRsbuildConfig(rslibConfig);
 
-    expect(composedRsbuildConfig[0]!.config.output?.overrideBrowserslist).toEqual(
-      ['node >= 20.19.0'],
-    );
+    expect(
+      composedRsbuildConfig[0]!.config.output?.overrideBrowserslist,
+    ).toEqual(['node >= 20.19.0']);
   });
 
   test('explicit `syntax` should take precedence over engines.node', async () => {

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@storybook/addon-docs": "^10.5.2",
     "@storybook/addon-onboarding": "^10.5.2",
     "@storybook/react": "^10.5.2",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@storybook/addon-docs": "^10.5.2",
     "@storybook/addon-onboarding": "^10.5.2",
     "@storybook/react": "^10.5.2",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@storybook/addon-docs": "^10.5.2",
     "@storybook/addon-onboarding": "^10.5.2",
     "@storybook/vue3": "^10.5.2",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@storybook/addon-docs": "^10.5.2",
     "@storybook/addon-onboarding": "^10.5.2",
     "@storybook/vue3": "^10.5.2",

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.11",
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@rslib/tsconfig": "workspace:*",
     "get-tsconfig": "5.0.0-beta.5",
     "magic-string": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
         version: 0.11.2(@rslib/core@1.0.0-beta.0)(@rstest/core@0.11.2)(typescript@6.0.3)
       '@rstest/core':
         specifier: ^0.11.2
-        version: 0.11.2
+        version: 0.11.2(@module-federation/runtime-tools@2.8.0)
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -77,13 +77,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.8.0
-        version: 2.8.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
+        version: 2.8.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.8.0)
+        specifier: ~2.1.7
+        version: 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -98,19 +98,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.8.0
-        version: 2.8.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
+        version: 2.8.0(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.8.0
-        version: 2.8.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
+        version: 2.8.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/storybook-addon':
         specifier: ^6.0.16
-        version: 6.0.16(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(storybook@10.5.2)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)
+        version: 6.0.16(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(storybook@10.5.2)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.8.0)
+        specifier: ~2.1.7
+        version: 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -140,10 +140,10 @@ importers:
         version: 10.5.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.6)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.7)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(supports-color@9.4.0)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -159,13 +159,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.8.0
-        version: 2.8.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
+        version: 2.8.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.8.0)
+        specifier: ~2.1.7
+        version: 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -180,10 +180,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(preact@10.29.7)
+        version: 2.0.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(preact@10.29.7)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)
+        version: 2.0.1(@rsbuild/core@2.1.7)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -195,10 +195,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)
+        version: 2.0.1(@rsbuild/core@2.1.7)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -213,10 +213,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)
+        version: 2.0.1(@rsbuild/core@2.1.7)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -231,10 +231,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)
+        version: 2.0.1(@rsbuild/core@2.1.7)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -249,13 +249,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(supports-color@9.4.0)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)
+        version: 2.0.1(@rsbuild/core@2.1.7)
       '@rsbuild/plugin-solid':
         specifier: ^1.2.2
-        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.6)(solid-js@1.9.14)(supports-color@9.4.0)
+        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.7)(solid-js@1.9.14)(supports-color@9.4.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -270,7 +270,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -287,11 +287,11 @@ importers:
   examples/vue-component-bundleless:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.8.0)
+        specifier: ~2.1.7
+        version: 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -309,10 +309,10 @@ importers:
         version: 10.5.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.6)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.7)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3)(vue@3.5.40)
+        version: 3.3.4(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3)(vue@3.5.40)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -326,15 +326,15 @@ importers:
   packages/core:
     dependencies:
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.8.0)
+        specifier: ~2.1.7
+        version: 2.1.7(@module-federation/runtime-tools@2.8.0)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.8.0
-        version: 2.8.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
+        version: 2.8.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -364,7 +364,7 @@ importers:
         version: 0.6.0
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.6)
+        version: 1.0.0(@rsbuild/core@2.1.7)
       rslib:
         specifier: npm:@rslib/core@0.23.2
         version: '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)'
@@ -401,7 +401,7 @@ importers:
         version: 11.3.6
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.6)
+        version: 1.0.0(@rsbuild/core@2.1.7)
       rslib:
         specifier: npm:@rslib/core@0.23.2
         version: '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)'
@@ -422,8 +422,8 @@ importers:
         specifier: ^7.58.11
         version: 7.58.11(@types/node@25.2.0)
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.8.0)
+        specifier: ~2.1.7
+        version: 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -435,7 +435,7 @@ importers:
         version: 1.0.0
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@2.1.6)
+        version: 1.0.0(@rsbuild/core@2.1.7)
       rslib:
         specifier: npm:@rslib/core@0.23.2
         version: '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)'
@@ -468,34 +468,34 @@ importers:
         version: 4.0.1(debug@4.4.3)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.8.0
-        version: 2.8.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
+        version: 2.8.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@playwright/test':
         specifier: 1.61.1
         version: 1.61.1
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.8.0)
+        specifier: ~2.1.7
+        version: 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@rsbuild/plugin-less':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)
+        version: 2.0.1(@rsbuild/core@2.1.7)
       '@rsbuild/plugin-toml':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)
+        version: 2.0.1(@rsbuild/core@2.1.7)
       '@rsbuild/plugin-typed-css-modules':
         specifier: ^1.2.4
-        version: 1.2.4(@rsbuild/core@2.1.6)
+        version: 1.2.4(@rsbuild/core@2.1.7)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rsbuild/plugin-yaml':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.6)
+        version: 2.0.0(@rsbuild/core@2.1.7)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -572,7 +572,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
 
   tests/integration/asset/json: {}
 
@@ -588,10 +588,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.5
-        version: 2.0.5(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -676,10 +676,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.5
-        version: 2.0.5(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/cli/build: {}
 
@@ -999,11 +999,11 @@ importers:
   tests/integration/node-polyfill/bundle:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.8.0)
+        specifier: ~2.1.7
+        version: 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.1.6)
+        version: 1.4.6(@rsbuild/core@2.1.7)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -1012,11 +1012,11 @@ importers:
         version: 6.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.8.0)
+        specifier: ~2.1.7
+        version: 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@2.1.6)
+        version: 1.4.6(@rsbuild/core@2.1.7)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1053,7 +1053,7 @@ importers:
         version: 8.0.1
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(supports-color@9.4.0)
       babel-plugin-polyfill-corejs3:
         specifier: ^1.0.0
         version: 1.0.0(@babel/core@8.0.1)
@@ -1066,7 +1066,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1207,19 +1207,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(supports-color@9.4.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(supports-color@9.4.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.0.3(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -1228,7 +1228,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.0.3(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -1276,10 +1276,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       vue:
         specifier: ^3.5.40
         version: 3.5.40(typescript@7.0.2)
@@ -1296,16 +1296,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.8.0
-        version: 2.8.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
+        version: 2.8.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.8.0)
+        specifier: ~2.1.7
+        version: 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rsbuild/plugin-sass':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)
+        version: 2.0.1(@rsbuild/core@2.1.7)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1314,7 +1314,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 2.0.18
-        version: 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+        version: 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@rspress/plugin-algolia':
         specifier: 2.0.18
         version: 2.0.18(@rspress/core@2.0.18)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
@@ -1353,10 +1353,10 @@ importers:
         version: 19.2.7(react@19.2.7)
       rsbuild-plugin-google-analytics:
         specifier: 1.0.6
-        version: 1.0.6(@rsbuild/core@2.1.6)
+        version: 1.0.6(@rsbuild/core@2.1.7)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.1.6)
+        version: 1.1.3(@rsbuild/core@2.1.7)
       rspress-plugin-file-tree:
         specifier: ^1.0.5
         version: 1.0.5(@rspress/core@2.0.18)(supports-color@9.4.0)
@@ -2647,6 +2647,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.1.7':
+    resolution: {integrity: sha512-Xhs8DkLw2Vk5ydwjNG3GMJe1h03lqlCO4dV9EOG9HSR6vDfh07K48aq3KJ8/ncEL/YuFBaCIJrVc7rMFoR1y7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.2.1':
     resolution: {integrity: sha512-6Zad7Ff/RUNc91AtftemJcJ1wcZRGOiwuJy349qlLJl9F++oRYwUhx+MxLSpNnVeIywWx2mKdZZBtD1hLqfj9w==}
     peerDependencies:
@@ -2862,13 +2872,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.1.5':
+    resolution: {integrity: sha512-XLAN6YSU36qkciJtV9DY9z57pdHOjKy/f1HyoqpZenRg8p46jnXPziV45lfrTZpG+FF6g/jtTUc4dKbeyoWqPw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.1.4':
     resolution: {integrity: sha512-bz/AsCplLs+3fXULPQU9d4r8H4PdeljgHFyItvVIrA/NKZqzQ8sX0topf/zJVZAOtPH7GNnrKjq0/F0U2DHikQ==}
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.1.5':
+    resolution: {integrity: sha512-KLW7PV86jyCOyqJSqrkZdvYUWYCFX/Q4LsGmVc8tyDA8jBYLMHJDewC/lNf9ot3rU2SoLDZKhDUh7q7dX0FRmg==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.1.4':
     resolution: {integrity: sha512-x0HQTLU1MusCtNamuXxf3ayEPkvh9uuaq4wVyBqveRkn4FznSOoHUsxTAKMnjGARX+vdLV/y/SwWJRDp2RI4zw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.5':
+    resolution: {integrity: sha512-KOooAC8L+Ljx5sY7ZuMeaXCQ310FNWaPWXcYQJpFPApF3qyLeSfuOftUGwxcxeo5U0mS5OY3zxp7/5CaHWKYjg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2879,8 +2905,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.1.5':
+    resolution: {integrity: sha512-0GFc07gT71+uRbHtejDecBfSL0fs7dQAwCtXYieXboACauL7UvS3Hwr6v8A91aGtAcvLotnCaIa3CWWYwtYlYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-riscv64-gnu@2.1.4':
     resolution: {integrity: sha512-jYtQKtnDRaVfyasvTGY04Z7m+xDWZYVwAIEOB4hP7czM7FVLOMgHlMlvw/EgF0DNHrBthqbPfBIS2tP50CzpEA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.5':
+    resolution: {integrity: sha512-isQQDp3fBzPSZpLVFzPqVXIVA4I9b9mKs58TfUgOzDP/1g1582YSV3iFopgFogvEliihXDuuXvM6aAkP+w8Z+Q==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -2891,8 +2929,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-riscv64-musl@2.1.5':
+    resolution: {integrity: sha512-/SP6VknY4kH60BYplI2FDNAJCo4U4DUszLxhKsgVlgA5ImgHC8Ew2AsKgidk7ceiYV9OcKzYuWYe9tVpysBYVA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@2.1.4':
     resolution: {integrity: sha512-C53B3e6M4yzlYn4hDxR9cHZV+HqkfFGR0zuhH8QCfdBfN5KyGsmXmujiFU85ANEvBgf9CF8VreBQeJ20lyto/g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.1.5':
+    resolution: {integrity: sha512-/GJmS+buA4pilT10gs5mfAhAZxSHXpDD8veZ3QpYvNUuoU9gvempAq9TgjbyNN/vc5pf76GdXPXKFMiehudYSA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -2903,12 +2953,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.1.5':
+    resolution: {integrity: sha512-iwS3t75nZ2TnUjB05KtvpvjpdkOy/nLxbaOnwjbdnNZZXpUaMadLbllGAWayHPGCMsL2yKBEhVEESZpR7tK3SA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.1.4':
     resolution: {integrity: sha512-0P1WZEfu7JOPzD/jQfk9U/6gnRFc7RpvYCQaYZVVYZNJ2gU6O0/yLegRGKNK/2L0zjYwiD0ynhOIBVUUERf5Pw==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.1.5':
+    resolution: {integrity: sha512-jOhW69t1H/jcRaSMB5U8jVzWP18j0YQIlo0nT8W+KvNVScJeyOze4FFc+5RIS7VmuT8/jid7hUyydZOfm6UgqA==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.1.4':
     resolution: {integrity: sha512-+aStQipk1EakLRPfD+/aQbtmTXfxqSWetcRRDWV3cAsD4ebv1tF8FLKYY1PCaFpQbX1FxzCBGF0KHxkAsi9cxA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.5':
+    resolution: {integrity: sha512-OLfMXmtFBcrWr9BRGKXJYrWgYR0JSaoAWr3EVFDjKGi/YR5aUwQSGc3AJPBph9g0YsdSqRuUhtQGtCk84DeeEA==}
     cpu: [arm64]
     os: [win32]
 
@@ -2917,16 +2982,41 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.1.5':
+    resolution: {integrity: sha512-p4OSmnj21+AY8vpIADveLEBXfXJRXonOTYim2VLVWV4TbXfhYNMLiX3qESHCdNnn6lVJM0q6zxxzEUfTyAKydw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.1.4':
     resolution: {integrity: sha512-Z4je7JBaDpO9vvNMgCxlycycRJq+GQwwuXSXagW2xvvGM10Ij63YVtIehSMG9xaW8PED41oc9nWndoEsiD60pA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.1.5':
+    resolution: {integrity: sha512-YCkLLDGMkHsw5CpcsFtFhzCu+JZEsNrcH9O1GpWMkyxR2ku2Fq1i2wEHYSm26HyW+PJ3+Fv347MPWMFZIz9q2g==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@2.1.4':
     resolution: {integrity: sha512-iye4BaTYtTt0qa39avWwEsUobVxFNhQHr6B8reFeKU7sdaZsC9LUoDR8JAt5gOnbnzFMPdKgrdU/VzkC6rXbIg==}
 
+  '@rspack/binding@2.1.5':
+    resolution: {integrity: sha512-lF3ZLeeyV0AN3BL0m2jAmNZD5pP9IHsQ8gUXN7mo0g4xsW6nf6hsN7o9CnEHECz5uUZb+EoWsuWzAAmnA9Ip8Q==}
+
   '@rspack/core@2.1.4':
     resolution: {integrity: sha512-lpJgtr+JAXuDAMBJfRJ1LHyWVuYJyhZu6L6aj9t4lipUU03qwakHnzn3vwSCr68PsVvVPzR6NbJE1gJienSV0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.1.5':
+    resolution: {integrity: sha512-YHjL7xVXycAWsjJtF39cRZ2u+ddiNFxY+FcNgEBe6Y8OaLeUfMfjba3gK+B1Oj32UcKD6BmXGsPfu9p+OII/Yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8456,7 +8546,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)':
+  '@module-federation/enhanced@2.8.0(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.0
       '@module-federation/cli': 2.8.0(typescript@6.0.3)(vue-tsc@3.3.7)
@@ -8465,7 +8555,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.0(@module-federation/runtime-tools@2.8.0)
       '@module-federation/managers': 2.8.0
       '@module-federation/manifest': 2.8.0(typescript@6.0.3)(vue-tsc@3.3.7)
-      '@module-federation/rspack': 2.8.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/rspack': 2.8.0(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/runtime-tools': 2.8.0
       '@module-federation/sdk': 2.8.0
       '@module-federation/webpack-bundler-runtime': 2.8.0
@@ -8479,7 +8569,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)':
+  '@module-federation/enhanced@2.8.0(@rspack/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.0
       '@module-federation/cli': 2.8.0(typescript@7.0.2)(vue-tsc@3.3.7)
@@ -8488,7 +8578,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.0(@module-federation/runtime-tools@2.8.0)
       '@module-federation/managers': 2.8.0
       '@module-federation/manifest': 2.8.0(typescript@7.0.2)(vue-tsc@3.3.7)
-      '@module-federation/rspack': 2.8.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
+      '@module-federation/rspack': 2.8.0(@rspack/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/runtime-tools': 2.8.0
       '@module-federation/sdk': 2.8.0
       '@module-federation/webpack-bundler-runtime': 2.8.0
@@ -8534,9 +8624,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.47(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)':
+  '@module-federation/node@2.7.47(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)':
     dependencies:
-      '@module-federation/enhanced': 2.8.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.8.0(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/runtime': 2.8.0
       '@module-federation/sdk': 2.8.0
       encoding: 0.1.13
@@ -8549,9 +8639,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.47(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)':
+  '@module-federation/node@2.7.47(@rspack/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)':
     dependencies:
-      '@module-federation/enhanced': 2.8.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.8.0(@rspack/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/runtime': 2.8.0
       '@module-federation/sdk': 2.8.0
       encoding: 0.1.13
@@ -8564,13 +8654,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.8.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)':
+  '@module-federation/rsbuild-plugin@2.8.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)':
     dependencies:
-      '@module-federation/enhanced': 2.8.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
-      '@module-federation/node': 2.7.47(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.8.0(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/node': 2.7.47(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/sdk': 2.8.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8579,13 +8669,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)':
+  '@module-federation/rsbuild-plugin@2.8.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)':
     dependencies:
-      '@module-federation/enhanced': 2.8.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
-      '@module-federation/node': 2.7.47(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.8.0(@rspack/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)
+      '@module-federation/node': 2.7.47(@rspack/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/sdk': 2.8.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8594,7 +8684,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.8.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)':
+  '@module-federation/rspack@2.8.0(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.0
       '@module-federation/dts-plugin': 2.8.0(typescript@6.0.3)(vue-tsc@3.3.7)
@@ -8603,7 +8693,7 @@ snapshots:
       '@module-federation/manifest': 2.8.0(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/runtime-tools': 2.8.0
       '@module-federation/sdk': 2.8.0
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.7(typescript@6.0.3)
@@ -8611,7 +8701,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rspack@2.8.0(@rspack/core@2.1.4)(typescript@7.0.2)(vue-tsc@3.3.7)':
+  '@module-federation/rspack@2.8.0(@rspack/core@2.1.5)(typescript@7.0.2)(vue-tsc@3.3.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.0
       '@module-federation/dts-plugin': 2.8.0(typescript@7.0.2)(vue-tsc@3.3.7)
@@ -8620,7 +8710,7 @@ snapshots:
       '@module-federation/manifest': 2.8.0(typescript@7.0.2)(vue-tsc@3.3.7)
       '@module-federation/runtime-tools': 2.8.0
       '@module-federation/sdk': 2.8.0
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 7.0.2
       vue-tsc: 3.3.7(typescript@7.0.2)
@@ -8646,12 +8736,12 @@ snapshots:
 
   '@module-federation/sdk@2.8.0': {}
 
-  '@module-federation/storybook-addon@6.0.16(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(storybook@10.5.2)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.16(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(storybook@10.5.2)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.8.0(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/enhanced': 2.8.0(@rspack/core@2.1.5)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/sdk': 2.8.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
       storybook: 10.5.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -8928,7 +9018,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.6)(supports-color@9.4.0)':
+  '@rsbuild/core@2.1.7(@module-federation/runtime-tools@2.8.0)':
+    dependencies:
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.7)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
@@ -8937,39 +9034,39 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(supports-color@9.4.0)':
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4)
+      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.5)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.4)(less@4.6.7)
+      less-loader: 12.3.3(@rspack/core@2.1.5)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.6)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.7)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -8995,30 +9092,30 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
 
-  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(preact@10.29.7)':
+  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(preact@10.29.7)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.7)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.4)
+      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.5)
       '@swc/plugin-prefresh': 12.12.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - preact
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.5)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.6)':
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.7)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9026,98 +9123,98 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
 
-  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.6)(solid-js@1.9.14)(supports-color@9.4.0)':
+  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.7)(solid-js@1.9.14)(supports-color@9.4.0)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.6)(supports-color@9.4.0)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.7)(supports-color@9.4.0)
       babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.14)
       solid-refresh: 0.6.3(solid-js@1.9.14)(supports-color@9.4.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(supports-color@9.4.0)':
+  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(supports-color@9.4.0)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0(supports-color@9.4.0)
-      stylus-loader: 8.1.3(@rspack/core@2.1.4)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.1.5)(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(supports-color@9.4.0)(typescript@7.0.2)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(supports-color@9.4.0)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@svgr/core': 8.1.0(supports-color@9.4.0)(typescript@7.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)(supports-color@9.4.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.4)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.5)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.6)':
+  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.7)':
     dependencies:
       toml: 4.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
 
-  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.4)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.5)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.6)':
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.7)':
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.5)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.1.6)':
+  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.1.7)':
     dependencies:
       yaml: 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
 
   '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
-      rsbuild-plugin-dts: 0.23.2(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.6)(typescript@7.0.2)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
+      rsbuild-plugin-dts: 0.23.2(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.7)(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.11(@types/node@25.2.0)
       typescript: 7.0.2
@@ -9126,7 +9223,7 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rslib/core@1.0.0-beta.0(@microsoft/api-extractor@7.58.11)(typescript@6.0.3)':
+  '@rslib/core@1.0.0-beta.0(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
       rsbuild-plugin-dts: 1.0.0-beta.0(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.6)(typescript@6.0.3)
@@ -9178,25 +9275,49 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.1.4':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.1.5':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.1.4':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.1.5':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.1.4':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.1.5':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.1.4':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.1.5':
     optional: true
 
   '@rspack/binding-linux-riscv64-gnu@2.1.4':
     optional: true
 
+  '@rspack/binding-linux-riscv64-gnu@2.1.5':
+    optional: true
+
   '@rspack/binding-linux-riscv64-musl@2.1.4':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.5':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.1.4':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.1.5':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.1.4':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.5':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.1.4':
@@ -9206,13 +9327,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.1.4':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.5':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.1.4':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.1.5':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.1.4':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.5':
     optional: true
 
   '@rspack/binding@2.1.4':
@@ -9230,6 +9367,21 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.1.4
       '@rspack/binding-win32-x64-msvc': 2.1.4
 
+  '@rspack/binding@2.1.5':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.5
+      '@rspack/binding-darwin-x64': 2.1.5
+      '@rspack/binding-linux-arm64-gnu': 2.1.5
+      '@rspack/binding-linux-arm64-musl': 2.1.5
+      '@rspack/binding-linux-riscv64-gnu': 2.1.5
+      '@rspack/binding-linux-riscv64-musl': 2.1.5
+      '@rspack/binding-linux-x64-gnu': 2.1.5
+      '@rspack/binding-linux-x64-musl': 2.1.5
+      '@rspack/binding-wasm32-wasi': 2.1.5
+      '@rspack/binding-win32-arm64-msvc': 2.1.5
+      '@rspack/binding-win32-ia32-msvc': 2.1.5
+      '@rspack/binding-win32-x64-msvc': 2.1.5
+
   '@rspack/core@2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.1.4
@@ -9237,27 +9389,34 @@ snapshots:
       '@module-federation/runtime-tools': 2.8.0
       '@swc/helpers': 0.5.23
 
+  '@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.5
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.8.0
+      '@swc/helpers': 0.5.23
+
   '@rspack/lite-tapable@1.1.2': {}
 
-  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.4)':
+  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.5)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.7)
       '@prefresh/utils': 1.2.1
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.5)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
+  '@rspress/core@2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)
       '@rspress/shared': 2.0.18(@module-federation/runtime-tools@2.8.0)
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -9306,7 +9465,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
-      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -9317,7 +9476,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.18(@rspress/core@2.0.18)(supports-color@9.4.0)':
     dependencies:
-      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       remark-mdx: 3.1.1(supports-color@9.4.0)
       remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
@@ -9328,17 +9487,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.18(@rspress/core@2.0.18)':
     dependencies:
-      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.18(@rspress/core@2.0.18)':
     dependencies:
-      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rspress/plugin-twoslash@2.0.18(@rspress/core@2.0.18)(react@19.2.7)(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@shikijs/twoslash': 4.3.0(supports-color@9.4.0)(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-gfm: 3.1.0(supports-color@9.4.0)
@@ -9352,7 +9511,7 @@ snapshots:
 
   '@rspress/shared@2.0.18(@module-federation/runtime-tools@2.8.0)':
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@shikijs/rehype': 4.3.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9361,16 +9520,16 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.5(@rspress/core@2.0.18)':
     optionalDependencies:
-      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rstest/adapter-rslib@0.11.2(@rslib/core@1.0.0-beta.0)(@rstest/core@0.11.2)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 1.0.0-beta.0(@microsoft/api-extractor@7.58.11)(typescript@6.0.3)
-      '@rstest/core': 0.11.2
+      '@rslib/core': 1.0.0-beta.0(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@6.0.3)
+      '@rstest/core': 0.11.2(@module-federation/runtime-tools@2.8.0)
     optionalDependencies:
       typescript: 6.0.3
 
-  '@rstest/core@0.11.2':
+  '@rstest/core@0.11.2(@module-federation/runtime-tools@2.8.0)':
     dependencies:
       '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
       '@types/chai': 5.2.3
@@ -9774,14 +9933,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.4)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.5)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10297,12 +10456,12 @@ snapshots:
 
   b-validate@1.5.3: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4):
+  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.5):
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       find-up: 5.0.0
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
 
   babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
     dependencies:
@@ -11745,11 +11904,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@rspack/core@2.1.4)(less@4.6.7):
+  less-loader@12.3.3(@rspack/core@2.1.5)(less@4.6.7):
     dependencies:
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
 
   less@4.6.7:
     dependencies:
@@ -13328,10 +13487,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.23.2(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.6)(typescript@7.0.2):
+  rsbuild-plugin-dts@0.23.2(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.7)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.11(@types/node@25.2.0)
       typescript: 7.0.2
@@ -13344,41 +13503,41 @@ snapshots:
       '@microsoft/api-extractor': 7.58.11(@types/node@24.13.3)
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.6):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.7):
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
 
-  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.6):
+  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.7):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.6):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.7):
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.6):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.7):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
 
   rslog@2.3.0: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.40)(vue@3.5.40):
+  rspack-vue-loader@17.5.1(@rspack/core@2.1.5)(@vue/compiler-sfc@3.5.40)(vue@3.5.40):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
       '@vue/compiler-sfc': 3.5.40
       vue: 3.5.40(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.18)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -13403,14 +13562,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.18)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.18)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.18):
     dependencies:
-      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   run-applescript@7.1.0: {}
 
@@ -13739,18 +13898,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.6)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.7)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
-      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -13762,7 +13921,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.6)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.7)
       sirv: 2.0.4
       storybook: 10.5.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.3.0
@@ -13779,10 +13938,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(supports-color@9.4.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@storybook/react': 10.5.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(supports-color@9.4.0)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(supports-color@9.4.0)(typescript@6.0.3)
       find-up: 5.0.0
@@ -13793,7 +13952,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
       storybook: 10.5.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -13808,12 +13967,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3)(vue@3.5.40):
+  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3)(vue@3.5.40):
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.8.0)
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
       '@storybook/vue3': 10.5.2(storybook@10.5.2)(vue@3.5.40)
       storybook: 10.5.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.7)(@rspack/core@2.1.5)(react-dom@19.2.7)(react@19.2.7)(storybook@10.5.2)(typescript@6.0.3)
       vue: 3.5.40(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.40)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -13935,13 +14094,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.1.4)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.1.5)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0(supports-color@9.4.0)
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
 
   stylus@0.64.0(supports-color@9.4.0):
     dependencies:
@@ -14055,7 +14214,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.4)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.5)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
@@ -14063,7 +14222,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)(@swc/helpers@0.5.23)
 
   ts-dedent@2.3.0: {}
 

--- a/tests/integration/cli/build/build.test.ts
+++ b/tests/integration/cli/build/build.test.ts
@@ -247,6 +247,7 @@ describe('build command', async () => {
         ],
         _privateMeta: {
           configFilePath: '<ROOT>/tests/integration/cli/build/options/rslib.config.ts',
+          configFileDependencies: [],
           envFilePaths: []
         },
         source: {

--- a/tests/integration/node-polyfill/bundle-false/package.json
+++ b/tests/integration/node-polyfill/bundle-false/package.json
@@ -7,7 +7,7 @@
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@rsbuild/plugin-node-polyfill": "^1.4.6"
   }
 }

--- a/tests/integration/node-polyfill/bundle/package.json
+++ b/tests/integration/node-polyfill/bundle/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@rsbuild/plugin-node-polyfill": "^1.4.6"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@codspeed/vitest-plugin": "^4.0.1",
     "@module-federation/rsbuild-plugin": "^2.8.0",
     "@playwright/test": "1.61.1",
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@rsbuild/plugin-less": "^2.0.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-sass": "^2.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.8.0",
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.1.7",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-sass": "^2.0.1",
     "@rslib/core": "workspace:*",


### PR DESCRIPTION
## Summary

This PR keeps Rslib aligned with Rsbuild 2.1.7 and its `@rspack/core` 2.1.5 upgrade. It updates all direct `@rsbuild/core` ranges and adjusts affected expectations for config-file dependency metadata and the `restart` watch type.

## Related Links

- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.1.7

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).