### PR TITLE
feat(core): preserve `new URL` assets as relative URLs

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -319,7 +319,7 @@ const composeFormatConfig = ({
   switch (format) {
     case 'esm':
       return {
-        plugins: [modifyRsbuildDefaultPlugin({ disableUrlParse: true })],
+        plugins: [modifyRsbuildDefaultPlugin({ relativeUrl: true })],
         output: {
           filenameHash: false,
           ...(bundle && { autoExternal: true }),
@@ -364,7 +364,7 @@ const composeFormatConfig = ({
       };
     case 'cjs':
       return {
-        plugins: [modifyRsbuildDefaultPlugin({ disableUrlParse: true })],
+        plugins: [modifyRsbuildDefaultPlugin({ relativeUrl: true })],
         output: {
           module: false,
           filenameHash: false,
@@ -530,22 +530,23 @@ const composeFormatConfig = ({
 };
 
 const modifyRsbuildDefaultPlugin = ({
-  disableUrlParse,
+  relativeUrl,
 }: {
-  disableUrlParse?: boolean;
+  relativeUrl?: boolean;
 } = {}): RsbuildPlugin => ({
   name: 'rslib:modify-rsbuild-default',
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID, target }) => {
-      // Part 1: disable URL parsing for library output.
+      // Part 1: emit relative `new URL()` for library output.
       // Fix for https://github.com/web-infra-dev/rslib/issues/499.
-      // Prevent parsing and try bundling `new URL()` in ESM/CJS format.
-      if (disableUrlParse) {
+      // Use Rspack's `new-url-relative` mode so `new URL()` references are
+      // preserved as static relative URLs instead of being bundled.
+      if (relativeUrl) {
         chain.module
           .rule(CHAIN_ID.RULE.JS)
           .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
           .parser({
-            url: false,
+            url: 'new-url-relative',
           });
       }
 
@@ -1204,6 +1205,13 @@ const composeBundlelessExternalConfig = (
               callback();
               return;
             }
+
+            // Do not externalize assets referenced via `new URL()`.
+            if (data.dependencyType === 'url') {
+              callback();
+              return;
+            }
+
             const { issuer } = contextInfo;
             const originExtension = extname(request);
 

--- a/packages/core/src/plugins/EntryChunkPlugin.ts
+++ b/packages/core/src/plugins/EntryChunkPlugin.ts
@@ -64,6 +64,26 @@ class EntryChunkPlugin {
             const oldSource = old.source().toString();
             const replaceSource = new rspack.sources.ReplaceSource(old);
 
+            // Rewrite the `import.meta.url` emitted by Rspack's
+            // `new-url-relative` URL template (e.g. `new URL(..., import.meta.url)`).
+            // `import.meta` is invalid in CommonJS output, and this occurrence is
+            // injected during code generation so it bypasses the `source.define`
+            // replacement in `pluginCjsShims`. Since that define has already
+            // rewritten every `import.meta.url` from user source, any remaining
+            // one here comes from the URL template and is safe to replace.
+            const IMPORT_META_URL = 'import.meta.url';
+            for (
+              let index = oldSource.indexOf(IMPORT_META_URL);
+              index !== -1;
+              index = oldSource.indexOf(IMPORT_META_URL, index + 1)
+            ) {
+              replaceSource.replace(
+                index,
+                index + IMPORT_META_URL.length - 1,
+                '__rslib_import_meta_url__',
+              );
+            }
+
             if (oldSource.startsWith('#!')) {
               const firstLineEnd = oldSource.indexOf('\n');
               replaceSource.insert(firstLineEnd + 1, IMPORT_META_URL_SHIM);

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -1,5 +1,5 @@
-import { join } from 'node:path';
 import { expect, test } from '@rstest/core';
+import { join } from 'node:path';
 import { buildAndGetResults, queryContent } from 'test-helper';
 
 test('set the size threshold to inline static assets', async () => {
@@ -457,4 +457,47 @@ test('use source.assetInclude', async () => {
   // esm
   const { content: dataJs } = queryContent(contents.esm1!, /assets\/draft\.js/);
   expect(dataJs).matchSnapshot();
+});
+
+test('preserve `new URL` as relative URL', async () => {
+  const fixturePath = join(__dirname, 'new-url');
+  const { contents, files } = await buildAndGetResults({ fixturePath });
+
+  // 0. bundle
+  // esm
+  // `new URL(..., import.meta.url)` should be preserved as a static relative
+  // URL that points to the emitted asset, instead of being bundled.
+  const { content: bundleEsm } = queryContent(contents.esm0!, /index\.js/);
+  expect(bundleEsm).toMatchInlineSnapshot(`
+    "const logo = new URL("./static/svg/logo.svg", import.meta.url);
+    export { logo };
+    "
+  `);
+  // cjs
+  // `import.meta.url` is invalid in CommonJS, so it is rewritten to the
+  // injected `__rslib_import_meta_url__` shim.
+  const { content: bundleCjs } = queryContent(contents.cjs0!, /index\.cjs/);
+  expect(bundleCjs).toContain(
+    'const logo = new URL("./static/svg/logo.svg", __rslib_import_meta_url__);',
+  );
+  expect(bundleCjs).not.toContain('import.meta.url');
+
+  // 1. bundleless
+  // esm
+  // The referenced asset is emitted (not externalized nor turned into a
+  // standalone JS chunk), and `new URL()` still resolves to it relatively.
+  const { content: bundlelessEsm } = queryContent(contents.esm1!, /index\.js/);
+  expect(bundlelessEsm).toMatchInlineSnapshot(`
+    "const logo = new URL("./static/svg/logo.svg", import.meta.url);
+    export { logo };
+    "
+  `);
+  // cjs
+  const { content: bundlelessCjs } = queryContent(contents.cjs1!, /index\.cjs/);
+  expect(bundlelessCjs).toContain(
+    'const logo = new URL("./static/svg/logo.svg", __rslib_import_meta_url__);',
+  );
+  expect(bundlelessCjs).not.toContain('import.meta.url');
+  // The asset is emitted as a file, without an extra `assets/logo.*` JS chunk.
+  expect(files.esm1!.some((f) => /assets\/logo\.js$/.test(f))).toBe(false);
 });

--- a/tests/integration/asset/new-url/package.json
+++ b/tests/integration/asset/new-url/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "asset-new-url-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/asset/new-url/rslib.config.ts
+++ b/tests/integration/asset/new-url/rslib.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    // 0. bundle
+    // esm
+    generateBundleEsmConfig({
+      output: {
+        distPath: './dist/esm/bundle',
+      },
+    }),
+    // cjs
+    generateBundleCjsConfig({
+      output: {
+        distPath: './dist/cjs/bundle',
+      },
+    }),
+    // 1. bundleless
+    // esm
+    generateBundleEsmConfig({
+      bundle: false,
+      source: {
+        // Exclude assets from the entry glob so they are only emitted via
+        // `new URL()`, not turned into standalone JS chunks.
+        entry: { index: ['src/**', '!src/**/*.svg'] },
+      },
+      output: {
+        distPath: './dist/esm/bundleless',
+      },
+    }),
+    // cjs
+    generateBundleCjsConfig({
+      bundle: false,
+      source: {
+        entry: { index: ['src/**', '!src/**/*.svg'] },
+      },
+      output: {
+        distPath: './dist/cjs/bundleless',
+      },
+    }),
+  ],
+  output: {
+    target: 'web',
+  },
+});

--- a/tests/integration/asset/new-url/src/assets/logo.svg
+++ b/tests/integration/asset/new-url/src/assets/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>

--- a/tests/integration/asset/new-url/src/index.js
+++ b/tests/integration/asset/new-url/src/index.js
@@ -1,0 +1,1 @@
+export const logo = new URL("./assets/logo.svg", import.meta.url);


### PR DESCRIPTION
## Summary

Support keeping `new URL(asset, import.meta.url)` as a static relative URL in library output (both bundle and bundleless), so referenced assets are emitted and pointed at relatively instead of being bundled. This involves three changes:

- **Enable the `new-url-relative` parser.** Switch the esm/cjs JS parser from `url: false` to `url: 'new-url-relative'`, so Rspack preserves `new URL(asset, import.meta.url)` pointing at the emitted asset.
- **Rewrite `import.meta.url` for CJS.** The `new-url-relative` template emits `new URL(..., import.meta.url)` during code generation, which is invalid in CommonJS. The existing CJS shim replaces `import.meta.url` via `source.define`, but that only rewrites occurrences in user source and does not see code injected by the URL template, so it doesn't apply here. We additionally rewrite that emitted `import.meta.url` to the injected `__rslib_import_meta_url__` shim in `EntryChunkPlugin`.
- **Don't externalize `new URL` assets in bundleless.** In bundleless mode all relative imports are externalized; `new URL()` asset requests (which arrive with `dependencyType === 'url'`) are now kept in the compilation so Rspack can emit the asset file.

## Related Links

- https://github.com/web-infra-dev/rslib/issues/499

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).