### PR TITLE
feat(core)!: preserve `new URL` assets as relative URLs

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -335,7 +335,11 @@ const composeFormatConfig = ({
         bundle === false || Object.keys(sourceEntry ?? {}).length > 1;
 
       return {
-        plugins: [modifyRsbuildDefaultPlugin({ disableUrlParse: true })],
+        plugins: [
+          modifyRsbuildDefaultPlugin({
+            urlParserMode: 'new-url-relative',
+          }),
+        ],
         output: {
           filenameHash: false,
           ...(bundle && { autoExternal: true }),
@@ -379,7 +383,7 @@ const composeFormatConfig = ({
     }
     case 'cjs':
       return {
-        plugins: [modifyRsbuildDefaultPlugin({ disableUrlParse: true })],
+        plugins: [modifyRsbuildDefaultPlugin({ urlParserMode: false })],
         output: {
           module: false,
           filenameHash: false,
@@ -545,22 +549,21 @@ const composeFormatConfig = ({
 };
 
 const modifyRsbuildDefaultPlugin = ({
-  disableUrlParse,
+  urlParserMode,
 }: {
-  disableUrlParse?: boolean;
+  urlParserMode?: false | 'new-url-relative';
 } = {}): RsbuildPlugin => ({
   name: 'rslib:modify-rsbuild-default',
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID, target }) => {
-      // Part 1: disable URL parsing for library output.
+      // Part 1: configure URL parsing for library output.
       // Fix for https://github.com/web-infra-dev/rslib/issues/499.
-      // Prevent parsing and try bundling `new URL()` in ESM/CJS format.
-      if (disableUrlParse) {
+      if (urlParserMode !== undefined) {
         chain.module
           .rule(CHAIN_ID.RULE.JS)
           .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
           .parser({
-            url: false,
+            url: urlParserMode,
           });
       }
 
@@ -1293,6 +1296,13 @@ const composeBundlelessExternalConfig = (
               callback();
               return;
             }
+
+            // Do not externalize assets referenced via `new URL()`.
+            if (data.dependencyType === 'url') {
+              callback();
+              return;
+            }
+
             const { issuer } = contextInfo;
             const originExtension = extname(request);
 

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -661,7 +661,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           /* config.module.rule('js').oneOf('js') */
           {
             parser: {
-              url: false
+              url: 'new-url-relative'
             },
             use: [
               /* config.module.rule('js').oneOf('js').use('swc') */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,6 +880,8 @@ importers:
 
   tests/integration/asset/limit: {}
 
+  tests/integration/asset/new-url: {}
+
   tests/integration/asset/node-addons: {}
 
   tests/integration/asset/path: {}

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -1,6 +1,8 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { expect, test } from '@rstest/core';
 import { buildAndGetResults, queryContent } from 'test-helper';
 
@@ -528,4 +530,43 @@ test('use Node.js addons', async () => {
       expect(typeof addon.readLength).toBe('function');
     }
   }
+});
+
+// Runtime helper: import the emitted module and assert `new URL(...)` resolves
+// against the module's own directory. `key` picks the matrix cell; `query`
+// selects the emitted entry file. `subpath` is appended to the module dir to
+// form the expected URL (empty for a directory reference). The resolved target
+// is also checked to exist on disk, so each cell proves the resource is emitted.
+const expectUrlResolves = async (
+  contents: Record<string, Record<string, string>>,
+  key: string,
+  query: RegExp,
+  exportName: string,
+  subpath: string,
+) => {
+  const { path } = queryContent(contents[key]!, query);
+  const mod = await import(path);
+  const resolved = mod[exportName];
+  const expected = `${pathToFileURL(dirname(path)).href}/${subpath}`;
+  expect(resolved.href).toBe(expected);
+  // The resolved URL must point to a real emitted target on disk.
+  expect(existsSync(resolved)).toBe(true);
+};
+
+test('preserve `new URL` file asset as relative URL', async () => {
+  // `new URL('./assets/logo.svg', import.meta.url)` points to an emitted asset
+  // and is kept as a static relative URL. At runtime it resolves to the emitted
+  // `static/svg/logo.svg` next to the module across every matrix cell.
+  // Matrix (lib array order): esm0 = bundle, esm1 = bundleless.
+  const { contents, files } = await buildAndGetResults({
+    fixturePath: join(__dirname, 'new-url'),
+  });
+
+  const asset = 'static/svg/logo.svg';
+  // esm × bundle
+  await expectUrlResolves(contents, 'esm0', /index\.js/, 'logo', asset);
+  // esm × bundleless
+  await expectUrlResolves(contents, 'esm1', /index\.js/, 'logo', asset);
+  // The asset is emitted as a file, without an extra `assets/logo.*` JS chunk.
+  expect(files.esm1!.some((f) => /assets\/logo\.js$/.test(f))).toBe(false);
 });

--- a/tests/integration/asset/new-url/package.json
+++ b/tests/integration/asset/new-url/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "asset-new-url-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/asset/new-url/rslib.config.ts
+++ b/tests/integration/asset/new-url/rslib.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+// File asset reference `new URL('./assets/logo.svg', import.meta.url)`.
+// Matrix: esm × { bundle, bundleless }.
+export default defineConfig({
+  lib: [
+    // 0. bundle
+    // esm
+    generateBundleEsmConfig({
+      output: {
+        distPath: './dist/esm/bundle',
+      },
+    }),
+    // 1. bundleless
+    // esm
+    generateBundleEsmConfig({
+      bundle: false,
+      source: {
+        // Exclude assets from the entry glob so they are only emitted via
+        // `new URL()`, not turned into standalone JS chunks.
+        entry: { index: ['src/**', '!src/**/*.svg'] },
+      },
+      output: {
+        distPath: './dist/esm/bundleless',
+      },
+    }),
+  ],
+  output: {
+    target: 'web',
+  },
+});

--- a/tests/integration/asset/new-url/src/assets/logo.svg
+++ b/tests/integration/asset/new-url/src/assets/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>

--- a/tests/integration/asset/new-url/src/index.js
+++ b/tests/integration/asset/new-url/src/index.js
@@ -1,0 +1,1 @@
+export const logo = new URL('./assets/logo.svg', import.meta.url);

--- a/tests/integration/format/import-meta-url/src/value.js
+++ b/tests/integration/format/import-meta-url/src/value.js
@@ -1,5 +1,5 @@
 import url from 'node:url';
 export const packageDirectory = url.fileURLToPath(
-  new URL('.', import.meta.url),
+  new URL(/* rspackIgnore: true */ '.', import.meta.url),
 );
 export const foo = 'foo';

--- a/tests/integration/format/index.test.ts
+++ b/tests/integration/format/index.test.ts
@@ -65,7 +65,11 @@ test('import.meta.url should be preserved', async () => {
   `);
   expect(entries.esm).toMatchInlineSnapshot(`
     "import node_url from "node:url";
-    const packageDirectory = node_url.fileURLToPath(new URL('.', import.meta.url));
+    var __webpack_require__ = {};
+    (()=>{
+        __webpack_require__.b = new URL("./", import.meta.url);
+    })();
+    const packageDirectory = node_url.fileURLToPath(new URL('.', __webpack_require__.b));
     const foo = 'foo';
     export { foo, packageDirectory };
     "

--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -22,6 +22,8 @@ To import assets in other formats, refer to [Extend Asset Types](#extend-asset-t
 
 ## Import assets in JavaScript file
 
+### `import` imports
+
 In JavaScript files, you can directly import static assets with relative paths through `import`:
 
 ```tsx
@@ -111,6 +113,56 @@ export { logo_namespaceObject as default };
 </Tab>
 
 </Tabs>
+
+### `new URL` imports
+
+:::note
+
+When referencing static assets with `new URL()`, only ESM output is supported, so [format](/config/lib/format) must be set to `'esm'` (the default).
+
+:::
+
+You can also reference static assets by using JavaScript's native `URL` together with `import.meta.url`:
+
+```js
+const logo = new URL('./assets/logo.svg', import.meta.url);
+```
+
+The following output will be emitted:
+
+<Tabs>
+<Tab label="dist/index.mjs">
+
+```js
+const logo = new URL('./static/svg/logo.svg', import.meta.url);
+export { logo };
+```
+
+</Tab>
+
+<Tab label="dist/static/svg/logo.svg">
+  <img src="https://assets.rspack.rs/rslib/rslib-logo.svg" width="100" height="100" loading="lazy" />
+</Tab>
+</Tabs>
+
+After build, the path in `new URL()` points to the emitted asset file.
+
+In bundleless mode, the default glob entry matches `src/**`. When referencing static assets with `new URL()`, you need to manually exclude the corresponding asset files from the entry:
+
+```ts title="rslib.config.ts"
+export default defineConfig({
+  lib: [
+    {
+      bundle: false,
+      source: {
+        entry: {
+          index: ['src/**', '!src/assets/logo.svg'],
+        },
+      },
+    },
+  ],
+});
+```
 
 ## Import assets in CSS file
 

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -22,6 +22,8 @@ Rslib 支持在代码中引用图片、字体、媒体和其他类型文件等�
 
 ## 在 JavaScript 文件中引用
 
+### `import` 引用
+
 在 JavaScript 文件中，可以直接通过 `import` 的方式引用相对路径下的静态资源：
 
 ```tsx
@@ -111,6 +113,56 @@ export { logo_namespaceObject as default };
 </Tab>
 
 </Tabs>
+
+### `new URL` 引用
+
+:::note
+
+使用 `new URL()` 引用静态资源时，仅支持生成 ESM 格式的产物，因此 [format](/config/lib/format) 必须设置为 `'esm'`（默认值）。
+
+:::
+
+你可以通过 JavaScript 原生的 `URL` 和 `import.meta.url` 相配合，来引用静态资源：
+
+```js
+const logo = new URL('./assets/logo.svg', import.meta.url);
+```
+
+将会输出如下产物：
+
+<Tabs>
+<Tab label="dist/index.mjs">
+
+```js
+const logo = new URL('./static/svg/logo.svg', import.meta.url);
+export { logo };
+```
+
+</Tab>
+
+<Tab label="dist/static/svg/logo.svg">
+  <img src="https://assets.rspack.rs/rslib/rslib-logo.svg" width="100" height="100" loading="lazy" />
+</Tab>
+</Tabs>
+
+构建后，`new URL()` 中的路径会指向产物中输出的资源文件。
+
+在 bundleless 模式下，默认的 glob 入口会匹配 `src/**`。使用 `new URL()` 引用静态资源时，需要手动将对应资源文件从入口中排除：
+
+```ts title="rslib.config.ts"
+export default defineConfig({
+  lib: [
+    {
+      bundle: false,
+      source: {
+        entry: {
+          index: ['src/**', '!src/assets/logo.svg'],
+        },
+      },
+    },
+  ],
+});
+```
 
 ## 在 CSS 文件中引用
 


### PR DESCRIPTION
## Summary

Support `new URL("path", import.meta.url)` as a static relative URL in library output.

- Enable the `new-url-relative` parser.
- Don't externalize `new URL` assets in bundleless.

Need:
- https://github.com/web-infra-dev/rspack/pull/14885

## Breaking change

For ESM output, Rslib now treats statically analyzable local references such as `new URL('./assets/logo.svg', import.meta.url)` as asset dependencies. The referenced file is automatically emitted to the output directory, and the URL in the generated JavaScript is rewritten to a relative path pointing to the emitted asset.

Previously, Rslib preserved the original `new URL()` expression without emitting the referenced file or rewriting path. Users therefore had to copy these assets manually. These workarounds should now be removed.
