### PR TITLE
feat(dts)!: enable declaration extension redirects by default

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -345,7 +345,7 @@ export type DtsRedirect = {
   path?: boolean;
   /**
    * Whether to automatically redirect the file extension to import paths based on the TypeScript declaration output files.
-   * @defaultValue `false`
+   * @defaultValue `true`
    */
   extension?: boolean;
 };

--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -236,7 +236,7 @@ type DtsRedirect = {
 ```ts
 const defaultRedirect = {
   path: true,
-  extension: false,
+  extension: true,
 };
 ```
 
@@ -246,7 +246,7 @@ Controls the redirect of the import paths of TypeScript declaration output files
 pluginDts({
   redirect: {
     path: true,
-    extension: false,
+    extension: true,
   },
 });
 ```
@@ -274,7 +274,7 @@ import { foo } from '../foo'; // expected output './dist/utils/index.d.ts'
 #### redirect.extension
 
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true`
 
 Whether to automatically redirect the file extension of import paths based on the TypeScript declaration output files.
 

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -317,7 +317,7 @@ export async function generateDts(data: DtsGenOptions): Promise<void> {
     footer,
     redirect = {
       path: true,
-      extension: false,
+      extension: true,
     },
     loggerLevel,
     typescriptPath,

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -64,7 +64,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
     options.build = options.build ?? false;
     options.redirect = options.redirect ?? {};
     options.redirect.path = options.redirect.path ?? true;
-    options.redirect.extension = options.redirect.extension ?? false;
+    options.redirect.extension = options.redirect.extension ?? true;
     options.alias = options.alias ?? {};
 
     let dtsPromise: Promise<TaskResult> = Promise.resolve({

--- a/packages/plugin-dts/src/isolated.ts
+++ b/packages/plugin-dts/src/isolated.ts
@@ -105,7 +105,7 @@ export async function processIsolatedDts(
     isolatedDtsContext.dtsExtension,
     isolatedDtsContext.redirect ?? {
       path: true,
-      extension: false,
+      extension: true,
     },
     isolatedDtsContext.tsconfigPath,
     isolatedDtsContext.rootDir,

--- a/tests/integration/dts-tsgo/bundle-false/__snapshots__/index.test.ts.snap
+++ b/tests/integration/dts-tsgo/bundle-false/__snapshots__/index.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`dts with tsgo when bundle: false > basic 3`] = `
 {
-  "<ROOT>/tests/integration/dts-tsgo/bundle-false/basic/dist/esm/index.d.ts": "export * from './sum';
-export * from './utils/numbers';
-export * from './utils/strings';
+  "<ROOT>/tests/integration/dts-tsgo/bundle-false/basic/dist/esm/index.d.ts": "export * from './sum.js';
+export * from './utils/numbers.js';
+export * from './utils/strings.js';
 ",
   "<ROOT>/tests/integration/dts-tsgo/bundle-false/basic/dist/esm/sum.d.ts": "export declare const numSum: number;
 export declare const strSum: string;

--- a/tests/integration/dts-tsgo/bundle-false/index.test.ts
+++ b/tests/integration/dts-tsgo/bundle-false/index.test.ts
@@ -161,14 +161,14 @@ describe('dts with tsgo when bundle: false', () => {
 
     expect(contents.esm).toMatchInlineSnapshot(`
       {
-        "<ROOT>/tests/integration/dts-tsgo/bundle-false/alias/dist/esm/index.d.ts": "export {} from '../../compile/prebundle-pkg';
+        "<ROOT>/tests/integration/dts-tsgo/bundle-false/alias/dist/esm/index.d.ts": "export {} from '../../compile/prebundle-pkg/index.js';
       ",
       }
     `);
 
     expect(contents.cjs).toMatchInlineSnapshot(`
       {
-        "<ROOT>/tests/integration/dts-tsgo/bundle-false/alias/dist/cjs/index.d.ts": "export {} from '../../compile/prebundle-pkg';
+        "<ROOT>/tests/integration/dts-tsgo/bundle-false/alias/dist/cjs/index.d.ts": "export {} from '../../compile/prebundle-pkg/index.js';
       ",
       }
     `);

--- a/tests/integration/dts/bundle-false/__snapshots__/index.test.ts.snap
+++ b/tests/integration/dts/bundle-false/__snapshots__/index.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`dts when bundle: false > basic 3`] = `
 {
-  "<ROOT>/tests/integration/dts/bundle-false/basic/dist/esm/index.d.ts": "export * from './sum';
-export * from './utils/numbers';
-export * from './utils/strings';
+  "<ROOT>/tests/integration/dts/bundle-false/basic/dist/esm/index.d.ts": "export * from './sum.js';
+export * from './utils/numbers.js';
+export * from './utils/strings.js';
 ",
   "<ROOT>/tests/integration/dts/bundle-false/basic/dist/esm/sum.d.ts": "export declare const numSum: number;
 export declare const strSum: string;

--- a/tests/integration/dts/bundle-false/index.test.ts
+++ b/tests/integration/dts/bundle-false/index.test.ts
@@ -200,14 +200,14 @@ describe('dts when bundle: false', () => {
 
     expect(contents.esm).toMatchInlineSnapshot(`
       {
-        "<ROOT>/tests/integration/dts/bundle-false/alias/dist/esm/index.d.ts": "export {} from '../../compile/prebundle-pkg';
+        "<ROOT>/tests/integration/dts/bundle-false/alias/dist/esm/index.d.ts": "export {} from '../../compile/prebundle-pkg/index.js';
       ",
       }
     `);
 
     expect(contents.cjs).toMatchInlineSnapshot(`
       {
-        "<ROOT>/tests/integration/dts/bundle-false/alias/dist/cjs/index.d.ts": "export {} from '../../compile/prebundle-pkg';
+        "<ROOT>/tests/integration/dts/bundle-false/alias/dist/cjs/index.d.ts": "export {} from '../../compile/prebundle-pkg/index.js';
       ",
       }
     `);

--- a/tests/integration/dts/composite/index.test.ts
+++ b/tests/integration/dts/composite/index.test.ts
@@ -88,9 +88,9 @@ describe('dts when composite: true', () => {
     expect(contents.esm).toMatchInlineSnapshot(`
       {
         "<ROOT>/tests/integration/dts/composite/process-files/dist/esm/index.d.ts": "/*! hello banner dts composite*/
-      export * from './sum';
-      export * from './utils/numbers';
-      export * from './utils/strings';
+      export * from './sum.js';
+      export * from './utils/numbers.js';
+      export * from './utils/strings.js';
 
       /*! hello banner dts composite*/
       ",

--- a/tests/integration/dts/isolated/index.test.ts
+++ b/tests/integration/dts/isolated/index.test.ts
@@ -58,8 +58,8 @@ describe('isolated dts', () => {
       basename: true,
     });
 
-    expect(esmIndex).toContain(`from '../../compile/aliased-pkg'`);
-    expect(cjsIndex).toContain(`from '../../compile/aliased-pkg'`);
+    expect(esmIndex).toContain(`from '../../compile/aliased-pkg/index.js'`);
+    expect(cjsIndex).toContain(`from '../../compile/aliased-pkg/index.js'`);
   });
 
   test('should support bundled output in isolated mode', async () => {

--- a/tests/integration/redirect/dts-tsgo/rslib.config.mts
+++ b/tests/integration/redirect/dts-tsgo/rslib.config.mts
@@ -3,7 +3,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
 
 export default defineConfig({
   lib: [
-    // 0 - default - path: true extension: false
+    // 0 - default - path: true extension: true
     generateBundleEsmConfig({
       dts: {
         tsgo: true,
@@ -23,20 +23,21 @@ export default defineConfig({
       redirect: {
         dts: {
           path: false,
+          extension: false,
         },
       },
     }),
-    // 2 - path: true extension: true
+    // 2 - path: true extension: false
     generateBundleEsmConfig({
       dts: {
         tsgo: true,
       },
       output: {
-        distPath: '../dts/dist-tsgo/extension-true/esm',
+        distPath: '../dts/dist-tsgo/extension-false/esm',
       },
       redirect: {
         dts: {
-          extension: true,
+          extension: false,
         },
       },
     }),

--- a/tests/integration/redirect/dts.test.ts
+++ b/tests/integration/redirect/dts.test.ts
@@ -15,7 +15,7 @@ describe('dts redirect', () => {
     ).contents;
   }, 20000);
 
-  test('redirect.dts.path: true with redirect.dts.extension: false - default', async () => {
+  test('redirect.dts.path: true with redirect.dts.extension: true - default', async () => {
     expect(contents.esm0).toMatchInlineSnapshot(`
       {
         "<ROOT>/tests/integration/redirect/dts/dist/default/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
@@ -26,44 +26,44 @@ describe('dts redirect', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist/default/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/config.d.ts": "export * from './config/load';
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/config.d.ts": "export * from './config/load.js';
       ",
         "<ROOT>/tests/integration/redirect/dts/dist/default/esm/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
         "<ROOT>/tests/integration/redirect/dts/dist/default/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/foo/foo.d.ts": "import { logRequest } from '../logger';
-      import { logger } from '../../../../compile/prebundle-pkg';
-      import { logRequest as logRequest2 } from '../logger';
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/foo/foo.d.ts": "import { logRequest } from '../logger.js';
+      import { logger } from '../../../../compile/prebundle-pkg/index.js';
+      import { logRequest as logRequest2 } from '../logger.js';
       export { logRequest, logRequest2, logger };
       ",
         "<ROOT>/tests/integration/redirect/dts/dist/default/esm/foo/index.d.ts": "export type Barrel = string;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/index.d.ts": "import { logRequest } from './logger';
-      import { logger } from '../../../compile/prebundle-pkg';
+        "<ROOT>/tests/integration/redirect/dts/dist/default/esm/index.d.ts": "import { logRequest } from './logger.js';
+      import { logger } from '../../../compile/prebundle-pkg/index.js';
       import { fooMjs } from './foo.mjs';
-      import type { Baz } from './';
-      import type { LoggerOptions } from './types';
+      import type { Baz } from './index.js';
+      import type { LoggerOptions } from './types.js';
       import { defaultOptions } from './types.js';
-      type sources = typeof import('./logger');
+      type sources = typeof import('./logger.js');
       export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
-      export * from './foo';
-      export * from './logger';
-      export type { Foo } from './types';
-      export type { TypesValue } from '../../../compile/types-pkg/types';
+      export * from './foo/index.js';
+      export * from './logger.js';
+      export type { Foo } from './types.js';
+      export type { TypesValue } from '../../../compile/types-pkg/types.js';
       export { Router } from 'express';
-      export * from '../../../compile/prebundle-pkg';
-      export type { Bar } from './types';
-      export * from './.hidden';
-      export * from './.hidden-folder';
-      export * from './a.b';
-      export * from './bar.baz';
-      export * from './config';
-      export * from './foo';
-      export * from './types';
+      export * from '../../../compile/prebundle-pkg/index.js';
+      export type { Bar } from './types.js';
+      export * from './.hidden.js';
+      export * from './.hidden-folder/index.js';
+      export * from './a.b/index.js';
+      export * from './bar.baz.js';
+      export * from './config.js';
+      export * from './foo/index.js';
+      export * from './types.js';
       ",
         "<ROOT>/tests/integration/redirect/dts/dist/default/esm/logger.d.ts": "import type { Request } from 'express';
-      import type { LoggerOptions } from './types';
+      import type { LoggerOptions } from './types.js';
       export declare function logRequest(req: Request, options: LoggerOptions): void;
       ",
         "<ROOT>/tests/integration/redirect/dts/dist/default/esm/types.d.ts": "export interface LoggerOptions {
@@ -155,58 +155,58 @@ describe('dts redirect', () => {
     `);
   });
 
-  test('redirect.dts.path: true with redirect.dts.extension: true', async () => {
+  test('redirect.dts.path: true with redirect.dts.extension: false', async () => {
     expect(contents.esm2).toMatchInlineSnapshot(`
       {
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/a.b/index.d.ts": "export declare const ab = "a.b";
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/a.b/index.d.ts": "export declare const ab = "a.b";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/config.d.ts": "export * from './config/load.js';
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/config.d.ts": "export * from './config/load';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/config/load.d.ts": "export declare const loadConfig: () => void;
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/foo/foo.d.ts": "import { logRequest } from '../logger.js';
-      import { logger } from '../../../../compile/prebundle-pkg/index.js';
-      import { logRequest as logRequest2 } from '../logger.js';
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/foo/foo.d.ts": "import { logRequest } from '../logger';
+      import { logger } from '../../../../compile/prebundle-pkg';
+      import { logRequest as logRequest2 } from '../logger';
       export { logRequest, logRequest2, logger };
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/foo/index.d.ts": "export type Barrel = string;
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/foo/index.d.ts": "export type Barrel = string;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/index.d.ts": "import { logRequest } from './logger.js';
-      import { logger } from '../../../compile/prebundle-pkg/index.js';
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/index.d.ts": "import { logRequest } from './logger';
+      import { logger } from '../../../compile/prebundle-pkg';
       import { fooMjs } from './foo.mjs';
-      import type { Baz } from './index.js';
-      import type { LoggerOptions } from './types.js';
+      import type { Baz } from './';
+      import type { LoggerOptions } from './types';
       import { defaultOptions } from './types.js';
-      type sources = typeof import('./logger.js');
+      type sources = typeof import('./logger');
       export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
-      export * from './foo/index.js';
-      export * from './logger.js';
-      export type { Foo } from './types.js';
-      export type { TypesValue } from '../../../compile/types-pkg/types.js';
+      export * from './foo';
+      export * from './logger';
+      export type { Foo } from './types';
+      export type { TypesValue } from '../../../compile/types-pkg/types';
       export { Router } from 'express';
-      export * from '../../../compile/prebundle-pkg/index.js';
-      export type { Bar } from './types.js';
-      export * from './.hidden.js';
-      export * from './.hidden-folder/index.js';
-      export * from './a.b/index.js';
-      export * from './bar.baz.js';
-      export * from './config.js';
-      export * from './foo/index.js';
-      export * from './types.js';
+      export * from '../../../compile/prebundle-pkg';
+      export type { Bar } from './types';
+      export * from './.hidden';
+      export * from './.hidden-folder';
+      export * from './a.b';
+      export * from './bar.baz';
+      export * from './config';
+      export * from './foo';
+      export * from './types';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/logger.d.ts": "import type { Request } from 'express';
-      import type { LoggerOptions } from './types.js';
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/logger.d.ts": "import type { Request } from 'express';
+      import type { LoggerOptions } from './types';
       export declare function logRequest(req: Request, options: LoggerOptions): void;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist/extension-true/esm/types.d.ts": "export interface LoggerOptions {
+        "<ROOT>/tests/integration/redirect/dts/dist/extension-false/esm/types.d.ts": "export interface LoggerOptions {
           logLevel: 'info' | 'debug' | 'warn' | 'error';
           logBody: boolean;
       }

--- a/tests/integration/redirect/dts/rslib.config.mts
+++ b/tests/integration/redirect/dts/rslib.config.mts
@@ -3,7 +3,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
 
 export default defineConfig({
   lib: [
-    // 0 - default - path: true extension: false
+    // 0 - default - path: true extension: true
     generateBundleEsmConfig({
       dts: true,
       output: {
@@ -19,18 +19,19 @@ export default defineConfig({
       redirect: {
         dts: {
           path: false,
+          extension: false,
         },
       },
     }),
-    // 2 - path: true extension: true
+    // 2 - path: true extension: false
     generateBundleEsmConfig({
       dts: true,
       output: {
-        distPath: './dist/extension-true/esm',
+        distPath: './dist/extension-false/esm',
       },
       redirect: {
         dts: {
-          extension: true,
+          extension: false,
         },
       },
     }),

--- a/tests/integration/redirect/dts/rslib.isolated.config.mts
+++ b/tests/integration/redirect/dts/rslib.isolated.config.mts
@@ -3,7 +3,7 @@ import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
 
 export default defineConfig({
   lib: [
-    // 0 - default - path: true extension: false
+    // 0 - default - path: true extension: true
     generateBundleEsmConfig({
       dts: {
         isolated: true,
@@ -23,20 +23,21 @@ export default defineConfig({
       redirect: {
         dts: {
           path: false,
+          extension: false,
         },
       },
     }),
-    // 2 - path: true extension: true
+    // 2 - path: true extension: false
     generateBundleEsmConfig({
       dts: {
         isolated: true,
       },
       output: {
-        distPath: './dist-isolated/extension-true/esm',
+        distPath: './dist-isolated/extension-false/esm',
       },
       redirect: {
         dts: {
-          extension: true,
+          extension: false,
         },
       },
     }),

--- a/tests/integration/redirect/dtsIsolated.test.ts
+++ b/tests/integration/redirect/dtsIsolated.test.ts
@@ -19,7 +19,7 @@ describe('dts redirect with isolated', () => {
     ).contents;
   }, 20000);
 
-  test('redirect.dts.path: true with redirect.dts.extension: false - default', async () => {
+  test('redirect.dts.path: true with redirect.dts.extension: true - default', async () => {
     expect(contents.esm0).toMatchInlineSnapshot(`
       {
         "<ROOT>/tests/integration/redirect/dts/dist-isolated/default/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = 'This is a hidden folder';
@@ -30,7 +30,7 @@ describe('dts redirect with isolated', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-isolated/default/esm/bar.baz.d.ts": "export declare const bar = 'bar-baz';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/default/esm/config.d.ts": "export * from './config/load';
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/default/esm/config.d.ts": "export * from './config/load.js';
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-isolated/default/esm/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
@@ -38,31 +38,31 @@ describe('dts redirect with isolated', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-isolated/default/esm/foo/index.d.ts": "export type Barrel = string;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/default/esm/index.d.ts": "import { logRequest } from './logger';
-      import { logger } from '../../../compile/prebundle-pkg';
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/default/esm/index.d.ts": "import { logRequest } from './logger.js';
+      import { logger } from '../../../compile/prebundle-pkg/index.js';
       import { fooMjs } from './foo.mjs';
-      import type { Baz } from './';
-      import type { LoggerOptions } from './types';
+      import type { Baz } from './index.js';
+      import type { LoggerOptions } from './types.js';
       import { defaultOptions } from './types.js';
-      type sources = typeof import('./logger');
+      type sources = typeof import('./logger.js');
       export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions };
-      export * from './foo';
-      export * from './logger';
-      export type { Foo } from './types';
-      export type { TypesValue } from '../../../compile/types-pkg/types';
+      export * from './foo/index.js';
+      export * from './logger.js';
+      export type { Foo } from './types.js';
+      export type { TypesValue } from '../../../compile/types-pkg/types.js';
       export { Router } from 'express';
-      export * from '../../../compile/prebundle-pkg';
-      export type { Bar } from './types';
-      export * from './.hidden';
-      export * from './.hidden-folder';
-      export * from './a.b';
-      export * from './bar.baz';
-      export * from './config';
-      export * from './foo';
-      export * from './types';
+      export * from '../../../compile/prebundle-pkg/index.js';
+      export type { Bar } from './types.js';
+      export * from './.hidden.js';
+      export * from './.hidden-folder/index.js';
+      export * from './a.b/index.js';
+      export * from './bar.baz.js';
+      export * from './config.js';
+      export * from './foo/index.js';
+      export * from './types.js';
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-isolated/default/esm/logger.d.ts": "import type { Request } from 'express';
-      import type { LoggerOptions } from './types';
+      import type { LoggerOptions } from './types.js';
       export declare function logRequest(req: Request, options: LoggerOptions): void;
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-isolated/default/esm/types.d.ts": "export interface LoggerOptions {
@@ -149,53 +149,53 @@ describe('dts redirect with isolated', () => {
     `);
   });
 
-  test('redirect.dts.path: true with redirect.dts.extension: true', async () => {
+  test('redirect.dts.path: true with redirect.dts.extension: false', async () => {
     expect(contents.esm2).toMatchInlineSnapshot(`
       {
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = 'This is a hidden folder';
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = 'This is a hidden folder';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/.hidden.d.ts": "export declare const hidden = 'This is a hidden file';
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/.hidden.d.ts": "export declare const hidden = 'This is a hidden file';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/a.b/index.d.ts": "export declare const ab = 'a.b';
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/a.b/index.d.ts": "export declare const ab = 'a.b';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/bar.baz.d.ts": "export declare const bar = 'bar-baz';
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/bar.baz.d.ts": "export declare const bar = 'bar-baz';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/config.d.ts": "export * from './config/load.js';
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/config.d.ts": "export * from './config/load';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/config/load.d.ts": "export declare const loadConfig: () => void;
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/foo.d.mts": "export declare const fooMjs = 'foo-mjs';
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/foo.d.mts": "export declare const fooMjs = 'foo-mjs';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/foo/index.d.ts": "export type Barrel = string;
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/foo/index.d.ts": "export type Barrel = string;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/index.d.ts": "import { logRequest } from './logger.js';
-      import { logger } from '../../../compile/prebundle-pkg/index.js';
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/index.d.ts": "import { logRequest } from './logger';
+      import { logger } from '../../../compile/prebundle-pkg';
       import { fooMjs } from './foo.mjs';
-      import type { Baz } from './index.js';
-      import type { LoggerOptions } from './types.js';
+      import type { Baz } from './';
+      import type { LoggerOptions } from './types';
       import { defaultOptions } from './types.js';
-      type sources = typeof import('./logger.js');
+      type sources = typeof import('./logger');
       export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions };
-      export * from './foo/index.js';
-      export * from './logger.js';
-      export type { Foo } from './types.js';
-      export type { TypesValue } from '../../../compile/types-pkg/types.js';
+      export * from './foo';
+      export * from './logger';
+      export type { Foo } from './types';
+      export type { TypesValue } from '../../../compile/types-pkg/types';
       export { Router } from 'express';
-      export * from '../../../compile/prebundle-pkg/index.js';
-      export type { Bar } from './types.js';
-      export * from './.hidden.js';
-      export * from './.hidden-folder/index.js';
-      export * from './a.b/index.js';
-      export * from './bar.baz.js';
-      export * from './config.js';
-      export * from './foo/index.js';
-      export * from './types.js';
+      export * from '../../../compile/prebundle-pkg';
+      export type { Bar } from './types';
+      export * from './.hidden';
+      export * from './.hidden-folder';
+      export * from './a.b';
+      export * from './bar.baz';
+      export * from './config';
+      export * from './foo';
+      export * from './types';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/logger.d.ts": "import type { Request } from 'express';
-      import type { LoggerOptions } from './types.js';
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/logger.d.ts": "import type { Request } from 'express';
+      import type { LoggerOptions } from './types';
       export declare function logRequest(req: Request, options: LoggerOptions): void;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-true/esm/types.d.ts": "export interface LoggerOptions {
+        "<ROOT>/tests/integration/redirect/dts/dist-isolated/extension-false/esm/types.d.ts": "export interface LoggerOptions {
           logLevel: 'info' | 'debug' | 'warn' | 'error';
           logBody: boolean;
       }

--- a/tests/integration/redirect/dtsTsgo.test.ts
+++ b/tests/integration/redirect/dtsTsgo.test.ts
@@ -15,7 +15,7 @@ describe('dts redirect with tsgo', () => {
     ).contents;
   }, 20000);
 
-  test('redirect.dts.path: true with redirect.dts.extension: false - default', async () => {
+  test('redirect.dts.path: true with redirect.dts.extension: true - default', async () => {
     expect(contents.esm0).toMatchInlineSnapshot(`
       {
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
@@ -26,44 +26,44 @@ describe('dts redirect with tsgo', () => {
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/config.d.ts": "export * from './config/load';
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/config.d.ts": "export * from './config/load.js';
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/foo/foo.d.ts": "import { logRequest } from '../logger';
-      import { logger } from '../../../../compile/prebundle-pkg';
-      import { logRequest as logRequest2 } from '../logger';
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/foo/foo.d.ts": "import { logRequest } from '../logger.js';
+      import { logger } from '../../../../compile/prebundle-pkg/index.js';
+      import { logRequest as logRequest2 } from '../logger.js';
       export { logRequest, logRequest2, logger };
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/foo/index.d.ts": "export type Barrel = string;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/index.d.ts": "import { logRequest } from './logger';
-      import { logger } from '../../../compile/prebundle-pkg';
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/index.d.ts": "import { logRequest } from './logger.js';
+      import { logger } from '../../../compile/prebundle-pkg/index.js';
       import { fooMjs } from './foo.mjs';
-      import type { Baz } from './';
-      import type { LoggerOptions } from './types';
+      import type { Baz } from './index.js';
+      import type { LoggerOptions } from './types.js';
       import { defaultOptions } from './types.js';
-      type sources = typeof import('./logger');
+      type sources = typeof import('./logger.js');
       export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
-      export * from './foo';
-      export * from './logger';
-      export type { Foo } from './types';
-      export type { TypesValue } from '../../../compile/types-pkg/types';
+      export * from './foo/index.js';
+      export * from './logger.js';
+      export type { Foo } from './types.js';
+      export type { TypesValue } from '../../../compile/types-pkg/types.js';
       export { Router } from 'express';
-      export * from '../../../compile/prebundle-pkg';
-      export type { Bar } from './types';
-      export * from './.hidden';
-      export * from './.hidden-folder';
-      export * from './a.b';
-      export * from './bar.baz';
-      export * from './config';
-      export * from './foo';
-      export * from './types';
+      export * from '../../../compile/prebundle-pkg/index.js';
+      export type { Bar } from './types.js';
+      export * from './.hidden.js';
+      export * from './.hidden-folder/index.js';
+      export * from './a.b/index.js';
+      export * from './bar.baz.js';
+      export * from './config.js';
+      export * from './foo/index.js';
+      export * from './types.js';
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/logger.d.ts": "import type { Request } from 'express';
-      import type { LoggerOptions } from './types';
+      import type { LoggerOptions } from './types.js';
       export declare function logRequest(req: Request, options: LoggerOptions): void;
       ",
         "<ROOT>/tests/integration/redirect/dts/dist-tsgo/default/esm/types.d.ts": "export interface LoggerOptions {
@@ -155,58 +155,58 @@ describe('dts redirect with tsgo', () => {
     `);
   });
 
-  test('redirect.dts.path: true with redirect.dts.extension: true', async () => {
+  test('redirect.dts.path: true with redirect.dts.extension: false', async () => {
     expect(contents.esm2).toMatchInlineSnapshot(`
       {
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/.hidden-folder/index.d.ts": "export declare const hiddenFolder = "This is a hidden folder";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/.hidden.d.ts": "export declare const hidden = "This is a hidden file";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/a.b/index.d.ts": "export declare const ab = "a.b";
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/a.b/index.d.ts": "export declare const ab = "a.b";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/bar.baz.d.ts": "export declare const bar = "bar-baz";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/config.d.ts": "export * from './config/load.js';
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/config.d.ts": "export * from './config/load';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/config/load.d.ts": "export declare const loadConfig: () => void;
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/config/load.d.ts": "export declare const loadConfig: () => void;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/foo.d.mts": "export declare const fooMjs = "foo-mjs";
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/foo/foo.d.ts": "import { logRequest } from '../logger.js';
-      import { logger } from '../../../../compile/prebundle-pkg/index.js';
-      import { logRequest as logRequest2 } from '../logger.js';
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/foo/foo.d.ts": "import { logRequest } from '../logger';
+      import { logger } from '../../../../compile/prebundle-pkg';
+      import { logRequest as logRequest2 } from '../logger';
       export { logRequest, logRequest2, logger };
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/foo/index.d.ts": "export type Barrel = string;
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/foo/index.d.ts": "export type Barrel = string;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/index.d.ts": "import { logRequest } from './logger.js';
-      import { logger } from '../../../compile/prebundle-pkg/index.js';
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/index.d.ts": "import { logRequest } from './logger';
+      import { logger } from '../../../compile/prebundle-pkg';
       import { fooMjs } from './foo.mjs';
-      import type { Baz } from './index.js';
-      import type { LoggerOptions } from './types.js';
+      import type { Baz } from './';
+      import type { LoggerOptions } from './types';
       import { defaultOptions } from './types.js';
-      type sources = typeof import('./logger.js');
+      type sources = typeof import('./logger');
       export { sources, type Baz as self, logRequest, logger, fooMjs, type LoggerOptions, defaultOptions, };
-      export * from './foo/index.js';
-      export * from './logger.js';
-      export type { Foo } from './types.js';
-      export type { TypesValue } from '../../../compile/types-pkg/types.js';
+      export * from './foo';
+      export * from './logger';
+      export type { Foo } from './types';
+      export type { TypesValue } from '../../../compile/types-pkg/types';
       export { Router } from 'express';
-      export * from '../../../compile/prebundle-pkg/index.js';
-      export type { Bar } from './types.js';
-      export * from './.hidden.js';
-      export * from './.hidden-folder/index.js';
-      export * from './a.b/index.js';
-      export * from './bar.baz.js';
-      export * from './config.js';
-      export * from './foo/index.js';
-      export * from './types.js';
+      export * from '../../../compile/prebundle-pkg';
+      export type { Bar } from './types';
+      export * from './.hidden';
+      export * from './.hidden-folder';
+      export * from './a.b';
+      export * from './bar.baz';
+      export * from './config';
+      export * from './foo';
+      export * from './types';
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/logger.d.ts": "import type { Request } from 'express';
-      import type { LoggerOptions } from './types.js';
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/logger.d.ts": "import type { Request } from 'express';
+      import type { LoggerOptions } from './types';
       export declare function logRequest(req: Request, options: LoggerOptions): void;
       ",
-        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-true/esm/types.d.ts": "export interface LoggerOptions {
+        "<ROOT>/tests/integration/redirect/dts/dist-tsgo/extension-false/esm/types.d.ts": "export interface LoggerOptions {
           logLevel: 'info' | 'debug' | 'warn' | 'error';
           logBody: boolean;
       }

--- a/website/docs/en/config/lib/redirect.mdx
+++ b/website/docs/en/config/lib/redirect.mdx
@@ -344,7 +344,7 @@ import { foo } from './foo.mjs'; // expected output of './dist/bar.d.mts'
 
 This option also applies to declaration import paths rewritten through [`paths`](https://typescriptlang.org/tsconfig#paths) or [`dts.alias`](/config/lib/dts#dtsalias). Note the following cases:
 
-- If a configured path is a package directory that relies on `types`, `exports.types`, or `typesVersions` to locate its declaration entry, configure the concrete declaration entry directly. For example, when `vendor/foo/package.json` contains `"types": "./dist/index.d.ts"`:
+- If a configured path is a package directory that relies on the `types` field, the `types` condition name in `exports`, or `typesVersions` to locate its declaration entry, configure the concrete declaration entry directly. For example, when `vendor/foo/package.json` contains `"types": "./dist/index.d.ts"`:
 
   ```diff title="rslib.config.ts"
    dts: {

--- a/website/docs/en/config/lib/redirect.mdx
+++ b/website/docs/en/config/lib/redirect.mdx
@@ -60,7 +60,7 @@ const defaultRedirect = {
   },
   dts: {
     path: true,
-    extension: false,
+    extension: true,
   },
 };
 ```
@@ -318,7 +318,7 @@ import { foo } from '../foo'; // expected output './dist/utils/index.d.ts'
 Whether to automatically redirect the file extension of import paths based on the TypeScript declaration output files.
 
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true`
 
 When set to `true`, the file extension of the import path in the declaration file will be automatically completed or replaced with the corresponding JavaScript file extension that can be resolved to the corresponding declaration file.
 
@@ -339,3 +339,32 @@ import { foo } from './foo.mjs'; // expected output of './dist/bar.d.mts'
 import { foo } from './foo.ts'; // source code of './src/bar.ts' ↓
 import { foo } from './foo.mjs'; // expected output of './dist/bar.d.mts'
 ```
+
+#### Notes
+
+This option also applies to declaration import paths rewritten through [`paths`](https://typescriptlang.org/tsconfig#paths) or [`dts.alias`](/config/lib/dts#dtsalias). Note the following cases:
+
+- If a configured path is a package directory that relies on `types`, `exports.types`, or `typesVersions` to locate its declaration entry, configure the concrete declaration entry directly. For example, when `vendor/foo/package.json` contains `"types": "./dist/index.d.ts"`:
+
+  ```diff title="rslib.config.ts"
+   dts: {
+     alias: {
+  -    foo: './vendor/foo',
+  +    foo: './vendor/foo/dist/index',
+     },
+   },
+  ```
+
+- If the CommonJS declaration referenced by a configured path originally uses `export =`, preserve that export form instead of converting it to `export default`. Otherwise, when the module is resolved with NodeNext from an ESM declaration, CommonJS default interop may combine with the explicit default export and move the original namespace members one level under `default`. For example:
+
+  ```diff title="foo/index.d.ts"
+   declare function Foo(): void;
+   declare namespace Foo {
+     interface Options {}
+   }
+
+  -export { Foo as default };
+  +export = Foo;
+  ```
+
+Bare package imports that do not match `paths` or `dts.alias` are not rewritten and continue to use TypeScript's package resolution.

--- a/website/docs/zh/config/lib/redirect.mdx
+++ b/website/docs/zh/config/lib/redirect.mdx
@@ -344,7 +344,7 @@ import { foo } from './foo.mjs'; // './dist/bar.d.mts' 预期生成的代码
 
 该配置也适用于通过 [`paths`](https://typescriptlang.org/tsconfig#paths) 或 [`dts.alias`](/config/lib/dts#dtsalias) 改写后的类型导入路径，因此需要注意以下情况：
 
-- 如果配置路径是包目录，并依赖 `types`、`exports.types` 或 `typesVersions` 定位类型入口，请直接配置具体的类型声明入口。例如，当 `vendor/foo/package.json` 中配置了 `"types": "./dist/index.d.ts"` 时：
+- 如果配置路径是包目录，并依赖 `types` 字段、`exports` 中的 `types` 条件名称或 `typesVersions` 定位类型入口，请直接配置具体的类型声明入口。例如，当 `vendor/foo/package.json` 中配置了 `"types": "./dist/index.d.ts"` 时：
 
   ```diff title="rslib.config.ts"
    dts: {

--- a/website/docs/zh/config/lib/redirect.mdx
+++ b/website/docs/zh/config/lib/redirect.mdx
@@ -60,7 +60,7 @@ const defaultRedirect = {
   },
   dts: {
     path: true,
-    extension: false,
+    extension: true,
   },
 };
 ```
@@ -318,7 +318,7 @@ import { foo } from '../foo'; // './dist/utils/index.d.ts' 预期生成的代码
 是否根据 TypeScript 类型文件自动重定向导入路径的文件扩展名。
 
 - **类型:** `boolean`
-- **默认值:** `false`
+- **默认值:** `true`
 
 当设置为 `true` 时，类型声明文件中的导入路径，其文件扩展名会被自动补全或替换为对应的可以解析到相应类型声明文件的 JavaScript 文件扩展名。
 
@@ -339,3 +339,32 @@ import { foo } from './foo.mjs'; // './dist/bar.d.mts' 预期生成的代码
 import { foo } from './foo.ts'; // './src/bar.ts' 的源码 ↓
 import { foo } from './foo.mjs'; // './dist/bar.d.mts' 预期生成的代码
 ```
+
+#### 注意事项
+
+该配置也适用于通过 [`paths`](https://typescriptlang.org/tsconfig#paths) 或 [`dts.alias`](/config/lib/dts#dtsalias) 改写后的类型导入路径，因此需要注意以下情况：
+
+- 如果配置路径是包目录，并依赖 `types`、`exports.types` 或 `typesVersions` 定位类型入口，请直接配置具体的类型声明入口。例如，当 `vendor/foo/package.json` 中配置了 `"types": "./dist/index.d.ts"` 时：
+
+  ```diff title="rslib.config.ts"
+   dts: {
+     alias: {
+  -    foo: './vendor/foo',
+  +    foo: './vendor/foo/dist/index',
+     },
+   },
+  ```
+
+- 如果配置路径对应的 CommonJS 类型声明原本使用 `export =`，请保留该导出形式，不要将其转换为 `export default`。否则，从 ESM 类型声明中使用 NodeNext 解析该模块时，CommonJS default interop 可能与显式 default 导出叠加，导致原本的命名空间成员出现在 `default` 下一层。例如：
+
+  ```diff title="foo/index.d.ts"
+   declare function Foo(): void;
+   declare namespace Foo {
+     interface Options {}
+   }
+
+  -export { Foo as default };
+  +export = Foo;
+  ```
+
+未命中 `paths` 或 `dts.alias` 的裸包导入不会被改写，仍由 TypeScript 按正常的包解析流程处理。


### PR DESCRIPTION
## Summary

- Enable `redirect.dts.extension` by default so declaration imports use runtime JavaScript extensions without extra configuration.
- **Breaking change:** declaration import specifiers may now gain or replace extensions; set `redirect.dts.extension` to `false` to preserve the previous behavior.
- Document path-mapping and CommonJS interop caveats, and cover tsc, tsgo, and isolated declaration outputs.

## Related Links

Closes #1733

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).