### PR TITLE
fix(dts): count `optionalDependencies` in autoExternal

### DIFF
--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -77,6 +77,7 @@ export const calcBundledPackages = (
     : {
         dependencies: false,
         peerDependencies: false,
+        optionalDependencies: false,
         devDependencies: false,
       };
 
@@ -110,6 +111,7 @@ export const calcBundledPackages = (
   for (const type of [
     'dependencies',
     'peerDependencies',
+    'optionalDependencies',
     'devDependencies',
   ] as const) {
     const deps = pkgJson[type] && Object.keys(pkgJson[type]);

--- a/packages/plugin-dts/tests/external.test.ts
+++ b/packages/plugin-dts/tests/external.test.ts
@@ -130,3 +130,42 @@ describe('should calcBundledPackages correctly', () => {
     expect(result).toEqual(['foo', '@bar/*']);
   });
 });
+
+describe('should handle optionalDependencies in calcBundledPackages', () => {
+  const optionalPkgJson = {
+    dependencies: {
+      foo: '1.0.0',
+    },
+    optionalDependencies: {
+      opt: '1.0.0',
+    },
+  };
+
+  it('optionalDependencies is bundled when autoExternal is false', () => {
+    rs.spyOn(fs, 'readFileSync').mockImplementation(() =>
+      JSON.stringify(optionalPkgJson),
+    );
+
+    const result = calcBundledPackages({
+      autoExternal: false,
+      cwd: 'pkg/to/root',
+    });
+
+    expect(result).toEqual(['foo', 'opt']);
+  });
+
+  it('optionalDependencies is bundled when optionalDependencies is false', () => {
+    rs.spyOn(fs, 'readFileSync').mockImplementation(() =>
+      JSON.stringify(optionalPkgJson),
+    );
+
+    const result = calcBundledPackages({
+      autoExternal: {
+        optionalDependencies: false,
+      },
+      cwd: 'pkg/to/root',
+    });
+
+    expect(result).toEqual(['opt']);
+  });
+});


### PR DESCRIPTION
## Summary

`optionalDependencies` was a typed and documented `autoExternal` option, but `calcBundledPackages` never added it to its dependency collection loop, so the option had no effect. This adds it to the loop, fixing `autoExternal: false` and `optionalDependencies: false` for optional dependencies.

## Related Links

Follow-up to #266.

## Checklist

- [x] Tests updated (or not required).