### PR TITLE
fix(core): preserve async config inference

### DIFF
--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -36,9 +36,13 @@ export type LoadConfigResult<Config = RslibConfig> = {
  * This function helps you to autocomplete configuration types.
  * It accepts a Rslib config object, or a function that returns a config.
  */
+export function defineConfig<const Config extends RslibConfig>(
+  config: (env: ConfigParams) => Config,
+): (env: ConfigParams) => Config;
+export function defineConfig<const Config extends RslibConfig>(
+  config: (env: ConfigParams) => Promise<Config>,
+): (env: ConfigParams) => Promise<Config>;
 export function defineConfig(config: RslibConfig): RslibConfig;
-export function defineConfig(config: RslibConfigSyncFn): RslibConfigSyncFn;
-export function defineConfig(config: RslibConfigAsyncFn): RslibConfigAsyncFn;
 export function defineConfig(
   config: RslibConfigDefinition,
 ): RslibConfigDefinition;

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -38,10 +38,10 @@ export type LoadConfigResult<Config = RslibConfig> = {
  */
 export function defineConfig<const Config extends RslibConfig>(
   config: (env: ConfigParams) => Config,
-): (env: ConfigParams) => Config;
+): RslibConfigSyncFn;
 export function defineConfig<const Config extends RslibConfig>(
   config: (env: ConfigParams) => Promise<Config>,
-): (env: ConfigParams) => Promise<Config>;
+): RslibConfigAsyncFn;
 export function defineConfig(config: RslibConfig): RslibConfig;
 export function defineConfig(
   config: RslibConfigDefinition,

--- a/tests/type-tests/resolution-bundler/defineConfig.ts
+++ b/tests/type-tests/resolution-bundler/defineConfig.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+
+defineConfig({
+  lib: [{ syntax: 'es2017' }],
+});
+
+defineConfig(() => ({
+  lib: [{ syntax: 'es2017' }],
+}));
+
+defineConfig(async () => ({
+  lib: [{ syntax: 'es2017' }],
+}));
+
+// @ts-expect-error invalid syntax
+defineConfig(async () => ({
+  lib: [{ syntax: 'invalid' }],
+}));

--- a/tests/type-tests/resolution-bundler/rslib.config.ts
+++ b/tests/type-tests/resolution-bundler/rslib.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig(async () => ({
+  lib: [
+    {
+      syntax: 'es2017',
+    },
+  ],
+}));

--- a/tests/type-tests/resolution-bundler/rslib.config.ts
+++ b/tests/type-tests/resolution-bundler/rslib.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from '@rslib/core';
-
-export default defineConfig(async () => ({
-  lib: [
-    {
-      syntax: 'es2017',
-    },
-  ],
-}));

--- a/tests/type-tests/resolution-bundler/tsconfig.json
+++ b/tests/type-tests/resolution-bundler/tsconfig.json
@@ -4,5 +4,5 @@
     "moduleResolution": "bundler",
     "skipLibCheck": false
   },
-  "include": ["index.ts", "rslib.config.ts"]
+  "include": ["defineConfig.ts", "index.ts"]
 }

--- a/tests/type-tests/resolution-bundler/tsconfig.json
+++ b/tests/type-tests/resolution-bundler/tsconfig.json
@@ -4,5 +4,5 @@
     "moduleResolution": "bundler",
     "skipLibCheck": false
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "rslib.config.ts"]
 }

--- a/tests/type-tests/resolution-nodenext/defineConfig.ts
+++ b/tests/type-tests/resolution-nodenext/defineConfig.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+
+defineConfig({
+  lib: [{ syntax: 'es2017' }],
+});
+
+defineConfig(() => ({
+  lib: [{ syntax: 'es2017' }],
+}));
+
+defineConfig(async () => ({
+  lib: [{ syntax: 'es2017' }],
+}));
+
+// @ts-expect-error invalid syntax
+defineConfig(async () => ({
+  lib: [{ syntax: 'invalid' }],
+}));

--- a/tests/type-tests/resolution-nodenext/tsconfig.json
+++ b/tests/type-tests/resolution-nodenext/tsconfig.json
@@ -5,5 +5,5 @@
     "moduleResolution": "NodeNext",
     "skipLibCheck": false
   },
-  "include": ["index.ts"]
+  "include": ["defineConfig.ts", "index.ts"]
 }


### PR DESCRIPTION
## Summary

Async `defineConfig` callbacks can widen literal config values, causing valid Rslib configs such as `syntax: 'es2017'` to fail overload resolution. This PR adds const-generic sync and async overloads to preserve inferred config literals and covers the regression with a minimal public type test.

<img width="1155" height="474" alt="Screenshot 2026-07-23 at 12 49 17" src="https://github.com/user-attachments/assets/9c557c49-e4e1-4468-80c6-444f5f45b73b" />

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).