### PR TITLE
fix(dts): support `packageJson` and `exclude` in autoExternal

### DIFF
--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -168,10 +168,24 @@ At this time, when [redirect.path](#redirectpath) is enabled, the import path of
 
 ### autoExternal
 
-- **Type:** `boolean`
+- **Type:**
+
+```ts
+type AutoExternal =
+  | boolean
+  | {
+      dependencies?: boolean;
+      optionalDependencies?: boolean;
+      peerDependencies?: boolean;
+      devDependencies?: boolean;
+      packageJson?: string | string[];
+      exclude?: string | RegExp | (string | RegExp)[];
+    };
+```
+
 - **Default:** `true`
 
-Whether to automatically externalize dependencies of different dependency types and do not bundle them into the declaration file.
+Controls which dependencies are automatically externalized and not bundled into the declaration file.
 
 The default value of `autoExternal` is `true`, which means the following dependency types will not be bundled:
 
@@ -190,6 +204,36 @@ pluginDts({
     optionalDependencies: true,
     peerDependencies: true,
     devDependencies: false,
+  },
+});
+```
+
+#### autoExternal.packageJson
+
+- **Type:** `string | string[]`
+- **Default:** `'<root>/package.json'`
+
+Specifies the `package.json` file path(s) used to collect dependencies. Relative paths are resolved from the Rsbuild root directory. When multiple files are specified, their dependency fields are merged.
+
+```js
+pluginDts({
+  autoExternal: {
+    packageJson: ['./package.json', './packages/foo/package.json'],
+  },
+});
+```
+
+#### autoExternal.exclude
+
+- **Type:** `string | RegExp | (string | RegExp)[]`
+- **Default:** `undefined`
+
+Excludes matched packages from automatic externalization so their declaration files are bundled. Strings match package names exactly, and regular expressions test package names.
+
+```js
+pluginDts({
+  autoExternal: {
+    exclude: ['react', /^@scope\//],
   },
 });
 ```

--- a/packages/plugin-dts/src/dts.ts
+++ b/packages/plugin-dts/src/dts.ts
@@ -26,6 +26,72 @@ import {
 const isObject = (obj: unknown): obj is Record<string, any> =>
   Object.prototype.toString.call(obj) === '[object Object]';
 
+const castArray = <T>(value: T | T[]): T[] =>
+  Array.isArray(value) ? value : [value];
+
+const PACKAGE_JSON_DEPENDENCY_TYPES = [
+  'dependencies',
+  'peerDependencies',
+  'devDependencies',
+  'optionalDependencies',
+] as const;
+
+type PackageJsonDeps = {
+  [key in (typeof PACKAGE_JSON_DEPENDENCY_TYPES)[number]]?: Record<
+    string,
+    string
+  >;
+};
+
+// Read one or more package.json files and merge their dependency fields,
+// aligning with Rsbuild's `output.autoExternal.packageJson` behavior.
+const readPackageJsonDeps = (
+  cwd: string,
+  packageJson?: string | string[],
+): PackageJsonDeps | undefined => {
+  const paths = castArray(packageJson ?? 'package.json').map((path) =>
+    resolve(cwd, path),
+  );
+
+  const merged: PackageJsonDeps = {};
+  let hasAny = false;
+
+  for (const path of paths) {
+    let content: PackageJsonDeps;
+    try {
+      content = JSON.parse(fs.readFileSync(path, 'utf-8'));
+    } catch {
+      continue;
+    }
+    hasAny = true;
+    for (const type of PACKAGE_JSON_DEPENDENCY_TYPES) {
+      const deps = content[type];
+      if (isObject(deps)) {
+        merged[type] = { ...merged[type], ...deps };
+      }
+    }
+  }
+
+  return hasAny ? merged : undefined;
+};
+
+// Whether a package name is matched by `autoExternal.exclude` conditions.
+const matchAutoExternalExclude = (
+  packageName: string,
+  conditions: (string | RegExp)[],
+): boolean => {
+  return conditions.some((condition) => {
+    if (typeof condition === 'string') {
+      return condition === packageName;
+    }
+
+    // Clone stateful regexps to avoid mutating user config via `lastIndex`.
+    const regexp =
+      condition.global || condition.sticky ? new RegExp(condition) : condition;
+    return regexp.test(packageName);
+  });
+};
+
 export const DEFAULT_EXCLUDED_PACKAGES: string[] = ['@types/react'];
 
 const isExecutableBackend = (
@@ -49,17 +115,12 @@ export const calcBundledPackages = (
     return overrideBundledPackages;
   }
 
-  let pkgJson: {
-    dependencies?: Record<string, string>;
-    peerDependencies?: Record<string, string>;
-    devDependencies?: Record<string, string>;
-    optionalDependencies?: Record<string, string>;
-  };
+  const autoExternalObject =
+    autoExternal && autoExternal !== true ? autoExternal : {};
 
-  try {
-    const content = fs.readFileSync(join(cwd, 'package.json'), 'utf-8');
-    pkgJson = JSON.parse(content);
-  } catch {
+  const pkgJson = readPackageJsonDeps(cwd, autoExternalObject.packageJson);
+
+  if (!pkgJson) {
     logger.warn(
       'The type of third-party packages will not be bundled due to read package.json failed',
     );
@@ -72,7 +133,7 @@ export const calcBundledPackages = (
         peerDependencies: true,
         optionalDependencies: true,
         devDependencies: false,
-        ...(autoExternal === true ? {} : autoExternal),
+        ...autoExternalObject,
       }
     : {
         dependencies: false,
@@ -80,6 +141,10 @@ export const calcBundledPackages = (
         optionalDependencies: false,
         devDependencies: false,
       };
+
+  const excludeConditions = autoExternalObject.exclude
+    ? castArray(autoExternalObject.exclude)
+    : undefined;
 
   // User externals should not bundled
   // Only handle the case where the externals type is string / (string | RegExp)[] / plain object, function type is too complex.
@@ -117,7 +182,15 @@ export const calcBundledPackages = (
     const deps = pkgJson[type] && Object.keys(pkgJson[type]);
     if (deps) {
       if (externalOptions[type]) {
-        externals.push(...deps);
+        // Packages matched by `exclude` are kept out of externals so their
+        // declarations are bundled, aligning with the JS auto externalization.
+        externals.push(
+          ...(excludeConditions
+            ? deps.filter(
+                (dep) => !matchAutoExternalExclude(dep, excludeConditions),
+              )
+            : deps),
+        );
       }
       allDeps.push(...deps);
     }

--- a/packages/plugin-dts/src/types/options.ts
+++ b/packages/plugin-dts/src/types/options.ts
@@ -3,6 +3,8 @@ export type DtsRedirect = {
   extension?: boolean;
 };
 
+export type AutoExternalExclude = (string | RegExp) | (string | RegExp)[];
+
 export type ApiExtractorOptions = {
   bundledPackages?: string[];
 };
@@ -22,6 +24,8 @@ export type PluginDtsOptions = {
         optionalDependencies?: boolean;
         peerDependencies?: boolean;
         devDependencies?: boolean;
+        packageJson?: string | string[];
+        exclude?: AutoExternalExclude;
       };
   banner?: string;
   footer?: string;

--- a/packages/plugin-dts/tests/external.test.ts
+++ b/packages/plugin-dts/tests/external.test.ts
@@ -1,7 +1,24 @@
 import fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { logger } from '@rsbuild/core';
-import { describe, expect, it, rs } from '@rstest/core';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { calcBundledPackages, DEFAULT_EXCLUDED_PACKAGES } from '../src/dts';
+
+const tempDirs: string[] = [];
+
+const createTempDir = (): string => {
+  const tempDir = fs.mkdtempSync(join(tmpdir(), 'rslib-plugin-dts-external-'));
+  tempDirs.push(tempDir);
+  return tempDir;
+};
+
+afterEach(() => {
+  for (const tempDir of tempDirs) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
 
 const defaultExcludePackages = DEFAULT_EXCLUDED_PACKAGES.reduce(
   (acc: Record<string, string>, cur: string) => {
@@ -128,6 +145,76 @@ describe('should calcBundledPackages correctly', () => {
     });
 
     expect(result).toEqual(['foo', '@bar/*']);
+  });
+
+  it('autoExternal exclude with string', () => {
+    rs.spyOn(fs, 'readFileSync').mockImplementation(() =>
+      JSON.stringify(commonPkgJson),
+    );
+
+    // `foo` is excluded from auto externalization, so it is bundled.
+    const result = calcBundledPackages({
+      autoExternal: {
+        exclude: ['foo'],
+      },
+      cwd: 'pkg/to/root',
+    });
+
+    expect(result).toEqual(['foo', 'bar']);
+  });
+
+  it('autoExternal exclude with RegExp', () => {
+    rs.spyOn(fs, 'readFileSync').mockImplementation(() =>
+      JSON.stringify(commonPkgJson),
+    );
+
+    // `baz` matches the RegExp and is excluded from auto externalization.
+    const result = calcBundledPackages({
+      autoExternal: {
+        exclude: [/^ba/],
+      },
+      cwd: 'pkg/to/root',
+    });
+
+    expect(result).toEqual(['baz', 'bar']);
+  });
+
+  it('autoExternal exclude with global RegExp', () => {
+    rs.spyOn(fs, 'readFileSync').mockImplementation(() =>
+      JSON.stringify(commonPkgJson),
+    );
+
+    // Global regexps must be cloned to avoid `lastIndex` side effects.
+    const result = calcBundledPackages({
+      autoExternal: {
+        exclude: /^ba/g,
+      },
+      cwd: 'pkg/to/root',
+    });
+
+    expect(result).toEqual(['baz', 'bar']);
+  });
+
+  it('autoExternal reads and merges packageJson files relative to cwd', () => {
+    const cwd = createTempDir();
+    fs.mkdirSync(join(cwd, 'packages', 'sub'), { recursive: true });
+    fs.writeFileSync(
+      join(cwd, 'package.json'),
+      JSON.stringify({ devDependencies: { foo: '1.0.0' } }),
+    );
+    fs.writeFileSync(
+      join(cwd, 'packages', 'sub', 'package.json'),
+      JSON.stringify({ devDependencies: { bar: '1.0.0' } }),
+    );
+
+    const result = calcBundledPackages({
+      autoExternal: {
+        packageJson: ['./package.json', './packages/sub/package.json'],
+      },
+      cwd,
+    });
+
+    expect(result).toEqual(['foo', 'bar']);
   });
 });
 


### PR DESCRIPTION
## Summary

Rslib passes Rsbuild’s `output.autoExternal` to `rsbuild-plugin-dts`. Rsbuild added the `packageJson` and `exclude` options, but the DTS plugin did not handle them.

This PR adds support for both options when calculating bundled packages.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).