### PR TITLE
docs: clarify declaration entry resolution

### DIFF
--- a/website/docs/en/config/lib/redirect.mdx
+++ b/website/docs/en/config/lib/redirect.mdx
@@ -344,13 +344,13 @@ import { foo } from './foo.mjs'; // expected output of './dist/bar.d.mts'
 
 This option also applies to declaration import paths rewritten through [`paths`](https://typescriptlang.org/tsconfig#paths) or [`dts.alias`](/config/lib/dts#dtsalias). Note the following cases:
 
-- When processing a configured path that points to a directory, Rslib only probes for an `index` declaration file in that directory. It does not use the `types` field, the `types` condition name in `exports`, or `typesVersions` from the directory's `package.json` to resolve a declaration entry. If a declaration entry must be resolved using this package metadata, point the configured path directly to that entry. For example, when `vendor/foo/package.json` contains `"types": "./dist/index.d.ts"`:
+- Rslib probes for an `index` entry under the configured path, but does not use the `types` field, the `types` condition name in `exports`, or `typesVersions` from the directory's `package.json` to locate a declaration entry. If an entry must be resolved using this package metadata, point the configured path directly to that entry. For example, when `vendor/foo/package.json` contains `"types": "./typings/main.d.ts"`:
 
   ```diff title="rslib.config.ts"
    dts: {
      alias: {
   -    foo: './vendor/foo',
-  +    foo: './vendor/foo/dist/index',
+  +    foo: './vendor/foo/typings/main',
      },
    },
   ```

--- a/website/docs/en/config/lib/redirect.mdx
+++ b/website/docs/en/config/lib/redirect.mdx
@@ -344,7 +344,7 @@ import { foo } from './foo.mjs'; // expected output of './dist/bar.d.mts'
 
 This option also applies to declaration import paths rewritten through [`paths`](https://typescriptlang.org/tsconfig#paths) or [`dts.alias`](/config/lib/dts#dtsalias). Note the following cases:
 
-- If a configured path is a package directory that relies on the `types` field, the `types` condition name in `exports`, or `typesVersions` to locate its declaration entry, configure the concrete declaration entry directly. For example, when `vendor/foo/package.json` contains `"types": "./dist/index.d.ts"`:
+- When processing a configured path that points to a directory, Rslib only probes for an `index` declaration file in that directory. It does not use the `types` field, the `types` condition name in `exports`, or `typesVersions` from the directory's `package.json` to resolve a declaration entry. If a declaration entry must be resolved using this package metadata, point the configured path directly to that entry. For example, when `vendor/foo/package.json` contains `"types": "./dist/index.d.ts"`:
 
   ```diff title="rslib.config.ts"
    dts: {

--- a/website/docs/zh/config/lib/redirect.mdx
+++ b/website/docs/zh/config/lib/redirect.mdx
@@ -344,13 +344,13 @@ import { foo } from './foo.mjs'; // './dist/bar.d.mts' 预期生成的代码
 
 该配置也适用于通过 [`paths`](https://typescriptlang.org/tsconfig#paths) 或 [`dts.alias`](/config/lib/dts#dtsalias) 改写后的类型导入路径，因此需要注意以下情况：
 
-- Rslib 仅会自动探测配置路径所指目录下的 `index` 类型声明文件，不会根据该目录 `package.json` 中的 `types`、`exports` 的 `types` 条件名称或 `typesVersions` 定位类型入口。若需根据这些包配置定位类型入口，请将配置路径直接指向具体入口。例如，当 `vendor/foo/package.json` 中配置了 `"types": "./dist/index.d.ts"` 时：
+- Rslib 会对配置路径进行 `index` 入口探测，但不会根据该目录 `package.json` 中的 `types`、`exports` 的 `types` 条件名称或 `typesVersions` 定位类型入口。若需根据这些包配置定位入口，请将配置路径直接指向具体入口。例如，当 `vendor/foo/package.json` 中配置了 `"types": "./typings/main.d.ts"` 时：
 
   ```diff title="rslib.config.ts"
    dts: {
      alias: {
   -    foo: './vendor/foo',
-  +    foo: './vendor/foo/dist/index',
+  +    foo: './vendor/foo/typings/main',
      },
    },
   ```

--- a/website/docs/zh/config/lib/redirect.mdx
+++ b/website/docs/zh/config/lib/redirect.mdx
@@ -344,7 +344,7 @@ import { foo } from './foo.mjs'; // './dist/bar.d.mts' 预期生成的代码
 
 该配置也适用于通过 [`paths`](https://typescriptlang.org/tsconfig#paths) 或 [`dts.alias`](/config/lib/dts#dtsalias) 改写后的类型导入路径，因此需要注意以下情况：
 
-- 如果配置路径是包目录，并依赖 `types` 字段、`exports` 中的 `types` 条件名称或 `typesVersions` 定位类型入口，请直接配置具体的类型声明入口。例如，当 `vendor/foo/package.json` 中配置了 `"types": "./dist/index.d.ts"` 时：
+- Rslib 仅会自动探测配置路径所指目录下的 `index` 类型声明文件，不会根据该目录 `package.json` 中的 `types`、`exports` 的 `types` 条件名称或 `typesVersions` 定位类型入口。若需根据这些包配置定位类型入口，请将配置路径直接指向具体入口。例如，当 `vendor/foo/package.json` 中配置了 `"types": "./dist/index.d.ts"` 时：
 
   ```diff title="rslib.config.ts"
    dts: {


### PR DESCRIPTION
## Summary

The `redirect.dts.extension` docs currently imply that directory-based path mappings always need a concrete declaration entry, even though Rslib probes for an `index` declaration file. This PR clarifies the `/index` probing behavior and when package metadata-based entries must be configured explicitly in both the English and Chinese docs.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).