### PR TITLE
chore(deps): upgrade Rslib to 1.0.0-beta.1

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -5,17 +5,9 @@ import packageJson from './package.json' with { type: 'json' };
 export default defineConfig({
   lib: [
     {
-      format: 'esm',
-      syntax: ['es2023'],
       dts: {
-        bundle: false,
         isolated: true,
         distPath: './dist-types',
-      },
-      redirect: {
-        dts: {
-          extension: true,
-        },
       },
     },
   ],

--- a/packages/create-rslib/rslib.config.ts
+++ b/packages/create-rslib/rslib.config.ts
@@ -2,11 +2,5 @@ import { pluginPublint } from 'rsbuild-plugin-publint';
 import { defineConfig } from 'rslib';
 
 export default defineConfig({
-  lib: [
-    {
-      format: 'esm',
-      syntax: ['es2023'],
-    },
-  ],
   plugins: [pluginPublint()],
 });

--- a/packages/plugin-dts/rslib.config.ts
+++ b/packages/plugin-dts/rslib.config.ts
@@ -4,16 +4,8 @@ import { defineConfig } from 'rslib';
 export default defineConfig({
   lib: [
     {
-      format: 'esm',
-      syntax: ['es2023'],
       dts: {
-        bundle: false,
         isolated: true,
-      },
-      redirect: {
-        dts: {
-          extension: true,
-        },
       },
       shims: {
         esm: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,8 +248,8 @@ catalogs:
       specifier: ^1.0.0
       version: 1.0.0
     rslib:
-      specifier: npm:@rslib/core@0.23.2
-      version: 0.23.2
+      specifier: npm:@rslib/core@1.0.0-beta.1
+      version: 1.0.0-beta.1
     rslog:
       specifier: ^2.3.0
       version: 2.3.0
@@ -322,7 +322,7 @@ importers:
         version: 0.7.0(jiti@2.7.0)
       '@rstest/adapter-rslib':
         specifier: 'catalog:'
-        version: 0.11.2(@rslib/core@1.0.0-beta.0)(@rstest/core@0.11.2)(typescript@6.0.3)
+        version: 0.11.2(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.2)(typescript@6.0.3)
       '@rstest/core':
         specifier: 'catalog:'
         version: 0.11.2
@@ -672,7 +672,7 @@ importers:
         version: 1.0.0(@rsbuild/core@2.1.7)
       rslib:
         specifier: 'catalog:'
-        version: '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)'
+        version: '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)'
       rslog:
         specifier: 'catalog:'
         version: 2.3.0
@@ -709,7 +709,7 @@ importers:
         version: 1.0.0(@rsbuild/core@2.1.7)
       rslib:
         specifier: 'catalog:'
-        version: '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)'
+        version: '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)'
       tsx:
         specifier: 'catalog:'
         version: 4.23.1
@@ -743,7 +743,7 @@ importers:
         version: 1.0.0(@rsbuild/core@2.1.7)
       rslib:
         specifier: 'catalog:'
-        version: '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)'
+        version: '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)'
       tinyglobby:
         specifier: 'catalog:'
         version: 0.2.17
@@ -3083,21 +3083,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@0.23.2':
-    resolution: {integrity: sha512-KxSp+/y0BJ1O4oKwxX4ydBY7/ZVeJCUpWAmQniCIct8mTxIQFPGO/ibKbKq2IxZYqRuRpM8g+Dtyq0VbEQf9HQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@microsoft/api-extractor': ^7
-      typescript: ^5 || ^6 || ^7.0.1-0
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      typescript:
-        optional: true
-
-  '@rslib/core@1.0.0-beta.0':
-    resolution: {integrity: sha512-l+NKLyVBnNPZ2WQoyVM8KoKhi4/mwo96A2fYqcPBXWg0nBJUdaIyJ5sJKAMxa39LR2a15ItShDHKYrQ48aUTbw==}
+  '@rslib/core@1.0.0-beta.1':
+    resolution: {integrity: sha512-HHPZ+wTUKT/3bEhw2y0JB0O62wMuljkSHVZelLbSGhBflCaUt+D3LohBcIxYW6bhzPbUp4gkJXo1pdTpxiuNLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -6722,24 +6709,8 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  rsbuild-plugin-dts@0.23.2:
-    resolution: {integrity: sha512-Ve8WOSPyTBjxH40O/6fChJtflL7yqcUtt5zbF0eHDM4hIt35jqLocRlSdCxFJdQm0blTjl6+hkmPa/vNI06ArA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@microsoft/api-extractor': ^7
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-      '@typescript/native-preview': ^7.0.0-0
-      typescript: ^5 || ^6 || ^7.0.1-0
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      '@typescript/native-preview':
-        optional: true
-      typescript:
-        optional: true
-
-  rsbuild-plugin-dts@1.0.0-beta.0:
-    resolution: {integrity: sha512-+WOBPjcADvQPdjQuIiNI6LLQgDFnwSDo7tl1Yn/sXmUH8YISp5PveSEU08B7ABPeiTgBUdevUnVrb8f/deYaxw==}
+  rsbuild-plugin-dts@1.0.0-beta.1:
+    resolution: {integrity: sha512-hAEjOXhfIHR4erqjsqjRvA9Yqzc6Thry06tHheXDJUVwmR3VbN8BSMDC8kBZzyKdypDF0IJ98FmLQRiC194sMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -9429,22 +9400,21 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
 
-  '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)':
+  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11)(@module-federation/runtime-tools@2.8.0)(typescript@7.0.2)':
     dependencies:
       '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
-      rsbuild-plugin-dts: 0.23.2(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.7)(typescript@7.0.2)
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.7)(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.11(@types/node@25.2.0)
       typescript: 7.0.2
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-      - '@typescript/native-preview'
       - core-js
 
-  '@rslib/core@1.0.0-beta.0(@microsoft/api-extractor@7.58.11)(typescript@6.0.3)':
+  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.11)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
-      rsbuild-plugin-dts: 1.0.0-beta.0(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.7)(typescript@6.0.3)
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.7)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.11(@types/node@24.13.3)
       typescript: 6.0.3
@@ -9678,9 +9648,9 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
-  '@rstest/adapter-rslib@0.11.2(@rslib/core@1.0.0-beta.0)(@rstest/core@0.11.2)(typescript@6.0.3)':
+  '@rstest/adapter-rslib@0.11.2(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.2)(typescript@6.0.3)':
     dependencies:
-      '@rslib/core': 1.0.0-beta.0(@microsoft/api-extractor@7.58.11)(typescript@6.0.3)
+      '@rslib/core': 1.0.0-beta.1(@microsoft/api-extractor@7.58.11)(typescript@6.0.3)
       '@rstest/core': 0.11.2
     optionalDependencies:
       typescript: 6.0.3
@@ -13660,21 +13630,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.23.2(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.7)(typescript@7.0.2):
-    dependencies:
-      '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.58.11(@types/node@25.2.0)
-      typescript: 7.0.2
-
-  rsbuild-plugin-dts@1.0.0-beta.0(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.7)(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.7)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.11(@types/node@24.13.3)
       typescript: 6.0.3
+
+  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.11)(@rsbuild/core@2.1.7)(typescript@7.0.2):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 2.1.7(@module-federation/runtime-tools@2.8.0)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.11(@types/node@25.2.0)
+      typescript: 7.0.2
 
   rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.7):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,7 +94,7 @@ catalog:
   'rsbuild-plugin-google-analytics': '1.0.6'
   'rsbuild-plugin-open-graph': '^1.1.3'
   'rsbuild-plugin-publint': '^1.0.0'
-  'rslib': 'npm:@rslib/core@0.23.2'
+  'rslib': 'npm:@rslib/core@1.0.0-beta.1'
   'rslog': '^2.3.0'
   'rspress-plugin-file-tree': '^1.0.5'
   'rspress-plugin-font-open-sans': '^1.0.4'


### PR DESCRIPTION
## Summary

- Upgrade the repository's self-hosted Rslib dependency from 0.23.2 to 1.0.0-beta.1.
- Remove redundant ESM and declaration settings, and let Rslib v1 infer the syntax target from each package's Node engine requirement.
- Artifact comparison found no declaration changes or executable JavaScript logic changes; only internal `rsbuild-plugin-dts` chunk and module identifiers changed.

## Related Links

- https://github.com/web-infra-dev/rslib/releases/tag/v1.0.0-beta.1
- https://github.com/web-infra-dev/rslib/releases/tag/v1.0.0-beta.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).