### PR TITLE
chore(deps): reorganize TypeScript catalogs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,11 @@
       matchPackageNames: ['**'],
       matchUpdateTypes: ['patch', 'minor'],
     },
+    // Intentional TypeScript 6 API and integration coverage
+    {
+      matchPackageNames: ['@typescript/typescript6'],
+      enabled: false,
+    },
     // manually update peer dependencies
     {
       matchDepTypes: ['peerDependencies'],

--- a/examples/express-plugin/package.json
+++ b/examples/express-plugin/package.json
@@ -10,7 +10,7 @@
     "@rslib/core": "workspace:*",
     "@types/express": "catalog:",
     "express": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript-6"
   },
   "peerDependencies": {
     "express": "^4"

--- a/examples/module-federation/mf-host/package.json
+++ b/examples/module-federation/mf-host/package.json
@@ -18,6 +18,6 @@
     "@rsbuild/plugin-react": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript-6"
   }
 }

--- a/examples/module-federation/mf-react-component/package.json
+++ b/examples/module-federation/mf-react-component/package.json
@@ -35,7 +35,7 @@
     "storybook": "catalog:",
     "storybook-addon-rslib": "catalog:",
     "storybook-react-rsbuild": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript-6"
   },
   "peerDependencies": {
     "react": "*"

--- a/examples/module-federation/mf-remote/package.json
+++ b/examples/module-federation/mf-remote/package.json
@@ -18,6 +18,6 @@
     "@rsbuild/plugin-react": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript-6"
   }
 }

--- a/examples/solid-component-bundle/package.json
+++ b/examples/solid-component-bundle/package.json
@@ -15,7 +15,7 @@
     "@rsbuild/plugin-solid": "catalog:",
     "@rslib/core": "workspace:*",
     "solid-js": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript-6"
   },
   "peerDependencies": {
     "solid-js": "^1.0.0"

--- a/examples/vue-component-bundle/package.json
+++ b/examples/vue-component-bundle/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@rsbuild/plugin-vue": "catalog:",
     "@rslib/core": "workspace:*",
-    "typescript": "catalog:",
+    "typescript": "catalog:typescript-6",
     "vue": "catalog:",
     "vue-tsc": "catalog:"
   },

--- a/examples/vue-component-bundleless/package.json
+++ b/examples/vue-component-bundleless/package.json
@@ -22,7 +22,7 @@
     "storybook": "catalog:",
     "storybook-addon-rslib": "catalog:",
     "storybook-vue3-rsbuild": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:typescript-6",
     "vue": "catalog:",
     "vue-tsc": "catalog:"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
     "rslog": "catalog:",
     "semver": "catalog:",
     "tinyglobby": "catalog:",
-    "typescript": "catalog:typescript-7"
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "@microsoft/api-extractor": "^7",

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -39,7 +39,7 @@
     "rsbuild-plugin-publint": "catalog:",
     "rslib": "catalog:",
     "tsx": "catalog:",
-    "typescript": "catalog:typescript-7"
+    "typescript": "catalog:"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/packages/plugin-dts/package.json
+++ b/packages/plugin-dts/package.json
@@ -42,8 +42,7 @@
     "rslib": "catalog:",
     "tinyglobby": "catalog:",
     "tsconfig-paths": "catalog:",
-    "typescript": "catalog:typescript-7",
-    "typescript6-api": "catalog:"
+    "typescript6-api": "catalog:typescript-6-fixed"
   },
   "peerDependencies": {
     "@microsoft/api-extractor": "^7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,23 +293,23 @@ catalogs:
       specifier: ^4.23.1
       version: 4.23.1
     typescript:
-      specifier: ^6.0.3
-      version: 6.0.3
-    typescript6-api:
-      specifier: npm:typescript@^6.0.3
-      version: 6.0.3
+      specifier: ^7.0.2
+      version: 7.0.2
     vue:
       specifier: ^3.5.40
       version: 3.5.40
     vue-tsc:
       specifier: ^3.3.8
       version: 3.3.8
-  typescript-7:
+  typescript-6:
     typescript:
-      specifier: ^7.0.2
-      version: 7.0.2
-  typescript-api-6:
+      specifier: ^6.0.3
+      version: 6.0.3
+  typescript-6-fixed:
     typescript:
+      specifier: npm:@typescript/typescript6@^6.0.2
+      version: 6.0.2
+    typescript6-api:
       specifier: npm:@typescript/typescript6@^6.0.2
       version: 6.0.2
 
@@ -322,7 +322,7 @@ importers:
         version: 0.7.1(jiti@2.7.0)
       '@rstest/adapter-rslib':
         specifier: 'catalog:'
-        version: 0.11.4(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.4)(typescript@6.0.3)
+        version: 0.11.4(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.4)(typescript@7.0.2)
       '@rstest/core':
         specifier: 'catalog:'
         version: 0.11.4
@@ -355,7 +355,7 @@ importers:
         version: 2.13.1
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   examples/express-plugin:
     devDependencies:
@@ -369,7 +369,7 @@ importers:
         specifier: 'catalog:'
         version: 5.2.1(supports-color@9.4.0)
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript-6
         version: 6.0.3
 
   examples/module-federation: {}
@@ -399,7 +399,7 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript-6
         version: 6.0.3
 
   examples/module-federation/mf-react-component:
@@ -453,7 +453,7 @@ importers:
         specifier: 'catalog:'
         version: 3.3.4(@rsbuild/core@2.1.8)(@rspack/core@2.1.5)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.4)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript-6
         version: 6.0.3
 
   examples/module-federation/mf-remote:
@@ -481,7 +481,7 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript-6
         version: 6.0.3
 
   examples/preact-component-bundle-false:
@@ -571,7 +571,7 @@ importers:
         specifier: 'catalog:'
         version: 1.9.14
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript-6
         version: 6.0.3
 
   examples/vue-component-bundle:
@@ -583,7 +583,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript-6
         version: 6.0.3
       vue:
         specifier: 'catalog:'
@@ -622,7 +622,7 @@ importers:
         specifier: 'catalog:'
         version: 3.3.4(@rsbuild/core@2.1.8)(@rspack/core@2.1.5)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.4)(typescript@6.0.3)(vue@3.5.40)
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript-6
         version: 6.0.3
       vue:
         specifier: 'catalog:'
@@ -683,7 +683,7 @@ importers:
         specifier: 'catalog:'
         version: 0.2.17
       typescript:
-        specifier: catalog:typescript-7
+        specifier: 'catalog:'
         version: 7.0.2
 
   packages/create-rslib:
@@ -714,7 +714,7 @@ importers:
         specifier: 'catalog:'
         version: 4.23.1
       typescript:
-        specifier: catalog:typescript-7
+        specifier: 'catalog:'
         version: 7.0.2
 
   packages/plugin-dts:
@@ -750,12 +750,9 @@ importers:
       tsconfig-paths:
         specifier: 'catalog:'
         version: 4.2.0
-      typescript:
-        specifier: catalog:typescript-7
-        version: 7.0.2
       typescript6-api:
-        specifier: 'catalog:'
-        version: typescript@6.0.3
+        specifier: catalog:typescript-6-fixed
+        version: '@typescript/typescript6@6.0.2'
 
   scripts/tsconfig: {}
 
@@ -832,7 +829,7 @@ importers:
         specifier: 'catalog:'
         version: 0.2.17
       typescript:
-        specifier: catalog:typescript-7
+        specifier: 'catalog:'
         version: 7.0.2
 
   tests/e2e/react-component:
@@ -1029,13 +1026,13 @@ importers:
   tests/integration/dts:
     devDependencies:
       typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
+        specifier: catalog:typescript-6-fixed
+        version: '@typescript/typescript6@6.0.2'
 
   tests/integration/dts-tsgo:
     devDependencies:
       typescript:
-        specifier: catalog:typescript-7
+        specifier: 'catalog:'
         version: 7.0.2
 
   tests/integration/dts-tsgo/build/__references__: {}
@@ -1146,7 +1143,7 @@ importers:
         specifier: 'catalog:'
         version: typescript@7.0.2
       typescript:
-        specifier: catalog:typescript-api-6
+        specifier: catalog:typescript-6-fixed
         version: '@typescript/typescript6@6.0.2'
 
   tests/integration/dts/bundle/abort-on-error: {}
@@ -1391,8 +1388,8 @@ importers:
         specifier: 'catalog:'
         version: 5.2.1(supports-color@9.4.0)
       typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
+        specifier: catalog:typescript-6-fixed
+        version: '@typescript/typescript6@6.0.2'
 
   tests/integration/redirect/dts-tsgo:
     devDependencies:
@@ -1406,7 +1403,7 @@ importers:
         specifier: 'catalog:'
         version: 5.2.1(supports-color@9.4.0)
       typescript:
-        specifier: catalog:typescript-7
+        specifier: 'catalog:'
         version: 7.0.2
 
   tests/integration/redirect/js:
@@ -1669,7 +1666,7 @@ importers:
         specifier: 'catalog:'
         version: 1.0.4(@rspress/core@2.0.18)
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:typescript-6
         version: 6.0.3
 
 packages:
@@ -9415,13 +9412,13 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(typescript@6.0.3)':
+  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(typescript@7.0.2)':
     dependencies:
       '@rsbuild/core': 2.1.8(@module-federation/runtime-tools@2.8.0)
-      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.8)(typescript@6.0.3)
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.8)(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - core-js
@@ -9652,12 +9649,12 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.18(@module-federation/runtime-tools@2.8.0)(@rspack/core@2.1.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
-  '@rstest/adapter-rslib@0.11.4(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.4)(typescript@6.0.3)':
+  '@rstest/adapter-rslib@0.11.4(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.4)(typescript@7.0.2)':
     dependencies:
-      '@rslib/core': 1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(typescript@6.0.3)
+      '@rslib/core': 1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(typescript@7.0.2)
       '@rstest/core': 0.11.4
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   '@rstest/core@0.11.4':
     dependencies:
@@ -13640,20 +13637,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.8)(typescript@6.0.3):
-    dependencies:
-      '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.8(@module-federation/runtime-tools@2.8.0)
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
-      typescript: 6.0.3
-
   rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.8)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.1.8(@module-federation/runtime-tools@2.8.0)
     optionalDependencies:
-      '@microsoft/api-extractor': 7.58.12(@types/node@25.2.0)
+      '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2
 
   rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.8):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -109,16 +109,16 @@ catalog:
   'tinyglobby': '^0.2.17'
   'tsconfig-paths': '^4.2.0'
   'tsx': '^4.23.1'
-  'typescript': '^6.0.3'
-  'typescript6-api': 'npm:typescript@^6.0.3'
+  'typescript': '^7.0.2'
   'vue': '^3.5.40'
   'vue-tsc': '^3.3.8'
 
 catalogs:
-  typescript-7:
-    'typescript': '^7.0.2'
-  typescript-api-6:
+  typescript-6:
+    'typescript': '^6.0.3'
+  typescript-6-fixed:
     'typescript': 'npm:@typescript/typescript6@^6.0.2'
+    'typescript6-api': 'npm:@typescript/typescript6@^6.0.2'
 
 allowBuilds:
   core-js-pure: false

--- a/tests/integration/dts-tsgo/package.json
+++ b/tests/integration/dts-tsgo/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "typescript": "catalog:typescript-7"
+    "typescript": "catalog:"
   }
 }

--- a/tests/integration/dts/bundle-false/typescript-path/package.json
+++ b/tests/integration/dts/bundle-false/typescript-path/package.json
@@ -5,6 +5,6 @@
   "type": "module",
   "devDependencies": {
     "@typescript/native": "catalog:",
-    "typescript": "catalog:typescript-api-6"
+    "typescript": "catalog:typescript-6-fixed"
   }
 }

--- a/tests/integration/dts/package.json
+++ b/tests/integration/dts/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript-6-fixed"
   }
 }

--- a/tests/integration/redirect/dts-tsgo/package.json
+++ b/tests/integration/redirect/dts-tsgo/package.json
@@ -6,7 +6,7 @@
     "@rslib/core": "workspace:*",
     "@types/express": "catalog:",
     "express": "catalog:",
-    "typescript": "catalog:typescript-7"
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "express": "^4"

--- a/tests/integration/redirect/dts/package.json
+++ b/tests/integration/redirect/dts/package.json
@@ -6,7 +6,7 @@
     "@rslib/core": "workspace:*",
     "@types/express": "catalog:",
     "express": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript-6-fixed"
   },
   "peerDependencies": {
     "express": "^4"

--- a/tests/package.json
+++ b/tests/package.json
@@ -33,6 +33,6 @@
     "path-serializer": "catalog:",
     "test-helper": "workspace:*",
     "tinyglobby": "catalog:",
-    "typescript": "catalog:typescript-7"
+    "typescript": "catalog:"
   }
 }

--- a/website/docs/en/guide/migration/modernjs-module.mdx
+++ b/website/docs/en/guide/migration/modernjs-module.mdx
@@ -58,7 +58,7 @@ Your `package.json` should look something like this:
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@rslib/core": "^1.0.0",
-    "typescript": "^6.0.2",
+    "typescript": "^7.0.2",
     "vitest": "^2.1.8"
   },
   "peerDependencies": {},

--- a/website/docs/zh/guide/migration/modernjs-module.mdx
+++ b/website/docs/zh/guide/migration/modernjs-module.mdx
@@ -58,7 +58,7 @@ import { PackageManagerTabs } from '@theme';
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@rslib/core": "^1.0.0",
-    "typescript": "^6.0.2",
+    "typescript": "^7.0.2",
     "vitest": "^2.1.8"
   },
   "peerDependencies": {},

--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,6 @@
     "rsbuild-plugin-open-graph": "catalog:",
     "rspress-plugin-file-tree": "catalog:",
     "rspress-plugin-font-open-sans": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:typescript-6"
   }
 }


### PR DESCRIPTION
## Summary

This PR makes TypeScript 7 the default workspace catalog while preserving explicit TypeScript 6 assignments for compatibility-sensitive consumers and intentional TS6 integration coverage.

- Add separate `typescript-6` and `typescript-6-fixed` catalogs for standard TS6 and the `@typescript/typescript6` compatibility package.
- Use the fixed TS6 package for legacy declaration API/tests, exclude it from Renovate updates, and remove the direct TS7 dependency from `rsbuild-plugin-dts`.
- Update the migration documentation to recommend TypeScript 7.

## TypeScript 6 compatibility

Some examples, generated templates, the website, and related tooling remain on TypeScript 6 because their direct dependencies do not yet fully support TypeScript 7:

- **`@rspress/plugin-twoslash`**: `@rspress/plugin-twoslash → @shikijs/twoslash → twoslash → @typescript/vfs → TypeScript` still uses legacy APIs such as `ts.sys`.
- **`vue-tsc`**: `vue-tsc → @vue/language-core → @volar/typescript → TypeScript` still resolves the `typescript/lib/tsc` path, which TypeScript 7 no longer exports.
- **`storybook-react-rsbuild` / `@rspress/plugin-api-docgen`**: their `react-docgen-typescript → TypeScript` path still relies on legacy APIs such as `JsxEmit` and `createProgram`.
- **`svelte-check` / `svelte2tsx`**: both still depend directly on legacy TypeScript Compiler APIs such as `ts.sys`.

## Related Links

- https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).