### PR TITLE
feat: support shared `dts` config

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1841,7 +1841,7 @@ export async function composeCreateRsbuildConfig(
 
     if (enabledDtsLibCount > 1) {
       logger.warn(
-        'The top-level "dts" option enables declaration generation for multiple lib items. These lib items may write to or clean the same declaration output concurrently. To avoid conflicts, configure "dts" in only one lib item.',
+        'When multiple lib items are present, using top-level "dts" may cause conflicting file writes or deletions during declaration generation, so configure "dts" on a specific lib item instead.',
       );
     }
   }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1833,6 +1833,19 @@ export async function composeCreateRsbuildConfig(
     );
   }
 
+  if (rslibConfig.dts !== undefined && rslibConfig.dts !== false) {
+    const enabledDtsLibCount = libConfigsArray.filter((libConfig) => {
+      const dts = libConfig.dts ?? rslibConfig.dts;
+      return dts !== undefined && dts !== false;
+    }).length;
+
+    if (enabledDtsLibCount > 1) {
+      logger.warn(
+        'The top-level "dts" option enables declaration generation for multiple lib items. These lib items may write to or clean the same declaration output concurrently. To avoid conflicts, configure "dts" in only one lib item.',
+      );
+    }
+  }
+
   const libConfigPromises = libConfigsArray.map(async (libConfig, index) => {
     if (libConfig.autoExternal !== undefined) {
       logger.warn(

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -523,6 +523,7 @@ export type SharedLibConfig = Pick<
   | 'banner'
   | 'footer'
   | 'shims'
+  | 'dts'
   | 'outBase'
   | 'wasm'
 >;

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -15,6 +15,7 @@ import { loadConfig } from '../src/loadConfig';
 import { mergeRslibConfig } from '../src/mergeConfig';
 import type { RslibConfig } from '../src/types/config';
 import { normalizeSlash } from '../src/utils/helper';
+import { logger } from '../src/utils/logger';
 
 rs.mock('rslog');
 
@@ -770,6 +771,61 @@ describe('Should compose create Rsbuild config correctly', () => {
     const [config] = await composeCreateRsbuildConfig(rslibConfig);
 
     expect(config?.config.output?.autoExternal).toBe(false);
+  });
+});
+
+describe('dts', () => {
+  test('supports top-level dts with the implicit default lib', async () => {
+    const [config] = await composeCreateRsbuildConfig({
+      dts: true,
+    });
+
+    expect(config?.config.plugins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'rsbuild:dts',
+        }),
+      ]),
+    );
+  });
+
+  test('lib.dts overrides top-level dts', async () => {
+    const [config] = await composeCreateRsbuildConfig({
+      dts: true,
+      lib: [{ dts: false }],
+    });
+
+    expect(config?.config.plugins).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'rsbuild:dts',
+        }),
+      ]),
+    );
+  });
+
+  test('warns when top-level dts enables multiple libs', async () => {
+    const warn = rs.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await composeCreateRsbuildConfig({
+      dts: true,
+      lib: [{ format: 'esm' }, { format: 'cjs' }],
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      'The top-level "dts" option enables declaration generation for multiple lib items. These lib items may write to or clean the same declaration output concurrently. To avoid conflicts, configure "dts" in only one lib item.',
+    );
+  });
+
+  test('does not warn when top-level dts enables only one lib', async () => {
+    const warn = rs.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await composeCreateRsbuildConfig({
+      dts: true,
+      lib: [{ format: 'esm' }, { format: 'cjs', dts: false }],
+    });
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -804,7 +804,7 @@ describe('dts', () => {
     );
   });
 
-  test('warns when top-level dts enables multiple libs', async () => {
+  test('warns about output risks when top-level dts enables multiple libs', async () => {
     const warn = rs.spyOn(logger, 'warn').mockImplementation(() => {});
 
     await composeCreateRsbuildConfig({
@@ -813,7 +813,7 @@ describe('dts', () => {
     });
 
     expect(warn).toHaveBeenCalledWith(
-      'The top-level "dts" option enables declaration generation for multiple lib items. These lib items may write to or clean the same declaration output concurrently. To avoid conflicts, configure "dts" in only one lib item.',
+      'When multiple lib items are present, using top-level "dts" may cause conflicting file writes or deletions during declaration generation, so configure "dts" on a specific lib item instead.',
     );
   });
 

--- a/tests/type-tests/resolution-bundler/index.ts
+++ b/tests/type-tests/resolution-bundler/index.ts
@@ -24,18 +24,13 @@ defineConfig({
   footer: {
     js: '/* footer */',
   },
+  dts: true,
   shims: {
     esm: {
       require: true,
     },
   },
   outBase: 'src',
-});
-
-defineConfig({
-  lib: [{}],
-  // @ts-expect-error dts is only supported in lib items.
-  dts: true,
 });
 
 defineConfig({

--- a/tests/type-tests/resolution-nodenext/index.ts
+++ b/tests/type-tests/resolution-nodenext/index.ts
@@ -24,18 +24,13 @@ defineConfig({
   footer: {
     js: '/* footer */',
   },
+  dts: true,
   shims: {
     esm: {
       require: true,
     },
   },
   outBase: 'src',
-});
-
-defineConfig({
-  lib: [{}],
-  // @ts-expect-error dts is only supported in lib items.
-  dts: true,
 });
 
 defineConfig({

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -25,8 +25,18 @@ type Dts =
 
 - **Default:** `undefined`
 - **CLI:** `--dts` / `--no-dts`
+- **Top-level config:** Supported
 
 Configure the generation of the TypeScript declaration files.
+
+When configured at the top level, `dts` is inherited by every `lib` item. A
+`dts` value in a `lib` item takes precedence over the top-level value.
+
+:::warning
+Enabling top-level `dts` with multiple `lib` items may cause them to write to or
+clean the same declaration output concurrently. To avoid conflicts, configure
+`dts` in only one `lib` item.
+:::
 
 ## Boolean type
 
@@ -34,12 +44,7 @@ Declaration files generation is an optional feature, you can set `dts: true` to 
 
 ```ts title="rslib.config.ts"
 export default {
-  lib: [
-    {
-      format: 'esm',
-      dts: true, // [!code highlight]
-    },
-  ],
+  dts: true, // [!code highlight]
 };
 ```
 

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -29,13 +29,10 @@ type Dts =
 
 Configure the generation of the TypeScript declaration files.
 
-When configured at the top level, `dts` is inherited by every `lib` item. A
-`dts` value in a `lib` item takes precedence over the top-level value.
+A top-level `dts` value is inherited by all `lib` items, but a `dts` value in a `lib` item takes precedence.
 
 :::warning
-Enabling top-level `dts` with multiple `lib` items may cause them to write to or
-clean the same declaration output concurrently. To avoid conflicts, configure
-`dts` in only one `lib` item.
+When multiple `lib` items are present, using top-level `dts` may cause conflicting file writes or deletions during declaration generation, so configure `dts` on a specific `lib` item instead.
 :::
 
 ## Boolean type
@@ -44,7 +41,12 @@ Declaration files generation is an optional feature, you can set `dts: true` to 
 
 ```ts title="rslib.config.ts"
 export default {
-  dts: true, // [!code highlight]
+  lib: [
+    {
+      format: 'esm',
+      dts: true, // [!code highlight]
+    },
+  ],
 };
 ```
 

--- a/website/docs/en/config/lib/index.mdx
+++ b/website/docs/en/config/lib/index.mdx
@@ -36,6 +36,7 @@ The following lib configurations can be placed outside the `lib` field as shared
 - [`autoExtension`](/config/lib/auto-extension)
 - [`banner`](/config/lib/banner)
 - [`bundle`](/config/lib/bundle)
+- [`dts`](/config/lib/dts)
 - [`externalHelpers`](/config/lib/external-helpers)
 - [`footer`](/config/lib/footer)
 - [`format`](/config/lib/format)
@@ -49,7 +50,6 @@ The following lib configurations can be placed outside the `lib` field as shared
 
 The following lib configurations do not support shared configuration and can only be specified in a `lib` item to configure an individual output:
 
-- [`dts`](/config/lib/dts)
 - [`experiments`](/config/lib/experiments)
 - [`id`](/config/lib/id)
 - [`umdName`](/config/lib/umd-name)

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -25,8 +25,17 @@ type Dts =
 
 - **默认值：** `undefined`
 - **命令行：** `--dts` / `--no-dts`
+- **顶层配置：** 支持
 
 配置 TypeScript 声明文件的生成。
+
+在顶层配置时，每个 `lib` 配置项都会继承 `dts`。`lib` 配置项中的 `dts`
+优先级高于顶层配置。
+
+:::warning
+在多个 `lib` 配置项中启用顶层 `dts`，可能导致它们并发写入或清理相同的类型声明输出。
+为避免冲突，请仅在一个 `lib` 配置项中配置 `dts`。
+:::
 
 ## 布尔类型
 
@@ -34,12 +43,7 @@ type Dts =
 
 ```ts title="rslib.config.ts"
 export default {
-  lib: [
-    {
-      format: 'esm',
-      dts: true, // [!code highlight]
-    },
-  ],
+  dts: true, // [!code highlight]
 };
 ```
 

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -29,12 +29,10 @@ type Dts =
 
 配置 TypeScript 声明文件的生成。
 
-在顶层配置时，每个 `lib` 配置项都会继承 `dts`。`lib` 配置项中的 `dts`
-优先级高于顶层配置。
+顶层 `dts` 会被所有 `lib` 配置项继承，但配置项自身的 `dts` 具有更高优先级。
 
 :::warning
-在多个 `lib` 配置项中启用顶层 `dts`，可能导致它们并发写入或清理相同的类型声明输出。
-为避免冲突，请仅在一个 `lib` 配置项中配置 `dts`。
+存在多个 `lib` 配置项时，使用顶层 `dts` 可能导致类型声明生成过程中的文件写入或删除操作发生冲突，建议改为在具体的 `lib` 配置项中配置 `dts`。
 :::
 
 ## 布尔类型
@@ -43,7 +41,12 @@ type Dts =
 
 ```ts title="rslib.config.ts"
 export default {
-  dts: true, // [!code highlight]
+  lib: [
+    {
+      format: 'esm',
+      dts: true, // [!code highlight]
+    },
+  ],
 };
 ```
 

--- a/website/docs/zh/config/lib/index.mdx
+++ b/website/docs/zh/config/lib/index.mdx
@@ -36,6 +36,7 @@ export default {
 - [`autoExtension`](/config/lib/auto-extension)
 - [`banner`](/config/lib/banner)
 - [`bundle`](/config/lib/bundle)
+- [`dts`](/config/lib/dts)
 - [`externalHelpers`](/config/lib/external-helpers)
 - [`footer`](/config/lib/footer)
 - [`format`](/config/lib/format)
@@ -49,7 +50,6 @@ export default {
 
 以下 lib 配置不支持共享配置，只能写在 `lib` 项中，用于单独配置对应产物：
 
-- [`dts`](/config/lib/dts)
 - [`experiments`](/config/lib/experiments)
 - [`id`](/config/lib/id)
 - [`umdName`](/config/lib/umd-name)


### PR DESCRIPTION
## Summary

This PR allows `dts` to be configured at the top level so the same declaration generation settings can be shared across all lib outputs, while still allowing each lib item to override or disable `dts`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).