### PR TITLE
feat(core): enable Rspack runtime mode by default

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -246,6 +246,9 @@ export async function createConstantRsbuildConfig(): Promise<EnvironmentConfig> 
     tools: {
       htmlPlugin: false,
       rspack: {
+        experiments: {
+          runtimeMode: 'rspack',
+        },
         module: {
           parser: {
             javascript: {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -308,7 +308,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    sourceImport: true
+    sourceImport: true,
+    runtimeMode: 'rspack'
   },
   devtool: false,
   cache: {
@@ -1180,7 +1181,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    sourceImport: true
+    sourceImport: true,
+    runtimeMode: 'rspack'
   },
   devtool: false,
   cache: {
@@ -2048,7 +2050,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    sourceImport: true
+    sourceImport: true,
+    runtimeMode: 'rspack'
   },
   devtool: false,
   cache: {
@@ -2821,7 +2824,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    sourceImport: true
+    sourceImport: true,
+    runtimeMode: 'rspack'
   },
   devtool: false,
   cache: {
@@ -3599,7 +3603,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    sourceImport: true
+    sourceImport: true,
+    runtimeMode: 'rspack'
   },
   devtool: false,
   cache: {
@@ -4430,6 +4435,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "htmlPlugin": false,
       "rspack": [
         {
+          "experiments": {
+            "runtimeMode": "rspack",
+          },
           "module": {
             "parser": {
               "javascript": {
@@ -4712,6 +4720,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "htmlPlugin": false,
       "rspack": [
         {
+          "experiments": {
+            "runtimeMode": "rspack",
+          },
           "module": {
             "parser": {
               "javascript": {
@@ -4967,6 +4978,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "htmlPlugin": false,
       "rspack": [
         {
+          "experiments": {
+            "runtimeMode": "rspack",
+          },
           "module": {
             "parser": {
               "javascript": {
@@ -5211,6 +5225,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "htmlPlugin": false,
       "rspack": [
         {
+          "experiments": {
+            "runtimeMode": "rspack",
+          },
           "module": {
             "parser": {
               "javascript": {
@@ -5410,6 +5427,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "htmlPlugin": false,
       "rspack": [
         {
+          "experiments": {
+            "runtimeMode": "rspack",
+          },
           "module": {
             "parser": {
               "javascript": {

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -463,6 +463,32 @@ describe('CLI options', () => {
 });
 
 describe('Should compose create Rsbuild config correctly', () => {
+  test('uses Rspack runtime mode by default and allows overriding it', async () => {
+    const defaultRslib = await createRslib({});
+    const {
+      origin: { bundlerConfigs: defaultBundlerConfigs },
+    } = await defaultRslib.inspectConfig({ verbose: true });
+    expect(defaultBundlerConfigs[0]?.experiments?.runtimeMode).toBe('rspack');
+
+    const overriddenRslib = await createRslib({
+      config: {
+        tools: {
+          rspack: {
+            experiments: {
+              runtimeMode: 'webpack',
+            },
+          },
+        },
+      },
+    });
+    const {
+      origin: { bundlerConfigs: overriddenBundlerConfigs },
+    } = await overriddenRslib.inspectConfig({ verbose: true });
+    expect(overriddenBundlerConfigs[0]?.experiments?.runtimeMode).toBe(
+      'webpack',
+    );
+  });
+
   test('treats omitted lib field as default library config', async () => {
     const rslibConfig: RslibConfig = {
       root: join(__dirname, '..'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,7 +314,7 @@ catalogs:
       version: 6.0.2
 
 overrides:
-  '@rsbuild/core>@rspack/core': 2.1.6
+  '@rspack/core': npm:@rspack-canary/core@2.1.8-canary-4b189917-20260802173728
 
 importers:
 
@@ -388,13 +388,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -409,19 +409,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 'catalog:'
-        version: 2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/storybook-addon':
         specifier: 'catalog:'
-        version: 6.0.17(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)
+        version: 6.0.17(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -454,7 +454,7 @@ importers:
         version: 3.3.4(@rsbuild/core@2.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3)
+        version: 3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -470,13 +470,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -491,7 +491,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(preact@10.29.8)
+        version: 2.0.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(preact@10.29.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -506,7 +506,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -524,7 +524,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -542,7 +542,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -560,7 +560,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)
+        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -581,7 +581,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -602,7 +602,7 @@ importers:
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -623,7 +623,7 @@ importers:
         version: 3.3.4(@rsbuild/core@2.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40)
+        version: 3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -645,7 +645,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -773,7 +773,7 @@ importers:
         version: 4.0.1(debug@4.4.3)(supports-color@9.4.0)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
@@ -782,10 +782,10 @@ importers:
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -797,7 +797,7 @@ importers:
         version: 1.2.4(@rsbuild/core@2.1.9)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rsbuild/plugin-yaml':
         specifier: 'catalog:'
         version: 2.0.0(@rsbuild/core@2.1.9)
@@ -877,7 +877,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
 
   tests/integration/asset/json: {}
 
@@ -897,10 +897,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -985,10 +985,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/cli/build: {}
 
@@ -1366,7 +1366,7 @@ importers:
         version: 8.0.1
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)
+        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)
       babel-plugin-polyfill-corejs3:
         specifier: 'catalog:'
         version: 1.0.0(@babel/core@8.0.1)
@@ -1379,7 +1379,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1520,19 +1520,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)
+        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)
+        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.0.3(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1541,7 +1541,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.0.3(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1589,10 +1589,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       vue:
         specifier: 'catalog:'
         version: 3.5.40(typescript@7.0.2)
@@ -1627,13 +1627,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -1645,7 +1645,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 'catalog:'
-        version: 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+        version: 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@rspress/plugin-algolia':
         specifier: 'catalog:'
         version: 2.0.19(@rspress/core@2.0.19)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
@@ -2521,7 +2521,6 @@ packages:
   '@module-federation/rspack@2.8.1':
     resolution: {integrity: sha512-jJYkARn1U1M92CbiLyoaP7+tNKh8YzzOTMSGzbdj6okTtWK0Z9ImyVoKEnAnjnLP1nbQjkPEaojkR2D2IQFhLw==}
     peerDependencies:
-      '@rspack/core': ^0.7.0 || ^1.0.0 || ^2.0.0-0
       typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
       vue-tsc: '>=1.0.24'
     peerDependenciesMeta:
@@ -3175,76 +3174,76 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@2.1.6':
-    resolution: {integrity: sha512-WRVMGOmVSLeQfu6uNuBjXyNhgs2j/1GWZhSL+vhieZGLwpSggBAZZpiRWd1jhFzQpRitQyWZYD+3XgoX5tiaPg==}
+  '@rspack-canary/binding-darwin-arm64@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-F8B3STugLaEVkNGM0KBsBckF0uWXh2oXiwotHSqRjOAssiJZ0bWrshH9qDscu6ct6yd9g3VEjVAeDKqkQDeQ0A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.1.6':
-    resolution: {integrity: sha512-bAIxknnQ4GsCKHNjBilXcrDVAQ3ciiJeVTWih0gKtc0HWSfFSGO9rgDx5c/dJQGPNphTV50EYBc1A+rBsmhSZA==}
+  '@rspack-canary/binding-darwin-x64@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-bNq1EcEAjckDHwmwuqOEf77Pt9BX4qZ3GLkwQXQIbCVbMlOUacVLR7EXzp4V2cUSxonAYw4UZvvYvQ8iIUvdVQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.1.6':
-    resolution: {integrity: sha512-UH2kjRj2vqizAdDiTmP9i6Y2aIzsOtPlg1xKTM2dqddhatHU2io4SHtGyO+m4QqIQrEjVYTqYYblapNYDRmdqA==}
+  '@rspack-canary/binding-linux-arm64-gnu@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-1O/sFau+348KTFmOFhArwkWTjlpK2QHtMRxOHV/oySuRQo0wQ+j7yQgZDPgytClkTR473kx1fxZCgOXP2JDMrw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.1.6':
-    resolution: {integrity: sha512-gYbLFVvhGPlAVTapprfC4FxeBNU6kgEn28KGO/ix/Yjo7mTR5DihmUomo/rpGtRUh6eB8qxr7SbZXZ6sCKpH/g==}
+  '@rspack-canary/binding-linux-arm64-musl@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-+oWoAvWp3SUE6CTVCf1GIlQ5uWGYKYEGSR+3HsNZLPe+R0XEWJ/90t1qw72tNXvj3jbkKfhAtxz8zoBtO4sdSw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.6':
-    resolution: {integrity: sha512-CFStUO9f2Yn8iAaym3mfaZnSxRbD5p2lZl0/rzNOBwtIt4mrKeYd3dtqfia21JzAN0mGQ2i2kEYt9dACFzzrkA==}
+  '@rspack-canary/binding-linux-riscv64-gnu@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-ywFtjKzmYIcD0rRj5qTwC3OMS4wsuQBBWLn1Unhjd01NwW1jlLiRC2m6810WCcyvauLmavU+eueAx2u7UJb96A==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.1.6':
-    resolution: {integrity: sha512-hms5zCvHhc3EA84w2n2bWi+mXplgEIBEyOHJxCY0+mm6X1oxENh9+Zcly6OcEtV/jmxjx4msWK7GB/HUE138/w==}
+  '@rspack-canary/binding-linux-riscv64-musl@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-jy4DzRvOHYUxmgXp5WhD/lKOxtpBgu9kgTb9R/qxB3lz1BBcVZ6h0epGif2BrriZn0VJG39RijQSGqvkm2GLyQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.1.6':
-    resolution: {integrity: sha512-s2ig83rYmcIxP8QaJy+GZQpN8/8U75PBr8HaV8DljdCl3zGR3xo1dLJh97JL23CQl+S32wYaj4PqiU7r+lNwwA==}
+  '@rspack-canary/binding-linux-x64-gnu@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-hLVpmOQyiUcMESf3mPdxR9GUadGnpI0sCLO9/jc1LEotM/GdHSCxEgWVvcLkV7QAmCD5n9Cf5dhZeh/mxc7wVQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.1.6':
-    resolution: {integrity: sha512-j2clfnzHHFSD58UEbySNGWn7lrNPEIMPgMF/J/tiFggXsIHo7NyK8pYquXRPEklYQBnotalLdgHZ6Eyyqx5POw==}
+  '@rspack-canary/binding-linux-x64-musl@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-keYKyplNmWUHCOFmm/6/4poYTvwU7TdHCZQTpNAA0pPEMuwP3pbJj0Cp3RwPji3o1ZCVmGzdknip3A0EwKadgw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.1.6':
-    resolution: {integrity: sha512-q8SUUwbCgJXaYw9AP2jh0HN4gxzDXWqemty+1qEt47VZz/XHBM4J6AvgY0XgqgAqbOCpsqX5LzAVq6ZIjH2Cjg==}
+  '@rspack-canary/binding-wasm32-wasi@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-p6lv6rsdyd5feI7rJ8Y2hmkC6geudCRBT4mIksrFbtH+tEt9HnoagsTZN0zHwg+lTERO8g5DKPqNq8DkcXC+JA==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.1.6':
-    resolution: {integrity: sha512-KMwwL+bqGHg2t0jaONdXWXmk2Z1IhFVI6yAB8x9PMTS5Pc4r4nILcUEkCu/+lbTD/WlDLySFjNGqm0eMFk/9Mg==}
+  '@rspack-canary/binding-win32-arm64-msvc@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-h/b3DVdNEv5IWaT+kOxD+5g7vU+3LHoyAwSBaEdXYeFKrcT7T+esh9QQ5A4vM1XJiMUZ0SEnc0WRdZC2DC166g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.1.6':
-    resolution: {integrity: sha512-ynVPvQFa0Cc4q94soHN+9qTp+NIYxdznnpVAJFbFHGLSX9V13dwOOOgmlE72c7E1noPfhnge632ea37zpqo3DA==}
+  '@rspack-canary/binding-win32-ia32-msvc@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-m+ynglM4twiq6z4PVRb/fE6RO7mn2PXxQFPLDAhZUG1CczrsmntfpJFfGCkOVaw8ccW0Jy32bjWULDMBaVdMJQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.1.6':
-    resolution: {integrity: sha512-7igSKhn2RWNYCfV2wXmE6xdqPVQEtTWSvOCUET7Jtbr4c6dqb6Y6rb9+EwcWvfVQ19e0NWsbqvtUTr2gJw3I2A==}
+  '@rspack-canary/binding-win32-x64-msvc@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-tC5jpDzIzBlgidZ7niGVvI4AJyXKlukvs8ZAS11F5Xe+Fbp6M93aLxs8DqX/xqtYKfNLPz/kcKG3CjyEFetMUQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.1.6':
-    resolution: {integrity: sha512-VGyknF2nMScPf0MpogF8voH7kHDNNjt+GMDcTDAh6CPqEb0bzPx545kf4oNUF4T1XbpvyMJ9UFRHDkwNlaes/g==}
+  '@rspack-canary/binding@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-TaMdQ5h841ekagcm3DGp6gZ9oMH4znxKNmje1gRm7Pu6Jgd50FfcTmbgD8RR0VYAoZEyAao1mMqi8mym9rVqgQ==}
 
-  '@rspack/core@2.1.6':
-    resolution: {integrity: sha512-/3PcODTDDy71oz5tOerq1g2tRljSCaNYu8NPjAGjzEzra2KbMSFkCVrI670AuHJ3qC0voKccIdxWCcQI0AKnDg==}
+  '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728':
+    resolution: {integrity: sha512-K9Vdd2JFxdoy+PgJ2MjBY68Vn2RgsEw7vdlm3Cqa2XzyT6mHsswNYMYONGOS/16INgKWGGgfH4muoaCVVqLobQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -3263,19 +3262,11 @@ packages:
     peerDependencies:
       '@prefresh/core': ^1.5.0
       '@prefresh/utils': ^1.2.0
-      '@rspack/core': ^2.0.0
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
 
   '@rspack/plugin-react-refresh@2.0.2':
     resolution: {integrity: sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==}
     peerDependencies:
-      '@rspack/core': ^2.0.0
       react-refresh: '>=0.10.0 <1.0.0'
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
 
   '@rspress/core@2.0.19':
     resolution: {integrity: sha512-m0KfQNNXxjP975652nIOwUTqrvbJapRp4NpnoQMc5heawGhkC4+F7zTHvxY+huvzGYnKtL2fMMTrgWhEjKkrug==}
@@ -3702,11 +3693,8 @@ packages:
   '@tailwindcss/webpack@4.3.1':
     resolution: {integrity: sha512-HM33EjYPbkMlBGcYoVA/pk/hML3wAn2JOnjF79eDWVLuktOhRczDwWsSBQBOWV6LLBVAgGZS/pZ519OHUF8vKg==}
     peerDependencies:
-      '@rspack/core': ^1.0.0 || ^2.0.0
       webpack: ^5.0.0
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       webpack:
         optional: true
 
@@ -4227,11 +4215,8 @@ packages:
     engines: {node: ^18.20.0 || ^20.10.0 || >=22.0.0}
     peerDependencies:
       '@babel/core': ^7.12.0 || ^8.0.0-beta.1
-      '@rspack/core': ^1.0.0 || ^2.0.0-0
       webpack: '>=5.61.0'
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       webpack:
         optional: true
 
@@ -5548,12 +5533,9 @@ packages:
     resolution: {integrity: sha512-F0+ErFFDj3Pt+nVrCN6VlEGEzocv9s7x/aR9v2riI+WM83UAfTYBDBjGPJnT55lBLR6JSI4fmWblt+aA2JN6/w==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
       less: ^3.5.0 || ^4.0.0
       webpack: ^5.0.0
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       webpack:
         optional: true
 
@@ -6792,12 +6774,9 @@ packages:
   rspack-vue-loader@17.5.1:
     resolution: {integrity: sha512-1pXdeqYM95P0T8DO2ZcOCBnfMp62W5IG2c0RICn1rFYjHcja41IYSQLzcdc1uePEq0n4JZwvfR2lVs8wRZuwzA==}
     peerDependencies:
-      '@rspack/core': ^1.0.0 || ^2.0.0-0
       '@vue/compiler-sfc': '*'
       vue: '*'
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       '@vue/compiler-sfc':
         optional: true
       vue:
@@ -7276,12 +7255,9 @@ packages:
     resolution: {integrity: sha512-Rxf+ybxW+wH9/fY2Qlaae/u/PrAck3I3LKXXZQq5XaxVGp1nNm/Z76vHSdhjXltyLETs+42lpQcA4SBY2DWswg==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
       stylus: '>=0.52.4'
       webpack: ^5.0.0
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       webpack:
         optional: true
 
@@ -7422,12 +7398,9 @@ packages:
   ts-checker-rspack-plugin@1.4.0:
     resolution: {integrity: sha512-xPBPe6n9XZW9vMw4PFJLZFY372rejKK8UFC12i33J+yJK+fmsQQ4k9eoOlbLE0zC6vftyKDhvfMF3RyMFFTOZw==}
     peerDependencies:
-      '@rspack/core': ^1.0.0 || ^2.0.0
       '@typescript/native-preview': ^7.0.0-0
       typescript: '>=3.8.0'
     peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
       '@typescript/native-preview':
         optional: true
 
@@ -8753,7 +8726,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/enhanced@2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/cli': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
@@ -8762,7 +8735,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.1(@module-federation/runtime-tools@2.8.1)
       '@module-federation/managers': 2.8.1
       '@module-federation/manifest': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
-      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/rspack': 2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
       '@module-federation/webpack-bundler-runtime': 2.8.1
@@ -8772,11 +8745,11 @@ snapshots:
       typescript: 6.0.3
       vue-tsc: 3.3.9(typescript@6.0.3)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@swc/helpers'
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/enhanced@2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/cli': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
@@ -8785,7 +8758,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.1(@module-federation/runtime-tools@2.8.1)
       '@module-federation/managers': 2.8.1
       '@module-federation/manifest': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/rspack': 2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
       '@module-federation/webpack-bundler-runtime': 2.8.1
@@ -8795,7 +8768,7 @@ snapshots:
       typescript: 7.0.2
       vue-tsc: 3.3.9(typescript@7.0.2)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@swc/helpers'
       - bufferutil
       - utf-8-validate
 
@@ -8831,67 +8804,97 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.48(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.48(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime': 2.8.1
       '@module-federation/sdk': 2.8.1
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
       tapable: 2.3.0
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@swc/helpers'
       - bufferutil
       - typescript
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.48(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.48(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime': 2.8.1
       '@module-federation/sdk': 2.8.1
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
       tapable: 2.3.0
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@swc/helpers'
       - bufferutil
       - typescript
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.48(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.48(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/runtime': 2.8.1
+      '@module-federation/sdk': 2.8.1
+      encoding: 0.1.13
+      node-fetch: 2.7.0(encoding@0.1.13)
+      tapable: 2.3.0
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
+  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)':
+    dependencies:
+      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.48(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@swc/helpers'
       - bufferutil
       - typescript
       - utf-8-validate
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.48(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.48(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@swc/helpers'
       - bufferutil
       - typescript
       - utf-8-validate
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)':
+    dependencies:
+      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.48(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/sdk': 2.8.1
+    optionalDependencies:
+      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - webpack
+
+  '@module-federation/rspack@2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/dts-plugin': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
@@ -8900,15 +8903,16 @@ snapshots:
       '@module-federation/manifest': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.9(typescript@6.0.3)
     transitivePeerDependencies:
+      - '@swc/helpers'
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rspack@2.8.1(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rspack@2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/dts-plugin': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
@@ -8917,11 +8921,12 @@ snapshots:
       '@module-federation/manifest': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
     optionalDependencies:
       typescript: 7.0.2
       vue-tsc: 3.3.9(typescript@7.0.2)
     transitivePeerDependencies:
+      - '@swc/helpers'
       - bufferutil
       - utf-8-validate
 
@@ -8943,16 +8948,16 @@ snapshots:
 
   '@module-federation/sdk@2.8.1': {}
 
-  '@module-federation/storybook-addon@6.0.17(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.17(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
       storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@swc/helpers'
       - bufferutil
       - typescript
       - utf-8-validate
@@ -9220,7 +9225,7 @@ snapshots:
 
   '@rsbuild/core@2.1.9(@module-federation/runtime-tools@2.8.1)':
     dependencies:
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -9238,32 +9243,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)':
+  '@rsbuild/plugin-babel@2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.6)
+      babel-loader: 10.1.1(@babel/core@7.29.7)(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)':
+  '@rsbuild/plugin-less@2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.6)(less@4.6.7)
+      less-loader: 12.3.3(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - webpack
 
   '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.9)':
@@ -9294,26 +9301,28 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(preact@10.29.8)':
+  '@rsbuild/plugin-preact@2.0.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(preact@10.29.8)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.6)
+      '@rspack/plugin-preact-refresh': 2.0.1(@module-federation/runtime-tools@2.8.1)(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@swc/helpers@0.5.23)
       '@swc/plugin-prefresh': 12.12.0
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - preact
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)':
+  '@rsbuild/plugin-react@2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.6)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
   '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.9)':
     dependencies:
@@ -9337,21 +9346,22 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)':
+  '@rsbuild/plugin-stylus@2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0(supports-color@9.4.0)
-      stylus-loader: 8.1.3(@rspack/core@2.1.6)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(stylus@0.64.0)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)(typescript@7.0.2)':
+  '@rsbuild/plugin-svgr@2.0.5(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+      '@rsbuild/plugin-react': 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@svgr/core': 8.1.0(supports-color@9.4.0)(typescript@7.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)(supports-color@9.4.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)
@@ -9360,17 +9370,19 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.6)
+      '@tailwindcss/webpack': 4.3.1(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - webpack
 
   '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.9)':
@@ -9379,29 +9391,31 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.4.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.6)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.4.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(typescript@6.0.3)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - typescript
 
   '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.9)':
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)':
+  '@rsbuild/plugin-vue@2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+      rspack-vue-loader: 17.5.1(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - '@vue/compiler-sfc'
       - vue
 
@@ -9460,89 +9474,93 @@ snapshots:
   '@rslint/native-win32-x64-msvc@0.7.2':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.1.6':
+  '@rspack-canary/binding-darwin-arm64@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.1.6':
+  '@rspack-canary/binding-darwin-x64@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.6':
+  '@rspack-canary/binding-linux-arm64-gnu@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.6':
+  '@rspack-canary/binding-linux-arm64-musl@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.6':
+  '@rspack-canary/binding-linux-riscv64-gnu@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding-linux-riscv64-musl@2.1.6':
+  '@rspack-canary/binding-linux-riscv64-musl@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.1.6':
+  '@rspack-canary/binding-linux-x64-gnu@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.1.6':
+  '@rspack-canary/binding-linux-x64-musl@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.1.6':
+  '@rspack-canary/binding-wasm32-wasi@2.1.8-canary-4b189917-20260802173728':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.6':
+  '@rspack-canary/binding-win32-arm64-msvc@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.1.6':
+  '@rspack-canary/binding-win32-ia32-msvc@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.1.6':
+  '@rspack-canary/binding-win32-x64-msvc@2.1.8-canary-4b189917-20260802173728':
     optional: true
 
-  '@rspack/binding@2.1.6':
+  '@rspack-canary/binding@2.1.8-canary-4b189917-20260802173728':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.6
-      '@rspack/binding-darwin-x64': 2.1.6
-      '@rspack/binding-linux-arm64-gnu': 2.1.6
-      '@rspack/binding-linux-arm64-musl': 2.1.6
-      '@rspack/binding-linux-riscv64-gnu': 2.1.6
-      '@rspack/binding-linux-riscv64-musl': 2.1.6
-      '@rspack/binding-linux-x64-gnu': 2.1.6
-      '@rspack/binding-linux-x64-musl': 2.1.6
-      '@rspack/binding-wasm32-wasi': 2.1.6
-      '@rspack/binding-win32-arm64-msvc': 2.1.6
-      '@rspack/binding-win32-ia32-msvc': 2.1.6
-      '@rspack/binding-win32-x64-msvc': 2.1.6
+      '@rspack/binding-darwin-arm64': '@rspack-canary/binding-darwin-arm64@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-darwin-x64': '@rspack-canary/binding-darwin-x64@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-linux-arm64-gnu': '@rspack-canary/binding-linux-arm64-gnu@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-linux-arm64-musl': '@rspack-canary/binding-linux-arm64-musl@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-linux-riscv64-gnu': '@rspack-canary/binding-linux-riscv64-gnu@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-linux-riscv64-musl': '@rspack-canary/binding-linux-riscv64-musl@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-linux-x64-gnu': '@rspack-canary/binding-linux-x64-gnu@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-linux-x64-musl': '@rspack-canary/binding-linux-x64-musl@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-wasm32-wasi': '@rspack-canary/binding-wasm32-wasi@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-win32-arm64-msvc': '@rspack-canary/binding-win32-arm64-msvc@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-win32-ia32-msvc': '@rspack-canary/binding-win32-ia32-msvc@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-win32-x64-msvc': '@rspack-canary/binding-win32-x64-msvc@2.1.8-canary-4b189917-20260802173728'
 
-  '@rspack/core@2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
+  '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': 2.1.6
+      '@rspack/binding': '@rspack-canary/binding@2.1.8-canary-4b189917-20260802173728'
     optionalDependencies:
       '@module-federation/runtime-tools': 2.8.1
       '@swc/helpers': 0.5.23
 
   '@rspack/lite-tapable@1.1.2': {}
 
-  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.6)':
+  '@rspack/plugin-preact-refresh@2.0.1(@module-federation/runtime-tools@2.8.1)(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@swc/helpers@0.5.23)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
-    optionalDependencies:
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.6)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(react-refresh@0.18.0)':
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       react-refresh: 0.18.0
-    optionalDependencies:
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
-  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
+  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
+      '@rsbuild/plugin-react': 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
       '@rspress/shared': 2.0.19(@module-federation/runtime-tools@2.8.1)(supports-color@9.4.0)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -9579,7 +9597,7 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-      - '@rspack/core'
+      - '@swc/helpers'
       - core-js
       - micromark
       - micromark-util-types
@@ -9589,7 +9607,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
@@ -9600,7 +9618,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.19(@rspress/core@2.0.19)(supports-color@9.4.0)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       remark-mdx: 3.1.1(supports-color@9.4.0)
       remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
@@ -9611,17 +9629,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rspress/plugin-twoslash@2.0.19(@rspress/core@2.0.19)(react@19.2.8)(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@shikijs/twoslash': 4.3.0(supports-color@9.4.0)(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-gfm: 3.1.0(supports-color@9.4.0)
@@ -9647,7 +9665,7 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.7(@rspress/core@2.0.19)':
     optionalDependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rstest/adapter-rslib@0.11.5(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.5)(typescript@7.0.2)':
     dependencies:
@@ -10022,14 +10040,16 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.6)':
+  '@tailwindcss/webpack@4.3.1(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-    optionalDependencies:
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10553,12 +10573,14 @@ snapshots:
 
   b-validate@1.5.3: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.6):
+  babel-loader@10.1.1(@babel/core@7.29.7)(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23):
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       find-up: 5.0.0
-    optionalDependencies:
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
   babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
     dependencies:
@@ -12015,11 +12037,13 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@rspack/core@2.1.6)(less@4.6.7):
+  less-loader@12.3.3(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(less@4.6.7):
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       less: 4.6.7
-    optionalDependencies:
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
   less@4.6.7:
     dependencies:
@@ -13630,18 +13654,21 @@ snapshots:
 
   rslog@2.3.0: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40):
+  rspack-vue-loader@17.5.1(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40):
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
       '@vue/compiler-sfc': 3.5.40
       vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.19)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
@@ -13666,14 +13693,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.19)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.19)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.19):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   run-applescript@7.1.0: {}
 
@@ -14006,14 +14033,14 @@ snapshots:
     dependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3):
     dependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)
+      '@rsbuild/plugin-type-check': 1.4.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14037,12 +14064,13 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       typescript: 6.0.3
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - '@typescript/native-preview'
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
@@ -14056,12 +14084,13 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
       storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - '@types/react'
       - '@types/react-dom'
       - '@typescript/native-preview'
@@ -14071,18 +14100,19 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40):
+  storybook-vue3-rsbuild@3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40):
     dependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@storybook/vue3': 10.5.5(storybook@10.5.5)(vue@3.5.40)
       storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
       vue: 3.5.40(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.40)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
     transitivePeerDependencies:
       - '@babel/preset-env'
-      - '@rspack/core'
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
       - '@typescript/native-preview'
       - msw
       - react
@@ -14198,13 +14228,15 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.1.6)(stylus@0.64.0):
+  stylus-loader@8.1.3(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(stylus@0.64.0):
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0(supports-color@9.4.0)
-    optionalDependencies:
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
   stylus@0.64.0(supports-color@9.4.0):
     dependencies:
@@ -14318,15 +14350,17 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.6)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.4.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(typescript@6.0.3):
     dependencies:
+      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
       memfs: 4.64.0
       picocolors: 1.1.1
       typescript: 6.0.3
-    optionalDependencies:
-      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@swc/helpers'
 
   ts-dedent@2.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,9 @@ catalogs:
       specifier: npm:@typescript/typescript6@^6.0.2
       version: 6.0.2
 
+overrides:
+  '@rsbuild/core>@rspack/core': 2.1.6
+
 importers:
 
   .:
@@ -385,13 +388,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -406,19 +409,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 'catalog:'
-        version: 2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/storybook-addon':
         specifier: 'catalog:'
-        version: 6.0.17(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)
+        version: 6.0.17(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -451,7 +454,7 @@ importers:
         version: 3.3.4(@rsbuild/core@2.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -467,13 +470,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -488,7 +491,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(preact@10.29.8)
+        version: 2.0.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(preact@10.29.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -503,7 +506,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -521,7 +524,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -539,7 +542,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -557,7 +560,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -578,7 +581,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -599,7 +602,7 @@ importers:
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -620,7 +623,7 @@ importers:
         version: 3.3.4(@rsbuild/core@2.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40)
+        version: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -642,7 +645,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -770,7 +773,7 @@ importers:
         version: 4.0.1(debug@4.4.3)(supports-color@9.4.0)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
@@ -779,10 +782,10 @@ importers:
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -794,7 +797,7 @@ importers:
         version: 1.2.4(@rsbuild/core@2.1.9)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rsbuild/plugin-yaml':
         specifier: 'catalog:'
         version: 2.0.0(@rsbuild/core@2.1.9)
@@ -874,7 +877,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
 
   tests/integration/asset/json: {}
 
@@ -894,10 +897,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -982,10 +985,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/cli/build: {}
 
@@ -1363,7 +1366,7 @@ importers:
         version: 8.0.1
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)
       babel-plugin-polyfill-corejs3:
         specifier: 'catalog:'
         version: 1.0.0(@babel/core@8.0.1)
@@ -1376,7 +1379,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1517,19 +1520,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1538,7 +1541,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1586,10 +1589,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       vue:
         specifier: 'catalog:'
         version: 3.5.40(typescript@7.0.2)
@@ -1624,13 +1627,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -1642,7 +1645,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 'catalog:'
-        version: 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+        version: 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@rspress/plugin-algolia':
         specifier: 'catalog:'
         version: 2.0.19(@rspress/core@2.0.19)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
@@ -3172,76 +3175,76 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@2.1.7':
-    resolution: {integrity: sha512-DwxzrXRctueP/3Pyom9JHcIsRShuEAlHb+mrE5OPT+4cdHI1UnJpbzEvEDLTo4IKJhDb3vjXdHLtjqtL0SYbeA==}
+  '@rspack/binding-darwin-arm64@2.1.6':
+    resolution: {integrity: sha512-WRVMGOmVSLeQfu6uNuBjXyNhgs2j/1GWZhSL+vhieZGLwpSggBAZZpiRWd1jhFzQpRitQyWZYD+3XgoX5tiaPg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.1.7':
-    resolution: {integrity: sha512-kPbrYvR/XUHfAMgRVq3QnC71DW/qjwsPj+3hEUuEnRmlploPNy9u8Szf1IHKSVUSrVZBTgDyMoZQdxYLfhResw==}
+  '@rspack/binding-darwin-x64@2.1.6':
+    resolution: {integrity: sha512-bAIxknnQ4GsCKHNjBilXcrDVAQ3ciiJeVTWih0gKtc0HWSfFSGO9rgDx5c/dJQGPNphTV50EYBc1A+rBsmhSZA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.1.7':
-    resolution: {integrity: sha512-VFB+YXM3kZ6IIuLV64H3vgnwqvQIIaqfR/aeGwuxYvwcZsrgblSBmXMeDULdgDjqP8Yr0VaFMBBiD9OtG5KdFw==}
+  '@rspack/binding-linux-arm64-gnu@2.1.6':
+    resolution: {integrity: sha512-UH2kjRj2vqizAdDiTmP9i6Y2aIzsOtPlg1xKTM2dqddhatHU2io4SHtGyO+m4QqIQrEjVYTqYYblapNYDRmdqA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.1.7':
-    resolution: {integrity: sha512-Mzbxyg0aJ+ITj526Iuz0enEDYY6WxhFIwEKXqwjQh+Vpd5v/+aPzPo83sSQVX/3puBV1sbmviTURbh6N9e1fvA==}
+  '@rspack/binding-linux-arm64-musl@2.1.6':
+    resolution: {integrity: sha512-gYbLFVvhGPlAVTapprfC4FxeBNU6kgEn28KGO/ix/Yjo7mTR5DihmUomo/rpGtRUh6eB8qxr7SbZXZ6sCKpH/g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.7':
-    resolution: {integrity: sha512-mpazwgT/Pse1720mvEJsoXfPkJ+enj0xUqpbe/wL6aedwjGT+9jJNB8HTJXE4XBX0UO7umGqcJMeKA6YsD2CDA==}
+  '@rspack/binding-linux-riscv64-gnu@2.1.6':
+    resolution: {integrity: sha512-CFStUO9f2Yn8iAaym3mfaZnSxRbD5p2lZl0/rzNOBwtIt4mrKeYd3dtqfia21JzAN0mGQ2i2kEYt9dACFzzrkA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.1.7':
-    resolution: {integrity: sha512-oU/l3soPRsDEWn7KZic+npyTMM2N1kRdHjoJ+L5IUBXs8bjdTXPLoyTbTdIOza5ZSoT4+UeEiEryj4BB0tQE5w==}
+  '@rspack/binding-linux-riscv64-musl@2.1.6':
+    resolution: {integrity: sha512-hms5zCvHhc3EA84w2n2bWi+mXplgEIBEyOHJxCY0+mm6X1oxENh9+Zcly6OcEtV/jmxjx4msWK7GB/HUE138/w==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.1.7':
-    resolution: {integrity: sha512-7Gtpl3h3jtnOpk1mYQE8mRndXAO2ibI8mnAbs7klevdKey+ZHneWMoMi2yOMQhhI/ifWEFxDzyGJ8bdxo0XTsA==}
+  '@rspack/binding-linux-x64-gnu@2.1.6':
+    resolution: {integrity: sha512-s2ig83rYmcIxP8QaJy+GZQpN8/8U75PBr8HaV8DljdCl3zGR3xo1dLJh97JL23CQl+S32wYaj4PqiU7r+lNwwA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.1.7':
-    resolution: {integrity: sha512-w+whI2Uy+DYkGN+MVkzMFWweL7B/s1gMqX+nvTE1vhOy3hGV0VyA9H6lqWjSD3I+eGkpYhN9Pr244cYnLpZOUQ==}
+  '@rspack/binding-linux-x64-musl@2.1.6':
+    resolution: {integrity: sha512-j2clfnzHHFSD58UEbySNGWn7lrNPEIMPgMF/J/tiFggXsIHo7NyK8pYquXRPEklYQBnotalLdgHZ6Eyyqx5POw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.1.7':
-    resolution: {integrity: sha512-cDVgvzRdTgxaeM+a5Lx0+7/VAvunvwO0wNtQ3ATQGOtFCW5b7cUzhNPcytH5ZSJTnFWuxinlGwtar5yfcnkdZQ==}
+  '@rspack/binding-wasm32-wasi@2.1.6':
+    resolution: {integrity: sha512-q8SUUwbCgJXaYw9AP2jh0HN4gxzDXWqemty+1qEt47VZz/XHBM4J6AvgY0XgqgAqbOCpsqX5LzAVq6ZIjH2Cjg==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.1.7':
-    resolution: {integrity: sha512-JDd85+iYwUvaG9Zrt5X7oIxRZRiTW+76FwkRakoXNy/5VAWQW32Jq4ESjSVz6l6mh0KnZxPq3TLMugacCPnLjw==}
+  '@rspack/binding-win32-arm64-msvc@2.1.6':
+    resolution: {integrity: sha512-KMwwL+bqGHg2t0jaONdXWXmk2Z1IhFVI6yAB8x9PMTS5Pc4r4nILcUEkCu/+lbTD/WlDLySFjNGqm0eMFk/9Mg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.1.7':
-    resolution: {integrity: sha512-y9PKEs6v9BLHV0i/4eaIRtxpATvSgcf/VYQkMT8mp+qWlPjUwDQNwU2ueWVGpff6INO+YAa7zobzziNFRgO7Lg==}
+  '@rspack/binding-win32-ia32-msvc@2.1.6':
+    resolution: {integrity: sha512-ynVPvQFa0Cc4q94soHN+9qTp+NIYxdznnpVAJFbFHGLSX9V13dwOOOgmlE72c7E1noPfhnge632ea37zpqo3DA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.1.7':
-    resolution: {integrity: sha512-BjkOzcPY/K8YlRRvyywz0mDWk89MMxqAMhDmgBXCWorh1IjgKTsWDJ2lCGIM8M9CZXUG3khom8AfrOGwRT2I+g==}
+  '@rspack/binding-win32-x64-msvc@2.1.6':
+    resolution: {integrity: sha512-7igSKhn2RWNYCfV2wXmE6xdqPVQEtTWSvOCUET7Jtbr4c6dqb6Y6rb9+EwcWvfVQ19e0NWsbqvtUTr2gJw3I2A==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.1.7':
-    resolution: {integrity: sha512-wYqi8TY30hsIzLry503o/Uqu7y9Ec7pEwN5TVmB7Pb3xHrR2eHsQPzdpF/GkCLUjQSgD2Es3CDVV1mr6zO/78g==}
+  '@rspack/binding@2.1.6':
+    resolution: {integrity: sha512-VGyknF2nMScPf0MpogF8voH7kHDNNjt+GMDcTDAh6CPqEb0bzPx545kf4oNUF4T1XbpvyMJ9UFRHDkwNlaes/g==}
 
-  '@rspack/core@2.1.7':
-    resolution: {integrity: sha512-d5Ju3zXzGgbqQWvlMlLUtek2eFPIzsFe2QOF4nwTAknxo/4OZ64t+kPT9nM6fr3aZX93VK0R3v02/kZYIRrV9Q==}
+  '@rspack/core@2.1.6':
+    resolution: {integrity: sha512-/3PcODTDDy71oz5tOerq1g2tRljSCaNYu8NPjAGjzEzra2KbMSFkCVrI670AuHJ3qC0voKccIdxWCcQI0AKnDg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8750,7 +8753,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/cli': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
@@ -8759,7 +8762,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.1(@module-federation/runtime-tools@2.8.1)
       '@module-federation/managers': 2.8.1
       '@module-federation/manifest': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
-      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
       '@module-federation/webpack-bundler-runtime': 2.8.1
@@ -8773,7 +8776,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/cli': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
@@ -8782,7 +8785,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.1(@module-federation/runtime-tools@2.8.1)
       '@module-federation/managers': 2.8.1
       '@module-federation/manifest': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
       '@module-federation/webpack-bundler-runtime': 2.8.1
@@ -8828,9 +8831,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.48(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.48(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime': 2.8.1
       '@module-federation/sdk': 2.8.1
       encoding: 0.1.13
@@ -8843,9 +8846,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.48(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.48(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime': 2.8.1
       '@module-federation/sdk': 2.8.1
       encoding: 0.1.13
@@ -8858,10 +8861,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.48(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.48(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
@@ -8873,10 +8876,10 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.48(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.48(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
@@ -8888,7 +8891,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/rspack@2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/dts-plugin': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
@@ -8897,7 +8900,7 @@ snapshots:
       '@module-federation/manifest': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.9(typescript@6.0.3)
@@ -8905,7 +8908,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rspack@2.8.1(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rspack@2.8.1(@rspack/core@2.1.6)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/dts-plugin': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
@@ -8914,7 +8917,7 @@ snapshots:
       '@module-federation/manifest': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 7.0.2
       vue-tsc: 3.3.9(typescript@7.0.2)
@@ -8940,9 +8943,9 @@ snapshots:
 
   '@module-federation/sdk@2.8.1': {}
 
-  '@module-federation/storybook-addon@6.0.17(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.17(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.6)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
@@ -9217,7 +9220,7 @@ snapshots:
 
   '@rsbuild/core@2.1.9(@module-federation/runtime-tools@2.8.1)':
     dependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -9235,14 +9238,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)':
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.7)
+      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.6)
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
@@ -9251,11 +9254,11 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.7)(less@4.6.7)
+      less-loader: 12.3.3(@rspack/core@2.1.6)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
@@ -9291,11 +9294,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(preact@10.29.8)':
+  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(preact@10.29.8)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.7)
+      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.6)
       '@swc/plugin-prefresh': 12.12.0
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
@@ -9303,9 +9306,9 @@ snapshots:
       - '@rspack/core'
       - preact
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.7)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.6)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
@@ -9334,11 +9337,11 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)':
+  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0(supports-color@9.4.0)
-      stylus-loader: 8.1.3(@rspack/core@2.1.7)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.1.6)(stylus@0.64.0)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
@@ -9346,9 +9349,9 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)(typescript@7.0.2)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(supports-color@9.4.0)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@svgr/core': 8.1.0(supports-color@9.4.0)(typescript@7.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)(supports-color@9.4.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)
@@ -9361,9 +9364,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.7)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.6)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
@@ -9376,12 +9379,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.7)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.6)(typescript@6.0.3)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
@@ -9392,9 +9395,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
@@ -9457,89 +9460,89 @@ snapshots:
   '@rslint/native-win32-x64-msvc@0.7.2':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.1.7':
+  '@rspack/binding-darwin-arm64@2.1.6':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.1.7':
+  '@rspack/binding-darwin-x64@2.1.6':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.7':
+  '@rspack/binding-linux-arm64-gnu@2.1.6':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.7':
+  '@rspack/binding-linux-arm64-musl@2.1.6':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.7':
+  '@rspack/binding-linux-riscv64-gnu@2.1.6':
     optional: true
 
-  '@rspack/binding-linux-riscv64-musl@2.1.7':
+  '@rspack/binding-linux-riscv64-musl@2.1.6':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.1.7':
+  '@rspack/binding-linux-x64-gnu@2.1.6':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.1.7':
+  '@rspack/binding-linux-x64-musl@2.1.6':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.1.7':
+  '@rspack/binding-wasm32-wasi@2.1.6':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.7':
+  '@rspack/binding-win32-arm64-msvc@2.1.6':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.1.7':
+  '@rspack/binding-win32-ia32-msvc@2.1.6':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.1.7':
+  '@rspack/binding-win32-x64-msvc@2.1.6':
     optional: true
 
-  '@rspack/binding@2.1.7':
+  '@rspack/binding@2.1.6':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.7
-      '@rspack/binding-darwin-x64': 2.1.7
-      '@rspack/binding-linux-arm64-gnu': 2.1.7
-      '@rspack/binding-linux-arm64-musl': 2.1.7
-      '@rspack/binding-linux-riscv64-gnu': 2.1.7
-      '@rspack/binding-linux-riscv64-musl': 2.1.7
-      '@rspack/binding-linux-x64-gnu': 2.1.7
-      '@rspack/binding-linux-x64-musl': 2.1.7
-      '@rspack/binding-wasm32-wasi': 2.1.7
-      '@rspack/binding-win32-arm64-msvc': 2.1.7
-      '@rspack/binding-win32-ia32-msvc': 2.1.7
-      '@rspack/binding-win32-x64-msvc': 2.1.7
+      '@rspack/binding-darwin-arm64': 2.1.6
+      '@rspack/binding-darwin-x64': 2.1.6
+      '@rspack/binding-linux-arm64-gnu': 2.1.6
+      '@rspack/binding-linux-arm64-musl': 2.1.6
+      '@rspack/binding-linux-riscv64-gnu': 2.1.6
+      '@rspack/binding-linux-riscv64-musl': 2.1.6
+      '@rspack/binding-linux-x64-gnu': 2.1.6
+      '@rspack/binding-linux-x64-musl': 2.1.6
+      '@rspack/binding-wasm32-wasi': 2.1.6
+      '@rspack/binding-win32-arm64-msvc': 2.1.6
+      '@rspack/binding-win32-ia32-msvc': 2.1.6
+      '@rspack/binding-win32-x64-msvc': 2.1.6
 
-  '@rspack/core@2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
+  '@rspack/core@2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': 2.1.7
+      '@rspack/binding': 2.1.6
     optionalDependencies:
       '@module-federation/runtime-tools': 2.8.1
       '@swc/helpers': 0.5.23
 
   '@rspack/lite-tapable@1.1.2': {}
 
-  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.7)':
+  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.6)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.7)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.6)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
+  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)
       '@rspress/shared': 2.0.19(@module-federation/runtime-tools@2.8.1)(supports-color@9.4.0)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -9586,7 +9589,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
@@ -9597,7 +9600,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.19(@rspress/core@2.0.19)(supports-color@9.4.0)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       remark-mdx: 3.1.1(supports-color@9.4.0)
       remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
@@ -9608,17 +9611,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rspress/plugin-twoslash@2.0.19(@rspress/core@2.0.19)(react@19.2.8)(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@shikijs/twoslash': 4.3.0(supports-color@9.4.0)(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-gfm: 3.1.0(supports-color@9.4.0)
@@ -9644,7 +9647,7 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.7(@rspress/core@2.0.19)':
     optionalDependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rstest/adapter-rslib@0.11.5(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.5)(typescript@7.0.2)':
     dependencies:
@@ -10019,14 +10022,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.7)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.6)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10550,12 +10553,12 @@ snapshots:
 
   b-validate@1.5.3: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.7):
+  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.6):
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       find-up: 5.0.0
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
     dependencies:
@@ -12012,11 +12015,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@rspack/core@2.1.7)(less@4.6.7):
+  less-loader@12.3.3(@rspack/core@2.1.6)(less@4.6.7):
     dependencies:
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   less@4.6.7:
     dependencies:
@@ -13627,18 +13630,18 @@ snapshots:
 
   rslog@2.3.0: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40):
+  rspack-vue-loader@17.5.1(@rspack/core@2.1.6)(@vue/compiler-sfc@3.5.40)(vue@3.5.40):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
       '@vue/compiler-sfc': 3.5.40
       vue: 3.5.40(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.19)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
@@ -13663,14 +13666,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.19)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.19)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.19):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.6)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   run-applescript@7.1.0: {}
 
@@ -14003,14 +14006,14 @@ snapshots:
     dependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3):
     dependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)
+      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14039,7 +14042,7 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
@@ -14053,7 +14056,7 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
       storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14068,12 +14071,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40):
+  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40):
     dependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@storybook/vue3': 10.5.5(storybook@10.5.5)(vue@3.5.40)
       storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.6)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
       vue: 3.5.40(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.40)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -14195,13 +14198,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.1.7)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.1.6)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0(supports-color@9.4.0)
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   stylus@0.64.0(supports-color@9.4.0):
     dependencies:
@@ -14315,7 +14318,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.7)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.6)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
@@ -14323,7 +14326,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.6(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   ts-dedent@2.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,7 +314,7 @@ catalogs:
       version: 6.0.2
 
 overrides:
-  '@rspack/core': npm:@rspack-canary/core@2.1.8-canary-4b189917-20260802173728
+  '@rspack/core': 2.1.8
 
 importers:
 
@@ -388,13 +388,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -409,19 +409,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 'catalog:'
-        version: 2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/storybook-addon':
         specifier: 'catalog:'
-        version: 6.0.17(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)
+        version: 6.0.17(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -448,13 +448,13 @@ importers:
         version: 19.2.8(react@19.2.8)
       storybook:
         specifier: 'catalog:'
-        version: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+        version: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
         version: 3.3.4(@rsbuild/core@2.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -470,13 +470,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -491,7 +491,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: 'catalog:'
-        version: 2.0.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(preact@10.29.8)
+        version: 2.0.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(preact@10.29.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -506,7 +506,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -524,7 +524,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -542,7 +542,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -560,7 +560,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(supports-color@9.4.0)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -581,7 +581,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -602,7 +602,7 @@ importers:
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -617,13 +617,13 @@ importers:
         version: 10.5.5(storybook@10.5.5)(vue@3.5.40)
       storybook:
         specifier: 'catalog:'
-        version: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+        version: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
         version: 3.3.4(@rsbuild/core@2.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40)
+        version: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -645,7 +645,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -773,7 +773,7 @@ importers:
         version: 4.0.1(debug@4.4.3)(supports-color@9.4.0)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
@@ -782,10 +782,10 @@ importers:
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -797,7 +797,7 @@ importers:
         version: 1.2.4(@rsbuild/core@2.1.9)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rsbuild/plugin-yaml':
         specifier: 'catalog:'
         version: 2.0.0(@rsbuild/core@2.1.9)
@@ -877,7 +877,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
 
   tests/integration/asset/json: {}
 
@@ -897,10 +897,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -985,10 +985,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/cli/build: {}
 
@@ -1366,7 +1366,7 @@ importers:
         version: 8.0.1
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(supports-color@9.4.0)
       babel-plugin-polyfill-corejs3:
         specifier: 'catalog:'
         version: 1.0.0(@babel/core@8.0.1)
@@ -1379,7 +1379,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1520,19 +1520,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(supports-color@9.4.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(supports-color@9.4.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1541,7 +1541,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1589,10 +1589,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       vue:
         specifier: 'catalog:'
         version: 3.5.40(typescript@7.0.2)
@@ -1627,13 +1627,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
         version: 2.0.1(@rsbuild/core@2.1.9)
@@ -1645,7 +1645,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 'catalog:'
-        version: 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+        version: 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@rspress/plugin-algolia':
         specifier: 'catalog:'
         version: 2.0.19(@rspress/core@2.0.19)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
@@ -2107,14 +2107,14 @@ packages:
       search-insights:
         optional: true
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -2122,8 +2122,8 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -2521,6 +2521,7 @@ packages:
   '@module-federation/rspack@2.8.1':
     resolution: {integrity: sha512-jJYkARn1U1M92CbiLyoaP7+tNKh8YzzOTMSGzbdj6okTtWK0Z9ImyVoKEnAnjnLP1nbQjkPEaojkR2D2IQFhLw==}
     peerDependencies:
+      '@rspack/core': 2.1.8
       typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
       vue-tsc: '>=1.0.24'
     peerDependenciesMeta:
@@ -3174,76 +3175,76 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack-canary/binding-darwin-arm64@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-F8B3STugLaEVkNGM0KBsBckF0uWXh2oXiwotHSqRjOAssiJZ0bWrshH9qDscu6ct6yd9g3VEjVAeDKqkQDeQ0A==}
+  '@rspack/binding-darwin-arm64@2.1.8':
+    resolution: {integrity: sha512-kia+eWtyWPvR4ntg1bWYoVU8nLPbUg2fG3zgBEocsTcsh5ZENSiEPxEKymDgMyIMONUqj611E0775cdUBoNmqw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack-canary/binding-darwin-x64@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-bNq1EcEAjckDHwmwuqOEf77Pt9BX4qZ3GLkwQXQIbCVbMlOUacVLR7EXzp4V2cUSxonAYw4UZvvYvQ8iIUvdVQ==}
+  '@rspack/binding-darwin-x64@2.1.8':
+    resolution: {integrity: sha512-08pBkFhlD3Y3Qzh94w/Fc3skaIE3e96kl2P14m8+tnYTcglpOfpA2OwS3iHt9fOqy0HjoAVe6/MW3cBgs5iabA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack-canary/binding-linux-arm64-gnu@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-1O/sFau+348KTFmOFhArwkWTjlpK2QHtMRxOHV/oySuRQo0wQ+j7yQgZDPgytClkTR473kx1fxZCgOXP2JDMrw==}
+  '@rspack/binding-linux-arm64-gnu@2.1.8':
+    resolution: {integrity: sha512-KLniMc9GzhKpVqhPzaJo3KJwzdAllXVVqZIk/uL1QipXOxs57fgM4u7IexKPFVla0o/u1PQG/Ah2YLDmda24Ow==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack-canary/binding-linux-arm64-musl@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-+oWoAvWp3SUE6CTVCf1GIlQ5uWGYKYEGSR+3HsNZLPe+R0XEWJ/90t1qw72tNXvj3jbkKfhAtxz8zoBtO4sdSw==}
+  '@rspack/binding-linux-arm64-musl@2.1.8':
+    resolution: {integrity: sha512-yUKAxHNGnICtw5RnxFWu4dHtsz/tdt7rbeFcsINNVre9HcrRxf5XP+FbOGL/SMxd9oM9XCo10paU2WckTKwbEA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack-canary/binding-linux-riscv64-gnu@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-ywFtjKzmYIcD0rRj5qTwC3OMS4wsuQBBWLn1Unhjd01NwW1jlLiRC2m6810WCcyvauLmavU+eueAx2u7UJb96A==}
+  '@rspack/binding-linux-riscv64-gnu@2.1.8':
+    resolution: {integrity: sha512-gg4S1jaitwYPHR9HZ3zNGH1EK2GXINm66p4kEpOP1gbc+akyOouVF/dMcu9NGPlRg58FbEhVRZYKu7Z/zcpKHg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack-canary/binding-linux-riscv64-musl@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-jy4DzRvOHYUxmgXp5WhD/lKOxtpBgu9kgTb9R/qxB3lz1BBcVZ6h0epGif2BrriZn0VJG39RijQSGqvkm2GLyQ==}
+  '@rspack/binding-linux-riscv64-musl@2.1.8':
+    resolution: {integrity: sha512-b/aU5j1h368SLNyz5u+flqpZVhzSZ1UIslaj9sZJuAvqkGWv3xsjc/28/PTo/RYXCxd0FNVAxTxWHKvRiAAS8w==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack-canary/binding-linux-x64-gnu@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-hLVpmOQyiUcMESf3mPdxR9GUadGnpI0sCLO9/jc1LEotM/GdHSCxEgWVvcLkV7QAmCD5n9Cf5dhZeh/mxc7wVQ==}
+  '@rspack/binding-linux-x64-gnu@2.1.8':
+    resolution: {integrity: sha512-EyegohSx0BJRqieCg9f/caCqFARRWkqI5hwJt6k530MoOTLeq8I3vsbeg24/2MktwIC1dmJi8bl0+WhPKQs4eQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack-canary/binding-linux-x64-musl@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-keYKyplNmWUHCOFmm/6/4poYTvwU7TdHCZQTpNAA0pPEMuwP3pbJj0Cp3RwPji3o1ZCVmGzdknip3A0EwKadgw==}
+  '@rspack/binding-linux-x64-musl@2.1.8':
+    resolution: {integrity: sha512-I6E+goN+UQ297q4r1qdbiAyNCI3t0+a5Y0xDIAPOZfRDRxDTnH/LF8/y65gjsJoKRKyn7zxRC0T/NURTkRNQ9A==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack-canary/binding-wasm32-wasi@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-p6lv6rsdyd5feI7rJ8Y2hmkC6geudCRBT4mIksrFbtH+tEt9HnoagsTZN0zHwg+lTERO8g5DKPqNq8DkcXC+JA==}
+  '@rspack/binding-wasm32-wasi@2.1.8':
+    resolution: {integrity: sha512-om7GAKWAU3lcSvbCon2m7mzw8v9OTrO2LW2MZ1lGe/uVJJmwGGkl9HVoXFyWFLrN6YVFyx8iP+AkN4owDWB9Cw==}
     cpu: [wasm32]
 
-  '@rspack-canary/binding-win32-arm64-msvc@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-h/b3DVdNEv5IWaT+kOxD+5g7vU+3LHoyAwSBaEdXYeFKrcT7T+esh9QQ5A4vM1XJiMUZ0SEnc0WRdZC2DC166g==}
+  '@rspack/binding-win32-arm64-msvc@2.1.8':
+    resolution: {integrity: sha512-WDnsP/SUb9zbxyGX9XjPw5AXrX86u5oidn0MDdfJduOOqdCSpHwmRjlQ8NUJhbBq9WqVJMFlcab7NwZVWX/yyg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack-canary/binding-win32-ia32-msvc@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-m+ynglM4twiq6z4PVRb/fE6RO7mn2PXxQFPLDAhZUG1CczrsmntfpJFfGCkOVaw8ccW0Jy32bjWULDMBaVdMJQ==}
+  '@rspack/binding-win32-ia32-msvc@2.1.8':
+    resolution: {integrity: sha512-QiMQMPNDiY3dhhaIdaFPzcPDC06cEYkNY89ea+EmDvNVgZq6V+2mFS/WnzZVMeEbGAYJCjsv/ABhhLT1hlYMvg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack-canary/binding-win32-x64-msvc@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-tC5jpDzIzBlgidZ7niGVvI4AJyXKlukvs8ZAS11F5Xe+Fbp6M93aLxs8DqX/xqtYKfNLPz/kcKG3CjyEFetMUQ==}
+  '@rspack/binding-win32-x64-msvc@2.1.8':
+    resolution: {integrity: sha512-b7sA5eB64vo2mbsuc//MOYzVLeCKHPn0dfP/GmNEoHdWbhRgZ/orZLWurYMQj04ELTLW6YCJEy59g5KRzNYHfw==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack-canary/binding@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-TaMdQ5h841ekagcm3DGp6gZ9oMH4znxKNmje1gRm7Pu6Jgd50FfcTmbgD8RR0VYAoZEyAao1mMqi8mym9rVqgQ==}
+  '@rspack/binding@2.1.8':
+    resolution: {integrity: sha512-tmAyHzDbPiy8V7HvQqtuPsbs6dPgwV0YjzW5XrPRV9gzf+Hdm7pvsZJKE1QKO9WV5RuvGYav98xIX6O+abZxzQ==}
 
-  '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728':
-    resolution: {integrity: sha512-K9Vdd2JFxdoy+PgJ2MjBY68Vn2RgsEw7vdlm3Cqa2XzyT6mHsswNYMYONGOS/16INgKWGGgfH4muoaCVVqLobQ==}
+  '@rspack/core@2.1.8':
+    resolution: {integrity: sha512-na1kyA6Mj8/LWw9O3A8NsrG9rNKN3Iq2WiXrEuIwsU5r/Nl/evm3hO7bWKHxgsRyydI6W7okwx3MXgf8rzel6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -3262,11 +3263,19 @@ packages:
     peerDependencies:
       '@prefresh/core': ^1.5.0
       '@prefresh/utils': ^1.2.0
+      '@rspack/core': 2.1.8
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
 
   '@rspack/plugin-react-refresh@2.0.2':
     resolution: {integrity: sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==}
     peerDependencies:
+      '@rspack/core': 2.1.8
       react-refresh: '>=0.10.0 <1.0.0'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
 
   '@rspress/core@2.0.19':
     resolution: {integrity: sha512-m0KfQNNXxjP975652nIOwUTqrvbJapRp4NpnoQMc5heawGhkC4+F7zTHvxY+huvzGYnKtL2fMMTrgWhEjKkrug==}
@@ -3693,8 +3702,11 @@ packages:
   '@tailwindcss/webpack@4.3.1':
     resolution: {integrity: sha512-HM33EjYPbkMlBGcYoVA/pk/hML3wAn2JOnjF79eDWVLuktOhRczDwWsSBQBOWV6LLBVAgGZS/pZ519OHUF8vKg==}
     peerDependencies:
+      '@rspack/core': 2.1.8
       webpack: ^5.0.0
     peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
       webpack:
         optional: true
 
@@ -4215,8 +4227,11 @@ packages:
     engines: {node: ^18.20.0 || ^20.10.0 || >=22.0.0}
     peerDependencies:
       '@babel/core': ^7.12.0 || ^8.0.0-beta.1
+      '@rspack/core': 2.1.8
       webpack: '>=5.61.0'
     peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
       webpack:
         optional: true
 
@@ -5533,9 +5548,12 @@ packages:
     resolution: {integrity: sha512-F0+ErFFDj3Pt+nVrCN6VlEGEzocv9s7x/aR9v2riI+WM83UAfTYBDBjGPJnT55lBLR6JSI4fmWblt+aA2JN6/w==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
+      '@rspack/core': 2.1.8
       less: ^3.5.0 || ^4.0.0
       webpack: ^5.0.0
     peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
       webpack:
         optional: true
 
@@ -6774,9 +6792,12 @@ packages:
   rspack-vue-loader@17.5.1:
     resolution: {integrity: sha512-1pXdeqYM95P0T8DO2ZcOCBnfMp62W5IG2c0RICn1rFYjHcja41IYSQLzcdc1uePEq0n4JZwvfR2lVs8wRZuwzA==}
     peerDependencies:
+      '@rspack/core': 2.1.8
       '@vue/compiler-sfc': '*'
       vue: '*'
     peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
       '@vue/compiler-sfc':
         optional: true
       vue:
@@ -7255,9 +7276,12 @@ packages:
     resolution: {integrity: sha512-Rxf+ybxW+wH9/fY2Qlaae/u/PrAck3I3LKXXZQq5XaxVGp1nNm/Z76vHSdhjXltyLETs+42lpQcA4SBY2DWswg==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
+      '@rspack/core': 2.1.8
       stylus: '>=0.52.4'
       webpack: ^5.0.0
     peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
       webpack:
         optional: true
 
@@ -7398,9 +7422,12 @@ packages:
   ts-checker-rspack-plugin@1.4.0:
     resolution: {integrity: sha512-xPBPe6n9XZW9vMw4PFJLZFY372rejKK8UFC12i33J+yJK+fmsQQ4k9eoOlbLE0zC6vftyKDhvfMF3RyMFFTOZw==}
     peerDependencies:
+      '@rspack/core': 2.1.8
       '@typescript/native-preview': ^7.0.0-0
       typescript: '>=3.8.0'
     peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
       '@typescript/native-preview':
         optional: true
 
@@ -8312,9 +8339,9 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -8324,7 +8351,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8339,7 +8366,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.2':
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8726,7 +8753,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/cli': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
@@ -8735,7 +8762,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.1(@module-federation/runtime-tools@2.8.1)
       '@module-federation/managers': 2.8.1
       '@module-federation/manifest': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
-      '@module-federation/rspack': 2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
       '@module-federation/webpack-bundler-runtime': 2.8.1
@@ -8745,11 +8772,11 @@ snapshots:
       typescript: 6.0.3
       vue-tsc: 3.3.9(typescript@6.0.3)
     transitivePeerDependencies:
-      - '@swc/helpers'
+      - '@rspack/core'
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/cli': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
@@ -8758,7 +8785,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.1(@module-federation/runtime-tools@2.8.1)
       '@module-federation/managers': 2.8.1
       '@module-federation/manifest': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/rspack': 2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
       '@module-federation/webpack-bundler-runtime': 2.8.1
@@ -8768,7 +8795,7 @@ snapshots:
       typescript: 7.0.2
       vue-tsc: 3.3.9(typescript@7.0.2)
     transitivePeerDependencies:
-      - '@swc/helpers'
+      - '@rspack/core'
       - bufferutil
       - utf-8-validate
 
@@ -8804,97 +8831,67 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.48(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.48(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime': 2.8.1
       '@module-federation/sdk': 2.8.1
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
       tapable: 2.3.0
     transitivePeerDependencies:
-      - '@swc/helpers'
+      - '@rspack/core'
       - bufferutil
       - typescript
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.48(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.48(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime': 2.8.1
       '@module-federation/sdk': 2.8.1
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
       tapable: 2.3.0
     transitivePeerDependencies:
-      - '@swc/helpers'
+      - '@rspack/core'
       - bufferutil
       - typescript
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.48(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/runtime': 2.8.1
-      '@module-federation/sdk': 2.8.1
-      encoding: 0.1.13
-      node-fetch: 2.7.0(encoding@0.1.13)
-      tapable: 2.3.0
-    transitivePeerDependencies:
-      - '@swc/helpers'
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-
-  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)':
-    dependencies:
-      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.48(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.48(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@swc/helpers'
+      - '@rspack/core'
       - bufferutil
       - typescript
       - utf-8-validate
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.48(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.48(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@swc/helpers'
+      - '@rspack/core'
       - bufferutil
       - typescript
       - utf-8-validate
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)':
-    dependencies:
-      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.48(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/sdk': 2.8.1
-    optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-      - webpack
-
-  '@module-federation/rspack@2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/rspack@2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/dts-plugin': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
@@ -8903,16 +8900,15 @@ snapshots:
       '@module-federation/manifest': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.9(typescript@6.0.3)
     transitivePeerDependencies:
-      - '@swc/helpers'
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rspack@2.8.1(@swc/helpers@0.5.23)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rspack@2.8.1(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/dts-plugin': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
@@ -8921,12 +8917,11 @@ snapshots:
       '@module-federation/manifest': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 7.0.2
       vue-tsc: 3.3.9(typescript@7.0.2)
     transitivePeerDependencies:
-      - '@swc/helpers'
       - bufferutil
       - utf-8-validate
 
@@ -8948,16 +8943,16 @@ snapshots:
 
   '@module-federation/sdk@2.8.1': {}
 
-  '@module-federation/storybook-addon@6.0.17(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.17(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@swc/helpers@0.5.23)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
-      - '@swc/helpers'
+      - '@rspack/core'
       - bufferutil
       - typescript
       - utf-8-validate
@@ -8971,10 +8966,10 @@ snapshots:
       '@module-federation/runtime': 2.8.1
       '@module-federation/sdk': 2.8.1
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -9111,9 +9106,9 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9225,7 +9220,7 @@ snapshots:
 
   '@rsbuild/core@2.1.9(@module-federation/runtime-tools@2.8.1)':
     dependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -9243,34 +9238,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)':
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7)(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.8)
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-less@2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(less@4.6.7)
+      less-loader: 12.3.3(@rspack/core@2.1.8)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - webpack
 
   '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.9)':
@@ -9301,28 +9294,26 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-preact@2.0.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(preact@10.29.8)':
+  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(preact@10.29.8)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 2.0.1(@module-federation/runtime-tools@2.8.1)(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@swc/helpers@0.5.23)
+      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.8)
       '@swc/plugin-prefresh': 12.12.0
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - preact
 
-  '@rsbuild/plugin-react@2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.8)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
 
   '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.9)':
     dependencies:
@@ -9346,22 +9337,21 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)':
+  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(supports-color@9.4.0)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0(supports-color@9.4.0)
-      stylus-loader: 8.1.3(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.1.8)(stylus@0.64.0)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.5(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(supports-color@9.4.0)(typescript@7.0.2)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(supports-color@9.4.0)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@svgr/core': 8.1.0(supports-color@9.4.0)(typescript@7.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)(supports-color@9.4.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)
@@ -9370,19 +9360,17 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.8)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - webpack
 
   '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.9)':
@@ -9391,31 +9379,29 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-type-check@1.4.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.4.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.8)(typescript@6.0.3)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - typescript
 
   '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.9)':
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-vue@2.0.1(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
     optionalDependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
@@ -9474,93 +9460,89 @@ snapshots:
   '@rslint/native-win32-x64-msvc@0.7.2':
     optional: true
 
-  '@rspack-canary/binding-darwin-arm64@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-darwin-arm64@2.1.8':
     optional: true
 
-  '@rspack-canary/binding-darwin-x64@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-darwin-x64@2.1.8':
     optional: true
 
-  '@rspack-canary/binding-linux-arm64-gnu@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-linux-arm64-gnu@2.1.8':
     optional: true
 
-  '@rspack-canary/binding-linux-arm64-musl@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-linux-arm64-musl@2.1.8':
     optional: true
 
-  '@rspack-canary/binding-linux-riscv64-gnu@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-linux-riscv64-gnu@2.1.8':
     optional: true
 
-  '@rspack-canary/binding-linux-riscv64-musl@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-linux-riscv64-musl@2.1.8':
     optional: true
 
-  '@rspack-canary/binding-linux-x64-gnu@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-linux-x64-gnu@2.1.8':
     optional: true
 
-  '@rspack-canary/binding-linux-x64-musl@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-linux-x64-musl@2.1.8':
     optional: true
 
-  '@rspack-canary/binding-wasm32-wasi@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-wasm32-wasi@2.1.8':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@rspack-canary/binding-win32-arm64-msvc@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-win32-arm64-msvc@2.1.8':
     optional: true
 
-  '@rspack-canary/binding-win32-ia32-msvc@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-win32-ia32-msvc@2.1.8':
     optional: true
 
-  '@rspack-canary/binding-win32-x64-msvc@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding-win32-x64-msvc@2.1.8':
     optional: true
 
-  '@rspack-canary/binding@2.1.8-canary-4b189917-20260802173728':
+  '@rspack/binding@2.1.8':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': '@rspack-canary/binding-darwin-arm64@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-darwin-x64': '@rspack-canary/binding-darwin-x64@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-linux-arm64-gnu': '@rspack-canary/binding-linux-arm64-gnu@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-linux-arm64-musl': '@rspack-canary/binding-linux-arm64-musl@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-linux-riscv64-gnu': '@rspack-canary/binding-linux-riscv64-gnu@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-linux-riscv64-musl': '@rspack-canary/binding-linux-riscv64-musl@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-linux-x64-gnu': '@rspack-canary/binding-linux-x64-gnu@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-linux-x64-musl': '@rspack-canary/binding-linux-x64-musl@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-wasm32-wasi': '@rspack-canary/binding-wasm32-wasi@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-win32-arm64-msvc': '@rspack-canary/binding-win32-arm64-msvc@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-win32-ia32-msvc': '@rspack-canary/binding-win32-ia32-msvc@2.1.8-canary-4b189917-20260802173728'
-      '@rspack/binding-win32-x64-msvc': '@rspack-canary/binding-win32-x64-msvc@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding-darwin-arm64': 2.1.8
+      '@rspack/binding-darwin-x64': 2.1.8
+      '@rspack/binding-linux-arm64-gnu': 2.1.8
+      '@rspack/binding-linux-arm64-musl': 2.1.8
+      '@rspack/binding-linux-riscv64-gnu': 2.1.8
+      '@rspack/binding-linux-riscv64-musl': 2.1.8
+      '@rspack/binding-linux-x64-gnu': 2.1.8
+      '@rspack/binding-linux-x64-musl': 2.1.8
+      '@rspack/binding-wasm32-wasi': 2.1.8
+      '@rspack/binding-win32-arm64-msvc': 2.1.8
+      '@rspack/binding-win32-ia32-msvc': 2.1.8
+      '@rspack/binding-win32-x64-msvc': 2.1.8
 
-  '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
+  '@rspack/core@2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': '@rspack-canary/binding@2.1.8-canary-4b189917-20260802173728'
+      '@rspack/binding': 2.1.8
     optionalDependencies:
       '@module-federation/runtime-tools': 2.8.1
       '@swc/helpers': 0.5.23
 
   '@rspack/lite-tapable@1.1.2': {}
 
-  '@rspack/plugin-preact-refresh@2.0.1(@module-federation/runtime-tools@2.8.1)(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@swc/helpers@0.5.23)':
+  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.8)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+    optionalDependencies:
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.8)(react-refresh@0.18.0)':
     dependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       react-refresh: 0.18.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+    optionalDependencies:
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
+  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      '@rsbuild/plugin-react': 2.1.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)
       '@rspress/shared': 2.0.19(@module-federation/runtime-tools@2.8.1)(supports-color@9.4.0)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -9597,7 +9579,7 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - core-js
       - micromark
       - micromark-util-types
@@ -9607,7 +9589,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
@@ -9618,7 +9600,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.19(@rspress/core@2.0.19)(supports-color@9.4.0)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       remark-mdx: 3.1.1(supports-color@9.4.0)
       remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
@@ -9629,17 +9611,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rspress/plugin-twoslash@2.0.19(@rspress/core@2.0.19)(react@19.2.8)(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@shikijs/twoslash': 4.3.0(supports-color@9.4.0)(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-gfm: 3.1.0(supports-color@9.4.0)
@@ -9665,7 +9647,7 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.7(@rspress/core@2.0.19)':
     optionalDependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rstest/adapter-rslib@0.11.5(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.5)(typescript@7.0.2)':
     dependencies:
@@ -9815,7 +9797,7 @@ snapshots:
       '@storybook/react-dom-shim': 10.5.5(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       ts-dedent: 2.3.0
     optionalDependencies:
       '@types/react': 19.2.18
@@ -9828,11 +9810,11 @@ snapshots:
 
   '@storybook/addon-onboarding@10.5.5(storybook@10.5.5)':
     dependencies:
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
 
   '@storybook/csf-plugin@10.5.5(esbuild@0.28.1)(storybook@10.5.5)':
     dependencies:
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
@@ -9861,7 +9843,7 @@ snapshots:
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
@@ -9874,7 +9856,7 @@ snapshots:
       react-docgen: 8.0.3(supports-color@9.4.0)
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.8(react@19.2.8)
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
@@ -9885,7 +9867,7 @@ snapshots:
   '@storybook/vue3@10.5.5(storybook@10.5.5)(vue@3.5.40)':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       type-fest: 5.7.0
       vue: 3.5.40(typescript@6.0.3)
       vue-component-type-helpers: 3.3.1
@@ -10040,16 +10022,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.8)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+    optionalDependencies:
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10573,14 +10553,12 @@ snapshots:
 
   b-validate@1.5.3: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23):
+  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.8):
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       find-up: 5.0.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+    optionalDependencies:
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
     dependencies:
@@ -12037,13 +12015,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(less@4.6.7):
+  less-loader@12.3.3(@rspack/core@2.1.8)(less@4.6.7):
     dependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       less: 4.6.7
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+    optionalDependencies:
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   less@4.6.7:
     dependencies:
@@ -12914,7 +12890,7 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
       '@oxc-parser/binding-win32-x64-msvc': 0.127.0
 
-  oxc-resolver@11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
+  oxc-resolver@11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -12932,7 +12908,7 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
@@ -13654,21 +13630,18 @@ snapshots:
 
   rslog@2.3.0: {}
 
-  rspack-vue-loader@17.5.1(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(@vue/compiler-sfc@3.5.40)(vue@3.5.40):
+  rspack-vue-loader@17.5.1(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40):
     dependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
       '@vue/compiler-sfc': 3.5.40
       vue: 3.5.40(typescript@6.0.3)
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.19)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
@@ -13693,14 +13666,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.19)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.19)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.19):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   run-applescript@7.1.0: {}
 
@@ -14033,14 +14006,14 @@ snapshots:
     dependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3):
     dependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      '@rsbuild/plugin-type-check': 1.4.0(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(typescript@6.0.3)
+      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14054,7 +14027,7 @@ snapshots:
       process: 0.11.10
       rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.9)
       sirv: 2.0.4
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       ts-dedent: 2.3.0
       url: 0.11.4
       util: 0.12.5
@@ -14064,13 +14037,12 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       typescript: 6.0.3
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - '@typescript/native-preview'
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
@@ -14083,14 +14055,13 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - '@types/react'
       - '@types/react-dom'
       - '@typescript/native-preview'
@@ -14100,19 +14071,18 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40):
+  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40):
     dependencies:
       '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
       '@storybook/vue3': 10.5.5(storybook@10.5.5)(vue@3.5.40)
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.3.4(@module-federation/runtime-tools@2.8.1)(@rsbuild/core@2.1.9)(@swc/helpers@0.5.23)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
       vue: 3.5.40(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.40)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
     transitivePeerDependencies:
       - '@babel/preset-env'
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+      - '@rspack/core'
       - '@typescript/native-preview'
       - msw
       - react
@@ -14122,7 +14092,7 @@ snapshots:
       - vite
       - webpack
 
-  storybook@10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8):
+  storybook@10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.8)(react@19.2.8)
@@ -14136,7 +14106,7 @@ snapshots:
       jsonc-parser: 3.3.1
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      oxc-resolver: 11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       recast: 0.23.11
       semver: 7.8.5
       use-sync-external-store: 1.6.0(react@19.2.8)
@@ -14228,15 +14198,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.1.8)(stylus@0.64.0):
     dependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0(supports-color@9.4.0)
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+    optionalDependencies:
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   stylus@0.64.0(supports-color@9.4.0):
     dependencies:
@@ -14350,17 +14318,15 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.4.0(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.8)(typescript@6.0.3):
     dependencies:
-      '@rspack/core': '@rspack-canary/core@2.1.8-canary-4b189917-20260802173728(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)'
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
       memfs: 4.64.0
       picocolors: 1.1.1
       typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@swc/helpers'
+    optionalDependencies:
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   ts-dedent@2.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,9 @@ catalogMode: prefer
 
 cleanupUnusedCatalogs: true
 
+overrides:
+  '@rsbuild/core>@rspack/core': 2.1.6
+
 catalog:
   '@arco-design/web-react': '^2.66.16'
   '@ast-grep/napi': '0.37.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalogMode: prefer
 cleanupUnusedCatalogs: true
 
 overrides:
-  '@rspack/core': 'npm:@rspack-canary/core@2.1.8-canary-4b189917-20260802173728'
+  '@rspack/core': 2.1.8
 
 catalog:
   '@arco-design/web-react': '^2.66.16'
@@ -149,7 +149,6 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - heading-case
-  - '@rspack-canary/*'
 
 # Prevent un-reviewed build scripts
 strictDepBuilds: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalogMode: prefer
 cleanupUnusedCatalogs: true
 
 overrides:
-  '@rsbuild/core>@rspack/core': 2.1.6
+  '@rspack/core': 'npm:@rspack-canary/core@2.1.8-canary-4b189917-20260802173728'
 
 catalog:
   '@arco-design/web-react': '^2.66.16'
@@ -149,6 +149,7 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - heading-case
+  - '@rspack-canary/*'
 
 # Prevent un-reviewed build scripts
 strictDepBuilds: true

--- a/tests/integration/alias/__snapshots__/index.test.ts.snap
+++ b/tests/integration/alias/__snapshots__/index.test.ts.snap
@@ -9,10 +9,10 @@ export { };
 
 exports[`source.alias 2`] = `
 ""use strict";
-var __webpack_exports__ = {};
+var __rspack_exports = {};
 const a = 'hello world';
 console.info(a);
-for(var __rspack_i in __webpack_exports__)exports[__rspack_i] = __webpack_exports__[__rspack_i];
+for(var __rspack_i in __rspack_exports)exports[__rspack_i] = __rspack_exports[__rspack_i];
 Object.defineProperty(exports, '__esModule', {
     value: true
 });
@@ -27,10 +27,10 @@ console.info(a);
 
 exports[`source.alias 4`] = `
 ""use strict";
-var __webpack_exports__ = {};
+var __rspack_exports = {};
 const external_a_cjs_namespaceObject = require("./a.cjs");
 console.info(external_a_cjs_namespaceObject.a);
-for(var __rspack_i in __webpack_exports__)exports[__rspack_i] = __webpack_exports__[__rspack_i];
+for(var __rspack_i in __rspack_exports)exports[__rspack_i] = __rspack_exports[__rspack_i];
 Object.defineProperty(exports, '__esModule', {
     value: true
 });

--- a/tests/integration/asset/__snapshots__/index.test.ts.snap
+++ b/tests/integration/asset/__snapshots__/index.test.ts.snap
@@ -311,18 +311,6 @@ console.log('defaultImport', 'Url', logo);
 
 exports[`use svgr 2`] = `
 ""use strict";
-var __rspack_module_cache = {};
-var __rspack_context = {};
-function __rspack_require(moduleId) {
-    var cachedModule = __rspack_module_cache[moduleId];
-    if (void 0 !== cachedModule) return cachedModule.exports;
-    var module = __rspack_module_cache[moduleId] = {
-        exports: {}
-    };
-    __rspack_modules[moduleId](module, module.exports, __rspack_context);
-    return module.exports;
-}
-__rspack_context.r = __rspack_require;
 var __rspack_exports = {};
 const jsx_runtime_namespaceObject = require("react/jsx-runtime");
 require("react");

--- a/tests/integration/asset/__snapshots__/index.test.ts.snap
+++ b/tests/integration/asset/__snapshots__/index.test.ts.snap
@@ -57,11 +57,11 @@ export { SvgLogo as ReactComponent };
 
 exports[`use svgr > mixedImport: true should contain export { url as default, ReactComponent } 2`] = `
 ""use strict";
-var __webpack_require__ = {};
-(()=>{
-    __webpack_require__.d = (exports1, getters, values)=>{
+var __rspack_context = {};
+(function() {
+    var definePropertyGetters = (exports1, getters, values)=>{
         var define = (defs, kind)=>{
-            for(var key in defs)if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
+            for(var key in defs)if (hasOwnProperty(defs, key) && !hasOwnProperty(exports1, key)) Object.defineProperty(exports1, key, {
                 enumerable: true,
                 [kind]: defs[key]
             });
@@ -69,12 +69,9 @@ var __webpack_require__ = {};
         define(getters, "get");
         define(values, "value");
     };
-})();
-(()=>{
-    __webpack_require__.o = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
-})();
-(()=>{
-    __webpack_require__.r = (exports1)=>{
+    __rspack_context.d = definePropertyGetters;
+    var hasOwnProperty = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
+    var makeNamespaceObject = (exports1)=>{
         if ("u" > typeof Symbol && Symbol.toStringTag) Object.defineProperty(exports1, Symbol.toStringTag, {
             value: 'Module'
         });
@@ -82,10 +79,11 @@ var __webpack_require__ = {};
             value: true
         });
     };
-})();
-var __webpack_exports__ = {};
-__webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
+    __rspack_context.N = makeNamespaceObject;
+}).call(this);
+var __rspack_exports = {};
+__rspack_context.N(__rspack_exports);
+__rspack_context.d(__rspack_exports, {
     ReactComponent: ()=>SvgLogo,
     default: ()=>logo
 });
@@ -113,12 +111,12 @@ const SvgLogo = (props)=>/*#__PURE__*/ (0, jsx_runtime_namespaceObject.jsx)("svg
         })
     });
 const logo = require("../static/svg/logo.svg");
-exports.ReactComponent = __webpack_exports__.ReactComponent;
-exports["default"] = __webpack_exports__["default"];
-for(var __rspack_i in __webpack_exports__)if (-1 === [
+exports.ReactComponent = __rspack_exports.ReactComponent;
+exports["default"] = __rspack_exports["default"];
+for(var __rspack_i in __rspack_exports)if (-1 === [
     "ReactComponent",
     "default"
-].indexOf(__rspack_i)) exports[__rspack_i] = __webpack_exports__[__rspack_i];
+].indexOf(__rspack_i)) exports[__rspack_i] = __rspack_exports[__rspack_i];
 Object.defineProperty(exports, '__esModule', {
     value: true
 });
@@ -156,11 +154,11 @@ export default logo;
 
 exports[`use svgr > should only contain svgr default export 2`] = `
 ""use strict";
-var __webpack_require__ = {};
-(()=>{
-    __webpack_require__.d = (exports1, getters, values)=>{
+var __rspack_context = {};
+(function() {
+    var definePropertyGetters = (exports1, getters, values)=>{
         var define = (defs, kind)=>{
-            for(var key in defs)if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
+            for(var key in defs)if (hasOwnProperty(defs, key) && !hasOwnProperty(exports1, key)) Object.defineProperty(exports1, key, {
                 enumerable: true,
                 [kind]: defs[key]
             });
@@ -168,12 +166,9 @@ var __webpack_require__ = {};
         define(getters, "get");
         define(values, "value");
     };
-})();
-(()=>{
-    __webpack_require__.o = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
-})();
-(()=>{
-    __webpack_require__.r = (exports1)=>{
+    __rspack_context.d = definePropertyGetters;
+    var hasOwnProperty = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
+    var makeNamespaceObject = (exports1)=>{
         if ("u" > typeof Symbol && Symbol.toStringTag) Object.defineProperty(exports1, Symbol.toStringTag, {
             value: 'Module'
         });
@@ -181,10 +176,11 @@ var __webpack_require__ = {};
             value: true
         });
     };
-})();
-var __webpack_exports__ = {};
-__webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
+    __rspack_context.N = makeNamespaceObject;
+}).call(this);
+var __rspack_exports = {};
+__rspack_context.N(__rspack_exports);
+__rspack_context.d(__rspack_exports, {
     default: ()=>logo
 });
 const jsx_runtime_namespaceObject = require("react/jsx-runtime");
@@ -211,10 +207,10 @@ const SvgLogo = (props)=>/*#__PURE__*/ (0, jsx_runtime_namespaceObject.jsx)("svg
         })
     });
 const logo = SvgLogo;
-exports["default"] = __webpack_exports__["default"];
-for(var __rspack_i in __webpack_exports__)if (-1 === [
+exports["default"] = __rspack_exports["default"];
+for(var __rspack_i in __rspack_exports)if (-1 === [
     "default"
-].indexOf(__rspack_i)) exports[__rspack_i] = __webpack_exports__[__rspack_i];
+].indexOf(__rspack_i)) exports[__rspack_i] = __rspack_exports[__rspack_i];
 Object.defineProperty(exports, '__esModule', {
     value: true
 });
@@ -229,26 +225,28 @@ export default logo2_namespaceObject;
 
 exports[`use svgr > should only contain url default export 2`] = `
 ""use strict";
-var __webpack_modules__ = {
+var __rspack_modules = {
     704 (module) {
         module.exports = require("../static/svg/logo2.svg");
     }
 };
-var __webpack_module_cache__ = {};
-function __webpack_require__(moduleId) {
-    var cachedModule = __webpack_module_cache__[moduleId];
+var __rspack_module_cache = {};
+var __rspack_context = {};
+function __rspack_require(moduleId) {
+    var cachedModule = __rspack_module_cache[moduleId];
     if (void 0 !== cachedModule) return cachedModule.exports;
-    var module = __webpack_module_cache__[moduleId] = {
+    var module = __rspack_module_cache[moduleId] = {
         exports: {}
     };
-    __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+    __rspack_modules[moduleId](module, module.exports, __rspack_context);
     return module.exports;
 }
-var __webpack_exports__ = __webpack_require__(704);
-exports["default"] = __webpack_exports__["default"];
-for(var __rspack_i in __webpack_exports__)if (-1 === [
+__rspack_context.r = __rspack_require;
+var __rspack_exports = __rspack_context.r(704);
+exports["default"] = __rspack_exports["default"];
+for(var __rspack_i in __rspack_exports)if (-1 === [
     "default"
-].indexOf(__rspack_i)) exports[__rspack_i] = __webpack_exports__[__rspack_i];
+].indexOf(__rspack_i)) exports[__rspack_i] = __rspack_exports[__rspack_i];
 Object.defineProperty(exports, '__esModule', {
     value: true
 });
@@ -313,7 +311,19 @@ console.log('defaultImport', 'Url', logo);
 
 exports[`use svgr 2`] = `
 ""use strict";
-var __webpack_exports__ = {};
+var __rspack_module_cache = {};
+var __rspack_context = {};
+function __rspack_require(moduleId) {
+    var cachedModule = __rspack_module_cache[moduleId];
+    if (void 0 !== cachedModule) return cachedModule.exports;
+    var module = __rspack_module_cache[moduleId] = {
+        exports: {}
+    };
+    __rspack_modules[moduleId](module, module.exports, __rspack_context);
+    return module.exports;
+}
+__rspack_context.r = __rspack_require;
+var __rspack_exports = {};
 const jsx_runtime_namespaceObject = require("react/jsx-runtime");
 require("react");
 const SvgLogo = (props)=>/*#__PURE__*/ (0, jsx_runtime_namespaceObject.jsx)("svg", {
@@ -365,7 +375,7 @@ const logo_SvgLogo = (props)=>/*#__PURE__*/ (0, jsx_runtime_namespaceObject.jsx)
 const logo = require("./static/svg/logo.svg");
 console.log('namedImport', 'ReactComponent', logo_SvgLogo);
 console.log('defaultImport', 'Url', logo);
-for(var __rspack_i in __webpack_exports__)exports[__rspack_i] = __webpack_exports__[__rspack_i];
+for(var __rspack_i in __rspack_exports)exports[__rspack_i] = __rspack_exports[__rspack_i];
 Object.defineProperty(exports, '__esModule', {
     value: true
 });

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -231,8 +231,7 @@ test('set the assets public path', async () => {
   // esm
   const { content: indexJs } = queryContent(contents.esm0!, /index\.js/);
   expect(indexJs).toMatchInlineSnapshot(`
-    "var publicPath;
-    var publicPath = "/public/path/";
+    "var publicPath = "/public/path/";
     const image_namespaceObject = publicPath + "static/image/image.png";
     const src = image_namespaceObject;
     export default src;

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -62,26 +62,28 @@ test('set the size threshold to inline static assets', async () => {
   );
   expect(logoCjs2).toMatchInlineSnapshot(`
     ""use strict";
-    var __webpack_modules__ = {
+    var __rspack_modules = {
         334 (module) {
             module.exports = require("../static/svg/logo.svg");
         }
     };
-    var __webpack_module_cache__ = {};
-    function __webpack_require__(moduleId) {
-        var cachedModule = __webpack_module_cache__[moduleId];
+    var __rspack_module_cache = {};
+    var __rspack_context = {};
+    function __rspack_require(moduleId) {
+        var cachedModule = __rspack_module_cache[moduleId];
         if (void 0 !== cachedModule) return cachedModule.exports;
-        var module = __webpack_module_cache__[moduleId] = {
+        var module = __rspack_module_cache[moduleId] = {
             exports: {}
         };
-        __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+        __rspack_modules[moduleId](module, module.exports, __rspack_context);
         return module.exports;
     }
-    var __webpack_exports__ = __webpack_require__(334);
-    exports["default"] = __webpack_exports__["default"];
-    for(var __rspack_i in __webpack_exports__)if (-1 === [
+    __rspack_context.r = __rspack_require;
+    var __rspack_exports = __rspack_context.r(334);
+    exports["default"] = __rspack_exports["default"];
+    for(var __rspack_i in __rspack_exports)if (-1 === [
         "default"
-    ].indexOf(__rspack_i)) exports[__rspack_i] = __webpack_exports__[__rspack_i];
+    ].indexOf(__rspack_i)) exports[__rspack_i] = __rspack_exports[__rspack_i];
     Object.defineProperty(exports, '__esModule', {
         value: true
     });
@@ -122,26 +124,28 @@ test('set the assets filename with hash', async () => {
   );
   expect(imageCjs1).toMatchInlineSnapshot(`
     ""use strict";
-    var __webpack_modules__ = {
+    var __rspack_modules = {
         369 (module) {
             module.exports = require("../static/image/image.c74653c171.png");
         }
     };
-    var __webpack_module_cache__ = {};
-    function __webpack_require__(moduleId) {
-        var cachedModule = __webpack_module_cache__[moduleId];
+    var __rspack_module_cache = {};
+    var __rspack_context = {};
+    function __rspack_require(moduleId) {
+        var cachedModule = __rspack_module_cache[moduleId];
         if (void 0 !== cachedModule) return cachedModule.exports;
-        var module = __webpack_module_cache__[moduleId] = {
+        var module = __rspack_module_cache[moduleId] = {
             exports: {}
         };
-        __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+        __rspack_modules[moduleId](module, module.exports, __rspack_context);
         return module.exports;
     }
-    var __webpack_exports__ = __webpack_require__(369);
-    exports["default"] = __webpack_exports__["default"];
-    for(var __rspack_i in __webpack_exports__)if (-1 === [
+    __rspack_context.r = __rspack_require;
+    var __rspack_exports = __rspack_context.r(369);
+    exports["default"] = __rspack_exports["default"];
+    for(var __rspack_i in __rspack_exports)if (-1 === [
         "default"
-    ].indexOf(__rspack_i)) exports[__rspack_i] = __webpack_exports__[__rspack_i];
+    ].indexOf(__rspack_i)) exports[__rspack_i] = __rspack_exports[__rspack_i];
     Object.defineProperty(exports, '__esModule', {
         value: true
     });
@@ -182,26 +186,28 @@ test('set the assets output path', async () => {
   );
   expect(imageCjs1).toMatchInlineSnapshot(`
     ""use strict";
-    var __webpack_modules__ = {
+    var __rspack_modules = {
         369 (module) {
             module.exports = require("../assets/bundleless/image.png");
         }
     };
-    var __webpack_module_cache__ = {};
-    function __webpack_require__(moduleId) {
-        var cachedModule = __webpack_module_cache__[moduleId];
+    var __rspack_module_cache = {};
+    var __rspack_context = {};
+    function __rspack_require(moduleId) {
+        var cachedModule = __rspack_module_cache[moduleId];
         if (void 0 !== cachedModule) return cachedModule.exports;
-        var module = __webpack_module_cache__[moduleId] = {
+        var module = __rspack_module_cache[moduleId] = {
             exports: {}
         };
-        __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+        __rspack_modules[moduleId](module, module.exports, __rspack_context);
         return module.exports;
     }
-    var __webpack_exports__ = __webpack_require__(369);
-    exports["default"] = __webpack_exports__["default"];
-    for(var __rspack_i in __webpack_exports__)if (-1 === [
+    __rspack_context.r = __rspack_require;
+    var __rspack_exports = __rspack_context.r(369);
+    exports["default"] = __rspack_exports["default"];
+    for(var __rspack_i in __rspack_exports)if (-1 === [
         "default"
-    ].indexOf(__rspack_i)) exports[__rspack_i] = __webpack_exports__[__rspack_i];
+    ].indexOf(__rspack_i)) exports[__rspack_i] = __rspack_exports[__rspack_i];
     Object.defineProperty(exports, '__esModule', {
         value: true
     });
@@ -213,23 +219,21 @@ test('set the assets public path', async () => {
   const fixturePath = join(__dirname, 'public-path');
   const { contents } = await buildAndGetResults({ fixturePath });
 
-  // 1. umd should preserve '__webpack_require__.p'
+  // 1. umd should preserve the runtime public path
   const { content: indexUmdJs } = queryContent(contents.umd!, /index\.js/);
 
-  expect(indexUmdJs).toContain('__webpack_require__.p = "/public/path/";');
+  expect(indexUmdJs).toContain('__rspack_context.p = publicPath;');
   expect(indexUmdJs).toContain(
-    'const image_namespaceObject = __webpack_require__.p + "static/image/image.png";',
+    'const image_namespaceObject = __rspack_context.p + "static/image/image.png";',
   );
 
   // 2. bundle
   // esm
   const { content: indexJs } = queryContent(contents.esm0!, /index\.js/);
   expect(indexJs).toMatchInlineSnapshot(`
-    "var __webpack_require__ = {};
-    (()=>{
-        __webpack_require__.p = "/public/path/";
-    })();
-    const image_namespaceObject = __webpack_require__.p + "static/image/image.png";
+    "var publicPath;
+    var publicPath = "/public/path/";
+    const image_namespaceObject = publicPath + "static/image/image.png";
     const src = image_namespaceObject;
     export default src;
     "
@@ -242,8 +246,8 @@ test('set the assets public path', async () => {
     /assets\/image\.js/,
   );
   expect(imageJs).toMatchInlineSnapshot(`
-    "import { __webpack_require__ } from "../rslib-runtime~2.js";
-    const image_namespaceObject = __webpack_require__.p + "static/image/image.png";
+    "import { publicPath } from "../rslib-runtime~2.js";
+    const image_namespaceObject = publicPath + "static/image/image.png";
     export default image_namespaceObject;
     "
   `);

--- a/tests/integration/auto-extension/index.test.ts
+++ b/tests/integration/auto-extension/index.test.ts
@@ -46,7 +46,7 @@ describe('should respect output.filename.js and output.filenameHash to override 
     // override output.filename.js
     expect(extname(entryFiles.esm0!)).toEqual('.mjs');
     expect(entryFiles.cjs0).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename/index.6e60045198.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename/index.7715de4f74.js"`,
     );
 
     // override output.filenameHash
@@ -54,7 +54,7 @@ describe('should respect output.filename.js and output.filenameHash to override 
       `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/esm-override-filename-hash/index.3ac7e0ff07.js"`,
     );
     expect(entryFiles.cjs1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename-hash/index.6e60045198.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-commonjs/config-override/dist/cjs-override-filename-hash/index.7715de4f74.js"`,
     );
 
     // override different file types with function
@@ -89,7 +89,7 @@ describe('should respect output.filename.js and output.filenameHash to override 
       `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/esm-override-filename-hash/index.3ac7e0ff07.js"`,
     );
     expect(entryFiles.cjs1).toMatchInlineSnapshot(
-      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/cjs-override-filename-hash/index.6e60045198.js"`,
+      `"<ROOT>/tests/integration/auto-extension/type-module/config-override/dist/cjs-override-filename-hash/index.7715de4f74.js"`,
     );
 
     // override different file types with function

--- a/tests/integration/bundle-false/__snapshots__/index.test.ts.snap
+++ b/tests/integration/bundle-false/__snapshots__/index.test.ts.snap
@@ -33,11 +33,11 @@ export { SvgLogo as ReactComponent };
 
 exports[`svgr in bundleless 2`] = `
 ""use strict";
-var __webpack_require__ = {};
-(()=>{
-    __webpack_require__.d = (exports1, getters, values)=>{
+var __rspack_context = {};
+(function() {
+    var definePropertyGetters = (exports1, getters, values)=>{
         var define = (defs, kind)=>{
-            for(var key in defs)if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
+            for(var key in defs)if (hasOwnProperty(defs, key) && !hasOwnProperty(exports1, key)) Object.defineProperty(exports1, key, {
                 enumerable: true,
                 [kind]: defs[key]
             });
@@ -45,12 +45,9 @@ var __webpack_require__ = {};
         define(getters, "get");
         define(values, "value");
     };
-})();
-(()=>{
-    __webpack_require__.o = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
-})();
-(()=>{
-    __webpack_require__.r = (exports1)=>{
+    __rspack_context.d = definePropertyGetters;
+    var hasOwnProperty = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
+    var makeNamespaceObject = (exports1)=>{
         if ("u" > typeof Symbol && Symbol.toStringTag) Object.defineProperty(exports1, Symbol.toStringTag, {
             value: 'Module'
         });
@@ -58,10 +55,11 @@ var __webpack_require__ = {};
             value: true
         });
     };
-})();
-var __webpack_exports__ = {};
-__webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
+    __rspack_context.N = makeNamespaceObject;
+}).call(this);
+var __rspack_exports = {};
+__rspack_context.N(__rspack_exports);
+__rspack_context.d(__rspack_exports, {
     ReactComponent: ()=>SvgLogo,
     default: ()=>logo
 });
@@ -89,12 +87,12 @@ const SvgLogo = (props)=>/*#__PURE__*/ (0, jsx_runtime_namespaceObject.jsx)("svg
         })
     });
 const logo = require("../static/svg/logo.svg");
-exports.ReactComponent = __webpack_exports__.ReactComponent;
-exports["default"] = __webpack_exports__["default"];
-for(var __rspack_i in __webpack_exports__)if (-1 === [
+exports.ReactComponent = __rspack_exports.ReactComponent;
+exports["default"] = __rspack_exports["default"];
+for(var __rspack_i in __rspack_exports)if (-1 === [
     "ReactComponent",
     "default"
-].indexOf(__rspack_i)) exports[__rspack_i] = __webpack_exports__[__rspack_i];
+].indexOf(__rspack_i)) exports[__rspack_i] = __rspack_exports[__rspack_i];
 Object.defineProperty(exports, '__esModule', {
     value: true
 });

--- a/tests/integration/bundle-false/index.test.ts
+++ b/tests/integration/bundle-false/index.test.ts
@@ -205,26 +205,28 @@ test('asset in bundleless', async () => {
   `);
   expect(Object.values(contents.cjs)[0]).toMatchInlineSnapshot(`
     ""use strict";
-    var __webpack_modules__ = {
+    var __rspack_modules = {
         "./src/assets/image.png" (module) {
             module.exports = require("../static/image/image.png");
         }
     };
-    var __webpack_module_cache__ = {};
-    function __webpack_require__(moduleId) {
-        var cachedModule = __webpack_module_cache__[moduleId];
+    var __rspack_module_cache = {};
+    var __rspack_context = {};
+    function __rspack_require(moduleId) {
+        var cachedModule = __rspack_module_cache[moduleId];
         if (void 0 !== cachedModule) return cachedModule.exports;
-        var module = __webpack_module_cache__[moduleId] = {
+        var module = __rspack_module_cache[moduleId] = {
             exports: {}
         };
-        __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+        __rspack_modules[moduleId](module, module.exports, __rspack_context);
         return module.exports;
     }
-    var __webpack_exports__ = __webpack_require__("./src/assets/image.png");
-    exports["default"] = __webpack_exports__["default"];
-    for(var __rspack_i in __webpack_exports__)if (-1 === [
+    __rspack_context.r = __rspack_require;
+    var __rspack_exports = __rspack_context.r("./src/assets/image.png");
+    exports["default"] = __rspack_exports["default"];
+    for(var __rspack_i in __rspack_exports)if (-1 === [
         "default"
-    ].indexOf(__rspack_i)) exports[__rspack_i] = __webpack_exports__[__rspack_i];
+    ].indexOf(__rspack_i)) exports[__rspack_i] = __rspack_exports[__rspack_i];
     Object.defineProperty(exports, '__esModule', {
         value: true
     });
@@ -232,26 +234,28 @@ test('asset in bundleless', async () => {
   `);
   expect(Object.values(contents.cjs)[1]).toMatchInlineSnapshot(`
     ""use strict";
-    var __webpack_modules__ = {
+    var __rspack_modules = {
         "./src/assets/logo.svg" (module) {
             module.exports = require("../static/svg/logo.svg");
         }
     };
-    var __webpack_module_cache__ = {};
-    function __webpack_require__(moduleId) {
-        var cachedModule = __webpack_module_cache__[moduleId];
+    var __rspack_module_cache = {};
+    var __rspack_context = {};
+    function __rspack_require(moduleId) {
+        var cachedModule = __rspack_module_cache[moduleId];
         if (void 0 !== cachedModule) return cachedModule.exports;
-        var module = __webpack_module_cache__[moduleId] = {
+        var module = __rspack_module_cache[moduleId] = {
             exports: {}
         };
-        __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+        __rspack_modules[moduleId](module, module.exports, __rspack_context);
         return module.exports;
     }
-    var __webpack_exports__ = __webpack_require__("./src/assets/logo.svg");
-    exports["default"] = __webpack_exports__["default"];
-    for(var __rspack_i in __webpack_exports__)if (-1 === [
+    __rspack_context.r = __rspack_require;
+    var __rspack_exports = __rspack_context.r("./src/assets/logo.svg");
+    exports["default"] = __rspack_exports["default"];
+    for(var __rspack_i in __rspack_exports)if (-1 === [
         "default"
-    ].indexOf(__rspack_i)) exports[__rspack_i] = __webpack_exports__[__rspack_i];
+    ].indexOf(__rspack_i)) exports[__rspack_i] = __rspack_exports[__rspack_i];
     Object.defineProperty(exports, '__esModule', {
         value: true
     });

--- a/tests/integration/extension-alias/__snapshots__/index.test.ts.snap
+++ b/tests/integration/extension-alias/__snapshots__/index.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`resolve.extensionAlias should work 1`] = `
 ""use strict";
-var __webpack_require__ = {};
-(()=>{
-    __webpack_require__.r = (exports1)=>{
+var __rspack_context = {};
+(function() {
+    var makeNamespaceObject = (exports1)=>{
         if ("u" > typeof Symbol && Symbol.toStringTag) Object.defineProperty(exports1, Symbol.toStringTag, {
             value: 'Module'
         });
@@ -12,11 +12,12 @@ var __webpack_require__ = {};
             value: true
         });
     };
-})();
-var __webpack_exports__ = {};
-__webpack_require__.r(__webpack_exports__);
+    __rspack_context.N = makeNamespaceObject;
+}).call(this);
+var __rspack_exports = {};
+__rspack_context.N(__rspack_exports);
 console.log("foobar");
-for(var __rspack_i in __webpack_exports__)exports[__rspack_i] = __webpack_exports__[__rspack_i];
+for(var __rspack_i in __rspack_exports)exports[__rspack_i] = __rspack_exports[__rspack_i];
 Object.defineProperty(exports, '__esModule', {
     value: true
 });

--- a/tests/integration/externals/index.test.ts
+++ b/tests/integration/externals/index.test.ts
@@ -133,7 +133,7 @@ test('modern-module externals should handle CommonJS requests by target', async 
   expect(nodeOutput).toContain('module.exports = __rspack_external_e8;');
   expect(nodeOutput).toContain('"./src/local-false.ts"');
   expect(nodeOutput).toContain(
-    'const localFalse = __webpack_require__("./src/local-false.ts");',
+    'const localFalse = rspackRequire("./src/local-false.ts");',
   );
   expect(nodeOutput).not.toContain('require("./local-false")');
 

--- a/tests/integration/format/index.test.ts
+++ b/tests/integration/format/index.test.ts
@@ -65,11 +65,9 @@ test('import.meta.url should be preserved', async () => {
   `);
   expect(entries.esm).toMatchInlineSnapshot(`
     "import node_url from "node:url";
-    var __webpack_require__ = {};
-    (()=>{
-        __webpack_require__.b = new URL("./", import.meta.url);
-    })();
-    const packageDirectory = node_url.fileURLToPath(new URL('.', __webpack_require__.b));
+    var baseUri;
+    baseUri = new URL("./", import.meta.url);
+    const packageDirectory = node_url.fileURLToPath(new URL('.', baseUri));
     const foo = 'foo';
     export { foo, packageDirectory };
     "

--- a/tests/integration/minify/index.test.ts
+++ b/tests/integration/minify/index.test.ts
@@ -67,7 +67,7 @@ describe('minify config (mf)', () => {
     expect(mfExposeEntry).toBeDefined();
     expect(normalizeMfExposeEntry(mfExposeEntry!)).toMatchInlineSnapshot(`
       "/*! LICENSE: __federation_expose_default_export.<HASH>.js.LICENSE.txt */
-      "use strict";(globalThis["default_minify"]||=[]).push([[525],{<MODULE_ID>(__unused_rspack_module,__webpack_exports__,__webpack_require__){__webpack_require__.r(__webpack_exports__);var react_jsx_runtime__rspack_import_0=__webpack_require__(491);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__rspack_import_0.jsx)("button",{});__webpack_require__.d(__webpack_exports__,{},{Button:Button,foo:foo})}}]);"
+      "use strict";(globalThis["default_minify"]||=[]).push([[525],{<MODULE_ID>(__unused_rspack_module,__rspack_exports,__rspack_context){__rspack_context.N(__rspack_exports);var react_jsx_runtime__rspack_import_0=__rspack_context.r(491);/*! Legal Comment */const foo=()=>{};const Button=()=>/*#__PURE__*/(0,react_jsx_runtime__rspack_import_0.jsx)("button",{});__rspack_context.d(__rspack_exports,{},{Button:Button,foo:foo})}}]);"
     `);
   });
 
@@ -79,10 +79,10 @@ describe('minify config (mf)', () => {
     expect(normalizeMfExposeEntry(mfExposeEntry!)).toMatchInlineSnapshot(`
       ""use strict";
       (globalThis["disable_minify"] ||= []).push([[525], {
-      <MODULE_ID>(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-      __webpack_require__.r(__webpack_exports__);
-      /* import */ var react_jsx_runtime__rspack_import_0 = __webpack_require__(491);
-      /* import */ var react_jsx_runtime__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(react_jsx_runtime__rspack_import_0);
+      <MODULE_ID>(__unused_rspack_module, __rspack_exports, __rspack_context) {
+      __rspack_context.N(__rspack_exports);
+      /* import */ var react_jsx_runtime__rspack_import_0 = __rspack_context.r(491);
+      /* import */ var react_jsx_runtime__rspack_import_0_default = /*#__PURE__*/__rspack_context.n(react_jsx_runtime__rspack_import_0);
       /*! Legal Comment */ 
       const foo = ()=>{};
       const bar = ()=>{};
@@ -92,7 +92,7 @@ describe('minify config (mf)', () => {
       // normal comment
       const Button = ()=>/*#__PURE__*/ (0,react_jsx_runtime__rspack_import_0.jsx)('button', {});
 
-      __webpack_require__.d(__webpack_exports__, {
+      __rspack_context.d(__rspack_exports, {
       }, {
         Button: Button,
         foo: foo

--- a/tests/integration/node-polyfill/index.test.ts
+++ b/tests/integration/node-polyfill/index.test.ts
@@ -6,7 +6,7 @@ test('`Buffer` should be imported from polyfill when bundled', async () => {
   const fixturePath = join(__dirname, './bundle');
   const { entries, entryFiles } = await buildAndGetResults({ fixturePath });
   const bufferRegex =
-    /var [\w$]+ = __webpack_require__\((?:"[^"]+"|\d+)\)\.[\w$]+/g;
+    /var [\w$]+ = (?:rspackRequire|__rspack_context\.r)\((?:"[^"]+"|\d+)\)\.[\w$]+/g;
 
   for (const format of ['esm', 'cjs'] as const) {
     expect(entries[format].match(bufferRegex)?.length).toBe(2);
@@ -27,10 +27,10 @@ test('`Buffer` should be aliased to polyfill packages when bundle is disabled', 
 
   expect(bufferContents).toMatchInlineSnapshot(`
     [
-      "import { __webpack_require__ } from "./rslib-runtime.js";
+      "import { moduleFactories } from "./rslib-runtime.js";
     import { createRequire as __rspack_createRequire } from "node:module";
     const __rspack_createRequire_require = __rspack_createRequire(import.meta.url);
-    __webpack_require__.add({
+    moduleFactories.add({
         181 (module) {
             module.exports = __rspack_createRequire_require("buffer");
         }

--- a/tests/integration/parser-javascript/require/index.test.ts
+++ b/tests/integration/parser-javascript/require/index.test.ts
@@ -18,8 +18,8 @@ test('require.resolve', async () => {
   ];
 
   const esmStatements = [
-    'import { createRequire as external_node_module_createRequire } from "node:module"',
-    'const _require = external_node_module_createRequire(import.meta.url)',
+    'import { createRequire } from "node:module"',
+    'const _require = createRequire(import.meta.url)',
   ];
 
   const cjsStatements = [
@@ -47,8 +47,8 @@ test('require dynamic', async () => {
   ];
 
   const esmStatements = [
-    'import { createRequire as external_node_module_createRequire } from "node:module"',
-    'const _require = external_node_module_createRequire(import.meta.url)',
+    'import { createRequire } from "node:module"',
+    'const _require = createRequire(import.meta.url)',
   ];
 
   const cjsStatements = [

--- a/tests/integration/parser-javascript/require/index.test.ts
+++ b/tests/integration/parser-javascript/require/index.test.ts
@@ -18,8 +18,8 @@ test('require.resolve', async () => {
   ];
 
   const esmStatements = [
-    'import { createRequire } from "node:module"',
-    'const _require = createRequire(import.meta.url)',
+    'import { createRequire as external_node_module_createRequire } from "node:module"',
+    'const _require = external_node_module_createRequire(import.meta.url)',
   ];
 
   const cjsStatements = [
@@ -47,8 +47,8 @@ test('require dynamic', async () => {
   ];
 
   const esmStatements = [
-    'import { createRequire } from "node:module"',
-    'const _require = createRequire(import.meta.url)',
+    'import { createRequire as external_node_module_createRequire } from "node:module"',
+    'const _require = external_node_module_createRequire(import.meta.url)',
   ];
 
   const cjsStatements = [

--- a/tests/integration/preserve-jsx/__snapshots__/index.test.ts.snap
+++ b/tests/integration/preserve-jsx/__snapshots__/index.test.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`JSX syntax should be preserved 1`] = `
 ""use strict";
-var __webpack_require__ = {};
-(()=>{
-    __webpack_require__.d = (exports1, getters, values)=>{
+var __rspack_context = {};
+(function() {
+    var definePropertyGetters = (exports1, getters, values)=>{
         var define = (defs, kind)=>{
-            for(var key in defs)if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports1, key)) Object.defineProperty(exports1, key, {
+            for(var key in defs)if (hasOwnProperty(defs, key) && !hasOwnProperty(exports1, key)) Object.defineProperty(exports1, key, {
                 enumerable: true,
                 [kind]: defs[key]
             });
@@ -14,12 +14,9 @@ var __webpack_require__ = {};
         define(getters, "get");
         define(values, "value");
     };
-})();
-(()=>{
-    __webpack_require__.o = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
-})();
-(()=>{
-    __webpack_require__.r = (exports1)=>{
+    __rspack_context.d = definePropertyGetters;
+    var hasOwnProperty = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
+    var makeNamespaceObject = (exports1)=>{
         if ("u" > typeof Symbol && Symbol.toStringTag) Object.defineProperty(exports1, Symbol.toStringTag, {
             value: 'Module'
         });
@@ -27,10 +24,11 @@ var __webpack_require__ = {};
             value: true
         });
     };
-})();
-var __webpack_exports__ = {};
-__webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
+    __rspack_context.N = makeNamespaceObject;
+}).call(this);
+var __rspack_exports = {};
+__rspack_context.N(__rspack_exports);
+__rspack_context.d(__rspack_exports, {
     default: ()=>Root
 });
 const external_App1_namespaceObject = require("./App1");
@@ -117,10 +115,10 @@ function Root() {
       </div>
     </>;
 }
-exports["default"] = __webpack_exports__["default"];
-for(var __rspack_i in __webpack_exports__)if (-1 === [
+exports["default"] = __rspack_exports["default"];
+for(var __rspack_i in __rspack_exports)if (-1 === [
     "default"
-].indexOf(__rspack_i)) exports[__rspack_i] = __webpack_exports__[__rspack_i];
+].indexOf(__rspack_i)) exports[__rspack_i] = __rspack_exports[__rspack_i];
 Object.defineProperty(exports, '__esModule', {
     value: true
 });

--- a/tests/integration/resolve/index.test.ts
+++ b/tests/integration/resolve/index.test.ts
@@ -20,52 +20,44 @@ test('resolve false', async () => {
 
   expect(isSuccess).toBeTruthy();
   expect(entries.esm).toMatchInlineSnapshot(`
-    "var __webpack_modules__ = {};
-    var __webpack_module_cache__ = {};
-    function __webpack_require__(moduleId) {
-        var cachedModule = __webpack_module_cache__[moduleId];
+    "var modules = {};
+    var moduleCache = {};
+    function rspackRequire(moduleId) {
+        var cachedModule = moduleCache[moduleId];
         if (void 0 !== cachedModule) return cachedModule.exports;
-        var module = __webpack_module_cache__[moduleId] = {
+        var module = moduleCache[moduleId] = {
             exports: {}
         };
-        __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+        modules[moduleId](module, module.exports, rspackRequire);
         return module.exports;
     }
-    __webpack_require__.m = __webpack_modules__;
-    (()=>{
-        __webpack_require__.n = (module)=>{
-            var getter = module && module.__esModule ? ()=>module['default'] : ()=>module;
-            __webpack_require__.d(getter, {
-                a: getter
+    var moduleFactories = modules;
+    var compatGetDefaultExport = (module)=>{
+        var getter = module && module.__esModule ? ()=>module['default'] : ()=>module;
+        definePropertyGetters(getter, {
+            a: getter
+        });
+        return getter;
+    };
+    var definePropertyGetters = (exports, getters, values)=>{
+        var define = (defs, kind)=>{
+            for(var key in defs)if (hasOwnProperty(defs, key) && !hasOwnProperty(exports, key)) Object.defineProperty(exports, key, {
+                enumerable: true,
+                [kind]: defs[key]
             });
-            return getter;
         };
-    })();
-    (()=>{
-        __webpack_require__.d = (exports, getters, values)=>{
-            var define = (defs, kind)=>{
-                for(var key in defs)if (__webpack_require__.o(defs, key) && !__webpack_require__.o(exports, key)) Object.defineProperty(exports, key, {
-                    enumerable: true,
-                    [kind]: defs[key]
-                });
-            };
-            define(getters, "get");
-            define(values, "value");
-        };
-    })();
-    (()=>{
-        __webpack_require__.add = function(modules) {
-            Object.assign(__webpack_require__.m, modules);
-        };
-    })();
-    (()=>{
-        __webpack_require__.o = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
-    })();
-    __webpack_require__.add({
+        define(getters, "get");
+        define(values, "value");
+    };
+    moduleFactories.add = function(modules) {
+        Object.assign(moduleFactories, modules);
+    };
+    var hasOwnProperty = (obj, prop)=>Object.prototype.hasOwnProperty.call(obj, prop);
+    moduleFactories.add({
         237 () {}
     });
-    const util_ignored_ = __webpack_require__("237");
-    var util_ignored__default = /*#__PURE__*/ __webpack_require__.n(util_ignored_);
+    const util_ignored_ = rspackRequire("237");
+    var util_ignored__default = /*#__PURE__*/ compatGetDefaultExport(util_ignored_);
     console.log('foo:', util_ignored__default());
     console.log('bar: ', "bar");
     "

--- a/tests/integration/style/css-modules-named/index.test.ts
+++ b/tests/integration/style/css-modules-named/index.test.ts
@@ -65,12 +65,12 @@ export { _1 as contentWrapper };`,
   expectFileContainContent(
     jsContents.cjs,
     'button/index.module.cjs',
-    `__webpack_require__.d(__webpack_exports__, {
+    `__rspack_context.d(__rspack_exports, {
     contentWrapper: ()=>_1
 });
 require("./index_module.css");
 var _1 = "content-wrapper-iNtwbA";
-exports.contentWrapper = __webpack_exports__.contentWrapper;`,
+exports.contentWrapper = __rspack_exports.contentWrapper;`,
   );
   // cspell:enable
 });

--- a/tests/integration/syntax/index.test.ts
+++ b/tests/integration/syntax/index.test.ts
@@ -25,7 +25,7 @@ test('should downgrade class private method with output.syntax config', async ()
   expect(entries.esm1).toContain('...a');
 
   expect(entries.cjs0).toContain('#bar');
-  expect(entries.cjs0).toContain('()=>{'); // test webpack runtime arrow function
+  expect(entries.cjs0).toContain('(exports1, getters, values)=>{'); // test Rspack runtime arrow function
   expect(entries.cjs1).not.toContain('#bar');
-  expect(entries.cjs1).not.toContain('()=>{'); // test webpack runtime arrow function
+  expect(entries.cjs1).not.toContain('(exports1, getters, values)=>{'); // test Rspack runtime arrow function
 });

--- a/tests/integration/transform-import/index.test.ts
+++ b/tests/integration/transform-import/index.test.ts
@@ -29,7 +29,7 @@ test('transformImport with lodash', async () => {
   for (const format of formats) {
     expect(Object.values(contents[format]!)[0]).toContain(
       format.startsWith('esm')
-        ? 'import get from "lodash/get"'
+        ? 'import lodash_get from "lodash/get"'
         : 'const get_namespaceObject = require("lodash/get")',
     );
     expect(Object.values(contents[format]!)[0]).toContain(

--- a/tests/integration/vue/index.test.ts
+++ b/tests/integration/vue/index.test.ts
@@ -13,8 +13,8 @@ const normalizeVueModuleIds = (contents: Record<string, string>) =>
           '$1<MODULE_ID>',
         )
         .replace(
-          /__webpack_require__\("?\d+"?\)/g,
-          '__webpack_require__("<MODULE_ID>")',
+          /(rspackRequire|__webpack_require__)\("?\d+"?\)/g,
+          '$1("<MODULE_ID>")',
         ),
     ]),
   );
@@ -37,68 +37,66 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
   test('bundle', async () => {
     expect(normalizeVueModuleIds(jsResult.contents.esm1!))
       .toMatchInlineSnapshot(`
-      {
-        "<ROOT>/tests/integration/vue/dist/bundle/index.js": "import { createElementBlock, openBlock, ref, toDisplayString } from "vue";
-      var __webpack_modules__ = {};
-      var __webpack_module_cache__ = {};
-      function __webpack_require__(moduleId) {
-          var cachedModule = __webpack_module_cache__[moduleId];
-          if (void 0 !== cachedModule) return cachedModule.exports;
-          var module = __webpack_module_cache__[moduleId] = {
-              exports: {}
-          };
-          __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-          return module.exports;
-      }
-      __webpack_require__.m = __webpack_modules__;
-      (()=>{
-          __webpack_require__.add = function(modules) {
-              Object.assign(__webpack_require__.m, modules);
-          };
-      })();
-      __webpack_require__.add({
-          <MODULE_ID> (__unused_rspack_module, exports) {
-              exports.A = (sfc, props)=>{
-                  const target = sfc.__vccOpts || sfc;
-                  for (const [key, val] of props)target[key] = val;
-                  return target;
-              };
-          }
-      });
-      const _hoisted_1 = {
-          class: "component button"
-      };
-      const Buttonvue_type_script_setup_true_lang_js = {
-          __name: 'Button',
-          setup (__props) {
-              const button = ref('Button!');
-              return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(button.value), 1));
-          }
-      };
-      const exportHelper = __webpack_require__("<MODULE_ID>");
-      const __exports__ = /*#__PURE__*/ (0, exportHelper.A)(Buttonvue_type_script_setup_true_lang_js, [
-          [
-              '__scopeId',
-              "data-v-1e8aa170"
-          ]
-      ]);
-      const Button = __exports__;
-      const Cardvue_type_script_setup_true_lang_js_hoisted_1 = {
-          class: "component card"
-      };
-      const Cardvue_type_script_setup_true_lang_js = {
-          __name: 'Card',
-          setup (__props) {
-              const card = ref('Card!');
-              return (_ctx, _cache)=>(openBlock(), createElementBlock("p", Cardvue_type_script_setup_true_lang_js_hoisted_1, toDisplayString(card.value), 1));
-          }
-      };
-      const Card_exports_ = Cardvue_type_script_setup_true_lang_js;
-      const Card = Card_exports_;
-      export { Button, Card };
-      ",
-      }
-    `);
+        {
+          "<ROOT>/tests/integration/vue/dist/bundle/index.js": "import { createElementBlock, openBlock, ref, toDisplayString } from "vue";
+        var modules = {};
+        var moduleCache = {};
+        function rspackRequire(moduleId) {
+            var cachedModule = moduleCache[moduleId];
+            if (void 0 !== cachedModule) return cachedModule.exports;
+            var module = moduleCache[moduleId] = {
+                exports: {}
+            };
+            modules[moduleId](module, module.exports, rspackRequire);
+            return module.exports;
+        }
+        var moduleFactories = modules;
+        moduleFactories.add = function(modules) {
+            Object.assign(moduleFactories, modules);
+        };
+        moduleFactories.add({
+            <MODULE_ID> (__unused_rspack_module, exports) {
+                exports.A = (sfc, props)=>{
+                    const target = sfc.__vccOpts || sfc;
+                    for (const [key, val] of props)target[key] = val;
+                    return target;
+                };
+            }
+        });
+        const _hoisted_1 = {
+            class: "component button"
+        };
+        const Buttonvue_type_script_setup_true_lang_js = {
+            __name: 'Button',
+            setup (__props) {
+                const button = ref('Button!');
+                return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(button.value), 1));
+            }
+        };
+        const exportHelper = rspackRequire("<MODULE_ID>");
+        const __exports__ = /*#__PURE__*/ (0, exportHelper.A)(Buttonvue_type_script_setup_true_lang_js, [
+            [
+                '__scopeId',
+                "data-v-1e8aa170"
+            ]
+        ]);
+        const Button = __exports__;
+        const Cardvue_type_script_setup_true_lang_js_hoisted_1 = {
+            class: "component card"
+        };
+        const Cardvue_type_script_setup_true_lang_js = {
+            __name: 'Card',
+            setup (__props) {
+                const card = ref('Card!');
+                return (_ctx, _cache)=>(openBlock(), createElementBlock("p", Cardvue_type_script_setup_true_lang_js_hoisted_1, toDisplayString(card.value), 1));
+            }
+        };
+        const Card_exports_ = Cardvue_type_script_setup_true_lang_js;
+        const Card = Card_exports_;
+        export { Button, Card };
+        ",
+        }
+      `);
 
     expect(cssResult.contents.esm1).toMatchInlineSnapshot(`
       {
@@ -124,82 +122,80 @@ describe.runIf(platform() !== 'win32')('ESM', async () => {
   test('bundleless', async () => {
     expect(normalizeVueModuleIds(jsResult.contents.esm0!))
       .toMatchInlineSnapshot(`
-      {
-        "<ROOT>/tests/integration/vue/dist/bundleless/Button/Button.js": "import { createElementBlock, openBlock, ref, toDisplayString } from "vue";
-      import "./style.css";
-      import "./Button.css";
-      import { __webpack_require__ } from "../rslib-runtime~0.js";
-      __webpack_require__.add({
-          <MODULE_ID> (__unused_rspack_module, exports) {
-              exports.A = (sfc, props)=>{
-                  const target = sfc.__vccOpts || sfc;
-                  for (const [key, val] of props)target[key] = val;
-                  return target;
-              };
-          }
-      });
-      const _hoisted_1 = {
-          class: "component button"
-      };
-      const Buttonvue_type_script_setup_true_lang_js = {
-          __name: 'Button',
-          setup (__props) {
-              const button = ref('Button!');
-              return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(button.value), 1));
-          }
-      };
-      const exportHelper = __webpack_require__("<MODULE_ID>");
-      const __exports__ = /*#__PURE__*/ (0, exportHelper.A)(Buttonvue_type_script_setup_true_lang_js, [
-          [
-              '__scopeId',
-              "data-v-1e8aa170"
-          ]
-      ]);
-      const Button = __exports__;
-      export default Button;
-      ",
-        "<ROOT>/tests/integration/vue/dist/bundleless/Button/index.js": "export { default } from "./Button.js";
-      ",
-        "<ROOT>/tests/integration/vue/dist/bundleless/Card.js": "import { createElementBlock, openBlock, ref, toDisplayString } from "vue";
-      import "./Card.css";
-      const _hoisted_1 = {
-          class: "component card"
-      };
-      const Cardvue_type_script_setup_true_lang_js = {
-          __name: 'Card',
-          setup (__props) {
-              const card = ref('Card!');
-              return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(card.value), 1));
-          }
-      };
-      const __exports__ = Cardvue_type_script_setup_true_lang_js;
-      const Card = __exports__;
-      export default Card;
-      ",
-        "<ROOT>/tests/integration/vue/dist/bundleless/index.js": "export { default as Button } from "./Button/index.js";
-      export { default as Card } from "./Card.js";
-      ",
-        "<ROOT>/tests/integration/vue/dist/bundleless/rslib-runtime~0.js": "var __webpack_modules__ = {};
-      var __webpack_module_cache__ = {};
-      function __webpack_require__(moduleId) {
-          var cachedModule = __webpack_module_cache__[moduleId];
-          if (void 0 !== cachedModule) return cachedModule.exports;
-          var module = __webpack_module_cache__[moduleId] = {
-              exports: {}
-          };
-          __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-          return module.exports;
-      }
-      __webpack_require__.m = __webpack_modules__;
-      (()=>{
-          __webpack_require__.add = function(modules) {
-              Object.assign(__webpack_require__.m, modules);
-          };
-      })();
-      export { __webpack_require__ };
-      ",
-      }
-    `);
+        {
+          "<ROOT>/tests/integration/vue/dist/bundleless/Button/Button.js": "import { rspackRequire, moduleFactories } from "../rslib-runtime~0.js";
+        import { createElementBlock, openBlock, ref, toDisplayString } from "vue";
+        import "./style.css";
+        import "./Button.css";
+        moduleFactories.add({
+            <MODULE_ID> (__unused_rspack_module, exports) {
+                exports.A = (sfc, props)=>{
+                    const target = sfc.__vccOpts || sfc;
+                    for (const [key, val] of props)target[key] = val;
+                    return target;
+                };
+            }
+        });
+        const _hoisted_1 = {
+            class: "component button"
+        };
+        const Buttonvue_type_script_setup_true_lang_js = {
+            __name: 'Button',
+            setup (__props) {
+                const button = ref('Button!');
+                return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(button.value), 1));
+            }
+        };
+        const exportHelper = rspackRequire("<MODULE_ID>");
+        const __exports__ = /*#__PURE__*/ (0, exportHelper.A)(Buttonvue_type_script_setup_true_lang_js, [
+            [
+                '__scopeId',
+                "data-v-1e8aa170"
+            ]
+        ]);
+        const Button = __exports__;
+        export default Button;
+        ",
+          "<ROOT>/tests/integration/vue/dist/bundleless/Button/index.js": "export { default } from "./Button.js";
+        ",
+          "<ROOT>/tests/integration/vue/dist/bundleless/Card.js": "import { createElementBlock, openBlock, ref, toDisplayString } from "vue";
+        import "./Card.css";
+        const _hoisted_1 = {
+            class: "component card"
+        };
+        const Cardvue_type_script_setup_true_lang_js = {
+            __name: 'Card',
+            setup (__props) {
+                const card = ref('Card!');
+                return (_ctx, _cache)=>(openBlock(), createElementBlock("p", _hoisted_1, toDisplayString(card.value), 1));
+            }
+        };
+        const __exports__ = Cardvue_type_script_setup_true_lang_js;
+        const Card = __exports__;
+        export default Card;
+        ",
+          "<ROOT>/tests/integration/vue/dist/bundleless/index.js": "export { default as Button } from "./Button/index.js";
+        export { default as Card } from "./Card.js";
+        ",
+          "<ROOT>/tests/integration/vue/dist/bundleless/rslib-runtime~0.js": "var modules = {};
+        var moduleCache = {};
+        function rspackRequire(moduleId) {
+            var cachedModule = moduleCache[moduleId];
+            if (void 0 !== cachedModule) return cachedModule.exports;
+            var module = moduleCache[moduleId] = {
+                exports: {}
+            };
+            modules[moduleId](module, module.exports, rspackRequire);
+            return module.exports;
+        }
+        var moduleFactories = modules;
+        moduleFactories.add = function(modules) {
+            Object.assign(moduleFactories, modules);
+        };
+        export { rspackRequire, moduleFactories };
+        ",
+        }
+      `);
     expect(cssResult.contents.esm0).toMatchInlineSnapshot(`
       {
         "<ROOT>/tests/integration/vue/dist/bundleless/Button/Button.css": ".button[data-v-1e8aa170] {


### PR DESCRIPTION
## Motivation

Enable Rspack's runtime implementation by default to align Rslib with the latest Rspack runtime behavior and output.

## Changes

- Set `tools.rspack.experiments.runtimeMode` to `'rspack'` in the default Rslib configuration.
- Update affected snapshots and integration test expectations.
- Preserve support for explicitly configured runtime modes.
- Document the default runtime behavior in the English and Chinese documentation.