### PR TITLE
chore(ci): add actionlint workflow and config

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,14 @@
+# actionlint configuration
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+self-hosted-runner:
+  labels: []
+
+# ShellCheck rules disabled inside run: blocks.
+# Each `run:` block is checked through ShellCheck; suppress noisy rules here.
+paths:
+  ".github/workflows/**/*.{yml,yaml}":
+    ignore:
+      - 'shellcheck reported issue in this script: SC1091:.+'  # Can't follow non-constant source
+      - 'shellcheck reported issue in this script: SC2086:.+'  # Double-quote to prevent globbing/word splitting
+      - 'shellcheck reported issue in this script: SC2129:.+'  # Consider using { cmd1; cmd2; } >> file
+      - 'shellcheck reported issue in this script: SC2155:.+'  # Declare and assign separately to avoid masking return values

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,34 @@
+name: Actionlint
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Download actionlint
+        id: download
+        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Run actionlint
+        run: |
+          ./actionlint -color
+        shell: bash

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -23,10 +23,11 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Download actionlint
-        id: download
-        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        env:
+          ACTIONLINT_VERSION: '1.7.12'
+        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash)
         shell: bash
       - name: Run actionlint
         run: |


### PR DESCRIPTION
## Summary

Adds actionlint CI integration to catch GitHub Actions schema errors and
ShellCheck issues in workflow `run:` blocks. The repo has 7 workflow files
and no existing actionlint setup.

Two files added:

- `.github/actionlint.yaml` — config that enables ShellCheck integration
  and suppresses rules that are noisy false-positives in GHA contexts
  (SC2086, SC2129, SC2155, SC1091).
- `.github/workflows/actionlint.yml` — dedicated workflow that runs
  actionlint on changes to `.github/workflows/**` and the actionlint config.

## Related Links

- [actionlint](https://github.com/rhysd/actionlint)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.
