### PR TITLE
feat(core)!: support mode in inspectConfig

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,7 +1,7 @@
-import type { LogLevel, RsbuildMode } from '@rsbuild/core';
+import type { LogLevel } from '@rsbuild/core';
 import cac, { type CAC } from 'cac';
 import type { ConfigLoader } from '../loadConfig';
-import type { Format, Syntax } from '../types';
+import type { Format, InspectConfigOptions, Syntax } from '../types';
 import { color } from '../utils/color';
 import { logger } from '../utils/logger';
 import { init, initCliAction } from './init';
@@ -37,7 +37,7 @@ export type BuildOptions = CommonOptions & {
 };
 
 export type InspectOptions = CommonOptions & {
-  mode?: RsbuildMode;
+  mode?: InspectConfigOptions['mode'];
   output?: string;
   verbose?: boolean;
 };
@@ -93,7 +93,7 @@ export function setupCommands(argv: string[]): void {
   const buildCommand = cli.command('', buildDescription).alias('build');
   const inspectCommand = cli.command(
     'inspect',
-    'inspect the Rsbuild / Rspack configs of Rslib projects',
+    'inspect the Rslib, Rsbuild, and Rspack configs',
   );
   const mfDevCommand = cli.command(
     'mf-dev',
@@ -162,10 +162,11 @@ export function setupCommands(argv: string[]): void {
     });
 
   inspectCommand
-    .option('--output <output>', 'specify inspect content output path', {
+    .option('--mode <mode>', 'set the build mode (development | production)')
+    .option('--output <output>', 'set the output path for inspection results', {
       default: '.rsbuild',
     })
-    .option('--verbose', 'show full function definitions in output')
+    .option('--verbose', 'show complete function definitions in output')
     .action(async (options: InspectOptions) => {
       initCliAction('inspect', options);
       try {

--- a/packages/core/src/createRslib.ts
+++ b/packages/core/src/createRslib.ts
@@ -244,9 +244,11 @@ export async function createRslib(
       setNodeEnv('production');
     }
 
+    const mode = getNodeEnv() === 'development' ? 'development' : 'production';
+
     const composedEnvironments = await composeRsbuildEnvironments(config);
     const environments =
-      inspectOptions.mode === 'development'
+      mode === 'development'
         ? pruneMFEnvironments(composedEnvironments, inspectOptions.lib)
         : pruneEnvironments(
             composedEnvironments.environments,
@@ -255,12 +257,12 @@ export async function createRslib(
 
     const rsbuildInstance = await createRsbuildInstance(
       options,
-      inspectOptions.mode ?? 'production',
+      mode,
       environments,
     );
 
     const inspectConfigResult = await rsbuildInstance.inspectConfig({
-      mode: inspectOptions.mode,
+      mode,
       verbose: inspectOptions.verbose,
       outputPath: inspectOptions.outputPath,
       writeToDisk: inspectOptions.writeToDisk,

--- a/packages/core/src/createRslib.ts
+++ b/packages/core/src/createRslib.ts
@@ -7,7 +7,7 @@ import {
 } from '@rsbuild/core';
 import util from 'node:util';
 import { composeRsbuildEnvironments, pruneEnvironments } from './config';
-import type { RslibConfig } from './types';
+import type { Format, RslibConfig } from './types';
 import type {
   BuildOptions,
   BuildResult,
@@ -26,6 +26,36 @@ import {
   setNodeEnv,
 } from './utils/helper';
 import { isDebug, isDebugKey, logger } from './utils/logger';
+
+const pruneMFEnvironments = (
+  {
+    environments,
+    environmentWithInfos,
+  }: {
+    environments: Record<string, EnvironmentConfig>;
+    environmentWithInfos: { id: string; format: Format }[];
+  },
+  libs?: string[],
+): Record<string, EnvironmentConfig> => {
+  const selectedEnvironmentIds = environmentWithInfos
+    .filter(
+      ({ format, id }) =>
+        format === 'mf' && (!libs?.length || libs.includes(id)),
+    )
+    .map(({ id }) => id);
+
+  if (!selectedEnvironmentIds.length) {
+    throw new Error(
+      `No mf format found in ${
+        libs?.length
+          ? `libs ${libs.map((lib) => `"${lib}"`).join(', ')}`
+          : 'your config'
+      }, please check your config to ensure that the mf format is enabled correctly.`,
+    );
+  }
+
+  return pruneEnvironments(environments, selectedEnvironmentIds);
+};
 
 const applyDebugInspectConfigPlugin = (
   rsbuildInstance: RsbuildInstance,
@@ -201,17 +231,32 @@ export async function createRslib(
     inspectOptions: InspectConfigOptions = {},
   ): Promise<InspectConfigResult> => {
     if (inspectOptions.mode) {
+      if (
+        inspectOptions.mode !== 'development' &&
+        inspectOptions.mode !== 'production'
+      ) {
+        throw new Error(
+          `Invalid inspect mode "${inspectOptions.mode}". Expected "development" or "production".`,
+        );
+      }
       setNodeEnv(inspectOptions.mode);
     } else if (!getNodeEnv()) {
       setNodeEnv('production');
     }
 
-    const { environments } = await composeRsbuildEnvironments(config);
+    const composedEnvironments = await composeRsbuildEnvironments(config);
+    const environments =
+      inspectOptions.mode === 'development'
+        ? pruneMFEnvironments(composedEnvironments, inspectOptions.lib)
+        : pruneEnvironments(
+            composedEnvironments.environments,
+            inspectOptions.lib,
+          );
 
     const rsbuildInstance = await createRsbuildInstance(
       options,
-      'production',
-      pruneEnvironments(environments, inspectOptions.lib),
+      inspectOptions.mode ?? 'production',
+      environments,
     );
 
     const inspectConfigResult = await rsbuildInstance.inspectConfig({
@@ -241,32 +286,10 @@ export async function createRslib(
       setNodeEnv('development');
     }
 
-    const { environments, environmentWithInfos } =
-      await composeRsbuildEnvironments(config);
-
-    const selectedEnvironmentIds = environmentWithInfos
-      .filter((env) => {
-        const isMf = env.format === 'mf';
-        if (!mfOptions.lib || mfOptions.lib.length === 0) {
-          return isMf;
-        }
-        return env.id && mfOptions.lib.includes(env.id);
-      })
-      .map((env) => env.id);
-
-    if (!selectedEnvironmentIds.length) {
-      throw new Error(
-        `No mf format found in ${
-          mfOptions.lib && mfOptions.lib.length > 0
-            ? `libs ${mfOptions.lib.map((lib) => `"${lib}"`).join(', ')}`
-            : 'your config'
-        }, please check your config to ensure that the mf format is enabled correctly.`,
-      );
-    }
-
-    const selectedEnvironments = pruneEnvironments(
-      environments,
-      selectedEnvironmentIds,
+    const composedEnvironments = await composeRsbuildEnvironments(config);
+    const selectedEnvironments = pruneMFEnvironments(
+      composedEnvironments,
+      mfOptions.lib,
     );
 
     const rsbuildInstance = await createRsbuildInstance(

--- a/packages/core/src/types/rslib.ts
+++ b/packages/core/src/types/rslib.ts
@@ -27,7 +27,7 @@ export type InspectConfigOptions = CommonOptions & {
   /**
    * Inspect the config in the specified mode.
    * Available options: 'development' or 'production'.
-   * @default 'production'
+   * @default Inferred from `process.env.NODE_ENV`: 'development' when set to 'development', otherwise 'production'.
    */
   mode?: 'development' | 'production';
   /**

--- a/packages/core/src/types/rslib.ts
+++ b/packages/core/src/types/rslib.ts
@@ -4,7 +4,6 @@ import type {
   LoadEnvOptions,
   RestartFn,
   RsbuildInstance,
-  RsbuildMode,
   StartDevServerResult,
 } from '@rsbuild/core';
 import type { RslibConfig } from './config';
@@ -30,7 +29,7 @@ export type InspectConfigOptions = CommonOptions & {
    * Available options: 'development' or 'production'.
    * @default 'production'
    */
-  mode?: RsbuildMode;
+  mode?: 'development' | 'production';
   /**
    * Enables verbose mode to display the complete function
    * content in the configuration.
@@ -39,7 +38,7 @@ export type InspectConfigOptions = CommonOptions & {
   verbose?: boolean;
   /**
    * Specify the output path for inspection results.
-   * @default 'output.distPath.root'
+   * @default '<output.distPath.root>/.rsbuild'
    */
   outputPath?: string;
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1284,6 +1284,8 @@ importers:
 
   tests/integration/iife: {}
 
+  tests/integration/javascript-api/inspect-config: {}
+
   tests/integration/javascript-api/start-mf-dev-server: {}
 
   tests/integration/json: {}

--- a/tests/integration/cli/help/__snapshots__/index.test.ts.snap
+++ b/tests/integration/cli/help/__snapshots__/index.test.ts.snap
@@ -40,8 +40,9 @@ Usage:
   $ rslib inspect [options]
 
 Options:
-  --output <output>         specify inspect content output path (default: .rsbuild)
-  --verbose                 show full function definitions in output
+  --mode <mode>             set the build mode (development | production)
+  --output <output>         set the output path for inspection results (default: .rsbuild)
+  --verbose                 show complete function definitions in output
   -c, --config <config>     specify the configuration file, can be a relative or absolute path
   --config-loader <loader>  Set the config file loader (auto | jiti | native) (default: auto)
   -r, --root <root>         specify the project root directory, can be an absolute path or a path relative to cwd
@@ -79,7 +80,7 @@ Usage:
 
 Commands:
   build    build the library for production (default if no command is given)
-  inspect  inspect the Rsbuild / Rspack configs of Rslib projects
+  inspect  inspect the Rslib, Rsbuild, and Rspack configs
   mf-dev   start Rsbuild dev server of Module Federation format
 
   For details on a sub-command, run:

--- a/tests/integration/cli/inspect/inspect.test.ts
+++ b/tests/integration/cli/inspect/inspect.test.ts
@@ -49,7 +49,7 @@ describe('inspect command', async () => {
     );
     const fileNames = Object.keys(files).sort();
 
-    // Rsbuild will emit dump files to `dist/esm` if only one environment is specified.
+    // Rsbuild emits inspection files to the selected environment's dist path.
     expect(fileNames).toMatchInlineSnapshot(`
       [
         "<ROOT>/tests/integration/cli/inspect/dist/esm/.rsbuild/rsbuild.config.mjs",
@@ -82,7 +82,6 @@ describe('inspect command', async () => {
     const files = await globContentJSON(path.join(__dirname, 'dist/.rsbuild'));
     const fileNames = Object.keys(files).sort();
 
-    // Rsbuild will emit dump files to `dist/esm` if only one environment is specified.
     expect(fileNames).toMatchInlineSnapshot(`
       [
         "<ROOT>/tests/integration/cli/inspect/dist/.rsbuild/rsbuild.config.cjs.mjs",
@@ -92,5 +91,17 @@ describe('inspect command', async () => {
         "<ROOT>/tests/integration/cli/inspect/dist/.rsbuild/rspack.config.esm.mjs",
       ]
     `);
+  });
+
+  test('--mode should reject unsupported values', () => {
+    const { status, stderr } = runCliSync('inspect --mode none', {
+      cwd: __dirname,
+      stdio: 'pipe',
+    });
+
+    expect(status).toBe(1);
+    expect(stderr).toContain(
+      'Invalid inspect mode "none". Expected "development" or "production".',
+    );
   });
 });

--- a/tests/integration/cli/mf/mf.test.ts
+++ b/tests/integration/cli/mf/mf.test.ts
@@ -107,3 +107,24 @@ describe('mf build', () => {
     expect(rspackConfigContent).toContain(`nodeEnv: 'production'`);
   });
 });
+
+describe('mf inspect', () => {
+  test('inspect in development mode', async () => {
+    const fixturePath = join(__dirname, 'dev');
+    const distFolder = join(fixturePath, 'dist-mf0');
+    const rspackConfigFile = join(distFolder, '.rsbuild/rspack.config.mf0.mjs');
+
+    fse.removeSync(distFolder);
+
+    const { status } = runCliSync('inspect --mode development --lib mf0', {
+      cwd: fixturePath,
+      stdio: 'pipe',
+    });
+
+    expect(status).toBe(0);
+
+    const rspackConfigContent = await fse.readFile(rspackConfigFile, 'utf-8');
+    expect(rspackConfigContent).toContain(`mode: 'development'`);
+    expect(rspackConfigContent).toContain(`nodeEnv: 'development'`);
+  });
+});

--- a/tests/integration/javascript-api/inspect-config/index.test.ts
+++ b/tests/integration/javascript-api/inspect-config/index.test.ts
@@ -59,6 +59,16 @@ describe('rslib.inspectConfig', async () => {
     );
   });
 
+  test('should infer development mode from NODE_ENV', async () => {
+    process.env.NODE_ENV = 'development';
+
+    const rslib = await createModeRslib();
+    const result = await rslib.inspectConfig();
+
+    expect(result.origin.rsbuildConfig.mode).toBe('development');
+    expect(Object.keys(result.origin.environmentConfigs)).toEqual(['mf']);
+  });
+
   test('should inspect only MF configs in development mode', async () => {
     const rslib = await createModeRslib();
     const result = await rslib.inspectConfig({

--- a/tests/integration/javascript-api/inspect-config/index.test.ts
+++ b/tests/integration/javascript-api/inspect-config/index.test.ts
@@ -1,29 +1,108 @@
 import { join } from 'node:path';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { createRslib } from '@rslib/core';
-import { describe, expect, test } from '@rstest/core';
+import { afterEach, describe, expect, test } from '@rstest/core';
 import fse from 'fs-extra';
 import { expectFile } from 'test-helper';
 
 describe('rslib.inspectConfig', async () => {
-  test('return Rsbuild and Rspack config', async () => {
-    const rslib = await createRslib({
+  const initialNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    if (initialNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = initialNodeEnv;
+    }
+  });
+
+  const createModeRslib = () => {
+    return createRslib({
       cwd: import.meta.dirname,
       config: {
         lib: [
           {
-            format: 'esm',
+            format: 'mf',
+            plugins: [
+              pluginModuleFederation({
+                name: 'inspect-mode',
+              }),
+            ],
+          },
+          {
+            format: 'umd',
+            umdName: 'InspectMode',
           },
         ],
         logLevel: 'silent',
       },
     });
-    const { rslibConfig, rsbuildConfig, bundlerConfigs } =
+  };
+
+  test('should apply production mode before composing configs', async () => {
+    process.env.NODE_ENV = 'development';
+
+    const rslib = await createModeRslib();
+    const result = await rslib.inspectConfig({
+      lib: ['umd'],
+      mode: 'production',
+    });
+
+    expect(process.env.NODE_ENV).toBe('production');
+    expect(result.origin.rsbuildConfig.mode).toBe('production');
+    expect(Object.keys(result.origin.environmentConfigs)).toEqual(['umd']);
+    expect(result.origin.bundlerConfigs).toHaveLength(1);
+    expect(result.origin.bundlerConfigs[0]!.mode).toBe('production');
+    expect(result.origin.bundlerConfigs[0]!.optimization?.nodeEnv).toBe(
+      'production',
+    );
+  });
+
+  test('should inspect only MF configs in development mode', async () => {
+    const rslib = await createModeRslib();
+    const result = await rslib.inspectConfig({
+      mode: 'development',
+    });
+
+    expect(process.env.NODE_ENV).toBe('development');
+    expect(result.origin.rsbuildConfig.mode).toBe('development');
+    expect(Object.keys(result.origin.environmentConfigs)).toEqual(['mf']);
+    expect(result.origin.bundlerConfigs).toHaveLength(1);
+    expect(result.origin.bundlerConfigs[0]!.name).toBe('mf');
+    expect(result.origin.bundlerConfigs[0]!.mode).toBe('development');
+    expect(result.origin.bundlerConfigs[0]!.optimization?.nodeEnv).toBe(
+      'development',
+    );
+  });
+
+  test('should reject unsupported inspect modes', async () => {
+    const rslib = await createModeRslib();
+
+    await expect(
+      rslib.inspectConfig({
+        // @ts-expect-error testing runtime validation for JavaScript callers
+        mode: 'none',
+      }),
+    ).rejects.toThrow(
+      'Invalid inspect mode "none". Expected "development" or "production".',
+    );
+  });
+
+  test('should inspect all configs in production mode by default', async () => {
+    const rslib = await createModeRslib();
+    const { rslibConfig, rsbuildConfig, bundlerConfigs, origin } =
       await rslib.inspectConfig();
 
     expect(rslibConfig).not.toBeUndefined();
     expect(rsbuildConfig).not.toBeUndefined();
     expect(bundlerConfigs).not.toBeUndefined();
+    expect(origin.rsbuildConfig.mode).toBe('production');
+    expect(Object.keys(origin.environmentConfigs)).toEqual(['mf', 'umd']);
+    expect(origin.bundlerConfigs).toHaveLength(2);
+    expect(
+      origin.bundlerConfigs.every((config) => config.mode === 'production'),
+    ).toBe(true);
   });
 
   test('should write to disk correctly', async () => {

--- a/tests/integration/javascript-api/inspect-config/package.json
+++ b/tests/integration/javascript-api/inspect-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "javascript-api-inspect-config-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -235,7 +235,7 @@ type InspectConfigOptions = {
    * Available options: 'development' or 'production'.
    * @default 'production'
    */
-  mode?: RsbuildMode;
+  mode?: 'development' | 'production';
   /**
    * Enables verbose mode to display the complete function
    * content in the configuration.
@@ -244,7 +244,7 @@ type InspectConfigOptions = {
   verbose?: boolean;
   /**
    * Specify the output path for inspection results.
-   * @default 'output.distPath.root'
+   * @default '<output.distPath.root>/.rsbuild'
    */
   outputPath?: string;
   /**
@@ -292,7 +292,15 @@ await rslib.inspectConfig({
 });
 ```
 
-可以通过 `lib` 参数指定需要查看配置的库 id。如果不指定该参数，则会输出所有配置。
+### Setting mode
+
+By default, `rslib.inspectConfig()` outputs production mode configurations for all libraries. You can set `mode` to `'development'` to output development mode configurations for libraries with [format](/config/lib/format) set to `mf`:
+
+```ts
+await rslib.inspectConfig({
+  mode: 'development',
+});
+```
 
 ### Run specified library
 
@@ -308,9 +316,9 @@ await rslib.inspectConfig({
 
 ### Output path
 
-You can set the output path using `outputPath`. The default value is [output.distPath.root](/config/rsbuild/output#outputdistpath).
+You can set the output path using `outputPath`. When `writeToDisk` is `true`, the files are written to the `.rsbuild` directory under [output.distPath.root](/config/rsbuild/output#outputdistpath) by default.
 
-If `outputPath` is a relative path, it will be concatenated relative to the value of `output.distPath.root`. You can also set `outputPath` to an absolute path, in which case the files will be written directly to that path. For example:
+If `outputPath` is a relative path, it will be resolved relative to `output.distPath.root`. You can also set `outputPath` to an absolute path, in which case the files will be written directly to that path. For example:
 
 ```ts
 import path from 'node:path';

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -233,7 +233,7 @@ type InspectConfigOptions = {
   /**
    * Inspect the config in the specified mode.
    * Available options: 'development' or 'production'.
-   * @default 'production'
+   * @default Inferred from `process.env.NODE_ENV`: 'development' when set to 'development', otherwise 'production'.
    */
   mode?: 'development' | 'production';
   /**
@@ -294,13 +294,17 @@ await rslib.inspectConfig({
 
 ### Setting mode
 
-By default, `rslib.inspectConfig()` outputs production mode configurations for all libraries. You can set `mode` to `'development'` to output development mode configurations for libraries with [format](/config/lib/format) set to `mf`:
+By default, `mode` is inferred from `process.env.NODE_ENV`. When `mode` is `'production'`, `rslib.inspectConfig()` outputs production mode configs for all libraries. You can also set `mode` to `'development'` to output development mode configs only for libraries with [format](/config/lib/format) set to `mf`:
 
 ```ts
 await rslib.inspectConfig({
   mode: 'development',
 });
 ```
+
+:::tip
+The Rslib config is resolved before `inspectConfig()` is called, so `mode` does not affect how it is loaded. To load different Rslib configs based on `NODE_ENV`, set it before calling [`createRslib()`](/api/javascript-api/core#createrslib).
+:::
 
 ### Run specified library
 

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -105,36 +105,45 @@ export default defineConfig({
 
 ## rslib inspect
 
-The `rslib inspect` command is used to view the Rsbuild config and Rspack config of the Rslib project.
+The `rslib inspect` command inspects a project's Rslib config and the corresponding Rsbuild and Rspack configs.
 
 ```bash
 Usage:
   $ rslib inspect
 
 Options:
-  --output <output>     specify inspect content output path (default: ".rsbuild")
-  --verbose             show full function definitions in output
+  --mode <mode>         set the build mode (development | production)
+  --output <output>     set the output path for inspection results (default: ".rsbuild")
+  --verbose             show complete function definitions in output
 ```
 
 When you run the command `npx rslib inspect` in the project root directory, the following files will be generated in the `dist/.rsbuild` directory of the project:
 
 - `rsbuild.config.mjs`: Represents the Rsbuild configuration used during the build.
-- `rspack.config.web.mjs`: Represents the Rspack configuration used during the build.
-- `rslib.config.mjs`: Represents the final Rslib configuration after normalization.
+- `rspack.config.esm.mjs`: Represents the Rspack configuration used during the build.
+- `rslib.config.mjs`: Represents the resolved Rslib configuration.
 
 ```text
 ➜ npx rslib inspect
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
-  - Rsbuild Config: /project/dist/.rsbuild/rsbuild.config.mjs
+  - Rsbuild config: /project/dist/.rsbuild/rsbuild.config.mjs
   - Rspack Config (esm): /project/dist/.rsbuild/rspack.config.esm.mjs
   - Rslib Config: /project/dist/.rsbuild/rslib.config.mjs
 ```
 
+### Setting mode
+
+By default, the inspect command outputs production mode configurations for all libraries. You can add the `--mode development` option to output development mode configurations for libraries with [format](/config/lib/format) set to `mf`:
+
+```bash
+rslib inspect --mode development
+```
+
 ### Verbose content
 
-By default, the inspect command omits the content of functions in the configuration object. You can add the `--verbose` option to output the complete content of functions:
+By default, the inspect command omits function bodies in the configuration object. To output complete function content, add the `--verbose` option:
 
 ```bash
 rslib inspect --verbose
@@ -147,10 +156,10 @@ If the current project has multiple output formats, such as ESM artifact and CJS
 ```text
 ➜ npx rslib inspect
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
-  - Rsbuild Config (esm): /project/dist/.rsbuild/rsbuild.config.esm.mjs
-  - Rsbuild Config (cjs): /project/dist/.rsbuild/rsbuild.config.cjs.mjs
+  - Rsbuild config (esm): /project/dist/.rsbuild/rsbuild.config.esm.mjs
+  - Rsbuild config (cjs): /project/dist/.rsbuild/rsbuild.config.cjs.mjs
   - Rspack Config (esm): /project/dist/.rsbuild/rspack.config.esm.mjs
   - Rspack Config (cjs): /project/dist/.rsbuild/rspack.config.cjs.mjs
   - Rslib Config: /project/dist/.rsbuild/rslib.config.mjs

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -135,7 +135,9 @@ config inspection completed, generated files:
 
 ### Setting mode
 
-By default, the inspect command outputs production mode configurations for all libraries. You can add the `--mode development` option to output development mode configurations for libraries with [format](/config/lib/format) set to `mf`:
+By default, `mode` is inferred from `process.env.NODE_ENV`: it is `'development'` when `NODE_ENV` is `'development'`, and `'production'` otherwise.
+
+When `mode` is `'production'`, the inspect command outputs production mode configurations for all libraries. You can add the `--mode development` option to output development mode configurations for libraries with [format](/config/lib/format) set to `mf`:
 
 ```bash
 rslib inspect --mode development

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -244,3 +244,4 @@ This option was originally used to generate ESM output that was more suitable fo
 ## JavaScript API
 
 - The type of `lib` in [RslibConfig](/api/javascript-api/types#rslibconfig) has changed from `LibConfig[]` to `LibConfig[] | undefined`. Omitting `lib` is equivalent to configuring `lib: [{}]`.
+- The invalid `'none'` value has been removed from the `mode` option of [`rslib.inspectConfig()`](/api/javascript-api/instance#rslibinspectconfig). When `mode` is `'development'`, `rslib.inspectConfig()` now only outputs configurations for libraries with `format: 'mf'`.

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -244,4 +244,4 @@ This option was originally used to generate ESM output that was more suitable fo
 ## JavaScript API
 
 - The type of `lib` in [RslibConfig](/api/javascript-api/types#rslibconfig) has changed from `LibConfig[]` to `LibConfig[] | undefined`. Omitting `lib` is equivalent to configuring `lib: [{}]`.
-- The invalid `'none'` value has been removed from the `mode` option of [`rslib.inspectConfig()`](/api/javascript-api/instance#rslibinspectconfig). When `mode` is `'development'`, `rslib.inspectConfig()` now only outputs configurations for libraries with `format: 'mf'`.
+- The invalid `'none'` value has been removed from the `mode` option of [`rslib.inspectConfig()`](/api/javascript-api/instance#rslibinspectconfig). When `mode` is omitted, it is now inferred from `process.env.NODE_ENV`: it is `'development'` when `NODE_ENV` is `'development'`, and `'production'` otherwise. When `mode` is `'development'`, `rslib.inspectConfig()` now only outputs configurations for libraries with `format: 'mf'`.

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -233,7 +233,7 @@ type InspectConfigOptions = {
   /**
    * 检查指定 mode 下的配置
    * 可选值：'development' 或 'production'
-   * @default 'production'
+   * @default 根据 `process.env.NODE_ENV` 推断：当值为 'development' 时使用 'development'，否则使用 'production'
    */
   mode?: 'development' | 'production';
   /**
@@ -293,13 +293,17 @@ await rslib.inspectConfig({
 
 ### 指定模式
 
-默认情况下，`rslib.inspectConfig()` 会输出所有库的生产模式配置，你可以将 `mode` 设置为 `'development'` 来输出 [format](/config/lib/format) 为 `mf` 的库的开发模式配置：
+默认情况下，`mode` 会根据 `process.env.NODE_ENV` 推断。当 `mode` 为 `'production'` 时，`rslib.inspectConfig()` 会输出所有库的生产模式配置。你也可以将 `mode` 设置为 `'development'` 来输出 [format](/config/lib/format) 为 `mf` 的库的开发模式配置：
 
 ```ts
 await rslib.inspectConfig({
   mode: 'development',
 });
 ```
+
+:::tip
+Rslib 配置会在调用 `inspectConfig()` 前完成解析，因此 `mode` 不会影响配置的加载方式。如需根据 `NODE_ENV` 加载不同的 Rslib 配置，请在调用 [`createRslib()`](/api/javascript-api/core#createrslib) 前进行设置。
+:::
 
 ### 运行指定的库
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -235,7 +235,7 @@ type InspectConfigOptions = {
    * 可选值：'development' 或 'production'
    * @default 'production'
    */
-  mode?: RsbuildMode;
+  mode?: 'development' | 'production';
   /**
    * 启用详细模式，显示配置中函数的完整内容
    * @default false
@@ -243,7 +243,7 @@ type InspectConfigOptions = {
   verbose?: boolean;
   /**
    * 指定检查结果的输出路径
-   * @default 'output.distPath.root'
+   * @default '<output.distPath.root>/.rsbuild'
    */
   outputPath?: string;
   /**
@@ -291,6 +291,16 @@ await rslib.inspectConfig({
 });
 ```
 
+### 指定模式
+
+默认情况下，`rslib.inspectConfig()` 会输出所有库的生产模式配置，你可以将 `mode` 设置为 `'development'` 来输出 [format](/config/lib/format) 为 `mf` 的库的开发模式配置：
+
+```ts
+await rslib.inspectConfig({
+  mode: 'development',
+});
+```
+
 ### 运行指定的库
 
 可以通过 `lib` 参数指定需要查看配置的库 id。如果不指定该参数，则会输出所有配置。
@@ -305,9 +315,9 @@ await rslib.inspectConfig({
 
 ### 输出路径
 
-你可以通过 `outputPath` 来设置输出目录，默认为 [output.distPath.root](/config/rsbuild/output#outputdistpath) 的值。
+你可以通过 `outputPath` 来设置输出目录。当 `writeToDisk` 为 `true` 时，文件默认会写入 [output.distPath.root](/config/rsbuild/output#outputdistpath) 下的 `.rsbuild` 目录。
 
-当 `outputPath` 是一个相对路径时，会相对于 `output.distPath.root` 的值进行拼接。你也可以将 `outputPath` 设置为一个绝对路径，此时会直接将文件写入到该路径下。比如：
+当 `outputPath` 是一个相对路径时，会相对于 `output.distPath.root` 进行解析。你也可以将 `outputPath` 设置为一个绝对路径，此时会直接将文件写入到该路径下。比如：
 
 ```ts
 import path from 'node:path';

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -105,31 +105,40 @@ export default defineConfig({
 
 ## rslib inspect
 
-`rslib inspect` 命令用于查看 Rslib 项目的 Rsbuild 配置和 Rspack 配置。
+`rslib inspect` 命令用于查看项目的 Rslib 配置及对应的 Rsbuild 和 Rspack 配置。
 
 ```bash
 Usage:
   $ rslib inspect
 
 Options:
-  --output <output>     指定检查内容输出路径（默认：".rsbuild"）
-  --verbose             在输出中显示完整的函数定义
+  --mode <mode>         指定构建模式（development | production）
+  --output <output>     指定在 dist 目录下输出的路径（默认：".rsbuild"）
+  --verbose             在结果中展示函数的完整内容
 ```
 
-当你在项目根目录下执行命令 `npx rsbuild inspect` 后，会在项目的 `dist/.rsbuild` 目录生成以下文件：
+当你在项目根目录下执行命令 `npx rslib inspect` 后，会在项目的 `dist/.rsbuild` 目录生成以下文件：
 
 - `rsbuild.config.mjs`: 表示在构建时使用的 Rsbuild 配置。
-- `rspack.config.web.mjs`: 表示在构建时使用的 Rspack 配置。
-- `rslib.config.mjs`: 表示归一化后的 Rslib 配置。
+- `rspack.config.esm.mjs`: 表示在构建时使用的 Rspack 配置。
+- `rslib.config.mjs`: 表示解析后的 Rslib 配置。
 
 ```text
 ➜ npx rslib inspect
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
-  - Rsbuild Config: /project/dist/.rsbuild/rsbuild.config.mjs
+  - Rsbuild config: /project/dist/.rsbuild/rsbuild.config.mjs
   - Rspack Config (esm): /project/dist/.rsbuild/rspack.config.esm.mjs
   - Rslib Config: /project/dist/.rsbuild/rslib.config.mjs
+```
+
+### 指定模式
+
+默认情况下，inspect 命令会输出所有库的生产模式配置，你可以添加 `--mode development` 选项来输出 [format](/config/lib/format) 为 `mf` 的库的开发模式配置：
+
+```bash
+rslib inspect --mode development
 ```
 
 ### 完整内容
@@ -147,10 +156,10 @@ rslib inspect --verbose
 ```text
 ➜ npx rslib inspect
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
-  - Rsbuild Config (esm): /project/dist/.rsbuild/rsbuild.config.esm.mjs
-  - Rsbuild Config (cjs): /project/dist/.rsbuild/rsbuild.config.cjs.mjs
+  - Rsbuild config (esm): /project/dist/.rsbuild/rsbuild.config.esm.mjs
+  - Rsbuild config (cjs): /project/dist/.rsbuild/rsbuild.config.cjs.mjs
   - Rspack Config (esm): /project/dist/.rsbuild/rspack.config.esm.mjs
   - Rspack Config (cjs): /project/dist/.rsbuild/rspack.config.cjs.mjs
   - Rslib Config: /project/dist/.rsbuild/rslib.config.mjs

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -135,7 +135,9 @@ config inspection completed, generated files:
 
 ### 指定模式
 
-默认情况下，inspect 命令会输出所有库的生产模式配置，你可以添加 `--mode development` 选项来输出 [format](/config/lib/format) 为 `mf` 的库的开发模式配置：
+默认情况下，`mode` 会根据 `process.env.NODE_ENV` 推断：当 `NODE_ENV` 为 `'development'` 时，`mode` 为 `'development'`，否则为 `'production'`。
+
+当 `mode` 为 `'production'` 时，inspect 命令会输出所有库的生产模式配置。你也可以添加 `--mode development` 选项来输出 [format](/config/lib/format) 为 `mf` 的库的开发模式配置：
 
 ```bash
 rslib inspect --mode development

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -244,4 +244,4 @@ export default {
 ## JavaScript API
 
 - [RslibConfig](/api/javascript-api/types#rslibconfig) 中 `lib` 的类型从 `LibConfig[]` 变为 `LibConfig[] | undefined`。省略 `lib` 时，行为等同于配置 `lib: [{}]`。
-- [`rslib.inspectConfig()`](/api/javascript-api/instance#rslibinspectconfig) 的 `mode` 选项移除了无效的 `'none'` 值。当 `mode` 为 `'development'` 时，`rslib.inspectConfig()` 现在仅会输出 `format: 'mf'` 的库配置。
+- [`rslib.inspectConfig()`](/api/javascript-api/instance#rslibinspectconfig) 的 `mode` 选项移除了无效的 `'none'` 值。未设置 `mode` 时，现在会根据 `process.env.NODE_ENV` 推断：当 `NODE_ENV` 为 `'development'` 时，`mode` 为 `'development'`，否则为 `'production'`。当 `mode` 为 `'development'` 时，`rslib.inspectConfig()` 现在仅会输出 `format: 'mf'` 的库配置。

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -244,3 +244,4 @@ export default {
 ## JavaScript API
 
 - [RslibConfig](/api/javascript-api/types#rslibconfig) 中 `lib` 的类型从 `LibConfig[]` 变为 `LibConfig[] | undefined`。省略 `lib` 时，行为等同于配置 `lib: [{}]`。
+- [`rslib.inspectConfig()`](/api/javascript-api/instance#rslibinspectconfig) 的 `mode` 选项移除了无效的 `'none'` 值。当 `mode` 为 `'development'` 时，`rslib.inspectConfig()` 现在仅会输出 `format: 'mf'` 的库配置。


### PR DESCRIPTION
## Summary

- Add `mode` support to `rslib inspect` and apply the selected mode before composing Rsbuild environments.
- Keep production as the default and inspect only Module Federation libraries in development mode.
- Remove the invalid `none` mode from `InspectConfigOptions`.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).