### PR TITLE
docs: fix WASM runtime support docs

### DIFF
--- a/website/docs/en/guide/advanced/wasm.mdx
+++ b/website/docs/en/guide/advanced/wasm.mdx
@@ -69,7 +69,7 @@ TypeScript cannot currently parse `import source` or `import.source()`. Use thes
 You can use [lib.wasm.mode](/config/lib/wasm#wasmmode) to select the output mode for `.wasm` modules:
 
 - [bundle](/config/lib/bundle) is `true`: Only `compile` mode is available.
-- [bundle](/config/lib/bundle) is `false`: `preserve` mode is used by default when the `.wasm` modules are resolved and loaded by a downstream build tool that supports WebAssembly ESM Integration (such as Rsbuild or Rspack) or a target runtime with native support (such as [Node.js](https://nodejs.org/api/esm.html#wasm-modules) versions matching `^22.19.0 || >=24.5.0`). If the consumer does not support this feature, or you do not want to rely on it to handle the `.wasm` modules, use `compile` mode.
+- [bundle](/config/lib/bundle) is `false`: `preserve` mode is used by default when the `.wasm` modules are resolved and loaded by a downstream build tool that supports WebAssembly ESM Integration (such as Rsbuild or Rspack) or a target runtime with native support (such as [Node.js](https://nodejs.org/api/esm.html#wasm-modules) versions matching `>=24.5.0`). If the consumer does not support this feature, or you do not want to rely on it to handle the `.wasm` modules, use `compile` mode.
 
 The following source files demonstrate how to configure the `compile` and `preserve` modes and their build outputs.
 

--- a/website/docs/zh/guide/advanced/wasm.mdx
+++ b/website/docs/zh/guide/advanced/wasm.mdx
@@ -69,7 +69,7 @@ TypeScript 目前无法解析 `import source` 和 `import.source()`。请在 Jav
 你可以通过 [lib.wasm.mode](/config/lib/wasm#wasmmode) 选择 `.wasm` 模块的输出模式：
 
 - [bundle](/config/lib/bundle) 为 `true`：仅支持 `compile` 模式。
-- [bundle](/config/lib/bundle) 为 `false`：默认使用 `preserve` 模式，适用于 `.wasm` 模块由支持 WebAssembly ESM Integration 的下游构建工具（如 Rsbuild 或 Rspack）或目标运行时（如 [Node.js](https://nodejs.org/api/esm.html#wasm-modules) `^22.19.0 || >=24.5.0`）解析和加载的场景。如果消费方不支持该特性，或不希望依赖其处理 `.wasm` 模块，则使用 `compile` 模式。
+- [bundle](/config/lib/bundle) 为 `false`：默认使用 `preserve` 模式，适用于 `.wasm` 模块由支持 WebAssembly ESM Integration 的下游构建工具（如 Rsbuild 或 Rspack）或目标运行时（如 [Node.js](https://nodejs.org/api/esm.html#wasm-modules) `>=24.5.0`）解析和加载的场景。如果消费方不支持该特性，或不希望依赖其处理 `.wasm` 模块，则使用 `compile` 模式。
 
 以下通过一组示例源码，介绍 compile 和 preserve 模式的配置方式及构建结果。
 


### PR DESCRIPTION
## Summary

- clarify that Node.js 22 is not supported for WASM preserve mode