### PR TITLE
feat(core)!: enable createRequire parser by default

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -246,6 +246,13 @@ export async function createConstantRsbuildConfig(): Promise<EnvironmentConfig> 
     tools: {
       htmlPlugin: false,
       rspack: {
+        module: {
+          parser: {
+            javascript: {
+              createRequire: true,
+            },
+          },
+        },
         optimization: {
           nodeEnv: false,
         },

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -456,6 +456,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     parser: {
       javascript: {
         typeReexportsPresence: 'tolerant',
+        createRequire: true,
         importMeta: false,
         importDynamic: false,
         commonjs: {
@@ -1321,6 +1322,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     parser: {
       javascript: {
         typeReexportsPresence: 'tolerant',
+        createRequire: true,
         importMeta: false,
         importDynamic: false,
         commonjs: {
@@ -2181,6 +2183,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     parser: {
       javascript: {
         typeReexportsPresence: 'tolerant',
+        createRequire: true,
         importMeta: false
       }
     },
@@ -2957,6 +2960,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     parser: {
       javascript: {
         typeReexportsPresence: 'tolerant',
+        createRequire: true,
         importMeta: false
       }
     },
@@ -3668,7 +3672,8 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   module: {
     parser: {
       javascript: {
-        typeReexportsPresence: 'tolerant'
+        typeReexportsPresence: 'tolerant',
+        createRequire: true
       }
     },
     rules: [
@@ -4423,6 +4428,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "htmlPlugin": false,
       "rspack": [
         {
+          "module": {
+            "parser": {
+              "javascript": {
+                "createRequire": true,
+              },
+            },
+          },
           "optimization": {
             "nodeEnv": false,
           },
@@ -4696,6 +4708,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "htmlPlugin": false,
       "rspack": [
         {
+          "module": {
+            "parser": {
+              "javascript": {
+                "createRequire": true,
+              },
+            },
+          },
           "optimization": {
             "nodeEnv": false,
           },
@@ -4944,6 +4963,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "htmlPlugin": false,
       "rspack": [
         {
+          "module": {
+            "parser": {
+              "javascript": {
+                "createRequire": true,
+              },
+            },
+          },
           "optimization": {
             "nodeEnv": false,
           },
@@ -5181,6 +5207,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "htmlPlugin": false,
       "rspack": [
         {
+          "module": {
+            "parser": {
+              "javascript": {
+                "createRequire": true,
+              },
+            },
+          },
           "optimization": {
             "nodeEnv": false,
           },
@@ -5373,6 +5406,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       "htmlPlugin": false,
       "rspack": [
         {
+          "module": {
+            "parser": {
+              "javascript": {
+                "createRequire": true,
+              },
+            },
+          },
           "optimization": {
             "nodeEnv": false,
           },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1332,6 +1332,8 @@ importers:
 
   tests/integration/parser-javascript/api-plugin: {}
 
+  tests/integration/parser-javascript/create-require/static-require: {}
+
   tests/integration/parser-javascript/module: {}
 
   tests/integration/parser-javascript/require/import-dynamic: {}

--- a/tests/integration/parser-javascript/create-require/index.test.ts
+++ b/tests/integration/parser-javascript/create-require/index.test.ts
@@ -1,0 +1,15 @@
+import { join } from 'node:path';
+import { expect, test } from '@rstest/core';
+import { buildAndGetResults } from 'test-helper';
+
+test('createRequire parser should be enabled by default', async () => {
+  const fixturePath = join(__dirname, 'static-require');
+  const { entries } = await buildAndGetResults({ fixturePath });
+
+  for (const content of [entries.esm, entries.cjs]) {
+    expect(content).toContain(
+      'const value = __webpack_require__("./src/answer.ts")',
+    );
+    expect(content).not.toContain('createRequire');
+  }
+});

--- a/tests/integration/parser-javascript/create-require/static-require/package.json
+++ b/tests/integration/parser-javascript/create-require/static-require/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "parser-javascript-create-require-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/parser-javascript/create-require/static-require/rslib.config.ts
+++ b/tests/integration/parser-javascript/create-require/static-require/rslib.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+});

--- a/tests/integration/parser-javascript/create-require/static-require/src/answer.ts
+++ b/tests/integration/parser-javascript/create-require/static-require/src/answer.ts
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/tests/integration/parser-javascript/create-require/static-require/src/index.ts
+++ b/tests/integration/parser-javascript/create-require/static-require/src/index.ts
@@ -1,0 +1,5 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export const value = require('./answer');

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -146,11 +146,9 @@ describe('CJS shims', () => {
     expect(importMetaFilename).toBe(entryFiles.cjs);
 
     for (const code of [cjsCode, dynamicContent]) {
-      expect(
-        code.startsWith(
-          `"use strict";\nconst __rslib_import_meta_url__ = /*#__PURE__*/ function() {`,
-        ),
-      ).toBe(true);
+      expect(code).toContain(
+        'const __rslib_import_meta_url__ = /*#__PURE__*/ function() {',
+      );
     }
   });
 
@@ -160,11 +158,12 @@ describe('CJS shims', () => {
 
     for (const code of [
       'const importMetaUrl = import.meta.url;',
-      'const src_require = createRequire(import.meta.url);',
+      'const requiredModule = __webpack_require__("./src/ok.cjs");',
       'const src_filename = fileURLToPath(import.meta.url);',
     ]) {
       expect(entries.esm).toContain(code);
     }
+    expect(entries.esm).not.toContain('createRequire(import.meta.url)');
   });
 });
 


### PR DESCRIPTION
## Summary

Enable Rspack's `createRequire` parser by default so Rslib can statically analyze and bundle `createRequire()` calls.

The ESM and CJS outputs in the `tests/integration/shims/cjs` case remain correct and preserve the expected module semantics.

## Breaking Change

Static dependencies loaded through `createRequire()` are now bundled instead of being preserved for runtime resolution. Set `tools.rspack.module.parser.javascript.createRequire` to `false` to restore the previous behavior.

## Output Changes

For static `createRequire()` calls, the dependency is bundled and the call is replaced with `__webpack_require__()`.

In the shims integration case:

- ESM output bundles the CommonJS dependency and adds a shared Rspack runtime chunk.
- CJS output embeds the CommonJS module and scopes `"use strict"` to the ESM module factory instead of the entire chunk, preserving the original non-strict CommonJS semantics.
- Dynamic chunks and runtime behavior remain unchanged.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/14783
- https://github.com/web-infra-dev/rspack/pull/14813
