### PR TITLE
docs: refine Web Workers guide

### DIFF
--- a/website/docs/en/guide/advanced/web-workers.mdx
+++ b/website/docs/en/guide/advanced/web-workers.mdx
@@ -32,26 +32,22 @@ new Worker(new URL('./worker.js', import.meta.url), {
 });
 ```
 
-For more Worker usage, see [Rsbuild - Web Workers - Import with constructors](https://rsbuild.rs/guide/basic/web-workers#import-with-constructors) and [Rspack - Web Workers - Usage](https://rspack.rs/guide/features/web-workers#usage).
+More Worker syntax can be found in [Rspack - Web Workers](https://rspack.rs/guide/features/web-workers).
 
 ### Limitations
 
-Processing this syntax relies on static analysis, so the `new URL(..., import.meta.url)` expression must remain inline. Passing a string or a variable is not supported:
+Rslib relies on static analysis to process `new Worker` and similar Worker APIs, so you must pass `new URL('./worker.ts', import.meta.url)` directly. URL strings and URL objects passed through variables are not supported:
 
 ```ts
-// Not supported
 new Worker('./worker.ts');
 
-// Not supported
 const workerUrl = new URL('./worker.ts', import.meta.url);
 new Worker(workerUrl);
 ```
 
-For details, see [Rspack - Web Workers - Limitations](https://rspack.rs/guide/features/web-workers#limitations).
-
 ### Output modes
 
-Depending on the [lib.bundle](/config/lib/bundle) option, the Worker constructor is compiled into different output. The following source files demonstrate the build output in both modes:
+The [lib.bundle](/config/lib/bundle) option determines how Workers are built. The following example uses the same source files to show the output generated in bundle and bundleless modes:
 
 <Tabs>
 <Tab label="src/index.ts">
@@ -111,7 +107,7 @@ export {};
 
 #### Bundleless mode
 
-In bundleless mode, Rslib transforms each source module separately. Worker URLs and imports inside Workers are rewritten to reference the corresponding generated ESM files:
+In bundleless mode, Rslib preserves the source module structure and rewrites Worker URLs and imports inside Workers to reference the corresponding ESM output files:
 
 <Tabs>
 <Tab label="dist/index.js">
@@ -146,17 +142,11 @@ export { add };
 
 ## Import with query suffixes
 
-Rslib also supports the [query suffix syntax provided by Rsbuild](https://rsbuild.rs/guide/basic/web-workers#import-with-query-suffixes).
-
-:::note
-
-Query suffixes currently only support bundle mode.
-
-:::
+Rslib supports importing Web Workers with query suffixes in bundle mode; for details, see [Rsbuild - Web Workers](https://rsbuild.rs/guide/basic/web-workers#import-with-query-suffixes).
 
 ### Emit a separate worker file
 
-Append `?worker` to a Worker import:
+You can append `?worker` to an import request to import a Web Worker script, and Rslib emits the script as a separate ESM file:
 
 ```ts title="index.ts"
 import MyWorker from './worker.ts?worker';
@@ -164,19 +154,15 @@ import MyWorker from './worker.ts?worker';
 export const worker = new MyWorker();
 ```
 
-Rslib emits the Worker as a separate ESM file.
-
 ### Inline a worker
 
-Append `?worker&inline` to inline the Worker:
+You can append `?worker&inline` to an import request to import a Web Worker script, and Rslib inlines the script into the JavaScript file that imports the Worker instead of emitting a separate Worker file:
 
 ```ts title="index.ts"
-import MyWorker from './worker.ts?worker&inline';
+import InlineWorker from './worker.ts?worker&inline';
 
-export const worker = new MyWorker();
+export const worker = new InlineWorker();
 ```
-
-Rslib encodes the Worker code as a data URL and inlines it into the JavaScript file that imports the Worker without emitting a separate Worker file.
 
 ### Type declarations
 
@@ -186,7 +172,7 @@ When you import a Worker with a query suffix in TypeScript code, TypeScript may 
 TS2307: Cannot find module './worker.ts?worker' or its corresponding type declarations.
 ```
 
-You can add the [preset types](/guide/basic/typescript#preset-types) provided by `@rslib/core` to `tsconfig.json`:
+In this case, you can add the [preset types](/guide/basic/typescript#preset-types) provided by `@rslib/core` to `tsconfig.json`:
 
 ```json title="tsconfig.json"
 {

--- a/website/docs/en/guide/advanced/web-workers.mdx
+++ b/website/docs/en/guide/advanced/web-workers.mdx
@@ -146,7 +146,7 @@ Rslib supports importing Web Workers with query suffixes in bundle mode; for det
 
 ### Emit a separate worker file
 
-You can append `?worker` to an import request to import a Web Worker script, and Rslib emits the script as a separate ESM file:
+You can append `?worker` to an import request to import a Web Worker script, which Rslib emits as a separate ESM file:
 
 ```ts title="index.ts"
 import MyWorker from './worker.ts?worker';
@@ -156,7 +156,7 @@ export const worker = new MyWorker();
 
 ### Inline a worker
 
-You can append `?worker&inline` to an import request to import a Web Worker script, and Rslib inlines the script into the JavaScript file that imports the Worker instead of emitting a separate Worker file:
+You can append `?worker&inline` to an import request to import a Web Worker script, which Rslib inlines into the JavaScript file that imports the Worker instead of emitting a separate Worker file:
 
 ```ts title="index.ts"
 import InlineWorker from './worker.ts?worker&inline';

--- a/website/docs/zh/guide/advanced/web-workers.mdx
+++ b/website/docs/zh/guide/advanced/web-workers.mdx
@@ -146,7 +146,7 @@ Rslib 支持在 bundle 模式下通过 query 后缀导入 Web Worker，详情请
 
 ### 输出独立 Worker 文件
 
-你可以在导入请求后添加 `?worker` 来导入 Web Worker 脚本，Rslib 会将该脚本输出为独立的 ESM 文件：
+你可以在导入请求后添加 `?worker` 来导入 Web Worker 脚本，Rslib 会为该 Worker 脚本生成独立的 ESM 文件：
 
 ```ts title="index.ts"
 import MyWorker from './worker.ts?worker';
@@ -156,7 +156,7 @@ export const worker = new MyWorker();
 
 ### 内联 Worker
 
-你可以在导入请求后添加 `?worker&inline` 来导入 Web Worker 脚本，Rslib 会将该脚本内联到导入该 Worker 的 JavaScript 文件中，不再输出独立的 Worker 文件：
+你可以在导入请求后添加 `?worker&inline` 来导入 Web Worker 脚本，Rslib 会在导入该 Worker 的 JavaScript 文件中内联 Worker 代码，不再生成独立的 Worker 文件：
 
 ```ts title="index.ts"
 import InlineWorker from './worker.ts?worker&inline';

--- a/website/docs/zh/guide/advanced/web-workers.mdx
+++ b/website/docs/zh/guide/advanced/web-workers.mdx
@@ -32,26 +32,22 @@ new Worker(new URL('./worker.js', import.meta.url), {
 });
 ```
 
-更多 Worker 用法，请参考 [Rsbuild - Web Workers - 使用 Worker 构造器](https://rsbuild.rs/zh/guide/basic/web-workers#%E4%BD%BF%E7%94%A8-worker-%E6%9E%84%E9%80%A0%E5%99%A8) 和 [Rspack - Web Workers - 使用方式](https://rspack.rs/zh/guide/features/web-workers#%E4%BD%BF%E7%94%A8%E6%96%B9%E5%BC%8F)。
+更多 Worker 语法可以查看 [Rspack - Web Workers](https://rspack.rs/zh/guide/features/web-workers)。
 
 ### 限制
 
-该语法的处理依赖静态分析，因此 `new URL(..., import.meta.url)` 表达式需要保持内联，不支持传入字符串或变量：
+Rslib 依赖静态分析处理 `new Worker` 及类似的 Worker API，因此必须直接传入 `new URL('./worker.ts', import.meta.url)`。URL 字符串和通过变量传入的 URL 对象均不受支持：
 
 ```ts
-// 不支持
 new Worker('./worker.ts');
 
-// 不支持
 const workerUrl = new URL('./worker.ts', import.meta.url);
 new Worker(workerUrl);
 ```
 
-相关限制请参考 [Rspack - Web Workers - 限制](https://rspack.rs/zh/guide/features/web-workers#%E9%99%90%E5%88%B6)。
-
 ### 产物模式
 
-由于 [lib.bundle](/config/lib/bundle) 配置项不同，Worker 构造器会被编译为不同的产物，下面通过一组示例源码展示两种模式下的构建结果：
+[lib.bundle](/config/lib/bundle) 配置项会影响 Worker 的构建方式。下面以同一组源码为例，展示 bundle 和 bundleless 模式分别生成的产物：
 
 <Tabs>
 <Tab label="src/index.ts">
@@ -111,7 +107,7 @@ export {};
 
 #### Bundleless 模式
 
-在 bundleless 模式下，Rslib 会分别转换每个源模块，并将 Worker URL 和 Worker 内部的导入重写为对应的 ESM 产物路径：
+在 bundleless 模式下，Rslib 会保留源码的模块结构，并将 Worker URL 和 Worker 内部的导入重写为对应的 ESM 产物路径：
 
 <Tabs>
 <Tab label="dist/index.js">
@@ -146,17 +142,11 @@ export { add };
 
 ## 使用 query 后缀导入
 
-Rslib 还支持 [Rsbuild 提供的 query 后缀语法](https://rsbuild.rs/zh/guide/basic/web-workers#使用-query-后缀导入)。
-
-:::note
-
-query 后缀目前仅支持 bundle 模式。
-
-:::
+Rslib 支持在 bundle 模式下通过 query 后缀导入 Web Worker，详情请参考 [Rsbuild - Web Workers](https://rsbuild.rs/zh/guide/basic/web-workers#使用-query-后缀导入)。
 
 ### 输出独立 Worker 文件
 
-在 Worker 导入路径后添加 `?worker`：
+你可以在导入请求后添加 `?worker` 来导入 Web Worker 脚本，Rslib 会将该脚本输出为独立的 ESM 文件：
 
 ```ts title="index.ts"
 import MyWorker from './worker.ts?worker';
@@ -164,19 +154,15 @@ import MyWorker from './worker.ts?worker';
 export const worker = new MyWorker();
 ```
 
-Rslib 会将 Worker 输出为独立的 ESM 文件。
-
 ### 内联 Worker
 
-添加 `?worker&inline` 可以内联 Worker：
+你可以在导入请求后添加 `?worker&inline` 来导入 Web Worker 脚本，Rslib 会将该脚本内联到导入该 Worker 的 JavaScript 文件中，不再输出独立的 Worker 文件：
 
 ```ts title="index.ts"
-import MyWorker from './worker.ts?worker&inline';
+import InlineWorker from './worker.ts?worker&inline';
 
-export const worker = new MyWorker();
+export const worker = new InlineWorker();
 ```
-
-Rslib 会将 Worker 代码编码为 data URL，并内联到导入该 Worker 的 JavaScript 文件中，不再输出独立的 Worker 文件。
 
 ### 类型声明
 
@@ -186,7 +172,7 @@ Rslib 会将 Worker 代码编码为 data URL，并内联到导入该 Worker 的 
 TS2307: Cannot find module './worker.ts?worker' or its corresponding type declarations.
 ```
 
-你可以在 `tsconfig.json` 中添加 `@rslib/core` 提供的 [预设类型](/guide/basic/typescript#预设类型)：
+此时你可以在 `tsconfig.json` 中添加 `@rslib/core` 提供的 [预设类型](/guide/basic/typescript#预设类型)：
 
 ```json title="tsconfig.json"
 {


### PR DESCRIPTION
## Summary

This PR refines the English and Chinese Web Workers guides after #1774. It clarifies Worker constructor limitations and bundle/bundleless output behavior, simplifies query suffix guidance, and corrects the inline Worker description without implying that the generated URL is always a data URL.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1774

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).