### PR TITLE
docs: add FAQ for preserving __webpack_require__

### DIFF
--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -282,3 +282,55 @@ export default defineConfig({
   },
 });
 ```
+
+### How to preserve `__webpack_require__` and its property accesses in the source code when generating outputs?
+
+Rspack, which Rslib uses under the hood, recognizes `__webpack_require__` and its property accesses as runtime variables. Unlike module variables such as `__webpack_hash__`, `source.define` cannot reliably preserve these runtime variables. Instead, use placeholders and replace them through `processAssets`:
+
+1. Replace them with unique placeholders in the source code:
+
+```ts title="src/index.ts"
+const webpackRequire = __webpack_require__; // [!code --]
+const webpackRequire = RSLIB_WEBPACK_REQUIRE; // [!code ++]
+
+__webpack_require__.i.push(handler); // [!code --]
+RSLIB_INTERCEPT_MODULE_EXECUTION.push(handler); // [!code ++]
+```
+
+2. Add a plugin that restores the placeholders with the [`processAssets`](https://rsbuild.rs/plugins/dev/core#apiprocessassets) hook:
+
+```ts title="rslib.config.ts"
+import { defineConfig, rspack, type RsbuildPlugin } from '@rslib/core';
+
+const preserveWebpackRuntimePlugin: RsbuildPlugin = {
+  name: 'preserve-webpack-runtime',
+  setup(api) {
+    api.processAssets(
+      { stage: 'optimize-inline' },
+      ({ assets, compilation, sources }) => {
+        for (const [assetName, asset] of Object.entries(assets)) {
+          if (!/\.[cm]?js$/.test(assetName)) continue;
+
+          const source = asset.source().toString();
+          const code = source
+            .replaceAll('RSLIB_WEBPACK_REQUIRE', rspack.RuntimeGlobals.require)
+            .replaceAll(
+              'RSLIB_INTERCEPT_MODULE_EXECUTION',
+              rspack.RuntimeGlobals.interceptModuleExecution,
+            );
+
+          if (code !== source) {
+            compilation.updateAsset(assetName, new sources.RawSource(code));
+          }
+        }
+      },
+    );
+  },
+};
+
+export default defineConfig({
+  plugins: [preserveWebpackRuntimePlugin],
+});
+```
+
+`RuntimeGlobals.require` maps to `__webpack_require__`, and `RuntimeGlobals.interceptModuleExecution` maps to `__webpack_require__.i`. See the [RuntimeGlobals list](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/RuntimeGlobals.ts) for other properties. If a property has no matching `RuntimeGlobals` value, write `RSLIB_WEBPACK_REQUIRE.foo` in the source code; the plugin will restore it as `__webpack_require__.foo`.

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -333,4 +333,6 @@ export default defineConfig({
 });
 ```
 
+> This plugin modifies JavaScript assets after source maps are generated without updating the source maps. When [`output.sourceMap`](/config/rsbuild/output#outputsourcemap) is enabled, the generated mappings may be inaccurate.
+
 `RuntimeGlobals.require` maps to `__webpack_require__`, and `RuntimeGlobals.interceptModuleExecution` maps to `__webpack_require__.i`. See the [RuntimeGlobals list](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/RuntimeGlobals.ts) for other properties. If a property has no matching `RuntimeGlobals` value, write `RSLIB_WEBPACK_REQUIRE.foo` in the source code; the plugin will restore it as `__webpack_require__.foo`.

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -282,3 +282,55 @@ export default defineConfig({
   },
 });
 ```
+
+### 如何在生成产物时保留源码中的 `__webpack_require__` 及其属性访问？
+
+Rslib 底层使用的 Rspack 会在构建时将 `__webpack_require__` 及其属性访问识别为运行时变量。与 `__webpack_hash__` 等模块变量不同，这类运行时变量无法通过 `source.define` 可靠地保留，需要通过占位符和 `processAssets` 进行处理：
+
+1. 在源码中将这些引用替换为唯一的占位符：
+
+```ts title="src/index.ts"
+const webpackRequire = __webpack_require__; // [!code --]
+const webpackRequire = RSLIB_WEBPACK_REQUIRE; // [!code ++]
+
+__webpack_require__.i.push(handler); // [!code --]
+RSLIB_INTERCEPT_MODULE_EXECUTION.push(handler); // [!code ++]
+```
+
+2. 在 Rslib 配置中添加插件，通过 [`processAssets`](https://rsbuild.rs/zh/plugins/dev/core#apiprocessassets) hook 还原占位符：
+
+```ts title="rslib.config.ts"
+import { defineConfig, rspack, type RsbuildPlugin } from '@rslib/core';
+
+const preserveWebpackRuntimePlugin: RsbuildPlugin = {
+  name: 'preserve-webpack-runtime',
+  setup(api) {
+    api.processAssets(
+      { stage: 'optimize-inline' },
+      ({ assets, compilation, sources }) => {
+        for (const [assetName, asset] of Object.entries(assets)) {
+          if (!/\.[cm]?js$/.test(assetName)) continue;
+
+          const source = asset.source().toString();
+          const code = source
+            .replaceAll('RSLIB_WEBPACK_REQUIRE', rspack.RuntimeGlobals.require)
+            .replaceAll(
+              'RSLIB_INTERCEPT_MODULE_EXECUTION',
+              rspack.RuntimeGlobals.interceptModuleExecution,
+            );
+
+          if (code !== source) {
+            compilation.updateAsset(assetName, new sources.RawSource(code));
+          }
+        }
+      },
+    );
+  },
+};
+
+export default defineConfig({
+  plugins: [preserveWebpackRuntimePlugin],
+});
+```
+
+`RuntimeGlobals.require` 对应 `__webpack_require__`，`RuntimeGlobals.interceptModuleExecution` 对应 `__webpack_require__.i`。其他属性可参考 [RuntimeGlobals 列表](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/RuntimeGlobals.ts)。如果某个属性没有对应的 `RuntimeGlobals` 值，可以在源码中写成 `RSLIB_WEBPACK_REQUIRE.foo`，插件会将其还原为 `__webpack_require__.foo`。

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -333,4 +333,6 @@ export default defineConfig({
 });
 ```
 
+> 该插件会在 source map 生成后修改 JavaScript 产物，但不会同步更新 source map。开启 [`output.sourceMap`](/config/rsbuild/output#outputsourcemap) 时，生成的映射可能不准确。
+
 `RuntimeGlobals.require` 对应 `__webpack_require__`，`RuntimeGlobals.interceptModuleExecution` 对应 `__webpack_require__.i`。其他属性可参考 [RuntimeGlobals 列表](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/RuntimeGlobals.ts)。如果某个属性没有对应的 `RuntimeGlobals` 值，可以在源码中写成 `RSLIB_WEBPACK_REQUIRE.foo`，插件会将其还原为 `__webpack_require__.foo`。


### PR DESCRIPTION
## Summary

This PR documents how to preserve `__webpack_require__` and its property accesses in Rslib output without binding them to the library build runtime. It adds matching English and Chinese examples that use placeholders with `processAssets` and map known properties through Rspack's `RuntimeGlobals`.

## Related Links

- Closes #1434

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).