### PR TITLE
docs: clarify TypeScript limitation note for wasm source imports

### DIFF
--- a/website/docs/en/guide/advanced/wasm.mdx
+++ b/website/docs/en/guide/advanced/wasm.mdx
@@ -60,7 +60,7 @@ const addModule = await import.source('./add.wasm');
 
 :::note
 
-TypeScript cannot currently parse `import source` or `import.source()`. Use these forms in JavaScript files, or choose a toolchain that supports them.
+TypeScript cannot currently parse `import source` or `import.source()`. If you need to generate declaration files, use these forms in JavaScript files.
 
 :::
 

--- a/website/docs/zh/guide/advanced/wasm.mdx
+++ b/website/docs/zh/guide/advanced/wasm.mdx
@@ -60,7 +60,7 @@ const addModule = await import.source('./add.wasm');
 
 :::note
 
-TypeScript 目前无法解析 `import source` 和 `import.source()`。请在 JavaScript 文件中使用这些语法，或选择支持它们的工具链。
+TypeScript 目前无法解析 `import source` 和 `import.source()`。如果你需要生成类型声明文件，请在 JavaScript 文件中使用这些语法。
 
 :::
 


### PR DESCRIPTION
## Summary

The note about `import source` / `import.source()` suggested choosing another toolchain, which is misleading. Reworded it in both the English and Chinese docs to say the limitation only matters when generating declaration files.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
