### PR TITLE
docs: document Node.js addon support

### DIFF
--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -16,6 +16,8 @@ Rslib supports these formats by default:
 - **Video**: mp4, webm, ogg, mov.
 - **Other**: webmanifest, pdf, txt, vtt.
 
+In addition to the static asset types listed above, when [output.target](/config/rsbuild/output#outputtarget) is `'node'`, Rslib also supports importing Node.js [addons](https://nodejs.org/api/addons.html) in JavaScript files.
+
 To import assets in other formats, refer to [Extend Asset Types](#extend-asset-types).
 
 ## Import assets in JavaScript file

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -16,6 +16,8 @@ Rslib 支持在代码中引用图片、字体、媒体和其他类型文件等�
 - **视频**：mp4、webm、ogg、mov。
 - **其他**：webmanifest、pdf、txt、vtt。
 
+除上述静态资源格式外，当 [output.target](/config/rsbuild/output#outputtarget) 为 `'node'` 时，Rslib 还支持在 JavaScript 文件中引入 Node.js [addons](https://nodejs.org/api/addons.html)。
+
 如果你需要引用其他格式的静态资源，请参考 [扩展静态资源类型](#扩展静态资源类型)。
 
 ## 在 JavaScript 文件中引用


### PR DESCRIPTION
## Summary

This PR documents the built-in support for importing Node.js addons when targeting Node.js. The note is added to both the English and Chinese static assets guides.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8203

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).