### PR TITLE
test: improve createRequire parser coverage

### DIFF
--- a/tests/integration/parser-javascript/create-require/index.test.ts
+++ b/tests/integration/parser-javascript/create-require/index.test.ts
@@ -2,14 +2,21 @@ import { join } from 'node:path';
 import { expect, test } from '@rstest/core';
 import { buildAndGetResults } from 'test-helper';
 
-test('createRequire parser should be enabled by default', async () => {
+test('createRequire parser', async () => {
   const fixturePath = join(__dirname, 'static-require');
-  const { entries } = await buildAndGetResults({ fixturePath });
+  const { entries, entryFiles } = await buildAndGetResults({ fixturePath });
 
-  for (const content of [entries.esm, entries.cjs]) {
-    expect(content).toContain(
-      'const value = __webpack_require__("./src/answer.ts")',
-    );
-    expect(content).not.toContain('createRequire');
+  for (const format of ['esm0', 'cjs0'] as const) {
+    expect(entries[format]).toContain('module.exports = 42');
+    expect(entries[format]).not.toContain('createRequire(');
+
+    const result = await import(entryFiles[format]!);
+    expect(result.value).toBe(42);
+  }
+
+  for (const format of ['esm1', 'cjs1'] as const) {
+    expect(entries[format]).toContain('createRequire');
+    expect(entries[format]).toMatch(/\(['"]\.\/answer['"]\)/);
+    expect(entries[format]).not.toContain('module.exports = 42');
   }
 });

--- a/tests/integration/parser-javascript/create-require/static-require/rslib.config.ts
+++ b/tests/integration/parser-javascript/create-require/static-require/rslib.config.ts
@@ -1,8 +1,45 @@
 import { defineConfig } from '@rslib/core';
 import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
 
+const createRequireDisabled = {
+  tools: {
+    rspack: {
+      module: {
+        parser: {
+          javascript: {
+            createRequire: false,
+          },
+        },
+      },
+    },
+  },
+};
+
 export default defineConfig({
-  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
+  lib: [
+    generateBundleEsmConfig({
+      output: {
+        distPath: './dist/enabled/esm',
+      },
+    }),
+    generateBundleCjsConfig({
+      output: {
+        distPath: './dist/enabled/cjs',
+      },
+    }),
+    generateBundleEsmConfig({
+      ...createRequireDisabled,
+      output: {
+        distPath: './dist/disabled/esm',
+      },
+    }),
+    generateBundleCjsConfig({
+      ...createRequireDisabled,
+      output: {
+        distPath: './dist/disabled/cjs',
+      },
+    }),
+  ],
   source: {
     entry: {
       index: './src/index.ts',

--- a/tests/integration/shims/cjs/rslib.config.ts
+++ b/tests/integration/shims/cjs/rslib.config.ts
@@ -12,13 +12,6 @@ export default defineConfig({
       },
     }),
   ],
-  output: {
-    copy: [
-      {
-        from: 'src/ok.cjs',
-      },
-    ],
-  },
   source: {
     entry: {
       index: './src/index.ts',

--- a/tests/integration/shims/cjs/src/index.ts
+++ b/tests/integration/shims/cjs/src/index.ts
@@ -3,6 +3,9 @@ import { createRequire } from 'node:module';
 const importMetaUrl = import.meta.url;
 const require = createRequire(import.meta.url);
 const requiredModule = require('./ok.cjs');
+const esmModuleIsStrict = (function (this: unknown) {
+  return this === undefined;
+})();
 
 const dynamicImportMetaUrl = async () => {
   const { dynamic } = await import('./dynamic');
@@ -28,4 +31,5 @@ export {
   __filename,
   importMetaDirname,
   importMetaFilename,
+  esmModuleIsStrict,
 };

--- a/tests/integration/shims/cjs/src/ok.cjs
+++ b/tests/integration/shims/cjs/src/ok.cjs
@@ -1,1 +1,6 @@
-module.exports = 'ok';
+module.exports = {
+  value: 'ok',
+  isStrict: (function () {
+    return this === undefined;
+  })(),
+};

--- a/tests/integration/shims/index.test.ts
+++ b/tests/integration/shims/index.test.ts
@@ -106,12 +106,13 @@ describe('ESM shims disabled', async () => {
   });
 });
 
-describe('CJS shims', () => {
+describe('CJS shims', async () => {
+  const fixturePath = join(__dirname, 'cjs');
+  const { entryFiles, entries, contents } = await buildAndGetResults({
+    fixturePath,
+  });
+
   test('import.meta.url', async () => {
-    const fixturePath = join(__dirname, 'cjs');
-    const { entryFiles, entries, contents } = await buildAndGetResults({
-      fixturePath,
-    });
     // `module.require` is not available in Rstest runner context. Manually create a context to run the CJS code.
     // As a temporary solution, we use `module.require` to avoid potential collision with module scope variable `require`.
     const cjsCode = entries.cjs;
@@ -129,6 +130,7 @@ describe('CJS shims', () => {
       requiredModule,
       importMetaDirname,
       importMetaFilename,
+      esmModuleIsStrict,
     } = vm.runInContext(cjsCode, context);
     const fileUrl = pathToFileURL(entryFiles.cjs).href;
     const dynamicUrl = await dynamicImportMetaUrl();
@@ -141,7 +143,9 @@ describe('CJS shims', () => {
     expect(dynamicUrl).toBe(
       fileUrl.replace('index.cjs', path.basename(dynamicPath)),
     );
-    expect(requiredModule).toBe('ok');
+    expect(requiredModule.value).toBe('ok');
+    expect(requiredModule.isStrict).toBe(false);
+    expect(esmModuleIsStrict).toBe(true);
     expect(importMetaDirname).toBe(path.dirname(entryFiles.cjs));
     expect(importMetaFilename).toBe(entryFiles.cjs);
 
@@ -153,17 +157,21 @@ describe('CJS shims', () => {
   });
 
   test('ESM should not be affected by CJS shims configuration', async () => {
-    const fixturePath = join(__dirname, 'cjs');
-    const { entries } = await buildAndGetResults({ fixturePath });
-
     for (const code of [
       'const importMetaUrl = import.meta.url;',
-      'const requiredModule = __webpack_require__("./src/ok.cjs");',
       'const src_filename = fileURLToPath(import.meta.url);',
     ]) {
       expect(entries.esm).toContain(code);
     }
-    expect(entries.esm).not.toContain('createRequire(import.meta.url)');
+    expect(entries.esm).not.toContain('createRequire');
+
+    const esmResult = await import(entryFiles.esm!);
+    expect(esmResult.importMetaUrl).toBe(pathToFileURL(entryFiles.esm!).href);
+    expect(esmResult.requiredModule.value).toBe('ok');
+    expect(esmResult.esmModuleIsStrict).toBe(true);
+    expect(esmResult.__filename).toBe(entryFiles.esm);
+    expect(esmResult.importMetaDirname).toBe(path.dirname(entryFiles.esm!));
+    expect(esmResult.importMetaFilename).toBe(entryFiles.esm);
   });
 });
 


### PR DESCRIPTION
## Summary

- Follow up on #1814 by covering both enabled and disabled `createRequire` parser behavior in one integration build and executing the generated ESM/CJS outputs.
- Verify that CJS shim output keeps ESM modules strict while preserving bundled CommonJS non-strict semantics, and remove the no-longer-needed copied fixture.

## Related Links

- #1814

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).