### PR TITLE
docs: unify top-level configuration terminology

### DIFF
--- a/website/docs/en/config/lib/index.mdx
+++ b/website/docs/en/config/lib/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Browse Rslib's lib configuration, including the lib and Rsbuild options available to each output and the shared and non-shared lib options."
+description: "Browse Rslib's lib configuration, including the lib and Rsbuild options available to each output and the top-level and non-top-level lib options."
 ---
 
 # Overview
@@ -29,9 +29,9 @@ export default {
 };
 ```
 
-## Shared lib configurations
+## Top-level lib configurations
 
-The following lib configurations can be placed outside the `lib` field as shared configuration for all outputs or inside a `lib` item to configure a specific output:
+The following lib configurations can be placed outside the `lib` field as top-level configuration shared across `lib` outputs, or inside a `lib` item to configure a specific output:
 
 - [`autoExtension`](/config/lib/auto-extension)
 - [`banner`](/config/lib/banner)
@@ -45,9 +45,9 @@ The following lib configurations can be placed outside the `lib` field as shared
 - [`syntax`](/config/lib/syntax)
 - [`wasm`](/config/lib/wasm)
 
-## Non-shared lib configurations
+## Non-top-level lib configurations
 
-The following lib configurations do not support shared configuration and can only be specified in a `lib` item to configure an individual output:
+The following lib configurations do not support top-level configuration and can only be specified in a `lib` item to configure an individual output:
 
 - [`dts`](/config/lib/dts)
 - [`experiments`](/config/lib/experiments)

--- a/website/docs/en/guide/basic/configure-rslib.mdx
+++ b/website/docs/en/guide/basic/configure-rslib.mdx
@@ -1,5 +1,5 @@
 ---
-description: 'Configure Rslib with lib configurations, Rsbuild configurations, shared configuration, config files, and defineConfig.'
+description: 'Configure Rslib with lib configurations, Rsbuild configurations, top-level configuration, config files, and defineConfig.'
 ---
 
 # Configure Rslib
@@ -13,15 +13,15 @@ Rslib configuration consists of two types of options:
 - [Lib configurations](/config/lib) describe library outputs, including their output formats, output structures, and syntax targets.
 - [Rsbuild configurations](/config/rsbuild) control the underlying compilation and build behavior, including module resolution, source processing, and related plugins.
 
-The `lib` field is an optional array of objects. Each object corresponds to one output and can contain both types of configuration above. Configurations inside a `lib` item apply only to that output, while configurations outside the `lib` field are shared across all outputs.
+The `lib` field is an optional array of objects. Each object corresponds to one output and can contain both types of configuration above. Configurations inside a `lib` item apply only to that output, while configurations outside the `lib` field are top-level configurations shared across `lib` outputs.
 
-Rslib merges the shared configuration with each `lib` item according to the [configuration merge rules](https://rsbuild.rs/api/javascript-api/core#merge-rules).
+Rslib merges the top-level configuration with each `lib` item according to the [configuration merge rules](https://rsbuild.rs/api/javascript-api/core#merge-rules).
 
 ### Lib configurations
 
-Lib configurations can be specified in a `lib` item to configure a specific output. [Some lib configurations](/config/lib#shared-lib-configurations) can also be placed outside the `lib` field as shared configuration for all outputs.
+Lib configurations can be specified in a `lib` item to configure a specific output. [Some lib configurations](/config/lib#top-level-lib-configurations) can also be placed outside the `lib` field as top-level configuration shared across `lib` outputs.
 
-For example, set [`syntax`](/config/lib/syntax) to `es2020` for the CJS output and use shared configuration to set `syntax` to `es2021` for the other outputs:
+For example, set [`syntax`](/config/lib/syntax) to `es2020` for the CJS output and use top-level configuration to set `syntax` to `es2021` for the other outputs:
 
 ```js title="rslib.config.mjs"
 export default {
@@ -44,9 +44,9 @@ When you only need to generate a single ESM output using the default configurati
 
 ### Rsbuild configurations
 
-Rsbuild configurations can be placed outside the `lib` field as shared configuration or inside a `lib` item to configure a specific output.
+Rsbuild configurations can be placed outside the `lib` field as top-level configuration shared across `lib` outputs, or inside a `lib` item to configure a specific output.
 
-For example, set the ESM output's [output.target](/config/rsbuild/output#outputtarget) to `'web'`, and use shared configuration to set `output.target` to `'node'` for the other outputs:
+For example, set the ESM output's [output.target](/config/rsbuild/output#outputtarget) to `'web'`, and use top-level configuration to set `output.target` to `'node'` for the other outputs:
 
 ```js title="rslib.config.mjs"
 export default {

--- a/website/docs/zh/config/lib/index.mdx
+++ b/website/docs/zh/config/lib/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: '查看 Rslib 的 lib 配置，了解每份库产物可用的 lib 配置和 Rsbuild 配置，以及共享与非共享 lib 配置项。'
+description: '查看 Rslib 的 lib 配置，了解每份库产物可用的 lib 配置和 Rsbuild 配置，以及顶层与非顶层 lib 配置项。'
 ---
 
 # 总览
@@ -29,9 +29,9 @@ export default {
 };
 ```
 
-## 共享 lib 配置
+## 顶层 lib 配置
 
-以下 lib 配置可以写在 `lib` 字段外，作为所有产物的共享配置，也可以写在 `lib` 项中，用于单独配置对应产物：
+以下 lib 配置可以写在 `lib` 字段外作为顶层配置，在各个 `lib` 产物之间共享；也可以写在 `lib` 项中，用于单独配置对应产物：
 
 - [`autoExtension`](/config/lib/auto-extension)
 - [`banner`](/config/lib/banner)
@@ -45,9 +45,9 @@ export default {
 - [`syntax`](/config/lib/syntax)
 - [`wasm`](/config/lib/wasm)
 
-## 非共享 lib 配置
+## 非顶层 lib 配置
 
-以下 lib 配置不支持共享配置，只能写在 `lib` 项中，用于单独配置对应产物：
+以下 lib 配置不支持顶层配置，只能写在 `lib` 项中，用于单独配置对应产物：
 
 - [`dts`](/config/lib/dts)
 - [`experiments`](/config/lib/experiments)

--- a/website/docs/zh/guide/basic/configure-rslib.mdx
+++ b/website/docs/zh/guide/basic/configure-rslib.mdx
@@ -1,5 +1,5 @@
 ---
-description: '配置 Rslib，了解 lib 配置、Rsbuild 配置、共享配置、配置文件与 defineConfig 的使用方式。'
+description: '配置 Rslib，了解 lib 配置、Rsbuild 配置、顶层配置、配置文件与 defineConfig 的使用方式。'
 ---
 
 # 配置 Rslib
@@ -13,15 +13,15 @@ Rslib 配置由两类配置组成：
 - [lib 配置](/config/lib)：描述库产物本身，包括输出格式、产物结构和语法目标等。
 - [Rsbuild 配置](/config/rsbuild)：控制底层编译和构建行为，包括模块解析、源码处理与相关插件等。
 
-`lib` 是一个可选的对象数组，每个对象对应一份产物，可包含上述两类配置。写在 `lib` 项中的配置仅作用于对应产物；写在 `lib` 字段外的配置则作为共享配置，应用于所有产物。
+`lib` 是一个可选的对象数组，每个对象对应一份产物，可包含上述两类配置。写在 `lib` 项中的配置仅作用于对应产物；写在 `lib` 字段外的配置则作为顶层配置，在各个 `lib` 产物之间共享。
 
-Rslib 会按照 [配置合并规则](https://rsbuild.rs/zh/api/javascript-api/core#合并规则) 将共享配置与每个 `lib` 项合并。
+Rslib 会按照 [配置合并规则](https://rsbuild.rs/zh/api/javascript-api/core#合并规则) 将顶层配置与每个 `lib` 项合并。
 
 ### lib 配置
 
-lib 配置可以写在 `lib` 项中，用于单独配置对应产物。[部分 lib 配置](/config/lib#共享-lib-配置)也可以写在 `lib` 字段外，作为共享配置应用于所有产物。
+lib 配置可以写在 `lib` 项中，用于单独配置对应产物。[部分 lib 配置](/config/lib#顶层-lib-配置)也可以写在 `lib` 字段外作为顶层配置，在各个 `lib` 产物之间共享。
 
-例如，将 CJS 产物的 [`syntax`](/config/lib/syntax) 设置为 `es2020`，并通过共享配置将其余产物的 `syntax` 设置为 `es2021`：
+例如，将 CJS 产物的 [`syntax`](/config/lib/syntax) 设置为 `es2020`，并通过顶层配置将其余产物的 `syntax` 设置为 `es2021`：
 
 ```js title="rslib.config.mjs"
 export default {
@@ -44,9 +44,9 @@ export default {
 
 ### Rsbuild 配置
 
-Rsbuild 配置可以写在 `lib` 字段外作为共享配置，也可以写在 `lib` 项中，用于单独配置对应产物。
+Rsbuild 配置可以写在 `lib` 字段外作为顶层配置，在各个 `lib` 产物之间共享；也可以写在 `lib` 项中，用于单独配置对应产物。
 
-例如，将 ESM 产物的 [output.target](/config/rsbuild/output#outputtarget) 设置为 `'web'`，并通过共享配置将其余产物的 `output.target` 设置为 `'node'`：
+例如，将 ESM 产物的 [output.target](/config/rsbuild/output#outputtarget) 设置为 `'web'`，并通过顶层配置将其余产物的 `output.target` 设置为 `'node'`：
 
 ```js title="rslib.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

- Use “top-level configuration” consistently across the English and Chinese documentation.
- Clarify that top-level configuration is shared across `lib` outputs.