### PR TITLE
docs: clarify new URL asset handling

### DIFF
--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -169,11 +169,11 @@ export default {
 
 #### Skip `new URL()` processing
 
-If you do not want `new URL()` to be parsed as a URL asset, choose one of the following approaches based on the required scope.
+If you do not want `new URL()` expressions in project source files to be parsed as URL assets, choose one of the following approaches based on the required scope.
 
 ##### Disable the URL parser
 
-Disable the [URL parser](https://rspack.rs/config/module-parser#javascripturl) on the built-in JavaScript rule through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to skip asset parsing for all `new URL()` expressions:
+By default, Rslib sets the [URL parser](https://rspack.rs/config/module-parser#javascripturl) on its built-in JavaScript rule to `'new-url-relative'`. You can set the rule's URL parser to `false` through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to skip asset parsing for all `new URL()` expressions in project source files:
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';

--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -122,20 +122,19 @@ When referencing static assets with `new URL()`, only ESM output is supported, s
 
 :::
 
-You can also reference static assets by using JavaScript's native `URL` together with `import.meta.url`:
+You can also reference static assets by using JavaScript's native [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) together with [import.meta.url](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta):
 
-```js
+```ts title="src/index.ts"
 const logo = new URL('./assets/logo.svg', import.meta.url);
 ```
 
-The following output will be emitted:
+After the build, the path in `new URL()` points to the emitted asset file, producing the following output:
 
 <Tabs>
-<Tab label="dist/index.mjs">
+<Tab label="dist/index.js">
 
 ```js
 const logo = new URL('./static/svg/logo.svg', import.meta.url);
-export { logo };
 ```
 
 </Tab>
@@ -145,12 +144,14 @@ export { logo };
 </Tab>
 </Tabs>
 
-After build, the path in `new URL()` points to the emitted asset file.
+Files such as `.js`, `.ts`, `.css`, and `.scss` referenced through `new URL()` are also treated as URL assets. They bypass the relevant built-in loaders, and their original contents are emitted as assets.
 
-In bundleless mode, the default glob entry matches `src/**`. When referencing static assets with `new URL()`, you need to manually exclude the corresponding asset files from the entry:
+:::note
+
+When [bundle](/config/lib/bundle) is `false`, the default entry is the `src/**` glob pattern, which also matches static asset files under `src`. Assets referenced through `new URL()` need to be excluded from [source.entry](/config/rsbuild/source#sourceentry).
 
 ```ts title="rslib.config.ts"
-export default defineConfig({
+export default {
   lib: [
     {
       bundle: false,
@@ -161,8 +162,56 @@ export default defineConfig({
       },
     },
   ],
+};
+```
+
+:::
+
+#### Skip `new URL()` processing
+
+If you do not want `new URL()` to be parsed as a URL asset, choose one of the following approaches based on the required scope.
+
+##### Disable the URL parser
+
+Disable the [URL parser](https://rspack.rs/config/module-parser#javascripturl) on the built-in JavaScript rule through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to skip asset parsing for all `new URL()` expressions:
+
+```ts title="rslib.config.ts"
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  tools: {
+    bundlerChain(chain, { CHAIN_ID }) {
+      chain.module
+        .rule(CHAIN_ID.RULE.JS)
+        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
+        .parser({
+          url: false,
+        });
+    },
+  },
 });
 ```
+
+After the parser is disabled, the `new URL()` expression is preserved unchanged, and Rslib does not emit the referenced file:
+
+```js title="dist/index.js"
+const logo = new URL('./assets/logo.svg', import.meta.url);
+```
+
+The output retains the standard `new URL(path, import.meta.url)` form. If the referenced asset needs to be published with the output, we recommend copying it to the output directory through [output.copy](/config/rsbuild/output#outputcopy) or a similar method and ensuring that its output path matches the relative path in `new URL()`. This allows the asset to be located correctly whether the output is processed by a downstream bundler or run directly in Node.js.
+
+##### Ignore a specific reference
+
+To skip processing for a specific `new URL()`, add the [rspackIgnore](https://rspack.rs/api/runtime-api/module-methods#rspackignore) comment before its first argument:
+
+```ts title="src/index.ts"
+const logo = new URL(
+  /* rspackIgnore: true */ './assets/logo.svg',
+  import.meta.url,
+);
+```
+
+At this point, Rslib uses a runtime variable as the base URL for `new URL()`, and the emitted expression no longer retains `import.meta.url`. This limits downstream bundlers' ability to statically analyze the asset reference when consuming the output.
 
 ## Import assets in CSS file
 

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -122,20 +122,19 @@ export { logo_namespaceObject as default };
 
 :::
 
-你可以通过 JavaScript 原生的 `URL` 和 `import.meta.url` 相配合，来引用静态资源：
+你可以通过 JavaScript 原生的 [URL](https://developer.mozilla.org/zh-CN/docs/Web/API/URL/URL) 和 [import.meta.url](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/import.meta) 相配合，来引用静态资源：
 
-```js
+```ts title="src/index.ts"
 const logo = new URL('./assets/logo.svg', import.meta.url);
 ```
 
-将会输出如下产物：
+构建后，`new URL()` 中的路径会指向构建产物中的资源文件，并输出如下产物：
 
 <Tabs>
-<Tab label="dist/index.mjs">
+<Tab label="dist/index.js">
 
 ```js
 const logo = new URL('./static/svg/logo.svg', import.meta.url);
-export { logo };
 ```
 
 </Tab>
@@ -145,12 +144,14 @@ export { logo };
 </Tab>
 </Tabs>
 
-构建后，`new URL()` 中的路径会指向产物中输出的资源文件。
+通过 `new URL()` 引用的 `.js`、`.ts`、`.css` 和 `.scss` 等文件也会被视为 URL assets，不会经过相关的内置 loader 处理，其原始内容将作为资源输出。
 
-在 bundleless 模式下，默认的 glob 入口会匹配 `src/**`。使用 `new URL()` 引用静态资源时，需要手动将对应资源文件从入口中排除：
+:::note
+
+当 [bundle](/config/lib/bundle) 为 `false` 时，默认入口为 glob 模式 `src/**`，会同时匹配 `src` 下的静态资源文件。对于已经通过 `new URL()` 引用的资源，需要在 [source.entry](/config/rsbuild/source#sourceentry) 中排除这些文件。
 
 ```ts title="rslib.config.ts"
-export default defineConfig({
+export default {
   lib: [
     {
       bundle: false,
@@ -161,8 +162,56 @@ export default defineConfig({
       },
     },
   ],
+};
+```
+
+:::
+
+#### 跳过 `new URL()` 处理
+
+如果不希望将 `new URL()` 解析为 URL asset，可以根据作用范围选择以下方式。
+
+##### 关闭 URL parser
+
+通过 [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) 关闭内置 JavaScript rule 的 [URL parser](https://rspack.rs/zh/config/module-parser#javascripturl)，从而跳过对所有 `new URL()` 的资源解析：
+
+```ts title="rslib.config.ts"
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  tools: {
+    bundlerChain(chain, { CHAIN_ID }) {
+      chain.module
+        .rule(CHAIN_ID.RULE.JS)
+        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
+        .parser({
+          url: false,
+        });
+    },
+  },
 });
 ```
+
+关闭后，`new URL()` 表达式会原样保留，引用的文件不会由 Rslib 输出：
+
+```js title="dist/index.js"
+const logo = new URL('./assets/logo.svg', import.meta.url);
+```
+
+产物仍会保留标准的 `new URL(path, import.meta.url)` 形式。如果引用的资源需要随产物一起发布，建议通过 [output.copy](/config/rsbuild/output#outputcopy) 等方式将其复制到产物目录，并确保输出路径与 `new URL()` 中的相对路径一致。这样无论产物由后续的打包工具继续处理，还是直接在 Node.js 中运行，都能正确定位该资源。
+
+##### 忽略特定引用
+
+如果只需要跳过某个 `new URL()` 的处理，可以在第一个参数前添加 [rspackIgnore](https://rspack.rs/zh/api/runtime-api/module-methods#rspackignore) 注释：
+
+```ts title="src/index.ts"
+const logo = new URL(
+  /* rspackIgnore: true */ './assets/logo.svg',
+  import.meta.url,
+);
+```
+
+此时，Rslib 会使用运行时变量作为 `new URL()` 的基准 URL，产物中的表达式将不再保留 `import.meta.url`，这会限制后续打包工具在二次消费产物时对该资源引用的静态分析。
 
 ## 在 CSS 文件中引用
 

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -169,11 +169,11 @@ export default {
 
 #### 跳过 `new URL()` 处理
 
-如果不希望将 `new URL()` 解析为 URL asset，可以根据作用范围选择以下方式。
+如果不希望将项目源码中的 `new URL()` 解析为 URL asset，可以根据作用范围选择以下方式。
 
 ##### 关闭 URL parser
 
-通过 [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) 关闭内置 JavaScript rule 的 [URL parser](https://rspack.rs/zh/config/module-parser#javascripturl)，从而跳过对所有 `new URL()` 的资源解析：
+Rslib 默认会将内置 JavaScript rule 的 [URL parser](https://rspack.rs/zh/config/module-parser#javascripturl) 设置为 `'new-url-relative'`。你可以通过 [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) 将该 rule 的 URL parser 设置为 `false`，来跳过项目源码中所有 `new URL()` 的资源解析：
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';


### PR DESCRIPTION
## Summary

This PR updates the English and Chinese static asset docs for the `new URL()` behavior introduced in #1781.

- Clarify URL asset output, built-in loader handling, and bundleless entry exclusions.
- Document how to disable URL parsing globally or skip individual references with `rspackIgnore`, including asset copying and downstream consumption considerations.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1781

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).