### PR TITLE
feat(deps): update Rsbuild to v2.1.10

### DIFF
--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.9",
+    "@rsbuild/core": "~2.1.10",
     "@storybook/addon-docs": "^10.5.5",
     "@storybook/addon-onboarding": "^10.5.5",
     "@storybook/react": "^10.5.5",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.9",
+    "@rsbuild/core": "~2.1.10",
     "@storybook/addon-docs": "^10.5.5",
     "@storybook/addon-onboarding": "^10.5.5",
     "@storybook/react": "^10.5.5",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.9",
+    "@rsbuild/core": "~2.1.10",
     "@storybook/addon-docs": "^10.5.5",
     "@storybook/addon-onboarding": "^10.5.5",
     "@storybook/vue3": "^10.5.5",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.9",
+    "@rsbuild/core": "~2.1.10",
     "@storybook/addon-docs": "^10.5.5",
     "@storybook/addon-onboarding": "^10.5.5",
     "@storybook/vue3": "^10.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ catalogs:
       specifier: ^2.12.0
       version: 2.12.0
     '@rsbuild/core':
-      specifier: ~2.1.9
-      version: 2.1.9
+      specifier: ~2.1.10
+      version: 2.1.10
     '@rsbuild/plugin-babel':
       specifier: ^2.0.1
       version: 2.0.1
@@ -385,13 +385,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.9(@module-federation/runtime-tools@2.8.1)
+        version: 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -406,19 +406,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 'catalog:'
-        version: 2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/storybook-addon':
         specifier: 'catalog:'
-        version: 6.0.17(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)
+        version: 6.0.17(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.9(@module-federation/runtime-tools@2.8.1)
+        version: 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -445,13 +445,13 @@ importers:
         version: 19.2.8(react@19.2.8)
       storybook:
         specifier: 'catalog:'
-        version: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+        version: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -467,13 +467,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.9(@module-federation/runtime-tools@2.8.1)
+        version: 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -488,10 +488,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(preact@10.29.8)
+        version: 2.0.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(preact@10.29.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)
+        version: 2.0.1(@rsbuild/core@2.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -503,10 +503,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)
+        version: 2.0.1(@rsbuild/core@2.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -521,10 +521,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)
+        version: 2.0.1(@rsbuild/core@2.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -539,10 +539,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)
+        version: 2.0.1(@rsbuild/core@2.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -557,13 +557,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)
+        version: 2.0.1(@rsbuild/core@2.1.10)
       '@rsbuild/plugin-solid':
         specifier: 'catalog:'
-        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.9)(solid-js@1.9.14)(supports-color@9.4.0)
+        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.10)(solid-js@1.9.14)(supports-color@9.4.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -578,7 +578,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -596,10 +596,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.9(@module-federation/runtime-tools@2.8.1)
+        version: 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -614,13 +614,13 @@ importers:
         version: 10.5.5(storybook@10.5.5)(vue@3.5.40)
       storybook:
         specifier: 'catalog:'
-        version: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+        version: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40)
+        version: 3.3.4(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -635,14 +635,14 @@ importers:
     dependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.9(@module-federation/runtime-tools@2.8.1)
+        version: 2.1.10(@module-federation/runtime-tools@2.8.1)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -669,7 +669,7 @@ importers:
         version: 0.6.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.1.9)
+        version: 1.0.0(@rsbuild/core@2.1.10)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)'
@@ -706,7 +706,7 @@ importers:
         version: 11.4.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.1.9)
+        version: 1.0.0(@rsbuild/core@2.1.10)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)'
@@ -728,7 +728,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.9(@module-federation/runtime-tools@2.8.1)
+        version: 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -740,7 +740,7 @@ importers:
         version: 1.1.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.1.9)
+        version: 1.0.0(@rsbuild/core@2.1.10)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)'
@@ -770,34 +770,34 @@ importers:
         version: 4.0.1(debug@4.4.3)(supports-color@9.4.0)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.9(@module-federation/runtime-tools@2.8.1)
+        version: 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)
+        version: 2.0.1(@rsbuild/core@2.1.10)
       '@rsbuild/plugin-toml':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)
+        version: 2.0.1(@rsbuild/core@2.1.10)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 'catalog:'
-        version: 1.2.4(@rsbuild/core@2.1.9)
+        version: 1.2.4(@rsbuild/core@2.1.10)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       '@rsbuild/plugin-yaml':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.1.9)
+        version: 2.0.0(@rsbuild/core@2.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -874,7 +874,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
 
   tests/integration/asset/json: {}
 
@@ -894,10 +894,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -982,10 +982,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/cli/build: {}
 
@@ -1308,10 +1308,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.9(@module-federation/runtime-tools@2.8.1)
+        version: 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.1.9)
+        version: 1.4.6(@rsbuild/core@2.1.10)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -1321,10 +1321,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.9(@module-federation/runtime-tools@2.8.1)
+        version: 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.1.9)
+        version: 1.4.6(@rsbuild/core@2.1.10)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1363,7 +1363,7 @@ importers:
         version: 8.0.1
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)
       babel-plugin-polyfill-corejs3:
         specifier: 'catalog:'
         version: 1.0.0(@babel/core@8.0.1)
@@ -1376,7 +1376,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1517,19 +1517,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.0.3(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1538,7 +1538,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.0.3(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1586,10 +1586,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
       vue:
         specifier: 'catalog:'
         version: 3.5.40(typescript@7.0.2)
@@ -1624,16 +1624,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.9(@module-federation/runtime-tools@2.8.1)
+        version: 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.9)
+        version: 2.0.1(@rsbuild/core@2.1.10)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1642,7 +1642,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 'catalog:'
-        version: 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+        version: 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@rspress/plugin-algolia':
         specifier: 'catalog:'
         version: 2.0.19(@rspress/core@2.0.19)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
@@ -1681,10 +1681,10 @@ importers:
         version: 19.2.8(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: 'catalog:'
-        version: 1.0.6(@rsbuild/core@2.1.9)
+        version: 1.0.6(@rsbuild/core@2.1.10)
       rsbuild-plugin-open-graph:
         specifier: 'catalog:'
-        version: 1.1.3(@rsbuild/core@2.1.9)
+        version: 1.1.3(@rsbuild/core@2.1.10)
       rspress-plugin-file-tree:
         specifier: 'catalog:'
         version: 1.0.5(@rspress/core@2.0.19)(supports-color@9.4.0)
@@ -2104,14 +2104,14 @@ packages:
       search-insights:
         optional: true
 
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -2119,8 +2119,8 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -2965,8 +2965,8 @@ packages:
       rollup:
         optional: true
 
-  '@rsbuild/core@2.1.9':
-    resolution: {integrity: sha512-yqf1hFZ3wbMYI431LqsxLH3r0VZkfyarVKTf7kMeIiGe0YLwsrgsfp+sKpIyVkQkq60J0qyp6l/CoqqsQZqEwQ==}
+  '@rsbuild/core@2.1.10':
+    resolution: {integrity: sha512-lwxC5w88U2AMv6aNwG3VH7+AV33N4JJQjD//egVWFsMbV+OE/bnfCsurSpX8s3lGyRYkJMwUVN+YXMbmmYZFfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3172,76 +3172,76 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@2.1.7':
-    resolution: {integrity: sha512-DwxzrXRctueP/3Pyom9JHcIsRShuEAlHb+mrE5OPT+4cdHI1UnJpbzEvEDLTo4IKJhDb3vjXdHLtjqtL0SYbeA==}
+  '@rspack/binding-darwin-arm64@2.1.8':
+    resolution: {integrity: sha512-kia+eWtyWPvR4ntg1bWYoVU8nLPbUg2fG3zgBEocsTcsh5ZENSiEPxEKymDgMyIMONUqj611E0775cdUBoNmqw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.1.7':
-    resolution: {integrity: sha512-kPbrYvR/XUHfAMgRVq3QnC71DW/qjwsPj+3hEUuEnRmlploPNy9u8Szf1IHKSVUSrVZBTgDyMoZQdxYLfhResw==}
+  '@rspack/binding-darwin-x64@2.1.8':
+    resolution: {integrity: sha512-08pBkFhlD3Y3Qzh94w/Fc3skaIE3e96kl2P14m8+tnYTcglpOfpA2OwS3iHt9fOqy0HjoAVe6/MW3cBgs5iabA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.1.7':
-    resolution: {integrity: sha512-VFB+YXM3kZ6IIuLV64H3vgnwqvQIIaqfR/aeGwuxYvwcZsrgblSBmXMeDULdgDjqP8Yr0VaFMBBiD9OtG5KdFw==}
+  '@rspack/binding-linux-arm64-gnu@2.1.8':
+    resolution: {integrity: sha512-KLniMc9GzhKpVqhPzaJo3KJwzdAllXVVqZIk/uL1QipXOxs57fgM4u7IexKPFVla0o/u1PQG/Ah2YLDmda24Ow==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.1.7':
-    resolution: {integrity: sha512-Mzbxyg0aJ+ITj526Iuz0enEDYY6WxhFIwEKXqwjQh+Vpd5v/+aPzPo83sSQVX/3puBV1sbmviTURbh6N9e1fvA==}
+  '@rspack/binding-linux-arm64-musl@2.1.8':
+    resolution: {integrity: sha512-yUKAxHNGnICtw5RnxFWu4dHtsz/tdt7rbeFcsINNVre9HcrRxf5XP+FbOGL/SMxd9oM9XCo10paU2WckTKwbEA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.7':
-    resolution: {integrity: sha512-mpazwgT/Pse1720mvEJsoXfPkJ+enj0xUqpbe/wL6aedwjGT+9jJNB8HTJXE4XBX0UO7umGqcJMeKA6YsD2CDA==}
+  '@rspack/binding-linux-riscv64-gnu@2.1.8':
+    resolution: {integrity: sha512-gg4S1jaitwYPHR9HZ3zNGH1EK2GXINm66p4kEpOP1gbc+akyOouVF/dMcu9NGPlRg58FbEhVRZYKu7Z/zcpKHg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.1.7':
-    resolution: {integrity: sha512-oU/l3soPRsDEWn7KZic+npyTMM2N1kRdHjoJ+L5IUBXs8bjdTXPLoyTbTdIOza5ZSoT4+UeEiEryj4BB0tQE5w==}
+  '@rspack/binding-linux-riscv64-musl@2.1.8':
+    resolution: {integrity: sha512-b/aU5j1h368SLNyz5u+flqpZVhzSZ1UIslaj9sZJuAvqkGWv3xsjc/28/PTo/RYXCxd0FNVAxTxWHKvRiAAS8w==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.1.7':
-    resolution: {integrity: sha512-7Gtpl3h3jtnOpk1mYQE8mRndXAO2ibI8mnAbs7klevdKey+ZHneWMoMi2yOMQhhI/ifWEFxDzyGJ8bdxo0XTsA==}
+  '@rspack/binding-linux-x64-gnu@2.1.8':
+    resolution: {integrity: sha512-EyegohSx0BJRqieCg9f/caCqFARRWkqI5hwJt6k530MoOTLeq8I3vsbeg24/2MktwIC1dmJi8bl0+WhPKQs4eQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.1.7':
-    resolution: {integrity: sha512-w+whI2Uy+DYkGN+MVkzMFWweL7B/s1gMqX+nvTE1vhOy3hGV0VyA9H6lqWjSD3I+eGkpYhN9Pr244cYnLpZOUQ==}
+  '@rspack/binding-linux-x64-musl@2.1.8':
+    resolution: {integrity: sha512-I6E+goN+UQ297q4r1qdbiAyNCI3t0+a5Y0xDIAPOZfRDRxDTnH/LF8/y65gjsJoKRKyn7zxRC0T/NURTkRNQ9A==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.1.7':
-    resolution: {integrity: sha512-cDVgvzRdTgxaeM+a5Lx0+7/VAvunvwO0wNtQ3ATQGOtFCW5b7cUzhNPcytH5ZSJTnFWuxinlGwtar5yfcnkdZQ==}
+  '@rspack/binding-wasm32-wasi@2.1.8':
+    resolution: {integrity: sha512-om7GAKWAU3lcSvbCon2m7mzw8v9OTrO2LW2MZ1lGe/uVJJmwGGkl9HVoXFyWFLrN6YVFyx8iP+AkN4owDWB9Cw==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.1.7':
-    resolution: {integrity: sha512-JDd85+iYwUvaG9Zrt5X7oIxRZRiTW+76FwkRakoXNy/5VAWQW32Jq4ESjSVz6l6mh0KnZxPq3TLMugacCPnLjw==}
+  '@rspack/binding-win32-arm64-msvc@2.1.8':
+    resolution: {integrity: sha512-WDnsP/SUb9zbxyGX9XjPw5AXrX86u5oidn0MDdfJduOOqdCSpHwmRjlQ8NUJhbBq9WqVJMFlcab7NwZVWX/yyg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.1.7':
-    resolution: {integrity: sha512-y9PKEs6v9BLHV0i/4eaIRtxpATvSgcf/VYQkMT8mp+qWlPjUwDQNwU2ueWVGpff6INO+YAa7zobzziNFRgO7Lg==}
+  '@rspack/binding-win32-ia32-msvc@2.1.8':
+    resolution: {integrity: sha512-QiMQMPNDiY3dhhaIdaFPzcPDC06cEYkNY89ea+EmDvNVgZq6V+2mFS/WnzZVMeEbGAYJCjsv/ABhhLT1hlYMvg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.1.7':
-    resolution: {integrity: sha512-BjkOzcPY/K8YlRRvyywz0mDWk89MMxqAMhDmgBXCWorh1IjgKTsWDJ2lCGIM8M9CZXUG3khom8AfrOGwRT2I+g==}
+  '@rspack/binding-win32-x64-msvc@2.1.8':
+    resolution: {integrity: sha512-b7sA5eB64vo2mbsuc//MOYzVLeCKHPn0dfP/GmNEoHdWbhRgZ/orZLWurYMQj04ELTLW6YCJEy59g5KRzNYHfw==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.1.7':
-    resolution: {integrity: sha512-wYqi8TY30hsIzLry503o/Uqu7y9Ec7pEwN5TVmB7Pb3xHrR2eHsQPzdpF/GkCLUjQSgD2Es3CDVV1mr6zO/78g==}
+  '@rspack/binding@2.1.8':
+    resolution: {integrity: sha512-tmAyHzDbPiy8V7HvQqtuPsbs6dPgwV0YjzW5XrPRV9gzf+Hdm7pvsZJKE1QKO9WV5RuvGYav98xIX6O+abZxzQ==}
 
-  '@rspack/core@2.1.7':
-    resolution: {integrity: sha512-d5Ju3zXzGgbqQWvlMlLUtek2eFPIzsFe2QOF4nwTAknxo/4OZ64t+kPT9nM6fr3aZX93VK0R3v02/kZYIRrV9Q==}
+  '@rspack/core@2.1.8':
+    resolution: {integrity: sha512-na1kyA6Mj8/LWw9O3A8NsrG9rNKN3Iq2WiXrEuIwsU5r/Nl/evm3hO7bWKHxgsRyydI6W7okwx3MXgf8rzel6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8336,9 +8336,9 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@emnapi/core@1.11.2':
+  '@emnapi/core@1.11.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.8.1
     optional: true
 
@@ -8348,7 +8348,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8363,7 +8363,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.2':
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8750,7 +8750,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/cli': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
@@ -8759,7 +8759,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.1(@module-federation/runtime-tools@2.8.1)
       '@module-federation/managers': 2.8.1
       '@module-federation/manifest': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
-      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
       '@module-federation/webpack-bundler-runtime': 2.8.1
@@ -8773,7 +8773,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/enhanced@2.8.1(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/cli': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
@@ -8782,7 +8782,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.1(@module-federation/runtime-tools@2.8.1)
       '@module-federation/managers': 2.8.1
       '@module-federation/manifest': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/rspack': 2.8.1(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
       '@module-federation/webpack-bundler-runtime': 2.8.1
@@ -8828,9 +8828,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.48(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.48(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime': 2.8.1
       '@module-federation/sdk': 2.8.1
       encoding: 0.1.13
@@ -8843,9 +8843,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.48(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.48(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime': 2.8.1
       '@module-federation/sdk': 2.8.1
       encoding: 0.1.13
@@ -8858,13 +8858,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.48(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.48(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8873,13 +8873,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rsbuild-plugin@2.8.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.48(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.48(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8888,7 +8888,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/rspack@2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/dts-plugin': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
@@ -8897,7 +8897,7 @@ snapshots:
       '@module-federation/manifest': 2.8.1(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.9(typescript@6.0.3)
@@ -8905,7 +8905,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rspack@2.8.1(@rspack/core@2.1.7)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rspack@2.8.1(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.1
       '@module-federation/dts-plugin': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
@@ -8914,7 +8914,7 @@ snapshots:
       '@module-federation/manifest': 2.8.1(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.1
       '@module-federation/sdk': 2.8.1
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 7.0.2
       vue-tsc: 3.3.9(typescript@7.0.2)
@@ -8940,13 +8940,13 @@ snapshots:
 
   '@module-federation/sdk@2.8.1': {}
 
-  '@module-federation/storybook-addon@6.0.17(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.17(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(storybook@10.5.5)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.7)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.1(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
       - '@rspack/core'
@@ -8963,10 +8963,10 @@ snapshots:
       '@module-federation/runtime': 2.8.1
       '@module-federation/sdk': 2.8.1
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -9103,9 +9103,9 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9215,14 +9215,14 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.4
 
-  '@rsbuild/core@2.1.9(@module-federation/runtime-tools@2.8.1)':
+  '@rsbuild/core@2.1.10(@module-federation/runtime-tools@2.8.1)':
     dependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.9)(supports-color@9.4.0)':
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.10)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
@@ -9231,39 +9231,39 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)':
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.7)
+      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.8)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.7)(less@4.6.7)
+      less-loader: 12.3.3(@rspack/core@2.1.8)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.9)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.10)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9289,30 +9289,30 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(preact@10.29.8)':
+  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(preact@10.29.8)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.7)
+      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.8)
       '@swc/plugin-prefresh': 12.12.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - preact
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.7)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.8)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.9)':
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.10)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9320,98 +9320,98 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.9)(solid-js@1.9.14)(supports-color@9.4.0)':
+  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.10)(solid-js@1.9.14)(supports-color@9.4.0)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.9)(supports-color@9.4.0)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.10)(supports-color@9.4.0)
       babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.14)
       solid-refresh: 0.6.3(solid-js@1.9.14)(supports-color@9.4.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)':
+  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0(supports-color@9.4.0)
-      stylus-loader: 8.1.3(@rspack/core@2.1.7)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.1.8)(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(supports-color@9.4.0)(typescript@7.0.2)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@svgr/core': 8.1.0(supports-color@9.4.0)(typescript@7.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)(supports-color@9.4.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.7)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.8)
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.9)':
+  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.10)':
     dependencies:
       toml: 4.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.4.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.7)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.4.0(@rspack/core@2.1.8)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.9)':
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.10)':
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40)
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.1.9)':
+  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.1.10)':
     dependencies:
       yaml: 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
 
   '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.9)(typescript@7.0.2)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.10)(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2
@@ -9457,89 +9457,89 @@ snapshots:
   '@rslint/native-win32-x64-msvc@0.7.2':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.1.7':
+  '@rspack/binding-darwin-arm64@2.1.8':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.1.7':
+  '@rspack/binding-darwin-x64@2.1.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.7':
+  '@rspack/binding-linux-arm64-gnu@2.1.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.7':
+  '@rspack/binding-linux-arm64-musl@2.1.8':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.7':
+  '@rspack/binding-linux-riscv64-gnu@2.1.8':
     optional: true
 
-  '@rspack/binding-linux-riscv64-musl@2.1.7':
+  '@rspack/binding-linux-riscv64-musl@2.1.8':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.1.7':
+  '@rspack/binding-linux-x64-gnu@2.1.8':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.1.7':
+  '@rspack/binding-linux-x64-musl@2.1.8':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.1.7':
+  '@rspack/binding-wasm32-wasi@2.1.8':
     dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.7':
+  '@rspack/binding-win32-arm64-msvc@2.1.8':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.1.7':
+  '@rspack/binding-win32-ia32-msvc@2.1.8':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.1.7':
+  '@rspack/binding-win32-x64-msvc@2.1.8':
     optional: true
 
-  '@rspack/binding@2.1.7':
+  '@rspack/binding@2.1.8':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.7
-      '@rspack/binding-darwin-x64': 2.1.7
-      '@rspack/binding-linux-arm64-gnu': 2.1.7
-      '@rspack/binding-linux-arm64-musl': 2.1.7
-      '@rspack/binding-linux-riscv64-gnu': 2.1.7
-      '@rspack/binding-linux-riscv64-musl': 2.1.7
-      '@rspack/binding-linux-x64-gnu': 2.1.7
-      '@rspack/binding-linux-x64-musl': 2.1.7
-      '@rspack/binding-wasm32-wasi': 2.1.7
-      '@rspack/binding-win32-arm64-msvc': 2.1.7
-      '@rspack/binding-win32-ia32-msvc': 2.1.7
-      '@rspack/binding-win32-x64-msvc': 2.1.7
+      '@rspack/binding-darwin-arm64': 2.1.8
+      '@rspack/binding-darwin-x64': 2.1.8
+      '@rspack/binding-linux-arm64-gnu': 2.1.8
+      '@rspack/binding-linux-arm64-musl': 2.1.8
+      '@rspack/binding-linux-riscv64-gnu': 2.1.8
+      '@rspack/binding-linux-riscv64-musl': 2.1.8
+      '@rspack/binding-linux-x64-gnu': 2.1.8
+      '@rspack/binding-linux-x64-musl': 2.1.8
+      '@rspack/binding-wasm32-wasi': 2.1.8
+      '@rspack/binding-win32-arm64-msvc': 2.1.8
+      '@rspack/binding-win32-ia32-msvc': 2.1.8
+      '@rspack/binding-win32-x64-msvc': 2.1.8
 
-  '@rspack/core@2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
+  '@rspack/core@2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': 2.1.7
+      '@rspack/binding': 2.1.8
     optionalDependencies:
       '@module-federation/runtime-tools': 2.8.1
       '@swc/helpers': 0.5.23
 
   '@rspack/lite-tapable@1.1.2': {}
 
-  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.7)':
+  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.8)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.7)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.8)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
+  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
       '@rspress/shared': 2.0.19(@module-federation/runtime-tools@2.8.1)(supports-color@9.4.0)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -9586,7 +9586,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
@@ -9597,7 +9597,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.19(@rspress/core@2.0.19)(supports-color@9.4.0)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       remark-mdx: 3.1.1(supports-color@9.4.0)
       remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
@@ -9608,17 +9608,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rspress/plugin-twoslash@2.0.19(@rspress/core@2.0.19)(react@19.2.8)(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@shikijs/twoslash': 4.3.0(supports-color@9.4.0)(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-gfm: 3.1.0(supports-color@9.4.0)
@@ -9632,7 +9632,7 @@ snapshots:
 
   '@rspress/shared@2.0.19(@module-federation/runtime-tools@2.8.1)(supports-color@9.4.0)':
     dependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@shikijs/rehype': 4.3.0
       '@types/react': 19.2.18
       mdast-util-mdx-jsx: 3.2.0(supports-color@9.4.0)
@@ -9644,7 +9644,7 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.7(@rspress/core@2.0.19)':
     optionalDependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rstest/adapter-rslib@0.11.5(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.5)(typescript@7.0.2)':
     dependencies:
@@ -9655,7 +9655,7 @@ snapshots:
 
   '@rstest/core@0.11.5':
     dependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@types/chai': 5.2.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -9794,7 +9794,7 @@ snapshots:
       '@storybook/react-dom-shim': 10.5.5(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       ts-dedent: 2.3.0
     optionalDependencies:
       '@types/react': 19.2.18
@@ -9807,11 +9807,11 @@ snapshots:
 
   '@storybook/addon-onboarding@10.5.5(storybook@10.5.5)':
     dependencies:
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
 
   '@storybook/csf-plugin@10.5.5(esbuild@0.28.1)(storybook@10.5.5)':
     dependencies:
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
@@ -9840,7 +9840,7 @@ snapshots:
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
@@ -9853,7 +9853,7 @@ snapshots:
       react-docgen: 8.0.3(supports-color@9.4.0)
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.8(react@19.2.8)
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
@@ -9864,7 +9864,7 @@ snapshots:
   '@storybook/vue3@10.5.5(storybook@10.5.5)(vue@3.5.40)':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       type-fest: 5.7.0
       vue: 3.5.40(typescript@6.0.3)
       vue-component-type-helpers: 3.3.1
@@ -10019,14 +10019,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.7)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.8)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10550,12 +10550,12 @@ snapshots:
 
   b-validate@1.5.3: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.7):
+  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.8):
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       find-up: 5.0.0
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
     dependencies:
@@ -12012,11 +12012,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@rspack/core@2.1.7)(less@4.6.7):
+  less-loader@12.3.3(@rspack/core@2.1.8)(less@4.6.7):
     dependencies:
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   less@4.6.7:
     dependencies:
@@ -12887,7 +12887,7 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
       '@oxc-parser/binding-win32-x64-msvc': 0.127.0
 
-  oxc-resolver@11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
+  oxc-resolver@11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -12905,7 +12905,7 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
@@ -13596,49 +13596,49 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.9)(typescript@7.0.2):
+  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.10)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.9):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.10):
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
 
-  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.9):
+  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.10):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.9):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.10):
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.9):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.10):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
 
   rslog@2.3.0: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.7)(@vue/compiler-sfc@3.5.40)(vue@3.5.40):
+  rspack-vue-loader@17.5.1(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.40)(vue@3.5.40):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
       '@vue/compiler-sfc': 3.5.40
       vue: 3.5.40(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.19)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
@@ -13663,14 +13663,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.19)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.19)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.19):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.7)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   run-applescript@7.1.0: {}
 
@@ -13999,18 +13999,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.9)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
-      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/plugin-type-check': 1.4.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14022,9 +14022,9 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.9)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.10)
       sirv: 2.0.4
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       ts-dedent: 2.3.0
       url: 0.11.4
       util: 0.12.5
@@ -14039,10 +14039,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.3.0
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@storybook/react': 10.5.5(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(supports-color@9.4.0)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(supports-color@9.4.0)(typescript@6.0.3)
       find-up: 5.0.0
@@ -14052,8 +14052,8 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14068,12 +14068,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40):
+  storybook-vue3-rsbuild@3.3.4(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)(vue@3.5.40):
     dependencies:
-      '@rsbuild/core': 2.1.9(@module-federation/runtime-tools@2.8.1)
+      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
       '@storybook/vue3': 10.5.5(storybook@10.5.5)(vue@3.5.40)
-      storybook: 10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.9)(@rspack/core@2.1.7)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
+      storybook: 10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.5)(typescript@6.0.3)
       vue: 3.5.40(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.40)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -14089,7 +14089,7 @@ snapshots:
       - vite
       - webpack
 
-  storybook@10.5.5(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8):
+  storybook@10.5.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.8)(react@19.2.8)
@@ -14103,7 +14103,7 @@ snapshots:
       jsonc-parser: 3.3.1
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      oxc-resolver: 11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       recast: 0.23.11
       semver: 7.8.5
       use-sync-external-store: 1.6.0(react@19.2.8)
@@ -14195,13 +14195,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.1.7)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.1.8)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0(supports-color@9.4.0)
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   stylus@0.64.0(supports-color@9.4.0):
     dependencies:
@@ -14315,7 +14315,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.7)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.1.8)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
@@ -14323,7 +14323,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.1.7(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.1)(@swc/helpers@0.5.23)
 
   ts-dedent@2.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalog:
   '@module-federation/storybook-addon': '^6.0.17'
   '@playwright/test': '1.62.1'
   '@reduxjs/toolkit': '^2.12.0'
-  '@rsbuild/core': '~2.1.9'
+  '@rsbuild/core': '~2.1.10'
   '@rsbuild/plugin-babel': '^2.0.1'
   '@rsbuild/plugin-less': '^2.0.1'
   '@rsbuild/plugin-node-polyfill': '^1.4.6'

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -473,6 +473,7 @@ test('use Node.js addons', async () => {
   const { content: bundleEsm } = queryContent(contents.esm0!, /index\.js/);
   const { content: bundleCjs } = queryContent(contents.cjs0!, /index\.cjs/);
   expect(bundleEsm).toContain('createRequire');
+  expect(bundleEsm).toContain('fileURLToPath');
   expect(bundleEsm).toContain('test.darwin.node');
   expect(bundleCjs).not.toContain('createRequire');
   expect(bundleCjs).toMatch(/require\(["']node:path["']\)/);
@@ -489,6 +490,7 @@ test('use Node.js addons', async () => {
   );
   expect(bundlelessEsmIndex).toMatch(/from ["']\.\/test\.darwin\.js["']/);
   expect(bundlelessEsmAddon).toContain('createRequire');
+  expect(bundlelessEsmAddon).toContain('fileURLToPath');
   expect(bundlelessEsmAddon).toContain('test.darwin.node');
 
   const { content: bundlelessCjsIndex } = queryContent(
@@ -517,10 +519,17 @@ test('use Node.js addons', async () => {
     expect(await readFile(join(fixturePath, addonPath))).toEqual(sourceAddon);
   }
 
-  // TODO: Also load the ESM outputs after Rsbuild #8203 is available in the
-  // pinned @rsbuild/core version.
   // The native fixture is only compatible with Darwin arm64.
   if (process.platform === 'darwin' && process.arch === 'arm64') {
+    const esmEntries = [
+      'dist/esm/bundle/index.js',
+      'dist/esm/bundleless/index.js',
+    ];
+    for (const entry of esmEntries) {
+      const { addon } = await import(join(fixturePath, entry));
+      expect(typeof addon.readLength).toBe('function');
+    }
+
     const cjsEntries = [
       'dist/cjs/bundle/index.cjs',
       'dist/cjs/bundleless/index.cjs',


### PR DESCRIPTION
## Summary

This PR updates `@rsbuild/core` to v2.1.10 across the workspace and Storybook templates, pulling in the environment-aware Node.js addon loader from Rsbuild #8203. It also exercises both bundled and bundleless ESM addon outputs at runtime on Darwin arm64 and deduplicates the lockfile.

## Related Links

- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.1.10
- https://github.com/web-infra-dev/rsbuild/pull/8203

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).