### PR TITLE
chore(deps): upgrade Rslib to 1.0.0-beta.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,8 +248,8 @@ catalogs:
       specifier: ^1.0.0
       version: 1.0.0
     rslib:
-      specifier: npm:@rslib/core@1.0.0-beta.1
-      version: 1.0.0-beta.1
+      specifier: npm:@rslib/core@1.0.0-beta.2
+      version: 1.0.0-beta.2
     rslog:
       specifier: ^2.3.0
       version: 2.3.0
@@ -322,7 +322,7 @@ importers:
         version: 0.7.3(jiti@2.7.0)
       '@rstest/adapter-rslib':
         specifier: 'catalog:'
-        version: 0.11.6(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.6)(typescript@7.0.2)
+        version: 0.11.6(@rslib/core@1.0.0-beta.2)(@rstest/core@0.11.6)(typescript@7.0.2)
       '@rstest/core':
         specifier: 'catalog:'
         version: 0.11.6
@@ -672,7 +672,7 @@ importers:
         version: 1.0.0(@rsbuild/core@2.1.10)
       rslib:
         specifier: 'catalog:'
-        version: '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)'
+        version: '@rslib/core@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)'
       rslog:
         specifier: 'catalog:'
         version: 2.3.0
@@ -709,7 +709,7 @@ importers:
         version: 1.0.0(@rsbuild/core@2.1.10)
       rslib:
         specifier: 'catalog:'
-        version: '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)'
+        version: '@rslib/core@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)'
       tsx:
         specifier: 'catalog:'
         version: 4.23.6
@@ -743,7 +743,7 @@ importers:
         version: 1.0.0(@rsbuild/core@2.1.10)
       rslib:
         specifier: 'catalog:'
-        version: '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)'
+        version: '@rslib/core@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)'
       tinyglobby:
         specifier: 'catalog:'
         version: 0.2.17
@@ -3106,8 +3106,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@1.0.0-beta.1':
-    resolution: {integrity: sha512-HHPZ+wTUKT/3bEhw2y0JB0O62wMuljkSHVZelLbSGhBflCaUt+D3LohBcIxYW6bhzPbUp4gkJXo1pdTpxiuNLQ==}
+  '@rslib/core@1.0.0-beta.2':
+    resolution: {integrity: sha512-A0j3MBP8Kga8Qrh7znO2UKf00Sga37PJCiTGUqVVBHb+u58fNoGXZtFAgeH6qKjf5eU1wYt4WptXX/1blOAfRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -6747,8 +6747,8 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  rsbuild-plugin-dts@1.0.0-beta.1:
-    resolution: {integrity: sha512-hAEjOXhfIHR4erqjsqjRvA9Yqzc6Thry06tHheXDJUVwmR3VbN8BSMDC8kBZzyKdypDF0IJ98FmLQRiC194sMA==}
+  rsbuild-plugin-dts@1.0.0-beta.2:
+    resolution: {integrity: sha512-xOYa/kw/y29kKFFNjd+CIemlq+CB8E7LhqNkIzg7HT9dYNBVBpZvnnL6OEsOgjeuqzKpGSCRgZN/dDoVOk4VhQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -9419,10 +9419,10 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
 
-  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)':
+  '@rslib/core@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)':
     dependencies:
       '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)
-      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.10)(typescript@7.0.2)
+      rsbuild-plugin-dts: 1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.10)(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2
@@ -9657,9 +9657,9 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
-  '@rstest/adapter-rslib@0.11.6(@rslib/core@1.0.0-beta.1)(@rstest/core@0.11.6)(typescript@7.0.2)':
+  '@rstest/adapter-rslib@0.11.6(@rslib/core@1.0.0-beta.2)(@rstest/core@0.11.6)(typescript@7.0.2)':
     dependencies:
-      '@rslib/core': 1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)
+      '@rslib/core': 1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)
       '@rstest/core': 0.11.6
     optionalDependencies:
       typescript: 7.0.2
@@ -13624,7 +13624,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.10)(typescript@7.0.2):
+  rsbuild-plugin-dts@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.10)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,7 +94,7 @@ catalog:
   'rsbuild-plugin-google-analytics': '1.0.6'
   'rsbuild-plugin-open-graph': '^1.1.3'
   'rsbuild-plugin-publint': '^1.0.0'
-  'rslib': 'npm:@rslib/core@1.0.0-beta.1'
+  'rslib': 'npm:@rslib/core@1.0.0-beta.2'
   'rslog': '^2.3.0'
   'rspress-plugin-file-tree': '^1.0.5'
   'rspress-plugin-font-open-sans': '^1.0.4'


### PR DESCRIPTION
## Summary

This PR upgrades the self-hosting Rslib build dependency from `1.0.0-beta.1` to `1.0.0-beta.2`. The existing Rslib configurations remain compatible, and the generated package outputs are byte-identical across the upgrade.

## Related Links

https://github.com/web-infra-dev/rslib/releases/tag/v1.0.0-beta.2

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).