### PR TITLE
fix(core)!: only parse createRequire() in user source code

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -16,6 +16,7 @@ import { composeAssetConfig } from './asset/assetConfig';
 import {
   DTS_EXTENSIONS_PATTERN,
   JS_EXTENSIONS_PATTERN,
+  NODE_MODULES_PATTERN,
   SWC_HELPERS,
 } from './constant';
 import {
@@ -556,7 +557,18 @@ const modifyRsbuildDefaultPlugin = ({
   name: 'rslib:modify-rsbuild-default',
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID, target }) => {
-      // Part 1: configure URL parsing for library output.
+      // Part 1: preserve runtime `createRequire()` calls in third-party code.
+      // Keep this rule before Rsbuild's typed rules so their parser options
+      // take precedence for assets, styles, and other non-JavaScript modules.
+      chain.module
+        .rule('rslib-third-party-parser')
+        .test(NODE_MODULES_PATTERN)
+        .parser({
+          createRequire: false,
+        })
+        .before(CHAIN_ID.RULE.MJS);
+
+      // Part 2: configure URL parsing for library output.
       // Fix for https://github.com/web-infra-dev/rslib/issues/499.
       if (urlParserMode !== undefined) {
         chain.module
@@ -567,7 +579,7 @@ const modifyRsbuildDefaultPlugin = ({
           });
       }
 
-      // Part 2: remove Rsbuild's `type: 'javascript/auto'` override.
+      // Part 3: remove Rsbuild's `type: 'javascript/auto'` override.
       // Rslib follows Rspack's original module type inference, so ESM-like
       // modules are treated as strict ESM (`javascript/esm`).
       chain.module
@@ -575,7 +587,7 @@ const modifyRsbuildDefaultPlugin = ({
         .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
         .delete('type');
 
-      // Part 3: reset Rsbuild's const environment override.
+      // Part 4: reset Rsbuild's const environment override.
       // Rsbuild disables `const` for web-like app runtimes. Rslib should
       // leave this to Rspack's target inference for library output.
       if (target !== 'web' && target !== 'web-worker') {

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -33,3 +33,5 @@ export const CSS_EXTENSIONS_PATTERN: RegExp = new RegExp(
 );
 
 export const DTS_EXTENSIONS_PATTERN: RegExp = /\.d\.(?:[cm]?ts|[^/\\]+\.ts)$/;
+
+export const NODE_MODULES_PATTERN: RegExp = /[\\/]node_modules[\\/]/;

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -471,6 +471,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       }
     },
     rules: [
+      /* config.module.rule('rslib-third-party-parser') */
+      {
+        test: /[\\\\/]node_modules[\\\\/]/,
+        parser: {
+          createRequire: false
+        }
+      },
       /* config.module.rule('mjs') */
       {
         test: /\\.m?js/,
@@ -1337,6 +1344,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       }
     },
     rules: [
+      /* config.module.rule('rslib-third-party-parser') */
+      {
+        test: /[\\\\/]node_modules[\\\\/]/,
+        parser: {
+          createRequire: false
+        }
+      },
       /* config.module.rule('mjs') */
       {
         test: /\\.m?js/,
@@ -2190,6 +2204,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       }
     },
     rules: [
+      /* config.module.rule('rslib-third-party-parser') */
+      {
+        test: /[\\\\/]node_modules[\\\\/]/,
+        parser: {
+          createRequire: false
+        }
+      },
       /* config.module.rule('mjs') */
       {
         test: /\\.m?js/,
@@ -2967,6 +2988,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       }
     },
     rules: [
+      /* config.module.rule('rslib-third-party-parser') */
+      {
+        test: /[\\\\/]node_modules[\\\\/]/,
+        parser: {
+          createRequire: false
+        }
+      },
       /* config.module.rule('mjs') */
       {
         test: /\\.m?js/,
@@ -3679,6 +3707,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       }
     },
     rules: [
+      /* config.module.rule('rslib-third-party-parser') */
+      {
+        test: /[\\\\/]node_modules[\\\\/]/,
+        parser: {
+          createRequire: false
+        }
+      },
       /* config.module.rule('mjs') */
       {
         test: /\\.m?js/,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1338,6 +1338,8 @@ importers:
 
   tests/integration/parser-javascript/create-require/static-require: {}
 
+  tests/integration/parser-javascript/create-require/third-party: {}
+
   tests/integration/parser-javascript/module: {}
 
   tests/integration/parser-javascript/require/import-dynamic: {}

--- a/tests/integration/parser-javascript/create-require/index.test.ts
+++ b/tests/integration/parser-javascript/create-require/index.test.ts
@@ -20,3 +20,14 @@ test('createRequire parser', async () => {
     expect(entries[format]).not.toContain('module.exports = 42');
   }
 });
+
+test('createRequire parser is not applied to third-party packages', async () => {
+  const fixturePath = join(__dirname, 'third-party');
+  const { entries } = await buildAndGetResults({ fixturePath });
+
+  for (const content of [entries.esm, entries.cjs]) {
+    expect(content).toContain('createRequire');
+    expect(content).toMatch(/\(['"]\.\/answer['"]\)/);
+    expect(content).not.toContain('module.exports = 42');
+  }
+});

--- a/tests/integration/parser-javascript/create-require/index.test.ts
+++ b/tests/integration/parser-javascript/create-require/index.test.ts
@@ -28,6 +28,5 @@ test('createRequire parser is not applied to third-party packages', async () => 
   for (const content of [entries.esm, entries.cjs]) {
     expect(content).toContain('createRequire');
     expect(content).toMatch(/\(['"]\.\/answer['"]\)/);
-    expect(content).not.toContain('module.exports = 42');
   }
 });

--- a/tests/integration/parser-javascript/create-require/third-party/.gitignore
+++ b/tests/integration/parser-javascript/create-require/third-party/.gitignore
@@ -1,0 +1,2 @@
+!node_modules/
+node_modules/.*

--- a/tests/integration/parser-javascript/create-require/third-party/node_modules/third-party-dep/index.js
+++ b/tests/integration/parser-javascript/create-require/third-party/node_modules/third-party-dep/index.js
@@ -1,0 +1,5 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export const value = require('./answer');

--- a/tests/integration/parser-javascript/create-require/third-party/node_modules/third-party-dep/package.json
+++ b/tests/integration/parser-javascript/create-require/third-party/node_modules/third-party-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "third-party-dep",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/tests/integration/parser-javascript/create-require/third-party/package.json
+++ b/tests/integration/parser-javascript/create-require/third-party/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "parser-javascript-create-require-third-party-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/parser-javascript/create-require/third-party/rslib.config.ts
+++ b/tests/integration/parser-javascript/create-require/third-party/rslib.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig(),
+    generateBundleCjsConfig(),
+  ],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+});

--- a/tests/integration/parser-javascript/create-require/third-party/src/index.ts
+++ b/tests/integration/parser-javascript/create-require/third-party/src/index.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error test fixture has no type declarations
+export { value } from 'third-party-dep';


### PR DESCRIPTION
## Summary

`module.parser.javascript.createRequire` is enabled globally, so it also applies to third-party packages that get bundled. In v1.0.0-beta.2 this broke too many packages, so we preserve the parser for project source and disable it for `node_modules`.
