### PR TITLE
fix(core)!: move URL parser to a dedicated module rule 

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -552,9 +552,10 @@ const modifyRsbuildDefaultPlugin = ({
     api.modifyBundlerChain((chain, { CHAIN_ID, target }) => {
       // Part 1: configure URL parsing for library output.
       if (urlParserMode !== undefined) {
-        chain.module.rule(NEW_URL_RULE).test(JS_EXTENSIONS_PATTERN).parser({
-          url: urlParserMode,
-        });
+        chain.module
+          .rule(NEW_URL_RULE)
+          .test(JS_EXTENSIONS_PATTERN)
+          .parser({ url: urlParserMode });
       }
 
       // Part 2: remove Rsbuild's `type: 'javascript/auto'` override.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,73 +1,73 @@
 import {
-  defineConfig as defineRsbuildConfig,
-  type EnvironmentConfig,
-  mergeRsbuildConfig,
-  type RsbuildConfig,
-  type RsbuildEntry,
-  type RsbuildPlugin,
-  type RsbuildPlugins,
-  type Rspack,
-  rspack,
-  type ToolsConfig,
+    defineConfig as defineRsbuildConfig,
+    type EnvironmentConfig,
+    mergeRsbuildConfig,
+    type RsbuildConfig,
+    type RsbuildEntry,
+    type RsbuildPlugin,
+    type RsbuildPlugins,
+    type Rspack,
+    rspack,
+    type ToolsConfig,
 } from '@rsbuild/core';
 import fs from 'node:fs';
 import path, { dirname, extname, join } from 'node:path';
 import { composeAssetConfig } from './asset/assetConfig';
 import {
-  DTS_EXTENSIONS_PATTERN,
-  JS_EXTENSIONS_PATTERN,
-  NEW_URL_RULE,
-  SWC_HELPERS,
+    DTS_EXTENSIONS_PATTERN,
+    JS_EXTENSIONS_PATTERN,
+    NEW_URL_RULE,
+    SWC_HELPERS,
 } from './constant';
 import {
-  composeCssConfig,
-  cssExternalHandler,
-  RSLIB_CSS_ENTRY_FLAG,
+    composeCssConfig,
+    cssExternalHandler,
+    RSLIB_CSS_ENTRY_FLAG,
 } from './css/cssConfig';
 import { type CssLoaderOptionsAuto, isCssGlobalFile } from './css/utils';
 import { composeExeConfig } from './exe';
 import { composeEntryChunkConfig } from './plugins/EntryChunkPlugin';
 import { pluginCjsShims, pluginEsmRequireShim } from './plugins/shims';
 import type {
-  BannerAndFooter,
-  DeepRequired,
-  ExcludesFalse,
-  Format,
-  JsRedirect,
-  LibConfig,
-  LibOnlyConfig,
-  PkgJson,
-  Redirect,
-  RequireKey,
-  RsbuildConfigEntry,
-  RsbuildConfigEntryItem,
-  RsbuildConfigOutputTarget,
-  RsbuildConfigWithLibInfo,
-  RslibConfig,
-  RspackResolver,
-  Shims,
-  Syntax,
+    BannerAndFooter,
+    DeepRequired,
+    ExcludesFalse,
+    Format,
+    JsRedirect,
+    LibConfig,
+    LibOnlyConfig,
+    PkgJson,
+    Redirect,
+    RequireKey,
+    RsbuildConfigEntry,
+    RsbuildConfigEntryItem,
+    RsbuildConfigOutputTarget,
+    RsbuildConfigWithLibInfo,
+    RslibConfig,
+    RspackResolver,
+    Shims,
+    Syntax,
 } from './types';
 import { color } from './utils/color';
 import { getDefaultExtension } from './utils/extension';
 import {
-  calcLongestCommonPath,
-  checkMFPlugin,
-  isDirectory,
-  isEmptyObject,
-  isIntermediateOutputFormat,
-  nodeBuiltInModules,
-  normalizeSlash,
-  omit,
-  pick,
-  readPackageJson,
+    calcLongestCommonPath,
+    checkMFPlugin,
+    isDirectory,
+    isEmptyObject,
+    isIntermediateOutputFormat,
+    nodeBuiltInModules,
+    normalizeSlash,
+    omit,
+    pick,
+    readPackageJson,
 } from './utils/helper';
 import { isDebug, logger } from './utils/logger';
 import {
-  ESX_TO_BROWSERSLIST,
-  resolveMinNodeVersion,
-  transformSyntaxToBrowserslist,
-  transformSyntaxToRspackTarget,
+    ESX_TO_BROWSERSLIST,
+    resolveMinNodeVersion,
+    transformSyntaxToBrowserslist,
+    transformSyntaxToRspackTarget,
 } from './utils/syntax';
 import { loadTsconfig } from './utils/tsconfig';
 import { composeWasmConfig, resolveWasmMode } from './wasm/compose';
@@ -555,8 +555,8 @@ const modifyRsbuildDefaultPlugin = ({
         chain.module
           .rule(NEW_URL_RULE)
           .test(JS_EXTENSIONS_PATTERN)
-          .parser({ 
-          	url: urlParserMode 
+          .parser({
+            url: urlParserMode
           });
       }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,73 +1,73 @@
 import {
-    defineConfig as defineRsbuildConfig,
-    type EnvironmentConfig,
-    mergeRsbuildConfig,
-    type RsbuildConfig,
-    type RsbuildEntry,
-    type RsbuildPlugin,
-    type RsbuildPlugins,
-    type Rspack,
-    rspack,
-    type ToolsConfig,
+  defineConfig as defineRsbuildConfig,
+  type EnvironmentConfig,
+  mergeRsbuildConfig,
+  type RsbuildConfig,
+  type RsbuildEntry,
+  type RsbuildPlugin,
+  type RsbuildPlugins,
+  type Rspack,
+  rspack,
+  type ToolsConfig,
 } from '@rsbuild/core';
 import fs from 'node:fs';
 import path, { dirname, extname, join } from 'node:path';
 import { composeAssetConfig } from './asset/assetConfig';
 import {
-    DTS_EXTENSIONS_PATTERN,
-    JS_EXTENSIONS_PATTERN,
-    NEW_URL_RULE,
-    SWC_HELPERS,
+  DTS_EXTENSIONS_PATTERN,
+  JS_EXTENSIONS_PATTERN,
+  NEW_URL_RULE,
+  SWC_HELPERS,
 } from './constant';
 import {
-    composeCssConfig,
-    cssExternalHandler,
-    RSLIB_CSS_ENTRY_FLAG,
+  composeCssConfig,
+  cssExternalHandler,
+  RSLIB_CSS_ENTRY_FLAG,
 } from './css/cssConfig';
 import { type CssLoaderOptionsAuto, isCssGlobalFile } from './css/utils';
 import { composeExeConfig } from './exe';
 import { composeEntryChunkConfig } from './plugins/EntryChunkPlugin';
 import { pluginCjsShims, pluginEsmRequireShim } from './plugins/shims';
 import type {
-    BannerAndFooter,
-    DeepRequired,
-    ExcludesFalse,
-    Format,
-    JsRedirect,
-    LibConfig,
-    LibOnlyConfig,
-    PkgJson,
-    Redirect,
-    RequireKey,
-    RsbuildConfigEntry,
-    RsbuildConfigEntryItem,
-    RsbuildConfigOutputTarget,
-    RsbuildConfigWithLibInfo,
-    RslibConfig,
-    RspackResolver,
-    Shims,
-    Syntax,
+  BannerAndFooter,
+  DeepRequired,
+  ExcludesFalse,
+  Format,
+  JsRedirect,
+  LibConfig,
+  LibOnlyConfig,
+  PkgJson,
+  Redirect,
+  RequireKey,
+  RsbuildConfigEntry,
+  RsbuildConfigEntryItem,
+  RsbuildConfigOutputTarget,
+  RsbuildConfigWithLibInfo,
+  RslibConfig,
+  RspackResolver,
+  Shims,
+  Syntax,
 } from './types';
 import { color } from './utils/color';
 import { getDefaultExtension } from './utils/extension';
 import {
-    calcLongestCommonPath,
-    checkMFPlugin,
-    isDirectory,
-    isEmptyObject,
-    isIntermediateOutputFormat,
-    nodeBuiltInModules,
-    normalizeSlash,
-    omit,
-    pick,
-    readPackageJson,
+  calcLongestCommonPath,
+  checkMFPlugin,
+  isDirectory,
+  isEmptyObject,
+  isIntermediateOutputFormat,
+  nodeBuiltInModules,
+  normalizeSlash,
+  omit,
+  pick,
+  readPackageJson,
 } from './utils/helper';
 import { isDebug, logger } from './utils/logger';
 import {
-    ESX_TO_BROWSERSLIST,
-    resolveMinNodeVersion,
-    transformSyntaxToBrowserslist,
-    transformSyntaxToRspackTarget,
+  ESX_TO_BROWSERSLIST,
+  resolveMinNodeVersion,
+  transformSyntaxToBrowserslist,
+  transformSyntaxToRspackTarget,
 } from './utils/syntax';
 import { loadTsconfig } from './utils/tsconfig';
 import { composeWasmConfig, resolveWasmMode } from './wasm/compose';

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -555,7 +555,9 @@ const modifyRsbuildDefaultPlugin = ({
         chain.module
           .rule(NEW_URL_RULE)
           .test(JS_EXTENSIONS_PATTERN)
-          .parser({ url: urlParserMode });
+          .parser({ 
+          	url: urlParserMode 
+          });
       }
 
       // Part 2: remove Rsbuild's `type: 'javascript/auto'` override.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -16,6 +16,7 @@ import { composeAssetConfig } from './asset/assetConfig';
 import {
   DTS_EXTENSIONS_PATTERN,
   JS_EXTENSIONS_PATTERN,
+  NEW_URL_RULE,
   SWC_HELPERS,
 } from './constant';
 import {
@@ -550,14 +551,10 @@ const modifyRsbuildDefaultPlugin = ({
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID, target }) => {
       // Part 1: configure URL parsing for library output.
-      // Fix for https://github.com/web-infra-dev/rslib/issues/499.
       if (urlParserMode !== undefined) {
-        chain.module
-          .rule(CHAIN_ID.RULE.JS)
-          .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
-          .parser({
-            url: urlParserMode,
-          });
+        chain.module.rule(NEW_URL_RULE).test(JS_EXTENSIONS_PATTERN).parser({
+          url: urlParserMode,
+        });
       }
 
       // Part 2: remove Rsbuild's `type: 'javascript/auto'` override.

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -33,3 +33,9 @@ export const CSS_EXTENSIONS_PATTERN: RegExp = new RegExp(
 );
 
 export const DTS_EXTENSIONS_PATTERN: RegExp = /\.d\.(?:[cm]?ts|[^/\\]+\.ts)$/;
+
+/**
+ * Chain id of the `new URL()` parser rule. Public: users can override it
+ * through `tools.bundlerChain`.
+ */
+export const NEW_URL_RULE = 'new-url';

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -38,4 +38,4 @@ export const DTS_EXTENSIONS_PATTERN: RegExp = /\.d\.(?:[cm]?ts|[^/\\]+\.ts)$/;
  * Chain id of the `new URL()` parser rule. Public: users can override it
  * through `tools.bundlerChain`.
  */
-export const NEW_URL_RULE = 'new-url';
+export const NEW_URL_RULE = 'rslib:new-url';

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -35,7 +35,7 @@ export const CSS_EXTENSIONS_PATTERN: RegExp = new RegExp(
 export const DTS_EXTENSIONS_PATTERN: RegExp = /\.d\.(?:[cm]?ts|[^/\\]+\.ts)$/;
 
 /**
- * Chain id of the `new URL()` parser rule. Public: users can override it
- * through `tools.bundlerChain`.
+ * Chain ID for the `new URL()` parser rule.
+ * Users can customize this rule through `tools.bundlerChain`.
  */
 export const NEW_URL_RULE = 'rslib:new-url';

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -1072,7 +1072,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           }
         ]
       },
-      /* config.module.rule('new-url') */
+      /* config.module.rule('rslib:new-url') */
       {
         test: /\\.(js|mjs|jsx|(?<!\\.d\\.)ts|(?<!\\.d\\.)mts|(?<!\\.d\\.)cts|tsx|cjs|cjsx|mjsx|mtsx|ctsx)$/,
         parser: {
@@ -1941,7 +1941,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           }
         ]
       },
-      /* config.module.rule('new-url') */
+      /* config.module.rule('rslib:new-url') */
       {
         test: /\\.(js|mjs|jsx|(?<!\\.d\\.)ts|(?<!\\.d\\.)mts|(?<!\\.d\\.)cts|tsx|cjs|cjsx|mjsx|mtsx|ctsx)$/,
         parser: {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -659,9 +659,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           },
           /* config.module.rule('js').oneOf('js') */
           {
-            parser: {
-              url: 'new-url-relative'
-            },
             use: [
               /* config.module.rule('js').oneOf('js').use('swc') */
               {
@@ -1074,6 +1071,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             }
           }
         ]
+      },
+      /* config.module.rule('new-url') */
+      {
+        test: /\\.(js|mjs|jsx|(?<!\\.d\\.)ts|(?<!\\.d\\.)mts|(?<!\\.d\\.)cts|tsx|cjs|cjsx|mjsx|mtsx|ctsx)$/,
+        parser: {
+          url: 'new-url-relative'
+        }
       }
     ]
   },
@@ -1524,9 +1528,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
           },
           /* config.module.rule('js').oneOf('js') */
           {
-            parser: {
-              url: false
-            },
             use: [
               /* config.module.rule('js').oneOf('js').use('swc') */
               {
@@ -1939,6 +1940,13 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
             }
           }
         ]
+      },
+      /* config.module.rule('new-url') */
+      {
+        test: /\\.(js|mjs|jsx|(?<!\\.d\\.)ts|(?<!\\.d\\.)mts|(?<!\\.d\\.)cts|tsx|cjs|cjsx|mjsx|mtsx|ctsx)$/,
+        parser: {
+          url: false
+        }
       }
     ]
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -882,6 +882,8 @@ importers:
 
   tests/integration/asset/new-url: {}
 
+  tests/integration/asset/new-url-node-modules: {}
+
   tests/integration/asset/node-addons: {}
 
   tests/integration/asset/path: {}

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -579,3 +579,31 @@ test('preserve `new URL` file asset as relative URL', async () => {
   // The asset is emitted as a file, without an extra `assets/logo.*` JS chunk.
   expect(files.esm1!.some((f) => /assets\/logo\.js$/.test(f))).toBe(false);
 });
+
+test('preserve `new URL` file asset as relative URL in node_modules', async () => {
+  // A package under `node_modules` is handled the same way as the source: the
+  // asset is emitted and the URL is kept relative, without any Rspack runtime.
+  const { contents } = await buildAndGetResults({
+    fixturePath: join(__dirname, 'new-url-node-modules'),
+  });
+
+  const { content } = queryContent(contents.esm!, /index\.js/);
+  expect(content).not.toContain('__webpack_require__');
+
+  // From the source.
+  await expectUrlResolves(
+    contents,
+    'esm',
+    /index\.js/,
+    'logo',
+    'static/svg/logo.svg',
+  );
+  // From `node_modules/dep`.
+  await expectUrlResolves(
+    contents,
+    'esm',
+    /index\.js/,
+    'depLogo',
+    'static/svg/dep-logo.svg',
+  );
+});

--- a/tests/integration/asset/new-url-node-modules/.gitignore
+++ b/tests/integration/asset/new-url-node-modules/.gitignore
@@ -1,0 +1,2 @@
+!node_modules/
+node_modules/.*

--- a/tests/integration/asset/new-url-node-modules/node_modules/dep/assets/dep-logo.svg
+++ b/tests/integration/asset/new-url-node-modules/node_modules/dep/assets/dep-logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>

--- a/tests/integration/asset/new-url-node-modules/node_modules/dep/index.js
+++ b/tests/integration/asset/new-url-node-modules/node_modules/dep/index.js
@@ -1,0 +1,1 @@
+export const depLogo = new URL('./assets/dep-logo.svg', import.meta.url);

--- a/tests/integration/asset/new-url-node-modules/node_modules/dep/package.json
+++ b/tests/integration/asset/new-url-node-modules/node_modules/dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dep",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/tests/integration/asset/new-url-node-modules/package.json
+++ b/tests/integration/asset/new-url-node-modules/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "asset-new-url-node-modules-test",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tests/integration/asset/new-url-node-modules/rslib.config.ts
+++ b/tests/integration/asset/new-url-node-modules/rslib.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+// `new URL()` in the source and in a package under `node_modules`.
+export default defineConfig({
+  lib: [generateBundleEsmConfig()],
+  output: {
+    target: 'web',
+  },
+});

--- a/tests/integration/asset/new-url-node-modules/src/assets/logo.svg
+++ b/tests/integration/asset/new-url-node-modules/src/assets/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>

--- a/tests/integration/asset/new-url-node-modules/src/index.js
+++ b/tests/integration/asset/new-url-node-modules/src/index.js
@@ -1,0 +1,3 @@
+export { depLogo } from 'dep';
+
+export const logo = new URL('./assets/logo.svg', import.meta.url);

--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -173,7 +173,7 @@ If you do not want `new URL()` expressions to be parsed as URL assets, choose on
 
 ##### Disable the URL parser
 
-By default, Rslib registers a module rule named `'new-url'` whose [URL parser](https://rspack.rs/config/module-parser#javascripturl) is set to `'new-url-relative'`. The rule applies to project source files and to packages under `node_modules` alike. You can set its URL parser to `false` through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to skip asset parsing for all `new URL()` expressions:
+By default, Rslib registers a module rule named `'rslib:new-url'` whose [URL parser](https://rspack.rs/config/module-parser#javascripturl) is set to `'new-url-relative'`. The rule applies to project source files and to packages under `node_modules` alike. You can set its URL parser to `false` through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to skip asset parsing for all `new URL()` expressions:
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
@@ -181,7 +181,7 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   tools: {
     bundlerChain(chain) {
-      chain.module.rule('new-url').parser({
+      chain.module.rule('rslib:new-url').parser({
         url: false,
       });
     },

--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -169,24 +169,21 @@ export default {
 
 #### Skip `new URL()` processing
 
-If you do not want `new URL()` expressions in project source files to be parsed as URL assets, choose one of the following approaches based on the required scope.
+If you do not want `new URL()` expressions to be parsed as URL assets, choose one of the following approaches based on the required scope.
 
 ##### Disable the URL parser
 
-By default, Rslib sets the [URL parser](https://rspack.rs/config/module-parser#javascripturl) on its built-in JavaScript rule to `'new-url-relative'`. You can set the rule's URL parser to `false` through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to skip asset parsing for all `new URL()` expressions in project source files:
+By default, Rslib registers a module rule named `'new-url'` whose [URL parser](https://rspack.rs/config/module-parser#javascripturl) is set to `'new-url-relative'`. The rule applies to project source files and to packages under `node_modules` alike. You can set its URL parser to `false` through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to skip asset parsing for all `new URL()` expressions:
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   tools: {
-    bundlerChain(chain, { CHAIN_ID }) {
-      chain.module
-        .rule(CHAIN_ID.RULE.JS)
-        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
-        .parser({
-          url: false,
-        });
+    bundlerChain(chain) {
+      chain.module.rule('new-url').parser({
+        url: false,
+      });
     },
   },
 });

--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -173,7 +173,9 @@ If you do not want `new URL()` expressions to be parsed as URL assets, choose on
 
 ##### Disable the URL parser
 
-By default, Rslib registers a module rule named `'rslib:new-url'` whose [URL parser](https://rspack.rs/config/module-parser#javascripturl) is set to `'new-url-relative'`. You can set its URL parser to `false` through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to skip asset parsing for all `new URL()` expressions:
+When building ESM output, Rslib processes `new URL()` expressions in JavaScript and TypeScript files with the URL parser's [`'new-url-relative'`](https://rspack.rs/config/module-parser#javascripturl) mode by default.
+
+To preserve the original `new URL()` expressions without having Rslib emit the corresponding assets, set the URL parser to `false` through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain):
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';

--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -173,7 +173,7 @@ If you do not want `new URL()` expressions to be parsed as URL assets, choose on
 
 ##### Disable the URL parser
 
-By default, Rslib registers a module rule named `'rslib:new-url'` whose [URL parser](https://rspack.rs/config/module-parser#javascripturl) is set to `'new-url-relative'`. The rule applies to project source files and to packages under `node_modules` alike. You can set its URL parser to `false` through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to skip asset parsing for all `new URL()` expressions:
+By default, Rslib registers a module rule named `'rslib:new-url'` whose [URL parser](https://rspack.rs/config/module-parser#javascripturl) is set to `'new-url-relative'`. You can set its URL parser to `false` through [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to skip asset parsing for all `new URL()` expressions:
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -161,11 +161,13 @@ When building ESM output, Rslib v1 treats statically analyzable local `new URL()
 const logo = new URL('./assets/logo.svg', import.meta.url);
 ```
 
-Rslib v0.x preserved this expression and did not emit `logo.svg`. Rslib v1 emits the file and rewrites the URL to a relative path that points to it:
+For project source files, Rslib v0.x preserved this expression and did not emit `logo.svg`. Rslib v1 emits the file and rewrites the URL to a relative path that points to it:
 
 ```js title="dist/index.js"
 const logo = new URL('./static/svg/logo.svg', import.meta.url);
 ```
+
+In addition, for third-party dependencies bundled into the output, Rslib v0.x fell back to Rspack's default URL handling and pulled in extra runtime code, while Rslib v1 consistently emits a static relative URL that points to the emitted asset.
 
 If the project previously copied these assets through [output.copy](/config/rsbuild/output#outputcopy) or a script, remove the corresponding configuration after upgrading to avoid duplicate outputs. In bundleless mode ([`bundle: false`](/config/lib/bundle)), also exclude assets referenced through `new URL()` from [source.entry](/config/rsbuild/source#sourceentry) to avoid generating an additional JavaScript entry for the same file.
 

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -167,8 +167,6 @@ Rslib v0.x preserved this expression and did not emit `logo.svg`. Rslib v1 emits
 const logo = new URL('./static/svg/logo.svg', import.meta.url);
 ```
 
-This applies to `new URL()` references in packages under `node_modules` as well, so a bundled dependency that ships assets this way has them emitted alongside the output.
-
 If the project previously copied these assets through [output.copy](/config/rsbuild/output#outputcopy) or a script, remove the corresponding configuration after upgrading to avoid duplicate outputs. In bundleless mode ([`bundle: false`](/config/lib/bundle)), also exclude assets referenced through `new URL()` from [source.entry](/config/rsbuild/source#sourceentry) to avoid generating an additional JavaScript entry for the same file.
 
 To restore the Rslib v0.x behavior—preserving all `new URL()` expressions without having Rslib emit the assets—[disable the URL parser](/guide/advanced/static-assets#disable-the-url-parser):

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -169,7 +169,7 @@ const logo = new URL('./static/svg/logo.svg', import.meta.url);
 
 If the project previously copied these assets through [output.copy](/config/rsbuild/output#outputcopy) or a script, remove the corresponding configuration after upgrading to avoid duplicate outputs. In bundleless mode ([`bundle: false`](/config/lib/bundle)), also exclude assets referenced through `new URL()` from [source.entry](/config/rsbuild/source#sourceentry) to avoid generating an additional JavaScript entry for the same file.
 
-To restore the Rslib v0.x behavior—preserving all `new URL()` expressions without having Rslib emit the assets—[disable the URL parser](/guide/advanced/static-assets#disable-the-url-parser):
+To keep the Rslib v0.x behavior—preserving all `new URL()` expressions without having Rslib emit the assets—[disable the URL parser](/guide/advanced/static-assets#disable-the-url-parser):
 
 ```ts title="rslib.config.ts"
 export default {

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -177,7 +177,7 @@ To restore the Rslib v0.x behavior—preserving all `new URL()` expressions with
 export default {
   tools: {
     bundlerChain(chain) {
-      chain.module.rule('new-url').parser({
+      chain.module.rule('rslib:new-url').parser({
         url: false,
       });
     },

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -167,20 +167,19 @@ Rslib v0.x preserved this expression and did not emit `logo.svg`. Rslib v1 emits
 const logo = new URL('./static/svg/logo.svg', import.meta.url);
 ```
 
+This applies to `new URL()` references in packages under `node_modules` as well, so a bundled dependency that ships assets this way has them emitted alongside the output.
+
 If the project previously copied these assets through [output.copy](/config/rsbuild/output#outputcopy) or a script, remove the corresponding configuration after upgrading to avoid duplicate outputs. In bundleless mode ([`bundle: false`](/config/lib/bundle)), also exclude assets referenced through `new URL()` from [source.entry](/config/rsbuild/source#sourceentry) to avoid generating an additional JavaScript entry for the same file.
 
-To restore the Rslib v0.x behavior—preserving all `new URL()` expressions without having Rslib emit the assets—disable the URL parser:
+To restore the Rslib v0.x behavior—preserving all `new URL()` expressions without having Rslib emit the assets—[disable the URL parser](/guide/advanced/static-assets#disable-the-url-parser):
 
 ```ts title="rslib.config.ts"
 export default {
   tools: {
-    bundlerChain(chain, { CHAIN_ID }) {
-      chain.module
-        .rule(CHAIN_ID.RULE.JS)
-        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
-        .parser({
-          url: false,
-        });
+    bundlerChain(chain) {
+      chain.module.rule('new-url').parser({
+        url: false,
+      });
     },
   },
 };

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -173,7 +173,7 @@ export default {
 
 ##### 关闭 URL parser
 
-Rslib 默认会注册一条名为 `'new-url'` 的 module rule，将其 [URL parser](https://rspack.rs/zh/config/module-parser#javascripturl) 设置为 `'new-url-relative'`。你可以通过 [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) 将该 rule 的 URL parser 设置为 `false`，来跳过对 `new URL()` 的资源解析：
+Rslib 默认会注册一条名为 `'rslib:new-url'` 的 module rule，将其 [URL parser](https://rspack.rs/zh/config/module-parser#javascripturl) 设置为 `'new-url-relative'`。你可以通过 [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) 将该 rule 的 URL parser 设置为 `false`，来跳过对 `new URL()` 的资源解析：
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
@@ -181,7 +181,7 @@ import { defineConfig } from '@rslib/core';
 export default defineConfig({
   tools: {
     bundlerChain(chain) {
-      chain.module.rule('new-url').parser({
+      chain.module.rule('rslib:new-url').parser({
         url: false,
       });
     },

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -169,24 +169,21 @@ export default {
 
 #### 跳过 `new URL()` 处理
 
-如果不希望将项目源码中的 `new URL()` 解析为 URL asset，可以根据作用范围选择以下方式。
+如果不希望将 `new URL()` 解析为 URL asset，可以根据作用范围选择以下方式。
 
 ##### 关闭 URL parser
 
-Rslib 默认会将内置 JavaScript rule 的 [URL parser](https://rspack.rs/zh/config/module-parser#javascripturl) 设置为 `'new-url-relative'`。你可以通过 [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) 将该 rule 的 URL parser 设置为 `false`，来跳过项目源码中所有 `new URL()` 的资源解析：
+Rslib 默认会注册一条名为 `'new-url'` 的 module rule，将其 [URL parser](https://rspack.rs/zh/config/module-parser#javascripturl) 设置为 `'new-url-relative'`。你可以通过 [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) 将该 rule 的 URL parser 设置为 `false`，来跳过对 `new URL()` 的资源解析：
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   tools: {
-    bundlerChain(chain, { CHAIN_ID }) {
-      chain.module
-        .rule(CHAIN_ID.RULE.JS)
-        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
-        .parser({
-          url: false,
-        });
+    bundlerChain(chain) {
+      chain.module.rule('new-url').parser({
+        url: false,
+      });
     },
   },
 });

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -173,7 +173,9 @@ export default {
 
 ##### 关闭 URL parser
 
-Rslib 默认会注册一条名为 `'rslib:new-url'` 的 module rule，将其 [URL parser](https://rspack.rs/zh/config/module-parser#javascripturl) 设置为 `'new-url-relative'`。你可以通过 [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) 将该 rule 的 URL parser 设置为 `false`，来跳过对 `new URL()` 的资源解析：
+构建 ESM 产物时，Rslib 默认使用 URL parser 的 [`'new-url-relative'`](https://rspack.rs/zh/config/module-parser#javascripturl) 模式处理 JavaScript 和 TypeScript 文件中的 `new URL()` 表达式。
+
+如果希望保留原始的 `new URL()` 表达式，且不由 Rslib 输出对应资源，可以通过 [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) 将 URL parser 设置为 `false`：
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -175,7 +175,7 @@ const logo = new URL('./static/svg/logo.svg', import.meta.url);
 export default {
   tools: {
     bundlerChain(chain) {
-      chain.module.rule('new-url').parser({
+      chain.module.rule('rslib:new-url').parser({
         url: false,
       });
     },

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -169,7 +169,7 @@ const logo = new URL('./static/svg/logo.svg', import.meta.url);
 
 如果项目此前通过 [output.copy](/config/rsbuild/output#outputcopy) 或脚本复制这类资源，升级后应移除相应配置，避免重复输出。在 bundleless 模式（[`bundle: false`](/config/lib/bundle)）下，还需要在 [source.entry](/config/rsbuild/source#sourceentry) 中排除已通过 `new URL()` 引用的资源，避免为同一文件额外生成 JavaScript 入口。
 
-如果希望恢复 Rslib v0.x 的行为，原样保留所有 `new URL()` 且不由 Rslib 输出资源，可以[关闭 URL parser](/guide/advanced/static-assets#关闭-url-parser)：
+如果希望保留 Rslib v0.x 的行为，原样保留所有 `new URL()` 且不由 Rslib 输出资源，可以[关闭 URL parser](/guide/advanced/static-assets#关闭-url-parser)：
 
 ```ts title="rslib.config.ts"
 export default {

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -169,18 +169,15 @@ const logo = new URL('./static/svg/logo.svg', import.meta.url);
 
 如果项目此前通过 [output.copy](/config/rsbuild/output#outputcopy) 或脚本复制这类资源，升级后应移除相应配置，避免重复输出。在 bundleless 模式（[`bundle: false`](/config/lib/bundle)）下，还需要在 [source.entry](/config/rsbuild/source#sourceentry) 中排除已通过 `new URL()` 引用的资源，避免为同一文件额外生成 JavaScript 入口。
 
-如果希望恢复 Rslib v0.x 的行为，原样保留所有 `new URL()` 且不由 Rslib 输出资源，可以关闭 URL parser：
+如果希望恢复 Rslib v0.x 的行为，原样保留所有 `new URL()` 且不由 Rslib 输出资源，可以[关闭 URL parser](/guide/advanced/static-assets#关闭-url-parser)：
 
 ```ts title="rslib.config.ts"
 export default {
   tools: {
-    bundlerChain(chain, { CHAIN_ID }) {
-      chain.module
-        .rule(CHAIN_ID.RULE.JS)
-        .oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
-        .parser({
-          url: false,
-        });
+    bundlerChain(chain) {
+      chain.module.rule('new-url').parser({
+        url: false,
+      });
     },
   },
 };

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -161,11 +161,13 @@ Rslib v1 调整了 ESM 产物（[`format: 'esm'`](/config/lib/format)）中通�
 const logo = new URL('./assets/logo.svg', import.meta.url);
 ```
 
-Rslib v0.x 会原样保留该表达式，且不会输出 `logo.svg`。Rslib v1 则会输出该文件，并将 URL 重写为指向该文件的相对路径：
+对于项目源码，Rslib v0.x 会原样保留该表达式，且不会输出 `logo.svg`。Rslib v1 则会输出该文件，并将 URL 重写为指向该文件的相对路径：
 
 ```js title="dist/index.js"
 const logo = new URL('./static/svg/logo.svg', import.meta.url);
 ```
+
+此外，对于被打包到产物中的三方依赖，Rslib v0.x 会回退到 Rspack 默认的 URL 处理并引入额外 runtime，Rslib v1 则会统一生成指向输出资源的静态相对 URL。
 
 如果项目此前通过 [output.copy](/config/rsbuild/output#outputcopy) 或脚本复制这类资源，升级后应移除相应配置，避免重复输出。在 bundleless 模式（[`bundle: false`](/config/lib/bundle)）下，还需要在 [source.entry](/config/rsbuild/source#sourceentry) 中排除已通过 `new URL()` 引用的资源，避免为同一文件额外生成 JavaScript 入口。
 


### PR DESCRIPTION
## Summary

Move URL parser setting to a dedicated module rule, `rslib:new-url`, so project source and dependencies are handled the same way. The rule id is public and can be overridden through `tools.bundlerChain`:

```ts
tools: {
  bundlerChain(chain) {
    chain.module.rule('rslib:new-url').parser({ url: false });
  },
},
```

## Breaking change

For ESM output, `new URL()` references inside dependencies bundled into the output now emit a static relative URL pointing at the emitted asset, instead of falling back to Rspack's default URL handling with its extra runtime.

To keep the previous behavior, set the rule's URL parser to `false`.