### PR TITLE
chore(deps): replace create-rstack with create-toolkit

### DIFF
--- a/packages/create-rslib/AGENTS.md
+++ b/packages/create-rslib/AGENTS.md
@@ -6,7 +6,7 @@ This guide extends the repository instructions in `../../AGENTS.md`. Refer there
 
 - `create-rslib` provides the `pnpm create rslib` scaffolding CLI shipped from `dist/`.
 - Author source changes under `src/`; treat `dist/` as build output regenerated via `pnpm -C packages/create-rslib build`.
-- Template inputs are the checked-in `template-*` directories. They are copied directly by `create-rstack` and published with this package.
+- Template inputs are the checked-in `template-*` directories. They are copied directly by `@rstackjs/create-toolkit` and published with this package.
 - Tests in `test/` use `@rstest/core` to exercise CLI flows and validate generated projects.
 
 ## Common commands

--- a/packages/create-rslib/package.json
+++ b/packages/create-rslib/package.json
@@ -29,7 +29,7 @@
     "test": "rstest"
   },
   "dependencies": {
-    "create-rstack": "catalog:"
+    "@rstackjs/create-toolkit": "catalog:"
   },
   "devDependencies": {
     "@rslib/tsconfig": "workspace:*",

--- a/packages/create-rslib/src/index.ts
+++ b/packages/create-rslib/src/index.ts
@@ -11,7 +11,7 @@ import {
   type ESLintTemplateName,
   type RslintTemplateName,
   select,
-} from 'create-rstack';
+} from '@rstackjs/create-toolkit';
 import { parseTemplateName } from './parseTemplateName';
 
 export type Lang = 'ts' | 'js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ catalogs:
     '@rstack-dev/doc-ui':
       specifier: 1.14.7
       version: 1.14.7
+    '@rstackjs/create-toolkit':
+      specifier: 2.1.4
+      version: 2.1.4
     '@rstest/adapter-rslib':
       specifier: ^0.11.6
       version: 0.11.6
@@ -172,9 +175,6 @@ catalogs:
     core-js-pure:
       specifier: ^3.49.0
       version: 3.49.0
-    create-rstack:
-      specifier: 2.1.3
-      version: 2.1.3
     cspell-ban-words:
       specifier: ^0.0.4
       version: 0.0.4
@@ -688,9 +688,9 @@ importers:
 
   packages/create-rslib:
     dependencies:
-      create-rstack:
+      '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.1.3
+        version: 2.1.4
     devDependencies:
       '@rslib/tsconfig':
         specifier: workspace:*
@@ -3324,6 +3324,10 @@ packages:
       '@rspress/core':
         optional: true
 
+  '@rstackjs/create-toolkit@2.1.4':
+    resolution: {integrity: sha512-kwPhfMdgWN7z/Op5UKMszhmZy7+hzqXeiQPli4uycYYTLxCVUGLlEW3etoGoZlrM2t5zLqXZQAgL60PTUR/ocw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@rstest/adapter-rslib@0.11.6':
     resolution: {integrity: sha512-0NOU3W63TWtbWExgT/gvpbQ5ZtWqW5HepvJ/mNne7FgZfjm2bNwDF2Saglpg/M83KuBpA9xmnrOUQXNosJkCBQ==}
     peerDependencies:
@@ -4625,10 +4629,6 @@ packages:
 
   create-hmac@1.1.7:
     resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
-
-  create-rstack@2.1.3:
-    resolution: {integrity: sha512-3n8JzuzbMYger7fnhIb8DDYs7b4lnNgLJm6kKve+qCKeqpCsTZaiZBQ3cYy7/FjWNtccbJ4XhfA/WNvzETD3vw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -9657,6 +9657,8 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
+  '@rstackjs/create-toolkit@2.1.4': {}
+
   '@rstest/adapter-rslib@0.11.6(@rslib/core@1.0.0-beta.2)(@rstest/core@0.11.6)(typescript@7.0.2)':
     dependencies:
       '@rslib/core': 1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.1)(typescript@7.0.2)
@@ -10986,8 +10988,6 @@ snapshots:
       ripemd160: 2.0.2
       safe-buffer: 5.2.1
       sha.js: 2.4.12
-
-  create-rstack@2.1.3: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,6 +47,7 @@ catalog:
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rspress/plugin-twoslash': '^2.0.19'
   '@rstack-dev/doc-ui': '1.14.7'
+  '@rstackjs/create-toolkit': '2.1.4'
   '@rstest/adapter-rslib': '^0.11.6'
   '@rstest/core': '^0.11.6'
   '@shikijs/transformers': '^4.4.2'
@@ -69,7 +70,6 @@ catalog:
   'buffer': '^6.0.3'
   'cac': '^7.0.0'
   'core-js-pure': '^3.49.0'
-  'create-rstack': '2.1.3'
   'cspell-ban-words': '^0.0.4'
   'express': '^5.2.1'
   'fs-extra': '^11.4.0'
@@ -141,6 +141,7 @@ minimumReleaseAgeExclude:
   - '@rslint/*'
   - reduce-configs
   - '@rstack-dev/doc-ui'
+  - '@rstackjs/create-toolkit'
   - 'rsbuild-plugin-*'
   - '@swc/*'
   - typescript


### PR DESCRIPTION
## Summary

- Replace `create-rstack` with its renamed package, `@rstackjs/create-toolkit` v2.1.4.
- Update `create-rslib` imports, workspace dependencies, and maintainer guidance without changing scaffolding behavior.

## Related Links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.1.4

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).