### PR TITLE
refactor(create-rslib): use Vue Test Utils in templates

### DIFF
--- a/packages/create-rslib/template-vue-js/package.json
+++ b/packages/create-rslib/template-vue-js/package.json
@@ -12,9 +12,6 @@
   "files": [
     "dist"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",
@@ -27,12 +24,14 @@
     "@rstest/adapter-rslib": "^0.11.6",
     "@rstest/core": "^0.11.6",
     "@testing-library/jest-dom": "^7.0.0",
-    "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1",
     "vue": "^3.5.40"
   },
   "peerDependencies": {
     "vue": "^3.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/create-rslib/template-vue-js/rstest.setup.js
+++ b/packages/create-rslib/template-vue-js/rstest.setup.js
@@ -1,4 +1,6 @@
-import { expect } from '@rstest/core';
+import { afterEach, expect } from '@rstest/core';
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+import { enableAutoUnmount } from '@vue/test-utils';
 
 expect.extend(jestDomMatchers);
+enableAutoUnmount(afterEach);

--- a/packages/create-rslib/template-vue-js/tests/index.test.js
+++ b/packages/create-rslib/template-vue-js/tests/index.test.js
@@ -10,7 +10,9 @@ test('The button should have correct background color', () => {
       label: 'Demo Button',
     },
   });
-  expect(wrapper.get('button').element).toHaveStyle({
+  const button = wrapper.get('button');
+  expect(button.text()).toBe('Demo Button');
+  expect(button.element).toHaveStyle({
     backgroundColor: '#ccc',
   });
   wrapper.unmount();

--- a/packages/create-rslib/template-vue-js/tests/index.test.js
+++ b/packages/create-rslib/template-vue-js/tests/index.test.js
@@ -15,5 +15,4 @@ test('The button should have correct background color', () => {
   expect(button.element).toHaveStyle({
     backgroundColor: '#ccc',
   });
-  wrapper.unmount();
 });

--- a/packages/create-rslib/template-vue-js/tests/index.test.js
+++ b/packages/create-rslib/template-vue-js/tests/index.test.js
@@ -1,16 +1,17 @@
 import { expect, test } from '@rstest/core';
-import { render, screen } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
 import Button from '../src/Button.vue';
 
-test('The button should have correct background color', async () => {
-  render(Button, {
+test('The button should have correct background color', () => {
+  const wrapper = mount(Button, {
+    attachTo: document.body,
     props: {
       backgroundColor: '#ccc',
       label: 'Demo Button',
     },
   });
-  const button = screen.getByText('Demo Button');
-  expect(button).toHaveStyle({
+  expect(wrapper.get('button').element).toHaveStyle({
     backgroundColor: '#ccc',
   });
+  wrapper.unmount();
 });

--- a/packages/create-rslib/template-vue-ts/package.json
+++ b/packages/create-rslib/template-vue-ts/package.json
@@ -12,9 +12,6 @@
   "files": [
     "dist"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "rslib && vue-tsc",
     "dev": "rslib --watch",
@@ -27,7 +24,6 @@
     "@rstest/adapter-rslib": "^0.11.6",
     "@rstest/core": "^0.11.6",
     "@testing-library/jest-dom": "^7.0.0",
-    "@testing-library/vue": "^8.1.0",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.11.1",
     "typescript": "^6.0.3",
@@ -36,5 +32,8 @@
   },
   "peerDependencies": {
     "vue": "^3.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/create-rslib/template-vue-ts/rstest.setup.ts
+++ b/packages/create-rslib/template-vue-ts/rstest.setup.ts
@@ -1,4 +1,6 @@
-import { expect } from '@rstest/core';
+import { afterEach, expect } from '@rstest/core';
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+import { enableAutoUnmount } from '@vue/test-utils';
 
 expect.extend(jestDomMatchers);
+enableAutoUnmount(afterEach);

--- a/packages/create-rslib/template-vue-ts/tests/index.test.ts
+++ b/packages/create-rslib/template-vue-ts/tests/index.test.ts
@@ -10,7 +10,9 @@ test('The button should have correct background color', () => {
       label: 'Demo Button',
     },
   });
-  expect(wrapper.get('button').element).toHaveStyle({
+  const button = wrapper.get('button');
+  expect(button.text()).toBe('Demo Button');
+  expect(button.element).toHaveStyle({
     backgroundColor: '#ccc',
   });
   wrapper.unmount();

--- a/packages/create-rslib/template-vue-ts/tests/index.test.ts
+++ b/packages/create-rslib/template-vue-ts/tests/index.test.ts
@@ -15,5 +15,4 @@ test('The button should have correct background color', () => {
   expect(button.element).toHaveStyle({
     backgroundColor: '#ccc',
   });
-  wrapper.unmount();
 });

--- a/packages/create-rslib/template-vue-ts/tests/index.test.ts
+++ b/packages/create-rslib/template-vue-ts/tests/index.test.ts
@@ -1,16 +1,17 @@
 import { expect, test } from '@rstest/core';
-import { render, screen } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
 import Button from '../src/Button.vue';
 
-test('The button should have correct background color', async () => {
-  render(Button, {
+test('The button should have correct background color', () => {
+  const wrapper = mount(Button, {
+    attachTo: document.body,
     props: {
       backgroundColor: '#ccc',
       label: 'Demo Button',
     },
   });
-  const button = screen.getByText('Demo Button');
-  expect(button).toHaveStyle({
+  expect(wrapper.get('button').element).toHaveStyle({
     backgroundColor: '#ccc',
   });
+  wrapper.unmount();
 });


### PR DESCRIPTION
## Summary

- Replace `@testing-library/vue` with the official `@vue/test-utils` package in the Vue JavaScript and TypeScript templates.
- Update the default component tests to mount and unmount Vue wrappers directly.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/269

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).