### PR TITLE
docs: how to bundle createRequire deps

### DIFF
--- a/website/docs/en/guide/advanced/third-party-deps.mdx
+++ b/website/docs/en/guide/advanced/third-party-deps.mdx
@@ -197,13 +197,15 @@ For more details, see the Rspack [Externals](https://rspack.rs/config/externals)
 
 ## Bundle dependencies loaded with createRequire
 
-In ESM source code, you can use Node.js [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename) to load CommonJS modules:
+There is no `require` function in ESM. If you need to load a third-party dependency that only ships CommonJS, you can create one with Node.js [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename):
 
 ```ts title="src/index.ts"
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-export const value = require('./value.cjs');
+const foo = require('foo');
+
+export const bar = foo.bar;
 ```
 
 Rslib preserves `createRequire()` calls by default. To let Rspack analyze these calls and bundle their static dependencies, enable [`module.parser.javascript.createRequire`](https://rspack.rs/config/module-parser#javascriptcreaterequire).
@@ -230,9 +232,7 @@ export default defineConfig({
 });
 ```
 
-### Enable only for user source code
-
-If some third-party dependencies require runtime behavior, use a module rule that excludes `node_modules` to enable `createRequire` parsing only for your source code:
+If some third-party dependencies rely on `createRequire()` being kept at runtime, use a module rule that excludes `node_modules` to enable `createRequire` parsing only for your own source code:
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';

--- a/website/docs/en/guide/advanced/third-party-deps.mdx
+++ b/website/docs/en/guide/advanced/third-party-deps.mdx
@@ -194,3 +194,68 @@ export default defineConfig({
 ```
 
 For more details, see the Rspack [Externals](https://rspack.rs/config/externals) documentation.
+
+## Bundle dependencies loaded with createRequire
+
+In ESM source code, you can use Node.js [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename) to load CommonJS modules:
+
+```ts title="src/index.ts"
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+export const value = require('./value.cjs');
+```
+
+Rslib preserves `createRequire()` calls by default. To let Rspack analyze these calls and bundle their static dependencies, enable [`module.parser.javascript.createRequire`](https://rspack.rs/config/module-parser#javascriptcreaterequire).
+
+```ts title="rslib.config.ts"
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      tools: {
+        rspack: {
+          module: {
+            parser: {
+              javascript: {
+                createRequire: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+});
+```
+
+### Enable only for user source code
+
+If some third-party dependencies require runtime behavior, use a module rule that excludes `node_modules` to enable `createRequire` parsing only for your source code:
+
+```ts title="rslib.config.ts"
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      tools: {
+        rspack: {
+          module: {
+            rules: [
+              {
+                test: /\.[cm]?[jt]sx?$/,
+                exclude: /node_modules/,
+                parser: {
+                  createRequire: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  ],
+});
+```

--- a/website/docs/en/guide/advanced/third-party-deps.mdx
+++ b/website/docs/en/guide/advanced/third-party-deps.mdx
@@ -208,27 +208,23 @@ const foo = require('foo');
 export const bar = foo.bar;
 ```
 
-Rslib preserves `createRequire()` calls by default. To let Rspack analyze these calls and bundle their static dependencies, enable [`module.parser.javascript.createRequire`](https://rspack.rs/config/module-parser#javascriptcreaterequire).
+Rslib preserves `createRequire()` calls by default. To let Rspack analyze these calls and bundle dependencies that can be statically analyzed, enable [`module.parser.javascript.createRequire`](https://rspack.rs/config/module-parser#javascriptcreaterequire).
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [
-    {
-      tools: {
-        rspack: {
-          module: {
-            parser: {
-              javascript: {
-                createRequire: true,
-              },
-            },
+  tools: {
+    rspack: {
+      module: {
+        parser: {
+          javascript: {
+            createRequire: true,
           },
         },
       },
     },
-  ],
+  },
 });
 ```
 

--- a/website/docs/en/guide/advanced/third-party-deps.mdx
+++ b/website/docs/en/guide/advanced/third-party-deps.mdx
@@ -195,9 +195,9 @@ export default defineConfig({
 
 For more details, see the Rspack [Externals](https://rspack.rs/config/externals) documentation.
 
-## Bundle dependencies loaded with createRequire
+## Bundle dependencies loaded via `createRequire()`
 
-There is no `require` function in ESM. If you need to load a third-party dependency that only ships CommonJS, you can create one with Node.js [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename):
+The Node.js ES module environment does not provide the CommonJS `require()` function. If you need to use CommonJS loading semantics in an ES module, you can create a `require` function with Node.js [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename):
 
 ```ts title="src/index.ts"
 import { createRequire } from 'node:module';
@@ -208,7 +208,7 @@ const foo = require('foo');
 export const bar = foo.bar;
 ```
 
-Rslib preserves `createRequire()` calls by default. To let Rspack analyze these calls and bundle dependencies that can be statically analyzed, enable [`module.parser.javascript.createRequire`](https://rspack.rs/config/module-parser#javascriptcreaterequire).
+Rslib keeps `createRequire()` calls in the output by default. To let Rspack analyze the `require()` calls created by it and bundle dependencies loaded by statically analyzable calls such as `require('foo')`, enable [`module.parser.javascript.createRequire`](https://rspack.rs/config/module-parser#javascriptcreaterequire).
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
@@ -228,7 +228,7 @@ export default defineConfig({
 });
 ```
 
-If some third-party dependencies rely on `createRequire()` being kept at runtime, use a module rule that excludes `node_modules` to enable `createRequire` parsing only for your own source code:
+If bundled dependencies contain `createRequire()` calls that need to be kept at runtime, use `module.rules` to enable this capability only for JavaScript/TypeScript modules outside `node_modules`:
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';

--- a/website/docs/en/guide/advanced/third-party-deps.mdx
+++ b/website/docs/en/guide/advanced/third-party-deps.mdx
@@ -197,7 +197,7 @@ For more details, see the Rspack [Externals](https://rspack.rs/config/externals)
 
 ## Bundle dependencies loaded via `createRequire()`
 
-The Node.js ES module environment does not provide the CommonJS `require()` function. If you need to use CommonJS loading semantics in an ES module, you can create a `require` function with Node.js [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename):
+The Node.js ES module environment does not provide the CommonJS `require` function. If you need to use CommonJS loading semantics in an ES module, you can create a `require` function with Node.js [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename):
 
 ```ts title="src/index.ts"
 import { createRequire } from 'node:module';

--- a/website/docs/en/guide/advanced/third-party-deps.mdx
+++ b/website/docs/en/guide/advanced/third-party-deps.mdx
@@ -234,24 +234,20 @@ If bundled dependencies contain `createRequire()` calls that need to be kept at 
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [
-    {
-      tools: {
-        rspack: {
-          module: {
-            rules: [
-              {
-                test: /\.[cm]?[jt]sx?$/,
-                exclude: /node_modules/,
-                parser: {
-                  createRequire: true,
-                },
-              },
-            ],
+  tools: {
+    rspack: {
+      module: {
+        rules: [
+          {
+            test: /\.[cm]?[jt]sx?$/,
+            exclude: /node_modules/,
+            parser: {
+              createRequire: true,
+            },
           },
-        },
+        ],
       },
     },
-  ],
+  },
 });
 ```

--- a/website/docs/zh/guide/advanced/third-party-deps.mdx
+++ b/website/docs/zh/guide/advanced/third-party-deps.mdx
@@ -203,27 +203,23 @@ const foo = require('foo');
 export const bar = foo.bar;
 ```
 
-Rslib 默认保留 `createRequire()` 调用。如果希望 Rspack 分析这些调用并打包其中的静态依赖，可以开启 [`module.parser.javascript.createRequire`](https://rspack.rs/zh/config/module-parser#javascriptcreaterequire)。
+Rslib 默认保留 `createRequire()` 调用。如果希望 Rspack 分析这些调用并打包其中可被静态分析的依赖，可以开启 [`module.parser.javascript.createRequire`](https://rspack.rs/zh/config/module-parser#javascriptcreaterequire)。
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [
-    {
-      tools: {
-        rspack: {
-          module: {
-            parser: {
-              javascript: {
-                createRequire: true,
-              },
-            },
+  tools: {
+    rspack: {
+      module: {
+        parser: {
+          javascript: {
+            createRequire: true,
           },
         },
       },
     },
-  ],
+  },
 });
 ```
 

--- a/website/docs/zh/guide/advanced/third-party-deps.mdx
+++ b/website/docs/zh/guide/advanced/third-party-deps.mdx
@@ -192,13 +192,15 @@ export default defineConfig({
 
 ## 打包 createRequire 加载的依赖
 
-在 ESM 源码中，你可以使用 Node.js 的 [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename) 加载 CommonJS 模块：
+ESM 中没有 `require` 函数，如果需要加载仅提供 CommonJS 产物的三方依赖，你可以使用 Node.js 的 [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename) 创建 `require`：
 
 ```ts title="src/index.ts"
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-export const value = require('./value.cjs');
+const foo = require('foo');
+
+export const bar = foo.bar;
 ```
 
 Rslib 默认保留 `createRequire()` 调用。如果希望 Rspack 分析这些调用并打包其中的静态依赖，可以开启 [`module.parser.javascript.createRequire`](https://rspack.rs/zh/config/module-parser#javascriptcreaterequire)。
@@ -225,9 +227,7 @@ export default defineConfig({
 });
 ```
 
-### 仅为用户源码开启
-
-如果某些三方依赖需要运行时行为，则可以使用排除 `node_modules` 的 module rule，仅对用户源码开启 `createRequire` 解析：
+如果某些三方依赖依赖于 `createRequire()` 在运行时被保留，则可以使用排除 `node_modules` 的 module rule，仅对用户源码开启 `createRequire` 解析：
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';

--- a/website/docs/zh/guide/advanced/third-party-deps.mdx
+++ b/website/docs/zh/guide/advanced/third-party-deps.mdx
@@ -189,3 +189,68 @@ export default defineConfig({
 ```
 
 更多用法可参考 Rspack 的 [Externals](https://rspack.rs/zh/config/externals) 文档。
+
+## 打包 createRequire 加载的依赖
+
+在 ESM 源码中，你可以使用 Node.js 的 [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename) 加载 CommonJS 模块：
+
+```ts title="src/index.ts"
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+export const value = require('./value.cjs');
+```
+
+Rslib 默认保留 `createRequire()` 调用。如果希望 Rspack 分析这些调用并打包其中的静态依赖，可以开启 [`module.parser.javascript.createRequire`](https://rspack.rs/zh/config/module-parser#javascriptcreaterequire)。
+
+```ts title="rslib.config.ts"
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      tools: {
+        rspack: {
+          module: {
+            parser: {
+              javascript: {
+                createRequire: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+});
+```
+
+### 仅为用户源码开启
+
+如果某些三方依赖需要运行时行为，则可以使用排除 `node_modules` 的 module rule，仅对用户源码开启 `createRequire` 解析：
+
+```ts title="rslib.config.ts"
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      tools: {
+        rspack: {
+          module: {
+            rules: [
+              {
+                test: /\.[cm]?[jt]sx?$/,
+                exclude: /node_modules/,
+                parser: {
+                  createRequire: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  ],
+});
+```

--- a/website/docs/zh/guide/advanced/third-party-deps.mdx
+++ b/website/docs/zh/guide/advanced/third-party-deps.mdx
@@ -190,9 +190,9 @@ export default defineConfig({
 
 更多用法可参考 Rspack 的 [Externals](https://rspack.rs/zh/config/externals) 文档。
 
-## 打包 createRequire 加载的依赖
+## 打包通过 `createRequire()` 加载的依赖
 
-ESM 中没有 `require` 函数，如果需要加载仅提供 CommonJS 产物的三方依赖，你可以使用 Node.js 的 [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename) 创建 `require`：
+Node.js 的 ES 模块环境不提供 CommonJS 的 require() 函数。若需要在 ES 模块中使用 CommonJS 的加载语义，可以通过 Node.js 的 [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename) 创建一个 `require` 函数：
 
 ```ts title="src/index.ts"
 import { createRequire } from 'node:module';
@@ -203,7 +203,7 @@ const foo = require('foo');
 export const bar = foo.bar;
 ```
 
-Rslib 默认保留 `createRequire()` 调用。如果希望 Rspack 分析这些调用并打包其中可被静态分析的依赖，可以开启 [`module.parser.javascript.createRequire`](https://rspack.rs/zh/config/module-parser#javascriptcreaterequire)。
+Rslib 默认会在产物中保留 `createRequire()` 调用。如果希望 Rspack 分析由它创建的 `require()` 调用，并打包由 `require('foo')` 这类可静态分析的调用所加载的依赖，可以启用 [`module.parser.javascript.createRequire`](https://rspack.rs/zh/config/module-parser#javascriptcreaterequire)。
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';
@@ -223,7 +223,7 @@ export default defineConfig({
 });
 ```
 
-如果某些三方依赖依赖于 `createRequire()` 在运行时被保留，则可以使用排除 `node_modules` 的 module rule，仅对用户源码开启 `createRequire` 解析：
+如果被打包的依赖中存在需要保留到运行时的 `createRequire()` 调用，可以改用 `module.rules`，仅对 node_modules 之外的 JavaScript/TypeScript 模块启用该能力：
 
 ```ts title="rslib.config.ts"
 import { defineConfig } from '@rslib/core';

--- a/website/docs/zh/guide/advanced/third-party-deps.mdx
+++ b/website/docs/zh/guide/advanced/third-party-deps.mdx
@@ -192,7 +192,7 @@ export default defineConfig({
 
 ## 打包通过 `createRequire()` 加载的依赖
 
-Node.js 的 ES 模块环境不提供 CommonJS 的 require() 函数。若需要在 ES 模块中使用 CommonJS 的加载语义，可以通过 Node.js 的 [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename) 创建一个 `require` 函数：
+Node.js 的 ES 模块环境不提供 CommonJS 的 `require` 函数。若需要在 ES 模块中使用 CommonJS 的加载语义，可以通过 Node.js 的 [`createRequire()`](https://nodejs.org/api/module.html#modulecreaterequirefilename) 创建一个 `require` 函数：
 
 ```ts title="src/index.ts"
 import { createRequire } from 'node:module';

--- a/website/docs/zh/guide/advanced/third-party-deps.mdx
+++ b/website/docs/zh/guide/advanced/third-party-deps.mdx
@@ -229,24 +229,20 @@ export default defineConfig({
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [
-    {
-      tools: {
-        rspack: {
-          module: {
-            rules: [
-              {
-                test: /\.[cm]?[jt]sx?$/,
-                exclude: /node_modules/,
-                parser: {
-                  createRequire: true,
-                },
-              },
-            ],
+  tools: {
+    rspack: {
+      module: {
+        rules: [
+          {
+            test: /\.[cm]?[jt]sx?$/,
+            exclude: /node_modules/,
+            parser: {
+              createRequire: true,
+            },
           },
-        },
+        ],
       },
     },
-  ],
+  },
 });
 ```


### PR DESCRIPTION
## Summary

Add documentation for bundling dependencies loaded with `createRequire()`, including global configuration and a source-only module rule that excludes `node_modules`.