### PR TITLE
refactor(create-rslib): simplify framework templates

### DIFF
--- a/packages/create-rslib/template-react-compiler/react-js/rslib.config.js
+++ b/packages/create-rslib/template-react-compiler/react-js/rslib.config.js
@@ -2,16 +2,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  source: {
-    entry: {
-      index: ['./src/**'],
-    },
-  },
-  lib: [
-    {
-      bundle: false,
-    },
-  ],
+  bundle: false,
   output: {
     target: 'web',
   },

--- a/packages/create-rslib/template-react-compiler/react-ts/rslib.config.ts
+++ b/packages/create-rslib/template-react-compiler/react-ts/rslib.config.ts
@@ -2,17 +2,8 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  source: {
-    entry: {
-      index: ['./src/**'],
-    },
-  },
-  lib: [
-    {
-      bundle: false,
-      dts: true,
-    },
-  ],
+  bundle: false,
+  dts: true,
   output: {
     target: 'web',
   },

--- a/packages/create-rslib/template-react-js/package.json
+++ b/packages/create-rslib/template-react-js/package.json
@@ -2,11 +2,7 @@
   "name": "rslib-react-js",
   "version": "0.0.0",
   "type": "module",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js"
-    }
-  },
+  "exports": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-react-js/rslib.config.js
+++ b/packages/create-rslib/template-react-js/rslib.config.js
@@ -2,16 +2,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  source: {
-    entry: {
-      index: ['./src/**'],
-    },
-  },
-  lib: [
-    {
-      bundle: false,
-    },
-  ],
+  bundle: false,
   output: {
     target: 'web',
   },

--- a/packages/create-rslib/template-react-ts/package.json
+++ b/packages/create-rslib/template-react-ts/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/create-rslib/template-react-ts/rslib.config.ts
+++ b/packages/create-rslib/template-react-ts/rslib.config.ts
@@ -2,17 +2,8 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  source: {
-    entry: {
-      index: ['./src/**'],
-    },
-  },
-  lib: [
-    {
-      bundle: false,
-      dts: true,
-    },
-  ],
+  bundle: false,
+  dts: true,
   output: {
     target: 'web',
   },

--- a/packages/create-rslib/template-solid-js/package.json
+++ b/packages/create-rslib/template-solid-js/package.json
@@ -5,15 +5,12 @@
   "exports": {
     ".": {
       "solid": "./dist/index.jsx",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "files": [
     "dist"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",
@@ -34,5 +31,8 @@
   },
   "peerDependencies": {
     "solid-js": "^1.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/create-rslib/template-solid-js/rslib.config.js
+++ b/packages/create-rslib/template-solid-js/rslib.config.js
@@ -6,7 +6,6 @@ export default defineConfig({
   lib: [
     {
       id: 'compiled',
-      bundle: false,
       plugins: [
         pluginBabel({
           include: /\.(?:jsx|tsx)$/,
@@ -16,7 +15,6 @@ export default defineConfig({
     },
     {
       id: 'source',
-      bundle: false,
       output: {
         filename: {
           js: '[name].jsx',
@@ -45,6 +43,7 @@ export default defineConfig({
       },
     },
   ],
+  bundle: false,
   output: {
     target: 'web',
   },

--- a/packages/create-rslib/template-solid-ts/package.json
+++ b/packages/create-rslib/template-solid-ts/package.json
@@ -4,18 +4,15 @@
   "type": "module",
   "exports": {
     ".": {
-      "solid": "./dist/index.jsx",
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "solid": "./dist/index.jsx",
+      "default": "./dist/index.js"
     }
   },
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",
@@ -37,5 +34,8 @@
   },
   "peerDependencies": {
     "solid-js": "^1.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/create-rslib/template-solid-ts/rslib.config.ts
+++ b/packages/create-rslib/template-solid-ts/rslib.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
   lib: [
     {
       id: 'compiled',
-      bundle: false,
       dts: true,
       plugins: [
         pluginBabel({
@@ -17,7 +16,6 @@ export default defineConfig({
     },
     {
       id: 'source',
-      bundle: false,
       output: {
         filename: {
           js: '[name].jsx',
@@ -46,6 +44,7 @@ export default defineConfig({
       },
     },
   ],
+  bundle: false,
   output: {
     target: 'web',
   },

--- a/packages/create-rslib/template-storybook/react-js/.storybook/main.js
+++ b/packages/create-rslib/template-storybook/react-js/.storybook/main.js
@@ -30,10 +30,6 @@ const config = {
     name: getAbsolutePath('storybook-react-rsbuild'),
     options: {},
   },
-  typescript: {
-    reactDocgen: 'react-docgen-typescript',
-    check: true,
-  },
 };
 
 export default config;

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -9,7 +9,7 @@
     "@storybook/addon-onboarding": "^10.5.7",
     "@storybook/react": "^10.5.7",
     "storybook": "^10.5.7",
-    "storybook-addon-rslib": "^3.4.0",
-    "storybook-react-rsbuild": "^3.4.0"
+    "storybook-addon-rslib": "^3.4.1",
+    "storybook-react-rsbuild": "^3.4.1"
   }
 }

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -9,7 +9,7 @@
     "@storybook/addon-onboarding": "^10.5.7",
     "@storybook/react": "^10.5.7",
     "storybook": "^10.5.7",
-    "storybook-addon-rslib": "^3.4.0",
-    "storybook-react-rsbuild": "^3.4.0"
+    "storybook-addon-rslib": "^3.4.1",
+    "storybook-react-rsbuild": "^3.4.1"
   }
 }

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -9,7 +9,7 @@
     "@storybook/addon-onboarding": "^10.5.7",
     "@storybook/vue3": "^10.5.7",
     "storybook": "^10.5.7",
-    "storybook-addon-rslib": "^3.4.0",
-    "storybook-vue3-rsbuild": "^3.4.0"
+    "storybook-addon-rslib": "^3.4.1",
+    "storybook-vue3-rsbuild": "^3.4.1"
   }
 }

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -9,7 +9,7 @@
     "@storybook/addon-onboarding": "^10.5.7",
     "@storybook/vue3": "^10.5.7",
     "storybook": "^10.5.7",
-    "storybook-addon-rslib": "^3.4.0",
-    "storybook-vue3-rsbuild": "^3.4.0"
+    "storybook-addon-rslib": "^3.4.1",
+    "storybook-vue3-rsbuild": "^3.4.1"
   }
 }

--- a/packages/create-rslib/template-svelte-js/package.json
+++ b/packages/create-rslib/template-svelte-js/package.json
@@ -3,17 +3,12 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
-    ".": {
-      "import": "./dist/index.js"
-    },
+    ".": "./dist/index.js",
     "./style.css": "./dist/index.css"
   },
   "files": [
     "dist"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "rslib",
     "dev": "rslib --watch",
@@ -30,5 +25,8 @@
   },
   "peerDependencies": {
     "svelte": "^5.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/create-rslib/template-svelte-js/rslib.config.js
+++ b/packages/create-rslib/template-svelte-js/rslib.config.js
@@ -2,11 +2,6 @@ import { pluginSvelte } from '@rsbuild/plugin-svelte';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [
-    {
-      format: 'esm',
-    },
-  ],
   output: {
     target: 'web',
   },

--- a/packages/create-rslib/template-svelte-ts/package.json
+++ b/packages/create-rslib/template-svelte-ts/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./style.css": "./dist/index.css"
   },
@@ -13,9 +13,6 @@
   "files": [
     "dist"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "rslib",
     "check": "svelte-check",
@@ -38,5 +35,8 @@
   },
   "peerDependencies": {
     "svelte": "^5.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/create-rslib/template-svelte-ts/rslib.config.ts
+++ b/packages/create-rslib/template-svelte-ts/rslib.config.ts
@@ -3,11 +3,6 @@ import { defineConfig } from '@rslib/core';
 import { svelteDtsPlugin } from './scripts/rslib-plugin-svelte-dts';
 
 export default defineConfig({
-  lib: [
-    {
-      format: 'esm',
-    },
-  ],
   output: {
     target: 'web',
   },

--- a/packages/create-rslib/template-vue-js/package.json
+++ b/packages/create-rslib/template-vue-js/package.json
@@ -2,13 +2,7 @@
   "name": "rslib-vue-js",
   "version": "0.0.0",
   "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "types": "./dist/index.d.ts",
+  "exports": "./dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/create-rslib/template-vue-js/rslib.config.ts
+++ b/packages/create-rslib/template-vue-js/rslib.config.ts
@@ -2,11 +2,7 @@ import { defineConfig } from '@rslib/core';
 import { pluginVue } from '@rsbuild/plugin-vue';
 
 export default defineConfig({
-  lib: [
-    {
-      bundle: false,
-    },
-  ],
+  bundle: false,
   output: {
     target: 'web',
   },

--- a/packages/create-rslib/template-vue-ts/package.json
+++ b/packages/create-rslib/template-vue-ts/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/create-rslib/template-vue-ts/rslib.config.ts
+++ b/packages/create-rslib/template-vue-ts/rslib.config.ts
@@ -2,11 +2,7 @@ import { defineConfig } from '@rslib/core';
 import { pluginVue } from '@rsbuild/plugin-vue';
 
 export default defineConfig({
-  lib: [
-    {
-      bundle: false,
-    },
-  ],
+  bundle: false,
   output: {
     target: 'web',
   },

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -164,6 +164,7 @@ export const createAndValidate = (
     expect(pkgJson.peerDependencies['@solidjs/web']).toBeFalsy();
 
     if (templateCase.lang === 'ts') {
+      expect(Object.keys(pkgJson.exports['.'])[0]).toBe('types');
       expect(pkgJson.exports['.'].types).toBe('./dist/index.d.ts');
       expect(pkgJson.types).toBe('./dist/index.d.ts');
     } else {

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -164,7 +164,11 @@ export const createAndValidate = (
     expect(pkgJson.peerDependencies['@solidjs/web']).toBeFalsy();
 
     if (templateCase.lang === 'ts') {
-      expect(Object.keys(pkgJson.exports['.'])[0]).toBe('types');
+      expect(Object.keys(pkgJson.exports['.'])).toEqual([
+        'types',
+        'solid',
+        'default',
+      ]);
       expect(pkgJson.exports['.'].types).toBe('./dist/index.d.ts');
       expect(pkgJson.types).toBe('./dist/index.d.ts');
     } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,14 +272,14 @@ catalogs:
       specifier: ^10.5.7
       version: 10.5.7
     storybook-addon-rslib:
-      specifier: ^3.4.0
-      version: 3.4.0
+      specifier: ^3.4.1
+      version: 3.4.1
     storybook-react-rsbuild:
-      specifier: ^3.4.0
-      version: 3.4.0
+      specifier: ^3.4.1
+      version: 3.4.1
     storybook-vue3-rsbuild:
-      specifier: ^3.4.0
-      version: 3.4.0
+      specifier: ^3.4.1
+      version: 3.4.1
     tailwindcss:
       specifier: ^4.3.3
       version: 4.3.3
@@ -448,10 +448,10 @@ importers:
         version: 10.5.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.4.0(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.0)(typescript@6.0.3)
+        version: 3.4.1(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.1)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.4.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(supports-color@9.4.0)(typescript@6.0.3)
+        version: 3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -617,10 +617,10 @@ importers:
         version: 10.5.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.4.0(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.0)(typescript@6.0.3)
+        version: 3.4.1(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.1)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: 'catalog:'
-        version: 3.4.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)(vue@3.5.41)
+        version: 3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)(vue@3.5.41)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -7154,8 +7154,8 @@ packages:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
-  storybook-addon-rslib@3.4.0:
-    resolution: {integrity: sha512-Ug51kCr82A7LSAMTeEDnaqy6pDawS4KeUEPco1IBpmX1whSZEaO+uZ/fRhaVkJOHqxyZ9QLIO2xiC2Ac3W9xVQ==}
+  storybook-addon-rslib@3.4.1:
+    resolution: {integrity: sha512-uTU9MKyactUvYjFE+Xy91xt8F5xA2+awu4KpHE3gOE0Vjg37RSAZSUztZLhgYHWAJBkz5+kCAG+rLg9htr9i2Q==}
     peerDependencies:
       '@rsbuild/core': ^1.5.0 || ^2.0.0-0
       '@rslib/core': '>= 0.1.1 || >= 0.2'
@@ -7165,8 +7165,8 @@ packages:
       typescript:
         optional: true
 
-  storybook-builder-rsbuild@3.4.0:
-    resolution: {integrity: sha512-holIoLbtZW5QMKsBrvGlkFsal3xKE/pm38kjFaFPnHkeBm7X0P17aluDECyXlS4T4zl2IP+vZahuMF20Vr2xvg==}
+  storybook-builder-rsbuild@3.4.1:
+    resolution: {integrity: sha512-g30oleetJ6HTuxX8YWsfRjsQjm8EmWoJRgvbnk3Ibqj2XLR/zfBGox9S476MulTtcJoGnieJ554FnmFz0jnsjA==}
     peerDependencies:
       '@rsbuild/core': ^1.5.0 || ^2.0.0-0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -7181,8 +7181,8 @@ packages:
       typescript:
         optional: true
 
-  storybook-react-rsbuild@3.4.0:
-    resolution: {integrity: sha512-0daXu24u7YDGObItqDdzkvlJUEUgIj9T21CGN7IkKTEfvPsKYz78ArOg/BG6L3fxLOS86HXdUwOH0a/R5eS93g==}
+  storybook-react-rsbuild@3.4.1:
+    resolution: {integrity: sha512-ZGMbLpC18c8SycnTTY7njEzWxBt6tcCBE4fu8cQJuoMeWxA8qPt81j3QheXPeUd1UiVQj0sNgXf2sMVvkLjDig==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@rsbuild/core': ^1.5.0 || ^2.0.0-0
@@ -7194,8 +7194,8 @@ packages:
       typescript:
         optional: true
 
-  storybook-vue3-rsbuild@3.4.0:
-    resolution: {integrity: sha512-47TfNFyTdbn7l63OIKn3haJIuVLrdYak/YmJdxo5WQjdxzgzkB5YpesDzAf8RFpqtNN0VkY7HncFEsXYC8xuNw==}
+  storybook-vue3-rsbuild@3.4.1:
+    resolution: {integrity: sha512-xNMcuhR+1Zfzsu+uFXF+0t68C1muyNNevPLmDjuGckZU4bXLQCCz8O8368zoMjTpFXV+nsCuNptdLa6ThIhj6A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@rsbuild/core': ^1.5.0 || ^2.0.0-0
@@ -14025,15 +14025,15 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.4.0(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.0)(typescript@6.0.3):
+  storybook-addon-rslib@3.4.1(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.1)(typescript@6.0.3):
     dependencies:
       '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.4.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.4.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3):
     dependencies:
       '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)
@@ -14066,7 +14066,7 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.4.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(supports-color@9.4.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.4.0
       '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
@@ -14080,7 +14080,7 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
       storybook: 10.5.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.4.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14095,12 +14095,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.4.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)(vue@3.5.41):
+  storybook-vue3-rsbuild@3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)(vue@3.5.41):
     dependencies:
       '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
       '@storybook/vue3': 10.5.7(storybook@10.5.7)(vue@3.5.41)
       storybook: 10.5.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.4.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
       vue: 3.5.41(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.41)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -102,9 +102,9 @@ catalog:
   'simple-git-hooks': '^2.13.1'
   'solid-js': '^1.9.14'
   'storybook': '^10.5.7'
-  'storybook-addon-rslib': '^3.4.0'
-  'storybook-react-rsbuild': '^3.4.0'
-  'storybook-vue3-rsbuild': '^3.4.0'
+  'storybook-addon-rslib': '^3.4.1'
+  'storybook-react-rsbuild': '^3.4.1'
+  'storybook-vue3-rsbuild': '^3.4.1'
   'tailwindcss': '^4.3.3'
   'tinyglobby': '^0.2.17'
   'tsconfig-paths': '^4.2.0'
@@ -143,6 +143,8 @@ minimumReleaseAgeExclude:
   - '@rstack-dev/doc-ui'
   - '@rstackjs/create-toolkit'
   - 'rsbuild-plugin-*'
+  - storybook-addon-rslib
+  - 'storybook-*-rsbuild'
   - '@swc/*'
   - typescript
   - '@typescript/*'

--- a/website/docs/en/guide/solution/solid.mdx
+++ b/website/docs/en/guide/solution/solid.mdx
@@ -75,7 +75,7 @@ Solid component libraries usually ship two types of outputs:
 - **Pre-compiled output**: JSX has already been transformed by `babel-preset-solid` into Solid runtime calls, such as `template()` and `insert()`. Application projects that use this component library can import this output directly, without configuring Solid JSX compilation.
 - **JSX source output**: the library build does not compile Solid JSX. Instead, it preserves the original JSX syntax and exposes it through the `"solid"` condition name in `package.json` for the application-side toolchain.
 
-When an application project that uses this component library can compile Solid JSX (for example, an Rsbuild project with `@rsbuild/plugin-solid` installed), module resolution will hit the `"solid"` condition name, read the JSX source output, and recompile it for the application's runtime target: browser apps compile it into client-side DOM rendering code (`generate: 'dom'`), while SSR frameworks compile it into server-side rendering code (`generate: 'ssr'`). Application projects without Solid JSX compilation configured fall back to the pre-compiled `"import"` entry.
+When an application project that uses this component library can compile Solid JSX (for example, an Rsbuild project with `@rsbuild/plugin-solid` installed), module resolution will hit the `"solid"` condition name, read the JSX source output, and recompile it for the application's runtime target: browser apps compile it into client-side DOM rendering code (`generate: 'dom'`), while SSR frameworks compile it into server-side rendering code (`generate: 'ssr'`). Application projects without Solid JSX compilation configured fall back to the pre-compiled `"default"` entry.
 
 ```ts title="rslib.config.ts"
 import { pluginBabel } from '@rsbuild/plugin-babel';
@@ -86,7 +86,6 @@ export default defineConfig({
   lib: [
     {
       // Compile JSX into Solid runtime calls, such as template(), insert(), and delegateEvents().
-      bundle: false,
       dts: true,
       plugins: [
         pluginBabel({
@@ -97,7 +96,6 @@ export default defineConfig({
     },
     {
       // Preserve JSX syntax for the "solid" condition name.
-      bundle: false,
       output: {
         filename: {
           js: '[name].jsx',
@@ -128,6 +126,7 @@ export default defineConfig({
       },
     },
   ],
+  bundle: false,
   output: {
     target: 'web',
   },
@@ -141,9 +140,9 @@ Then configure the `"exports"` field in `package.json`:
   // [!code highlight:7]
   "exports": {
     ".": {
-      "solid": "./dist/index.jsx",
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "solid": "./dist/index.jsx",
+      "default": "./dist/index.js"
     }
   }
 }

--- a/website/docs/zh/guide/solution/solid.mdx
+++ b/website/docs/zh/guide/solution/solid.mdx
@@ -75,7 +75,7 @@ Solid 组件库通常会同时发布两类产物：
 - **预编译产物**：JSX 已经通过 `babel-preset-solid` 转换为 Solid 的运行时调用（例如 `template()`、`insert()` 等）。使用该组件库的应用项目可以直接引入这类产物，无需额外配置 Solid JSX 编译能力。
 - **保留 JSX 的源码产物**：库构建阶段不进行 Solid 编译，而是保留原始 JSX 语法，并通过 `package.json` 中的 `"solid"` condition name（条件名称）暴露给应用侧工具链。
 
-当使用该组件库的应用项目具备 Solid JSX 编译能力时（例如安装了 `@rsbuild/plugin-solid` 的 Rsbuild 项目），模块解析会命中 `"solid"` condition name，从而读取保留 JSX 的源码产物，并根据应用自身的运行目标重新编译：浏览器端应用会编译为客户端 DOM 渲染代码（`generate: 'dom'`），SSR 框架则会编译为服务端渲染代码（`generate: 'ssr'`）。未配置 Solid JSX 编译能力的应用项目会回退到预编译的 `"import"` 入口。
+当使用该组件库的应用项目具备 Solid JSX 编译能力时（例如安装了 `@rsbuild/plugin-solid` 的 Rsbuild 项目），模块解析会命中 `"solid"` condition name，从而读取保留 JSX 的源码产物，并根据应用自身的运行目标重新编译：浏览器端应用会编译为客户端 DOM 渲染代码（`generate: 'dom'`），SSR 框架则会编译为服务端渲染代码（`generate: 'ssr'`）。未配置 Solid JSX 编译能力的应用项目会回退到预编译的 `"default"` 入口。
 
 ```ts title="rslib.config.ts"
 import { pluginBabel } from '@rsbuild/plugin-babel';
@@ -86,7 +86,6 @@ export default defineConfig({
   lib: [
     {
       // 将 JSX 编译为 Solid 运行时调用，例如 template()、insert() 和 delegateEvents()。
-      bundle: false,
       dts: true,
       plugins: [
         pluginBabel({
@@ -97,7 +96,6 @@ export default defineConfig({
     },
     {
       // 为 "solid" condition name 保留 JSX 语法。
-      bundle: false,
       output: {
         filename: {
           js: '[name].jsx',
@@ -128,6 +126,7 @@ export default defineConfig({
       },
     },
   ],
+  bundle: false,
   output: {
     target: 'web',
   },
@@ -141,9 +140,9 @@ export default defineConfig({
   // [!code highlight:7]
   "exports": {
     ".": {
-      "solid": "./dist/index.jsx",
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "solid": "./dist/index.jsx",
+      "default": "./dist/index.js"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Flatten single-output framework configs and hoist shared options in Solid's multi-output configs to keep generated Rslib templates concise without changing their output.
- Use `default` package export fallbacks, remove the invalid Vue JS declaration entry, and enforce Solid's `types` → `solid` → `default` condition order in the templates and guides.
- Remove unnecessary TypeScript handling from React JS Storybook and update the Storybook Rsbuild packages to v3.4.1, which supports Rslib configs without an explicit `lib` array.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1837
- https://github.com/rstackjs/storybook-rsbuild/pull/532
- https://github.com/rstackjs/storybook-rsbuild/releases/tag/v3.4.1

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).