### PR TITLE
fix(core): restore config key completions in defineConfig

### DIFF
--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -36,12 +36,22 @@ export type LoadConfigResult<Config = RslibConfig> = {
  * This function helps you to autocomplete configuration types.
  * It accepts a Rslib config object, or a function that returns a config.
  */
-export function defineConfig<const Config extends RslibConfig>(
-  config: (env: ConfigParams) => Config,
-): RslibConfigSyncFn;
-export function defineConfig<const Config extends RslibConfig>(
-  config: (env: ConfigParams) => Promise<Config>,
-): RslibConfigAsyncFn;
+export function defineConfig<
+  const Config extends RslibConfig,
+  const Definition extends
+    | Config
+    | ((env: ConfigParams) => Config)
+    | ((env: ConfigParams) => Promise<Config>),
+>(
+  config: Definition &
+    (Definition extends (...args: never[]) => unknown
+      ? unknown
+      : Record<Exclude<keyof Definition, keyof RslibConfig>, never>),
+): Definition extends (env: ConfigParams) => Promise<unknown>
+  ? RslibConfigAsyncFn
+  : Definition extends (env: ConfigParams) => unknown
+    ? RslibConfigSyncFn
+    : RslibConfig;
 export function defineConfig(config: RslibConfig): RslibConfig;
 export function defineConfig(
   config: RslibConfigDefinition,

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -46,12 +46,19 @@ export function defineConfig<
   config: Definition &
     (Definition extends (...args: never[]) => unknown
       ? unknown
-      : Record<Exclude<keyof Definition, keyof RslibConfig>, never>),
-): Definition extends (env: ConfigParams) => Promise<unknown>
-  ? RslibConfigAsyncFn
-  : Definition extends (env: ConfigParams) => unknown
-    ? RslibConfigSyncFn
+      : RslibConfig &
+          Record<Exclude<keyof Definition, keyof RslibConfig>, never>),
+): Definition extends RslibConfigSyncFn
+  ? RslibConfigSyncFn
+  : Definition extends RslibConfigAsyncFn
+    ? RslibConfigAsyncFn
     : RslibConfig;
+export function defineConfig<const Config extends RslibConfig>(
+  config: (env: ConfigParams) => Config,
+): RslibConfigSyncFn;
+export function defineConfig<const Config extends RslibConfig>(
+  config: (env: ConfigParams) => Promise<Config>,
+): RslibConfigAsyncFn;
 export function defineConfig(config: RslibConfig): RslibConfig;
 export function defineConfig(
   config: RslibConfigDefinition,

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -44,15 +44,17 @@ export function defineConfig<
     | ((env: ConfigParams) => Promise<Config>),
 >(
   config: Definition &
-    (Definition extends (...args: never[]) => unknown
-      ? unknown
+    (Definition extends (...args: never[]) => infer CallbackResult
+      ? [Awaited<CallbackResult>] extends [RslibConfig]
+        ? unknown
+        : never
       : RslibConfig &
           Record<Exclude<keyof Definition, keyof RslibConfig>, never>),
-): Definition extends RslibConfigSyncFn
-  ? RslibConfigSyncFn
-  : Definition extends RslibConfigAsyncFn
-    ? RslibConfigAsyncFn
-    : RslibConfig;
+): Definition extends (...args: never[]) => infer CallbackResult
+  ? [CallbackResult] extends [RslibConfig]
+    ? RslibConfigSyncFn
+    : RslibConfigAsyncFn
+  : RslibConfig;
 export function defineConfig<const Config extends RslibConfig>(
   config: (env: ConfigParams) => Config,
 ): RslibConfigSyncFn;

--- a/tests/type-tests/resolution-bundler/defineConfig.ts
+++ b/tests/type-tests/resolution-bundler/defineConfig.ts
@@ -6,23 +6,6 @@ import {
   type RslibConfigSyncFn,
 } from '@rslib/core';
 
-defineConfig({
-  lib: [{ syntax: 'es2017' }],
-});
-
-defineConfig(() => ({
-  lib: [{ syntax: 'es2017' }],
-}));
-
-defineConfig(async () => ({
-  lib: [{ syntax: 'es2017' }],
-}));
-
-// @ts-expect-error invalid syntax
-defineConfig(async () => ({
-  lib: [{ syntax: 'invalid' }],
-}));
-
 export const objectConfig: RslibConfig = defineConfig({
   lib: [{ syntax: 'es2017' }],
 });
@@ -33,6 +16,11 @@ export const syncConfig: RslibConfigSyncFn = defineConfig(() => ({
 
 export const asyncConfig: RslibConfigAsyncFn = defineConfig(async () => ({
   lib: [{ syntax: 'es2017' }],
+}));
+
+// @ts-expect-error invalid syntax
+defineConfig(async () => ({
+  lib: [{ syntax: 'invalid' }],
 }));
 
 declare const dynamicDefinition: RslibConfigDefinition;

--- a/tests/type-tests/resolution-bundler/defineConfig.ts
+++ b/tests/type-tests/resolution-bundler/defineConfig.ts
@@ -31,6 +31,9 @@ export const syncConfig: RslibConfigSyncFn = defineConfig((env) => {
   };
 });
 
+declare const configParams: ConfigParams;
+void defineConfig(() => ({ lib: [] }))(configParams).output;
+
 export const asyncConfig: RslibConfigAsyncFn = defineConfig(async () => ({
   lib: [{ syntax: 'es2017' }],
 }));
@@ -44,6 +47,21 @@ export const explicitConfig: RslibConfigSyncFn = defineConfig<RslibConfig>(
 export const anyConfig: RslibConfigSyncFn = defineConfig(() =>
   JSON.parse('{}'),
 );
+
+export function forwardSyncConfig<Config extends RslibConfig>(
+  config: (env: ConfigParams) => Config,
+): RslibConfigSyncFn {
+  return defineConfig(config);
+}
+
+export function forwardAsyncConfig<Config extends RslibConfig>(
+  config: (env: ConfigParams) => Promise<Config>,
+): RslibConfigAsyncFn {
+  return defineConfig(config);
+}
+
+// @ts-expect-error invalid syntax
+defineConfig({ lib: [{ syntax: 'invalid' }] });
 
 // @ts-expect-error invalid syntax
 defineConfig(async () => ({

--- a/tests/type-tests/resolution-bundler/defineConfig.ts
+++ b/tests/type-tests/resolution-bundler/defineConfig.ts
@@ -1,4 +1,10 @@
-import { defineConfig } from '@rslib/core';
+import {
+  defineConfig,
+  type RslibConfig,
+  type RslibConfigAsyncFn,
+  type RslibConfigDefinition,
+  type RslibConfigSyncFn,
+} from '@rslib/core';
 
 defineConfig({
   lib: [{ syntax: 'es2017' }],
@@ -16,3 +22,18 @@ defineConfig(async () => ({
 defineConfig(async () => ({
   lib: [{ syntax: 'invalid' }],
 }));
+
+export const objectConfig: RslibConfig = defineConfig({
+  lib: [{ syntax: 'es2017' }],
+});
+
+export const syncConfig: RslibConfigSyncFn = defineConfig(() => ({
+  lib: [{ syntax: 'es2017' }],
+}));
+
+export const asyncConfig: RslibConfigAsyncFn = defineConfig(async () => ({
+  lib: [{ syntax: 'es2017' }],
+}));
+
+declare const dynamicDefinition: RslibConfigDefinition;
+defineConfig(dynamicDefinition);

--- a/tests/type-tests/resolution-bundler/defineConfig.ts
+++ b/tests/type-tests/resolution-bundler/defineConfig.ts
@@ -1,4 +1,5 @@
 import {
+  type ConfigParams,
   defineConfig,
   type RslibConfig,
   type RslibConfigAsyncFn,
@@ -10,13 +11,39 @@ export const objectConfig: RslibConfig = defineConfig({
   lib: [{ syntax: 'es2017' }],
 });
 
-export const syncConfig: RslibConfigSyncFn = defineConfig(() => ({
-  lib: [{ syntax: 'es2017' }],
-}));
+defineConfig({
+  lib: [
+    {
+      syntax: 'es2017',
+      // @ts-expect-error unknown config key
+      typo: true,
+    },
+  ],
+});
+
+export const syncConfig: RslibConfigSyncFn = defineConfig((env) => {
+  void (env satisfies ConfigParams);
+  // @ts-expect-error ConfigParams does not include unknown properties
+  void env.unknown;
+
+  return {
+    lib: [{ syntax: 'es2017' }],
+  };
+});
 
 export const asyncConfig: RslibConfigAsyncFn = defineConfig(async () => ({
   lib: [{ syntax: 'es2017' }],
 }));
+
+export const explicitConfig: RslibConfigSyncFn = defineConfig<RslibConfig>(
+  () => ({
+    lib: [],
+  }),
+);
+
+export const anyConfig: RslibConfigSyncFn = defineConfig(() =>
+  JSON.parse('{}'),
+);
 
 // @ts-expect-error invalid syntax
 defineConfig(async () => ({

--- a/tests/type-tests/resolution-nodenext/defineConfig.ts
+++ b/tests/type-tests/resolution-nodenext/defineConfig.ts
@@ -6,23 +6,6 @@ import {
   type RslibConfigSyncFn,
 } from '@rslib/core';
 
-defineConfig({
-  lib: [{ syntax: 'es2017' }],
-});
-
-defineConfig(() => ({
-  lib: [{ syntax: 'es2017' }],
-}));
-
-defineConfig(async () => ({
-  lib: [{ syntax: 'es2017' }],
-}));
-
-// @ts-expect-error invalid syntax
-defineConfig(async () => ({
-  lib: [{ syntax: 'invalid' }],
-}));
-
 export const objectConfig: RslibConfig = defineConfig({
   lib: [{ syntax: 'es2017' }],
 });
@@ -33,6 +16,11 @@ export const syncConfig: RslibConfigSyncFn = defineConfig(() => ({
 
 export const asyncConfig: RslibConfigAsyncFn = defineConfig(async () => ({
   lib: [{ syntax: 'es2017' }],
+}));
+
+// @ts-expect-error invalid syntax
+defineConfig(async () => ({
+  lib: [{ syntax: 'invalid' }],
 }));
 
 declare const dynamicDefinition: RslibConfigDefinition;

--- a/tests/type-tests/resolution-nodenext/defineConfig.ts
+++ b/tests/type-tests/resolution-nodenext/defineConfig.ts
@@ -31,6 +31,9 @@ export const syncConfig: RslibConfigSyncFn = defineConfig((env) => {
   };
 });
 
+declare const configParams: ConfigParams;
+void defineConfig(() => ({ lib: [] }))(configParams).output;
+
 export const asyncConfig: RslibConfigAsyncFn = defineConfig(async () => ({
   lib: [{ syntax: 'es2017' }],
 }));
@@ -44,6 +47,21 @@ export const explicitConfig: RslibConfigSyncFn = defineConfig<RslibConfig>(
 export const anyConfig: RslibConfigSyncFn = defineConfig(() =>
   JSON.parse('{}'),
 );
+
+export function forwardSyncConfig<Config extends RslibConfig>(
+  config: (env: ConfigParams) => Config,
+): RslibConfigSyncFn {
+  return defineConfig(config);
+}
+
+export function forwardAsyncConfig<Config extends RslibConfig>(
+  config: (env: ConfigParams) => Promise<Config>,
+): RslibConfigAsyncFn {
+  return defineConfig(config);
+}
+
+// @ts-expect-error invalid syntax
+defineConfig({ lib: [{ syntax: 'invalid' }] });
 
 // @ts-expect-error invalid syntax
 defineConfig(async () => ({

--- a/tests/type-tests/resolution-nodenext/defineConfig.ts
+++ b/tests/type-tests/resolution-nodenext/defineConfig.ts
@@ -1,4 +1,10 @@
-import { defineConfig } from '@rslib/core';
+import {
+  defineConfig,
+  type RslibConfig,
+  type RslibConfigAsyncFn,
+  type RslibConfigDefinition,
+  type RslibConfigSyncFn,
+} from '@rslib/core';
 
 defineConfig({
   lib: [{ syntax: 'es2017' }],
@@ -16,3 +22,18 @@ defineConfig(async () => ({
 defineConfig(async () => ({
   lib: [{ syntax: 'invalid' }],
 }));
+
+export const objectConfig: RslibConfig = defineConfig({
+  lib: [{ syntax: 'es2017' }],
+});
+
+export const syncConfig: RslibConfigSyncFn = defineConfig(() => ({
+  lib: [{ syntax: 'es2017' }],
+}));
+
+export const asyncConfig: RslibConfigAsyncFn = defineConfig(async () => ({
+  lib: [{ syntax: 'es2017' }],
+}));
+
+declare const dynamicDefinition: RslibConfigDefinition;
+defineConfig(dynamicDefinition);

--- a/tests/type-tests/resolution-nodenext/defineConfig.ts
+++ b/tests/type-tests/resolution-nodenext/defineConfig.ts
@@ -1,4 +1,5 @@
 import {
+  type ConfigParams,
   defineConfig,
   type RslibConfig,
   type RslibConfigAsyncFn,
@@ -10,13 +11,39 @@ export const objectConfig: RslibConfig = defineConfig({
   lib: [{ syntax: 'es2017' }],
 });
 
-export const syncConfig: RslibConfigSyncFn = defineConfig(() => ({
-  lib: [{ syntax: 'es2017' }],
-}));
+defineConfig({
+  lib: [
+    {
+      syntax: 'es2017',
+      // @ts-expect-error unknown config key
+      typo: true,
+    },
+  ],
+});
+
+export const syncConfig: RslibConfigSyncFn = defineConfig((env) => {
+  void (env satisfies ConfigParams);
+  // @ts-expect-error ConfigParams does not include unknown properties
+  void env.unknown;
+
+  return {
+    lib: [{ syntax: 'es2017' }],
+  };
+});
 
 export const asyncConfig: RslibConfigAsyncFn = defineConfig(async () => ({
   lib: [{ syntax: 'es2017' }],
 }));
+
+export const explicitConfig: RslibConfigSyncFn = defineConfig<RslibConfig>(
+  () => ({
+    lib: [],
+  }),
+);
+
+export const anyConfig: RslibConfigSyncFn = defineConfig(() =>
+  JSON.parse('{}'),
+);
 
 // @ts-expect-error invalid syntax
 defineConfig(async () => ({


### PR DESCRIPTION
## Summary

- Typing a partial key inside `defineConfig({ ... })` currently falls back to `Function.prototype` completions because TypeScript selects a callback overload.
- Use a const-generic definition with conditional return types while preserving Rslib top-level config validation, and cover object, sync, async, and dynamic definitions under Bundler and NodeNext resolution.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8248

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).