### PR TITLE
feat(deps): update Rsbuild to v2.1.11

### DIFF
--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.10",
+    "@rsbuild/core": "~2.1.11",
     "@storybook/addon-docs": "^10.5.7",
     "@storybook/addon-onboarding": "^10.5.7",
     "@storybook/react": "^10.5.7",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.10",
+    "@rsbuild/core": "~2.1.11",
     "@storybook/addon-docs": "^10.5.7",
     "@storybook/addon-onboarding": "^10.5.7",
     "@storybook/react": "^10.5.7",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.10",
+    "@rsbuild/core": "~2.1.11",
     "@storybook/addon-docs": "^10.5.7",
     "@storybook/addon-onboarding": "^10.5.7",
     "@storybook/vue3": "^10.5.7",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.10",
+    "@rsbuild/core": "~2.1.11",
     "@storybook/addon-docs": "^10.5.7",
     "@storybook/addon-onboarding": "^10.5.7",
     "@storybook/vue3": "^10.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ catalogs:
       specifier: ^2.12.0
       version: 2.12.0
     '@rsbuild/core':
-      specifier: ~2.1.10
-      version: 2.1.10
+      specifier: ~2.1.11
+      version: 2.1.11
     '@rsbuild/plugin-babel':
       specifier: ^2.0.1
       version: 2.0.1
@@ -325,7 +325,7 @@ importers:
         version: 0.11.6(@rslib/core@1.0.0-beta.2)(@rstest/core@0.11.6)(typescript@7.0.2)
       '@rstest/core':
         specifier: 'catalog:'
-        version: 0.11.6
+        version: 0.11.6(@module-federation/runtime-tools@2.8.2)
       '@types/fs-extra':
         specifier: 'catalog:'
         version: 11.0.4
@@ -385,13 +385,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.2(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.10(@module-federation/runtime-tools@2.8.2)
+        version: 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -406,19 +406,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 'catalog:'
-        version: 2.8.2(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.2(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.2(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/storybook-addon':
         specifier: 'catalog:'
-        version: 6.0.18(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(storybook@10.5.7)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)
+        version: 6.0.18(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(storybook@10.5.7)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.10(@module-federation/runtime-tools@2.8.2)
+        version: 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -448,10 +448,10 @@ importers:
         version: 10.5.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.4.1(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.1)(typescript@6.0.3)
+        version: 3.4.1(@rsbuild/core@2.1.11)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.1)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(supports-color@9.4.0)(typescript@6.0.3)
+        version: 3.4.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -467,13 +467,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.2(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.10(@module-federation/runtime-tools@2.8.2)
+        version: 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -488,10 +488,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(preact@10.29.8)
+        version: 2.0.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(preact@10.29.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)
+        version: 2.0.1(@rsbuild/core@2.1.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -503,10 +503,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)
+        version: 2.0.1(@rsbuild/core@2.1.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -521,10 +521,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)
+        version: 2.0.1(@rsbuild/core@2.1.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -539,10 +539,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)
+        version: 2.0.1(@rsbuild/core@2.1.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -557,13 +557,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(supports-color@9.4.0)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)
+        version: 2.0.1(@rsbuild/core@2.1.11)
       '@rsbuild/plugin-solid':
         specifier: 'catalog:'
-        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.10)(solid-js@1.9.14)(supports-color@9.4.0)
+        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.11)(solid-js@1.9.14)(supports-color@9.4.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -578,7 +578,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
+        version: 2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -596,10 +596,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.10(@module-federation/runtime-tools@2.8.2)
+        version: 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
+        version: 2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -617,10 +617,10 @@ importers:
         version: 10.5.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.4.1(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.1)(typescript@6.0.3)
+        version: 3.4.1(@rsbuild/core@2.1.11)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.1)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: 'catalog:'
-        version: 3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)(vue@3.5.41)
+        version: 3.4.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)(vue@3.5.41)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -635,14 +635,14 @@ importers:
     dependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.10(@module-federation/runtime-tools@2.8.2)
+        version: 2.1.11(@module-federation/runtime-tools@2.8.2)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
+        version: 2.8.2(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -669,7 +669,7 @@ importers:
         version: 0.6.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.1.10)
+        version: 1.0.0(@rsbuild/core@2.1.11)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
@@ -706,7 +706,7 @@ importers:
         version: 11.4.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.1.10)
+        version: 1.0.0(@rsbuild/core@2.1.11)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
@@ -728,7 +728,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.10(@module-federation/runtime-tools@2.8.2)
+        version: 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -740,7 +740,7 @@ importers:
         version: 1.1.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.1.10)
+        version: 1.0.0(@rsbuild/core@2.1.11)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
@@ -770,34 +770,34 @@ importers:
         version: 4.0.1(debug@4.4.3)(supports-color@9.4.0)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
+        version: 2.8.2(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.10(@module-federation/runtime-tools@2.8.2)
+        version: 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)
+        version: 2.0.1(@rsbuild/core@2.1.11)
       '@rsbuild/plugin-toml':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)
+        version: 2.0.1(@rsbuild/core@2.1.11)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 'catalog:'
-        version: 1.2.4(@rsbuild/core@2.1.10)
+        version: 1.2.4(@rsbuild/core@2.1.11)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
+        version: 2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
       '@rsbuild/plugin-yaml':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.1.10)
+        version: 2.0.0(@rsbuild/core@2.1.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -874,7 +874,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
 
   tests/integration/asset/json: {}
 
@@ -896,10 +896,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -984,10 +984,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/cli/build: {}
 
@@ -1310,10 +1310,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.10(@module-federation/runtime-tools@2.8.2)
+        version: 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.1.10)
+        version: 1.4.6(@rsbuild/core@2.1.11)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -1323,10 +1323,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.10(@module-federation/runtime-tools@2.8.2)
+        version: 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.1.10)
+        version: 1.4.6(@rsbuild/core@2.1.11)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1363,7 +1363,7 @@ importers:
         version: 8.0.1
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(supports-color@9.4.0)
       babel-plugin-polyfill-corejs3:
         specifier: 'catalog:'
         version: 1.0.0(@babel/core@8.0.1)
@@ -1376,7 +1376,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1517,19 +1517,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(supports-color@9.4.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(supports-color@9.4.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.0.3(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1538,7 +1538,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.0.3(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1586,10 +1586,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
+        version: 2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
       vue:
         specifier: 'catalog:'
         version: 3.5.41(typescript@7.0.2)
@@ -1624,16 +1624,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+        version: 2.8.2(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.10(@module-federation/runtime-tools@2.8.2)
+        version: 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+        version: 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.1.10)
+        version: 2.0.1(@rsbuild/core@2.1.11)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1642,7 +1642,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 'catalog:'
-        version: 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+        version: 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@rspress/plugin-algolia':
         specifier: 'catalog:'
         version: 2.0.19(@rspress/core@2.0.19)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
@@ -1681,10 +1681,10 @@ importers:
         version: 19.2.8(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: 'catalog:'
-        version: 1.0.6(@rsbuild/core@2.1.10)
+        version: 1.0.6(@rsbuild/core@2.1.11)
       rsbuild-plugin-open-graph:
         specifier: 'catalog:'
-        version: 1.1.3(@rsbuild/core@2.1.10)
+        version: 1.1.3(@rsbuild/core@2.1.11)
       rspress-plugin-file-tree:
         specifier: 'catalog:'
         version: 1.0.5(@rspress/core@2.0.19)(supports-color@9.4.0)
@@ -2975,6 +2975,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.1.11':
+    resolution: {integrity: sha512-jA/QwZu8wIljp70TjERVoX+vk2cWU+viHpV9EAdKpA6ifu/pFnThEhbV3RFxBvF/9mB3h7ZRUfdDIyknT+9MWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.2.1':
     resolution: {integrity: sha512-6Zad7Ff/RUNc91AtftemJcJ1wcZRGOiwuJy349qlLJl9F++oRYwUhx+MxLSpNnVeIywWx2mKdZZBtD1hLqfj9w==}
     peerDependencies:
@@ -3177,13 +3187,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.1.9':
+    resolution: {integrity: sha512-sQQgKx+1ckW5GI6w/ozJkoaQM0Skbwj7hFiv+Y2d7+iAB7OVz83LWFrodRl1QGCg1QNuaEmlVo9AUapWUSr/8g==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.1.8':
     resolution: {integrity: sha512-08pBkFhlD3Y3Qzh94w/Fc3skaIE3e96kl2P14m8+tnYTcglpOfpA2OwS3iHt9fOqy0HjoAVe6/MW3cBgs5iabA==}
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.1.9':
+    resolution: {integrity: sha512-kuWzn8JFKJUxSFwX/+rzvZUm4fRrSbXCTCAlzb0iHvP6vftjCFHGpNJfWjD7yX9O7C/dtoGiNT1O1veJytVsWA==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.1.8':
     resolution: {integrity: sha512-KLniMc9GzhKpVqhPzaJo3KJwzdAllXVVqZIk/uL1QipXOxs57fgM4u7IexKPFVla0o/u1PQG/Ah2YLDmda24Ow==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.9':
+    resolution: {integrity: sha512-rj1TjWGuG9Zc+fmwfvOpRO9npuHMKE4xXSB/BZqZNcH5Uey4NcAo1/GF8zHRoalQrwf0roP9WsFX1tk85rzP/Q==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3194,8 +3220,26 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.1.9':
+    resolution: {integrity: sha512-Z2+sS2z9Imt3og0e3Kq4hEumiqTajQBXkl9cqSYj1lwOgmViLAvMX4BlCL1cinIEstixFKQ+xsta9SI6ivCKtg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-ppc64-gnu@2.1.9':
+    resolution: {integrity: sha512-xK90IHipRDgxvDF9n90HRNklci0G2Amk0ZMsM3t3YX+/8jIJNcuEPk6hJ1hlY6KZu7U9enqGbNQ7Fe0StBeLVA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-riscv64-gnu@2.1.8':
     resolution: {integrity: sha512-gg4S1jaitwYPHR9HZ3zNGH1EK2GXINm66p4kEpOP1gbc+akyOouVF/dMcu9NGPlRg58FbEhVRZYKu7Z/zcpKHg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.9':
+    resolution: {integrity: sha512-aaOwU3voq20Vwmfu1V6UPz8eQJBitBUNbLc08dxHGsmQM+ap6dd4j5xn/i5Y6AfLro2Q3GJvpCayc+dVIOR32g==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -3206,8 +3250,26 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-riscv64-musl@2.1.9':
+    resolution: {integrity: sha512-tF7XnEtpTYyVS8ef96IKUjFhd9lFa9Swv212fcyWxRhxRn4PEYVWpSh/D3NDVX+i69Z7xFDDEoyMUdYBkkVTlw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-s390x-gnu@2.1.9':
+    resolution: {integrity: sha512-rGmeME3Pd8k/55txP+19ceZJxhVN2mtC8TLzB1ycTrhy8U+ZnN7J8rZSl89LYrZGYewd1UmOcY0QKKy05FS3FA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-x64-gnu@2.1.8':
     resolution: {integrity: sha512-EyegohSx0BJRqieCg9f/caCqFARRWkqI5hwJt6k530MoOTLeq8I3vsbeg24/2MktwIC1dmJi8bl0+WhPKQs4eQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.1.9':
+    resolution: {integrity: sha512-YimUCS//wl+AZjXvgVig7sJtPiGs+WNMH4g49F1msB5T40rw0aOopp9O3MdC+LFfRm6vpIJwOHd6alo/UUs7nA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3218,12 +3280,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.1.9':
+    resolution: {integrity: sha512-tYJRdoB3IWVVcnGPZqCnRjC5MJle7xHucKkIuKtGbSMS6hzg6B1oKZav1BBw72gxnrW4n2Bwt82TBKQKBUSjmA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.1.8':
     resolution: {integrity: sha512-om7GAKWAU3lcSvbCon2m7mzw8v9OTrO2LW2MZ1lGe/uVJJmwGGkl9HVoXFyWFLrN6YVFyx8iP+AkN4owDWB9Cw==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.1.9':
+    resolution: {integrity: sha512-TF6oZRU23x6vHzGuvRFszvEnmC5Yn8PHbKmeZWsUHj4Mtv4tDdDGVdlxj6Kq3pySS6sRknv8gzpRMhXqHD3I5g==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.1.8':
     resolution: {integrity: sha512-WDnsP/SUb9zbxyGX9XjPw5AXrX86u5oidn0MDdfJduOOqdCSpHwmRjlQ8NUJhbBq9WqVJMFlcab7NwZVWX/yyg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.9':
+    resolution: {integrity: sha512-tLt4gbvUelmtJGI3PHtQHZuGpaO2z/ym6+OXAjc6NR2jWbzljardSjONiXVWIi1zmzODt4dD/fL3Ncb+RU/jHQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -3232,16 +3309,41 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.1.9':
+    resolution: {integrity: sha512-VznxSrGPb4mvxkTHTdGolEpBOuDW7RICD9Rp266MhYLQG4c0uNcX7+vWF4HbFvB0kN+Gdkj7vz+5shWdrfK72Q==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.1.8':
     resolution: {integrity: sha512-b7sA5eB64vo2mbsuc//MOYzVLeCKHPn0dfP/GmNEoHdWbhRgZ/orZLWurYMQj04ELTLW6YCJEy59g5KRzNYHfw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.1.9':
+    resolution: {integrity: sha512-P1dGC6t3PJinqN6tBZ+jyou4LvwpD2ygeovKgg5tuYWKFMUwh1v60yX3afOUwaJMEGbHUye7xuYRd84NCMSNOQ==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@2.1.8':
     resolution: {integrity: sha512-tmAyHzDbPiy8V7HvQqtuPsbs6dPgwV0YjzW5XrPRV9gzf+Hdm7pvsZJKE1QKO9WV5RuvGYav98xIX6O+abZxzQ==}
 
+  '@rspack/binding@2.1.9':
+    resolution: {integrity: sha512-0ZZj+RE62/jFRwX5czqjjGiMGgzSK0hm7/66PtCKjyZjb2tNAg3WGyWv+ref7684ZAjtbHHpZ+EOGswQYBjklA==}
+
   '@rspack/core@2.1.8':
     resolution: {integrity: sha512-na1kyA6Mj8/LWw9O3A8NsrG9rNKN3Iq2WiXrEuIwsU5r/Nl/evm3hO7bWKHxgsRyydI6W7okwx3MXgf8rzel6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.1.9':
+    resolution: {integrity: sha512-kXd5aYrkO+91fYolNYAjUhW/1F9kGmw7PtneNRY6z3KK6ttJgQWMVNypiCkhK3TOcyWPGH42qd0bzHZlH72JaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8761,7 +8863,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.2(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/enhanced@2.8.2(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.2
       '@module-federation/cli': 2.8.2(typescript@6.0.3)(vue-tsc@3.3.9)
@@ -8770,7 +8872,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.2(@module-federation/runtime-tools@2.8.2)
       '@module-federation/managers': 2.8.2
       '@module-federation/manifest': 2.8.2(typescript@6.0.3)(vue-tsc@3.3.9)
-      '@module-federation/rspack': 2.8.2(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/rspack': 2.8.2(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.2
       '@module-federation/sdk': 2.8.2
       '@module-federation/webpack-bundler-runtime': 2.8.2
@@ -8784,7 +8886,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.2(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/enhanced@2.8.2(@rspack/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.2
       '@module-federation/cli': 2.8.2(typescript@7.0.2)(vue-tsc@3.3.9)
@@ -8793,7 +8895,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.2(@module-federation/runtime-tools@2.8.2)
       '@module-federation/managers': 2.8.2
       '@module-federation/manifest': 2.8.2(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/rspack': 2.8.2(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/rspack': 2.8.2(@rspack/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.2
       '@module-federation/sdk': 2.8.2
       '@module-federation/webpack-bundler-runtime': 2.8.2
@@ -8839,9 +8941,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.49(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.49(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime': 2.8.2
       '@module-federation/sdk': 2.8.2
       encoding: 0.1.13
@@ -8854,9 +8956,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.49(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/node@2.7.49(@rspack/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime': 2.8.2
       '@module-federation/sdk': 2.8.2
       encoding: 0.1.13
@@ -8869,13 +8971,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.49(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.49(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8884,13 +8986,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
-      '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
-      '@module-federation/node': 2.7.49(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)
+      '@module-federation/node': 2.7.49(@rspack/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -8899,7 +9001,7 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.8.2(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)':
+  '@module-federation/rspack@2.8.2(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.2
       '@module-federation/dts-plugin': 2.8.2(typescript@6.0.3)(vue-tsc@3.3.9)
@@ -8908,7 +9010,7 @@ snapshots:
       '@module-federation/manifest': 2.8.2(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.2
       '@module-federation/sdk': 2.8.2
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.9(typescript@6.0.3)
@@ -8916,7 +9018,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rspack@2.8.2(@rspack/core@2.1.8)(typescript@7.0.2)(vue-tsc@3.3.9)':
+  '@module-federation/rspack@2.8.2(@rspack/core@2.1.9)(typescript@7.0.2)(vue-tsc@3.3.9)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.2
       '@module-federation/dts-plugin': 2.8.2(typescript@7.0.2)(vue-tsc@3.3.9)
@@ -8925,7 +9027,7 @@ snapshots:
       '@module-federation/manifest': 2.8.2(typescript@7.0.2)(vue-tsc@3.3.9)
       '@module-federation/runtime-tools': 2.8.2
       '@module-federation/sdk': 2.8.2
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 7.0.2
       vue-tsc: 3.3.9(typescript@7.0.2)
@@ -8951,12 +9053,12 @@ snapshots:
 
   '@module-federation/sdk@2.8.2': {}
 
-  '@module-federation/storybook-addon@6.0.18(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(storybook@10.5.7)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.18(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(storybook@10.5.7)(typescript@6.0.3)(vue-tsc@3.3.9)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.8)(typescript@6.0.3)(vue-tsc@3.3.9)
+      '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.9)(typescript@6.0.3)(vue-tsc@3.3.9)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
       storybook: 10.5.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -9233,7 +9335,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.10)(supports-color@9.4.0)':
+  '@rsbuild/core@2.1.11(@module-federation/runtime-tools@2.8.2)':
+    dependencies:
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.11)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
@@ -9242,39 +9351,39 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)':
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.8)
+      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.9)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.1.8)(less@4.6.7)
+      less-loader: 12.3.3(@rspack/core@2.1.9)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.10)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.11)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9300,30 +9409,30 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
 
-  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(preact@10.29.8)':
+  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(preact@10.29.8)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.8)
+      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.9)
       '@swc/plugin-prefresh': 12.12.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - preact
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.8)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.9)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.10)':
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.11)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9331,93 +9440,93 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
 
-  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.10)(solid-js@1.9.14)(supports-color@9.4.0)':
+  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.11)(solid-js@1.9.14)(supports-color@9.4.0)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.10)(supports-color@9.4.0)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.11)(supports-color@9.4.0)
       babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.14)
       solid-refresh: 0.6.3(solid-js@1.9.14)(supports-color@9.4.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)':
+  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(supports-color@9.4.0)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0(supports-color@9.4.0)
-      stylus-loader: 8.1.3(@rspack/core@2.1.8)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.1.9)(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(supports-color@9.4.0)(typescript@7.0.2)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(supports-color@9.4.0)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@svgr/core': 8.1.0(supports-color@9.4.0)(typescript@7.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)(supports-color@9.4.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.8)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.9)
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.10)':
+  '@rsbuild/plugin-toml@2.0.1(@rsbuild/core@2.1.11)':
     dependencies:
       toml: 4.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
 
-  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.1.8)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.1.9)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.10)':
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.1.11)':
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.9)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.1.10)':
+  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.1.11)':
     dependencies:
       yaml: 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
 
   '@rslib/core@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)':
     dependencies:
@@ -9471,25 +9580,55 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.1.8':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.1.9':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.1.8':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.1.9':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.1.8':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.1.9':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.1.8':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.1.9':
+    optional: true
+
+  '@rspack/binding-linux-ppc64-gnu@2.1.9':
     optional: true
 
   '@rspack/binding-linux-riscv64-gnu@2.1.8':
     optional: true
 
+  '@rspack/binding-linux-riscv64-gnu@2.1.9':
+    optional: true
+
   '@rspack/binding-linux-riscv64-musl@2.1.8':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.9':
+    optional: true
+
+  '@rspack/binding-linux-s390x-gnu@2.1.9':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.1.8':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.1.9':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.1.8':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.9':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.1.8':
@@ -9499,13 +9638,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.1.9':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.1.8':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.9':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.1.8':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.1.9':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.1.8':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.9':
     optional: true
 
   '@rspack/binding@2.1.8':
@@ -9523,6 +9678,23 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.1.8
       '@rspack/binding-win32-x64-msvc': 2.1.8
 
+  '@rspack/binding@2.1.9':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.9
+      '@rspack/binding-darwin-x64': 2.1.9
+      '@rspack/binding-linux-arm64-gnu': 2.1.9
+      '@rspack/binding-linux-arm64-musl': 2.1.9
+      '@rspack/binding-linux-ppc64-gnu': 2.1.9
+      '@rspack/binding-linux-riscv64-gnu': 2.1.9
+      '@rspack/binding-linux-riscv64-musl': 2.1.9
+      '@rspack/binding-linux-s390x-gnu': 2.1.9
+      '@rspack/binding-linux-x64-gnu': 2.1.9
+      '@rspack/binding-linux-x64-musl': 2.1.9
+      '@rspack/binding-wasm32-wasi': 2.1.9
+      '@rspack/binding-win32-arm64-msvc': 2.1.9
+      '@rspack/binding-win32-ia32-msvc': 2.1.9
+      '@rspack/binding-win32-x64-msvc': 2.1.9
+
   '@rspack/core@2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.1.8
@@ -9530,27 +9702,34 @@ snapshots:
       '@module-federation/runtime-tools': 2.8.2
       '@swc/helpers': 0.5.23
 
+  '@rspack/core@2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.9
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.8.2
+      '@swc/helpers': 0.5.23
+
   '@rspack/lite-tapable@1.1.2': {}
 
-  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.8)':
+  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.9)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
     optionalDependencies:
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.8)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.9)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
+  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)
       '@rspress/shared': 2.0.19(@module-federation/runtime-tools@2.8.2)(supports-color@9.4.0)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -9597,7 +9776,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
@@ -9608,7 +9787,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.19(@rspress/core@2.0.19)(supports-color@9.4.0)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       remark-mdx: 3.1.1(supports-color@9.4.0)
       remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
@@ -9619,17 +9798,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rspress/plugin-twoslash@2.0.19(@rspress/core@2.0.19)(react@19.2.8)(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@shikijs/twoslash': 4.3.0(supports-color@9.4.0)(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-gfm: 3.1.0(supports-color@9.4.0)
@@ -9643,7 +9822,7 @@ snapshots:
 
   '@rspress/shared@2.0.19(@module-federation/runtime-tools@2.8.2)(supports-color@9.4.0)':
     dependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@shikijs/rehype': 4.3.0
       '@types/react': 19.2.18
       mdast-util-mdx-jsx: 3.2.0(supports-color@9.4.0)
@@ -9655,18 +9834,18 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.14.7(@rspress/core@2.0.19)':
     optionalDependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rstackjs/create-toolkit@2.2.1': {}
 
   '@rstest/adapter-rslib@0.11.6(@rslib/core@1.0.0-beta.2)(@rstest/core@0.11.6)(typescript@7.0.2)':
     dependencies:
       '@rslib/core': 1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)
-      '@rstest/core': 0.11.6
+      '@rstest/core': 0.11.6(@module-federation/runtime-tools@2.8.2)
     optionalDependencies:
       typescript: 7.0.2
 
-  '@rstest/core@0.11.6':
+  '@rstest/core@0.11.6(@module-federation/runtime-tools@2.8.2)':
     dependencies:
       '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
       '@types/chai': 5.2.3
@@ -10032,14 +10211,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.8)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.9)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
     optionalDependencies:
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10578,12 +10757,12 @@ snapshots:
 
   b-validate@1.5.3: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.8):
+  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.9):
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       find-up: 5.0.0
     optionalDependencies:
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
   babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
     dependencies:
@@ -12038,11 +12217,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@rspack/core@2.1.8)(less@4.6.7):
+  less-loader@12.3.3(@rspack/core@2.1.9)(less@4.6.7):
     dependencies:
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
   less@4.6.7:
     dependencies:
@@ -13632,41 +13811,41 @@ snapshots:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.10):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.11):
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
 
-  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.10):
+  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.1.11):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.10):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.11):
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.10):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.11):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
 
   rslog@2.3.0: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.8)(@vue/compiler-sfc@3.5.41)(vue@3.5.41):
+  rspack-vue-loader@17.5.1(@rspack/core@2.1.9)(@vue/compiler-sfc@3.5.41)(vue@3.5.41):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
       '@vue/compiler-sfc': 3.5.41
       vue: 3.5.41(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.19)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
@@ -13691,14 +13870,14 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.19)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.19)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.19):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.8)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.9)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   run-applescript@7.1.0: {}
 
@@ -14027,18 +14206,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.4.1(@rsbuild/core@2.1.10)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.1)(typescript@6.0.3):
+  storybook-addon-rslib@3.4.1(@rsbuild/core@2.1.11)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.1)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.4.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
-      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(typescript@6.0.3)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(typescript@6.0.3)
       '@vitest/mocker': 3.2.7
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14051,7 +14230,7 @@ snapshots:
       pathe: 2.0.3
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.10)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.1.11)
       sirv: 2.0.4
       storybook: 10.5.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       ts-dedent: 2.3.0
@@ -14068,10 +14247,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(supports-color@9.4.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.4.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.4.0
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@storybook/react': 10.5.7(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(supports-color@9.4.0)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(supports-color@9.4.0)(typescript@6.0.3)
       find-up: 5.0.0
@@ -14082,7 +14261,7 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
       storybook: 10.5.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14097,12 +14276,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)(vue@3.5.41):
+  storybook-vue3-rsbuild@3.4.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)(vue@3.5.41):
     dependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@storybook/vue3': 10.5.7(storybook@10.5.7)(vue@3.5.41)
       storybook: 10.5.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.4.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.1(@rsbuild/core@2.1.11)(@rspack/core@2.1.9)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.7)(typescript@6.0.3)
       vue: 3.5.41(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.41)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -14224,13 +14403,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.1.8)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.1.9)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0(supports-color@9.4.0)
     optionalDependencies:
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
   stylus@0.64.0(supports-color@9.4.0):
     dependencies:
@@ -14344,7 +14523,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.6.0(@rspack/core@2.1.8)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.6.0(@rspack/core@2.1.9)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
@@ -14352,7 +14531,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
   ts-dedent@2.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,7 +325,7 @@ importers:
         version: 0.11.6(@rslib/core@1.0.0-beta.2)(@rstest/core@0.11.6)(typescript@7.0.2)
       '@rstest/core':
         specifier: 'catalog:'
-        version: 0.11.6(@module-federation/runtime-tools@2.8.2)
+        version: 0.11.6
       '@types/fs-extra':
         specifier: 'catalog:'
         version: 11.0.4
@@ -2965,16 +2965,6 @@ packages:
       rollup:
         optional: true
 
-  '@rsbuild/core@2.1.10':
-    resolution: {integrity: sha512-lwxC5w88U2AMv6aNwG3VH7+AV33N4JJQjD//egVWFsMbV+OE/bnfCsurSpX8s3lGyRYkJMwUVN+YXMbmmYZFfw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
   '@rsbuild/core@2.1.11':
     resolution: {integrity: sha512-jA/QwZu8wIljp70TjERVoX+vk2cWU+viHpV9EAdKpA6ifu/pFnThEhbV3RFxBvF/9mB3h7ZRUfdDIyknT+9MWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3182,19 +3172,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@2.1.8':
-    resolution: {integrity: sha512-kia+eWtyWPvR4ntg1bWYoVU8nLPbUg2fG3zgBEocsTcsh5ZENSiEPxEKymDgMyIMONUqj611E0775cdUBoNmqw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@2.1.9':
     resolution: {integrity: sha512-sQQgKx+1ckW5GI6w/ozJkoaQM0Skbwj7hFiv+Y2d7+iAB7OVz83LWFrodRl1QGCg1QNuaEmlVo9AUapWUSr/8g==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@2.1.8':
-    resolution: {integrity: sha512-08pBkFhlD3Y3Qzh94w/Fc3skaIE3e96kl2P14m8+tnYTcglpOfpA2OwS3iHt9fOqy0HjoAVe6/MW3cBgs5iabA==}
-    cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@2.1.9':
@@ -3202,23 +3182,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.1.8':
-    resolution: {integrity: sha512-KLniMc9GzhKpVqhPzaJo3KJwzdAllXVVqZIk/uL1QipXOxs57fgM4u7IexKPFVla0o/u1PQG/Ah2YLDmda24Ow==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-arm64-gnu@2.1.9':
     resolution: {integrity: sha512-rj1TjWGuG9Zc+fmwfvOpRO9npuHMKE4xXSB/BZqZNcH5Uey4NcAo1/GF8zHRoalQrwf0roP9WsFX1tk85rzP/Q==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rspack/binding-linux-arm64-musl@2.1.8':
-    resolution: {integrity: sha512-yUKAxHNGnICtw5RnxFWu4dHtsz/tdt7rbeFcsINNVre9HcrRxf5XP+FbOGL/SMxd9oM9XCo10paU2WckTKwbEA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-arm64-musl@2.1.9':
     resolution: {integrity: sha512-Z2+sS2z9Imt3og0e3Kq4hEumiqTajQBXkl9cqSYj1lwOgmViLAvMX4BlCL1cinIEstixFKQ+xsta9SI6ivCKtg==}
@@ -3232,23 +3200,11 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.8':
-    resolution: {integrity: sha512-gg4S1jaitwYPHR9HZ3zNGH1EK2GXINm66p4kEpOP1gbc+akyOouVF/dMcu9NGPlRg58FbEhVRZYKu7Z/zcpKHg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-riscv64-gnu@2.1.9':
     resolution: {integrity: sha512-aaOwU3voq20Vwmfu1V6UPz8eQJBitBUNbLc08dxHGsmQM+ap6dd4j5xn/i5Y6AfLro2Q3GJvpCayc+dVIOR32g==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rspack/binding-linux-riscv64-musl@2.1.8':
-    resolution: {integrity: sha512-b/aU5j1h368SLNyz5u+flqpZVhzSZ1UIslaj9sZJuAvqkGWv3xsjc/28/PTo/RYXCxd0FNVAxTxWHKvRiAAS8w==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-riscv64-musl@2.1.9':
     resolution: {integrity: sha512-tF7XnEtpTYyVS8ef96IKUjFhd9lFa9Swv212fcyWxRhxRn4PEYVWpSh/D3NDVX+i69Z7xFDDEoyMUdYBkkVTlw==}
@@ -3262,23 +3218,11 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-gnu@2.1.8':
-    resolution: {integrity: sha512-EyegohSx0BJRqieCg9f/caCqFARRWkqI5hwJt6k530MoOTLeq8I3vsbeg24/2MktwIC1dmJi8bl0+WhPKQs4eQ==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-x64-gnu@2.1.9':
     resolution: {integrity: sha512-YimUCS//wl+AZjXvgVig7sJtPiGs+WNMH4g49F1msB5T40rw0aOopp9O3MdC+LFfRm6vpIJwOHd6alo/UUs7nA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rspack/binding-linux-x64-musl@2.1.8':
-    resolution: {integrity: sha512-I6E+goN+UQ297q4r1qdbiAyNCI3t0+a5Y0xDIAPOZfRDRxDTnH/LF8/y65gjsJoKRKyn7zxRC0T/NURTkRNQ9A==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-x64-musl@2.1.9':
     resolution: {integrity: sha512-tYJRdoB3IWVVcnGPZqCnRjC5MJle7xHucKkIuKtGbSMS6hzg6B1oKZav1BBw72gxnrW4n2Bwt82TBKQKBUSjmA==}
@@ -3286,27 +3230,13 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.1.8':
-    resolution: {integrity: sha512-om7GAKWAU3lcSvbCon2m7mzw8v9OTrO2LW2MZ1lGe/uVJJmwGGkl9HVoXFyWFLrN6YVFyx8iP+AkN4owDWB9Cw==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@2.1.9':
     resolution: {integrity: sha512-TF6oZRU23x6vHzGuvRFszvEnmC5Yn8PHbKmeZWsUHj4Mtv4tDdDGVdlxj6Kq3pySS6sRknv8gzpRMhXqHD3I5g==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.1.8':
-    resolution: {integrity: sha512-WDnsP/SUb9zbxyGX9XjPw5AXrX86u5oidn0MDdfJduOOqdCSpHwmRjlQ8NUJhbBq9WqVJMFlcab7NwZVWX/yyg==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rspack/binding-win32-arm64-msvc@2.1.9':
     resolution: {integrity: sha512-tLt4gbvUelmtJGI3PHtQHZuGpaO2z/ym6+OXAjc6NR2jWbzljardSjONiXVWIi1zmzODt4dD/fL3Ncb+RU/jHQ==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@2.1.8':
-    resolution: {integrity: sha512-QiMQMPNDiY3dhhaIdaFPzcPDC06cEYkNY89ea+EmDvNVgZq6V+2mFS/WnzZVMeEbGAYJCjsv/ABhhLT1hlYMvg==}
-    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@2.1.9':
@@ -3314,33 +3244,13 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.1.8':
-    resolution: {integrity: sha512-b7sA5eB64vo2mbsuc//MOYzVLeCKHPn0dfP/GmNEoHdWbhRgZ/orZLWurYMQj04ELTLW6YCJEy59g5KRzNYHfw==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@2.1.9':
     resolution: {integrity: sha512-P1dGC6t3PJinqN6tBZ+jyou4LvwpD2ygeovKgg5tuYWKFMUwh1v60yX3afOUwaJMEGbHUye7xuYRd84NCMSNOQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.1.8':
-    resolution: {integrity: sha512-tmAyHzDbPiy8V7HvQqtuPsbs6dPgwV0YjzW5XrPRV9gzf+Hdm7pvsZJKE1QKO9WV5RuvGYav98xIX6O+abZxzQ==}
-
   '@rspack/binding@2.1.9':
     resolution: {integrity: sha512-0ZZj+RE62/jFRwX5czqjjGiMGgzSK0hm7/66PtCKjyZjb2tNAg3WGyWv+ref7684ZAjtbHHpZ+EOGswQYBjklA==}
-
-  '@rspack/core@2.1.8':
-    resolution: {integrity: sha512-na1kyA6Mj8/LWw9O3A8NsrG9rNKN3Iq2WiXrEuIwsU5r/Nl/evm3hO7bWKHxgsRyydI6W7okwx3MXgf8rzel6g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
 
   '@rspack/core@2.1.9':
     resolution: {integrity: sha512-kXd5aYrkO+91fYolNYAjUhW/1F9kGmw7PtneNRY6z3KK6ttJgQWMVNypiCkhK3TOcyWPGH42qd0bzHZlH72JaA==}
@@ -9328,13 +9238,6 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.5
 
-  '@rsbuild/core@2.1.10(@module-federation/runtime-tools@2.8.2)':
-    dependencies:
-      '@rspack/core': 2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
   '@rsbuild/core@2.1.11(@module-federation/runtime-tools@2.8.2)':
     dependencies:
       '@rspack/core': 2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
@@ -9530,8 +9433,8 @@ snapshots:
 
   '@rslib/core@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
-      rsbuild-plugin-dts: 1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.10)(typescript@7.0.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
+      rsbuild-plugin-dts: 1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.11)(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2
@@ -9577,25 +9480,13 @@ snapshots:
   '@rslint/native-win32-x64-msvc@0.7.3':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.1.8':
-    optional: true
-
   '@rspack/binding-darwin-arm64@2.1.9':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.1.8':
     optional: true
 
   '@rspack/binding-darwin-x64@2.1.9':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.8':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@2.1.9':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@2.1.8':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.1.9':
@@ -9604,13 +9495,7 @@ snapshots:
   '@rspack/binding-linux-ppc64-gnu@2.1.9':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.8':
-    optional: true
-
   '@rspack/binding-linux-riscv64-gnu@2.1.9':
-    optional: true
-
-  '@rspack/binding-linux-riscv64-musl@2.1.8':
     optional: true
 
   '@rspack/binding-linux-riscv64-musl@2.1.9':
@@ -9619,23 +9504,10 @@ snapshots:
   '@rspack/binding-linux-s390x-gnu@2.1.9':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.1.8':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@2.1.9':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.1.8':
-    optional: true
-
   '@rspack/binding-linux-x64-musl@2.1.9':
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.1.8':
-    dependencies:
-      '@emnapi/core': 1.11.3
-      '@emnapi/runtime': 1.11.3
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.1.9':
@@ -9645,38 +9517,14 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.8':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@2.1.9':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@2.1.8':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.1.9':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.1.8':
-    optional: true
-
   '@rspack/binding-win32-x64-msvc@2.1.9':
     optional: true
-
-  '@rspack/binding@2.1.8':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.8
-      '@rspack/binding-darwin-x64': 2.1.8
-      '@rspack/binding-linux-arm64-gnu': 2.1.8
-      '@rspack/binding-linux-arm64-musl': 2.1.8
-      '@rspack/binding-linux-riscv64-gnu': 2.1.8
-      '@rspack/binding-linux-riscv64-musl': 2.1.8
-      '@rspack/binding-linux-x64-gnu': 2.1.8
-      '@rspack/binding-linux-x64-musl': 2.1.8
-      '@rspack/binding-wasm32-wasi': 2.1.8
-      '@rspack/binding-win32-arm64-msvc': 2.1.8
-      '@rspack/binding-win32-ia32-msvc': 2.1.8
-      '@rspack/binding-win32-x64-msvc': 2.1.8
 
   '@rspack/binding@2.1.9':
     optionalDependencies:
@@ -9694,13 +9542,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 2.1.9
       '@rspack/binding-win32-ia32-msvc': 2.1.9
       '@rspack/binding-win32-x64-msvc': 2.1.9
-
-  '@rspack/core@2.1.8(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)':
-    dependencies:
-      '@rspack/binding': 2.1.8
-    optionalDependencies:
-      '@module-federation/runtime-tools': 2.8.2
-      '@swc/helpers': 0.5.23
 
   '@rspack/core@2.1.9(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)':
     dependencies:
@@ -9841,13 +9682,13 @@ snapshots:
   '@rstest/adapter-rslib@0.11.6(@rslib/core@1.0.0-beta.2)(@rstest/core@0.11.6)(typescript@7.0.2)':
     dependencies:
       '@rslib/core': 1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)
-      '@rstest/core': 0.11.6(@module-federation/runtime-tools@2.8.2)
+      '@rstest/core': 0.11.6
     optionalDependencies:
       typescript: 7.0.2
 
-  '@rstest/core@0.11.6(@module-federation/runtime-tools@2.8.2)':
+  '@rstest/core@0.11.6':
     dependencies:
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
       '@types/chai': 5.2.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -13803,10 +13644,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.10)(typescript@7.0.2):
+  rsbuild-plugin-dts@1.0.0-beta.2(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.11)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.10(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.1.11(@module-federation/runtime-tools@2.8.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalog:
   '@module-federation/storybook-addon': '^6.0.18'
   '@playwright/test': '1.62.1'
   '@reduxjs/toolkit': '^2.12.0'
-  '@rsbuild/core': '~2.1.10'
+  '@rsbuild/core': '~2.1.11'
   '@rsbuild/plugin-babel': '^2.0.1'
   '@rsbuild/plugin-less': '^2.0.1'
   '@rsbuild/plugin-node-polyfill': '^1.4.6'

--- a/tests/integration/decorators/__snapshots__/index.test.ts.snap
+++ b/tests/integration/decorators/__snapshots__/index.test.ts.snap
@@ -249,7 +249,7 @@ export { _Person as Person };
 `;
 
 exports[`decorators support 2022-03 config 1`] = `
-"function applyDecs2203RFactory() {
+"function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
     function createAddInitializerMethod(initializers, decoratorFinishedRef) {
         return function(initializer) {
             assertNotFinished(decoratorFinishedRef, "addInitializer");
@@ -555,7 +555,7 @@ exports[`decorators support 2022-03 config 1`] = `
             value: metadata
         });
     }
-    return function(targetClass, memberDecs, classDecs, parentClass) {
+    _apply_decs_2203_r = function(targetClass, memberDecs, classDecs, parentClass) {
         if (void 0 !== parentClass) var parentMetadata = parentClass[Symbol.metadata || Symbol.for("Symbol.metadata")];
         var metadata = Object.create(void 0 === parentMetadata ? null : parentMetadata);
         var e = applyMemberDecs(targetClass, memberDecs, metadata);
@@ -567,9 +567,7 @@ exports[`decorators support 2022-03 config 1`] = `
             }
         };
     };
-}
-function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
-    return (_apply_decs_2203_r = applyDecs2203RFactory())(targetClass, memberDecs, classDecs, parentClass);
+    return _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass);
 }
 var _dec, _initClass;
 function src_enhancer(name) {
@@ -604,8 +602,8 @@ exports[`decorators with experimentalDecorators in tsconfig 1`] = `
     else for(var i = decorators.length - 1; i >= 0; i--)if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 }
-function _ts_metadata(k, v) {
-    if ("object" == typeof Reflect && "function" == typeof Reflect.metadata) return Reflect.metadata(k, v);
+function _ts_metadata(metadataKey, metadataValue) {
+    if ("object" == typeof Reflect && "function" == typeof Reflect.metadata) return Reflect.metadata(metadataKey, metadataValue);
 }
 function src_enhancer(name) {
     return function(target) {
@@ -627,7 +625,7 @@ export { Person };
 `;
 
 exports[`decorators with experimentalDecorators in tsconfig 2`] = `
-"function applyDecs2203RFactory() {
+"function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
     function createAddInitializerMethod(initializers, decoratorFinishedRef) {
         return function(initializer) {
             assertNotFinished(decoratorFinishedRef, "addInitializer");
@@ -933,7 +931,7 @@ exports[`decorators with experimentalDecorators in tsconfig 2`] = `
             value: metadata
         });
     }
-    return function(targetClass, memberDecs, classDecs, parentClass) {
+    _apply_decs_2203_r = function(targetClass, memberDecs, classDecs, parentClass) {
         if (void 0 !== parentClass) var parentMetadata = parentClass[Symbol.metadata || Symbol.for("Symbol.metadata")];
         var metadata = Object.create(void 0 === parentMetadata ? null : parentMetadata);
         var e = applyMemberDecs(targetClass, memberDecs, metadata);
@@ -945,9 +943,7 @@ exports[`decorators with experimentalDecorators in tsconfig 2`] = `
             }
         };
     };
-}
-function _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass) {
-    return (_apply_decs_2203_r = applyDecs2203RFactory())(targetClass, memberDecs, classDecs, parentClass);
+    return _apply_decs_2203_r(targetClass, memberDecs, classDecs, parentClass);
 }
 var _dec, _initClass;
 function src_enhancer(name) {

--- a/tests/integration/format/index.test.ts
+++ b/tests/integration/format/index.test.ts
@@ -65,11 +65,7 @@ test('import.meta.url should be preserved', async () => {
   `);
   expect(entries.esm).toMatchInlineSnapshot(`
     "import node_url from "node:url";
-    var __webpack_require__ = {};
-    (()=>{
-        __webpack_require__.b = new URL("./", import.meta.url);
-    })();
-    const packageDirectory = node_url.fileURLToPath(new URL('.', __webpack_require__.b));
+    const packageDirectory = node_url.fileURLToPath(new URL('.', import.meta.url));
     const foo = 'foo';
     export { foo, packageDirectory };
     "


### PR DESCRIPTION
## Summary

This PR updates `@rsbuild/core` to v2.1.11 across the workspace.

The snapshot changes come from the @rspack/core 2.1.8 → 2.1.9 bump, with swc helper changed and import.meta.url bug fixed, and both are correct:

- https://github.com/web-infra-dev/rspack/pull/15075
- https://github.com/web-infra-dev/rspack/pull/15122 

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).