### PR TITLE
docs: document new URL directory reference limitation

### DIFF
--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -173,7 +173,7 @@ If the project previously copied these assets through [output.copy](/config/rsbu
 
 :::note
 
-Due to a limitation in Rslib v1's implementation for parsing `new URL()` references, references that do not point to an existing source file cannot be processed correctly. This includes references to directories and files that are expected to exist in the build output. For example:
+Because Rslib v1 bundles assets referenced through `new URL()` by default, the referenced target must be an existing source file. For references to directories or files that are expected to exist only in the build output:
 
 ```ts
 const currentDirectory = new URL('.', import.meta.url);

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -392,7 +392,7 @@ const currentDirectory = new URL(/* rspackIgnore: true */ '.', import.meta.url);
 const parentDirectory = new URL(/* rspackIgnore: true */ '..', import.meta.url);
 ```
 
-You can also use `fileURLToPath()` and `path.dirname()` to get the directory paths:
+If the target platform is Node.js, you can also use `fileURLToPath()` and `path.dirname()` to get the directory paths:
 
 ```ts
 import path from 'node:path';

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -171,6 +171,37 @@ In addition, for third-party dependencies bundled into the output, Rslib v0.x fe
 
 If the project previously copied these assets through [output.copy](/config/rsbuild/output#outputcopy) or a script, remove the corresponding configuration after upgrading to avoid duplicate outputs. In bundleless mode ([`bundle: false`](/config/lib/bundle)), also exclude assets referenced through `new URL()` from [source.entry](/config/rsbuild/source#sourceentry) to avoid generating an additional JavaScript entry for the same file.
 
+:::note
+
+Due to a limitation in Rslib v1's implementation for parsing `new URL()` references, references that do not point to an existing source file cannot be processed correctly. This includes references to directories and files that are expected to exist in the build output. For example:
+
+```ts
+const currentDirectory = new URL('.', import.meta.url);
+const generatedFile = new URL('./generated.js', import.meta.url);
+```
+
+You can add the [`rspackIgnore`](https://rspack.rs/api/runtime-api/module-methods#rspackignore) magic comment to skip processing the `new URL()` expression and preserve the expected runtime behavior:
+
+```ts
+const currentDirectory = new URL(/* rspackIgnore: true */ '.', import.meta.url);
+const generatedFile = new URL(
+  /* rspackIgnore: true */ './generated.js',
+  import.meta.url,
+);
+```
+
+If the target platform is Node.js, you can also use Node.js path APIs:
+
+```ts
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const generatedFile = path.join(currentDirectory, 'generated.js');
+```
+
+:::
+
 To keep the Rslib v0.x behavior—preserving all `new URL()` expressions without having Rslib emit the assets—[disable the URL parser](/guide/advanced/static-assets#disable-the-url-parser):
 
 ```ts title="rslib.config.ts"
@@ -374,32 +405,6 @@ This option was originally used to generate ESM output that was more suitable fo
      },
    ],
  };
-```
-
-## Directory references with `new URL()`
-
-Due to a limitation in Rslib v1's implementation for parsing `new URL()` references, using `new URL()` to reference a directory does not work correctly. For example:
-
-```ts
-const currentDirectory = new URL('.', import.meta.url);
-const parentDirectory = new URL('..', import.meta.url);
-```
-
-You can add the [`rspackIgnore`](https://rspack.rs/api/runtime-api/module-methods#rspackignore) magic comment to skip processing the `new URL()` expression and preserve the expected runtime behavior:
-
-```ts
-const currentDirectory = new URL(/* rspackIgnore: true */ '.', import.meta.url);
-const parentDirectory = new URL(/* rspackIgnore: true */ '..', import.meta.url);
-```
-
-If the target platform is Node.js, you can also use `fileURLToPath()` and `path.dirname()` to get the directory paths:
-
-```ts
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
-const parentDirectory = path.dirname(currentDirectory);
 ```
 
 ## JavaScript API

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -376,6 +376,32 @@ This option was originally used to generate ESM output that was more suitable fo
  };
 ```
 
+## Directory references with `new URL()`
+
+Due to a limitation in Rslib v1's implementation for parsing `new URL()` references, using `new URL()` to reference a directory does not work correctly. For example:
+
+```ts
+const currentDirectory = new URL('.', import.meta.url);
+const parentDirectory = new URL('..', import.meta.url);
+```
+
+You can add the [`rspackIgnore`](https://rspack.rs/api/runtime-api/module-methods#rspackignore) magic comment to skip processing the `new URL()` expression and preserve the expected runtime behavior:
+
+```ts
+const currentDirectory = new URL(/* rspackIgnore: true */ '.', import.meta.url);
+const parentDirectory = new URL(/* rspackIgnore: true */ '..', import.meta.url);
+```
+
+You can also use `fileURLToPath()` and `path.dirname()` to get the directory paths:
+
+```ts
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const parentDirectory = path.dirname(currentDirectory);
+```
+
 ## JavaScript API
 
 - The type of `lib` in [RslibConfig](/api/javascript-api/types#rslibconfig) has changed from `LibConfig[]` to `LibConfig[] | undefined`. Omitting `lib` is equivalent to configuring `lib: [{}]`.

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -171,6 +171,37 @@ const logo = new URL('./static/svg/logo.svg', import.meta.url);
 
 如果项目此前通过 [output.copy](/config/rsbuild/output#outputcopy) 或脚本复制这类资源，升级后应移除相应配置，避免重复输出。在 bundleless 模式（[`bundle: false`](/config/lib/bundle)）下，还需要在 [source.entry](/config/rsbuild/source#sourceentry) 中排除已通过 `new URL()` 引用的资源，避免为同一文件额外生成 JavaScript 入口。
 
+:::note
+
+由于 Rslib v1 对 `new URL()` 引用的解析存在实现上的限制，无法正确处理未指向现有源文件的引用，例如目录或预期存在于构建产物中的文件：
+
+```ts
+const currentDirectory = new URL('.', import.meta.url);
+const generatedFile = new URL('./generated.js', import.meta.url);
+```
+
+你可以添加 [`rspackIgnore`](https://rspack.rs/zh/api/runtime-api/module-methods#rspackignore) magic comment 跳过对 `new URL()` 表达式的处理，以保留预期的运行时行为：
+
+```ts
+const currentDirectory = new URL(/* rspackIgnore: true */ '.', import.meta.url);
+const generatedFile = new URL(
+  /* rspackIgnore: true */ './generated.js',
+  import.meta.url,
+);
+```
+
+如果目标平台为 Node.js，你也可以改用 Node.js path API：
+
+```ts
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const generatedFile = path.join(currentDirectory, 'generated.js');
+```
+
+:::
+
 如果希望保留 Rslib v0.x 的行为，原样保留所有 `new URL()` 且不由 Rslib 输出资源，可以[关闭 URL parser](/guide/advanced/static-assets#关闭-url-parser)：
 
 ```ts title="rslib.config.ts"
@@ -374,32 +405,6 @@ export default {
      },
    ],
  };
-```
-
-## 使用 `new URL()` 引用目录
-
-由于 Rslib v1 对 `new URL()` 引用的解析存在实现上的限制，使用 `new URL()` 引用目录时无法正确工作。例如：
-
-```ts
-const currentDirectory = new URL('.', import.meta.url);
-const parentDirectory = new URL('..', import.meta.url);
-```
-
-你可以添加 magic comment 跳过对 `new URL()` 表达式的处理，以保留预期的运行时行为：
-
-```ts
-const currentDirectory = new URL(/* rspackIgnore: true */ '.', import.meta.url);
-const parentDirectory = new URL(/* rspackIgnore: true */ '..', import.meta.url);
-```
-
-如果目标平台为 Node.js，你也可以改用 `fileURLToPath()` 和 `path.dirname()` 获取目录路径：
-
-```ts
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
-const parentDirectory = path.dirname(currentDirectory);
 ```
 
 ## JavaScript API

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -173,7 +173,7 @@ const logo = new URL('./static/svg/logo.svg', import.meta.url);
 
 :::note
 
-由于 Rslib v1 对 `new URL()` 引用的解析存在实现上的限制，无法正确处理未指向现有源文件的引用，例如目录或预期存在于构建产物中的文件：
+由于 Rslib v1 默认会对 `new URL()` 引用的资源进行打包，因此引用目标需要是现有的源文件。对于目录或预期仅存在于构建产物中的文件等引用：
 
 ```ts
 const currentDirectory = new URL('.', import.meta.url);

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -392,7 +392,7 @@ const currentDirectory = new URL(/* rspackIgnore: true */ '.', import.meta.url);
 const parentDirectory = new URL(/* rspackIgnore: true */ '..', import.meta.url);
 ```
 
-你也可以改用 `fileURLToPath()` 和 `path.dirname()` 获取目录路径：
+如果目标平台为 Node.js，你也可以改用 `fileURLToPath()` 和 `path.dirname()` 获取目录路径：
 
 ```ts
 import path from 'node:path';

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -376,6 +376,32 @@ export default {
  };
 ```
 
+## 使用 `new URL()` 引用目录
+
+由于 Rslib v1 对 `new URL()` 引用的解析存在实现上的限制，使用 `new URL()` 引用目录时无法正确工作。例如：
+
+```ts
+const currentDirectory = new URL('.', import.meta.url);
+const parentDirectory = new URL('..', import.meta.url);
+```
+
+你可以添加 magic comment 跳过对 `new URL()` 表达式的处理，以保留预期的运行时行为：
+
+```ts
+const currentDirectory = new URL(/* rspackIgnore: true */ '.', import.meta.url);
+const parentDirectory = new URL(/* rspackIgnore: true */ '..', import.meta.url);
+```
+
+你也可以改用 `fileURLToPath()` 和 `path.dirname()` 获取目录路径：
+
+```ts
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const parentDirectory = path.dirname(currentDirectory);
+```
+
 ## JavaScript API
 
 - [RslibConfig](/api/javascript-api/types#rslibconfig) 中 `lib` 的类型从 `LibConfig[]` 变为 `LibConfig[] | undefined`。省略 `lib` 时，行为等同于配置 `lib: [{}]`。


### PR DESCRIPTION
## Summary

Document the limitation of using `new URL()` to reference directories in Rslib v1, and provide alternatives using the `rspackIgnore` magic comment or Node.js path APIs.

Update both the English and Chinese v1 upgrade guides.
