### PR TITLE
test: skip `import.meta` warning assertions in env-define integration test

### DIFF
--- a/tests/integration/env-define/index.test.ts
+++ b/tests/integration/env-define/index.test.ts
@@ -4,7 +4,6 @@ import { buildAndGetResults, proxyConsole } from 'test-helper';
 
 test('esm preserves `import.meta.env.*` / `process.env.*` presets instead of inlining', async () => {
   const fixturePath = __dirname;
-  // The cjs lib of this fixture warns about unknown `import.meta` properties.
   const { restore } = proxyConsole('warn');
   const { entries } = await buildAndGetResults({ fixturePath }).finally(
     restore,
@@ -26,13 +25,13 @@ test('esm preserves `import.meta.env.*` / `process.env.*` presets instead of inl
 
 test('cjs preserves `process.env.*` and replaces `import.meta.env.*` with undefined', async () => {
   const fixturePath = __dirname;
-  const { logs, restore } = proxyConsole('warn');
+  const { restore } = proxyConsole('warn');
   const { entries } = await buildAndGetResults({ fixturePath }).finally(
     restore,
   );
 
   // `import.meta` is a syntax error in CJS, so it cannot be preserved. Rspack
-  // replaces unknown properties with `undefined` and emits a warning.
+  // replaces unknown properties with `undefined`.
   expect(entries.cjs).not.toContain('import.meta.env');
   expect(entries.cjs).not.toContain('"production"');
   expect(entries.cjs).toContain('const env = void 0;');
@@ -45,6 +44,15 @@ test('cjs preserves `process.env.*` and replaces `import.meta.env.*` with undefi
   expect(entries.cjs).toContain('process.env.BASE_URL');
   expect(entries.cjs).toContain('process.env.ASSET_PREFIX');
   expect(entries.cjs).toContain('process.env.MY_CUSTOM');
+});
+
+// Rspack has temporarily reverted the warning emitted when an unknown
+// `import.meta` property is replaced with `undefined`. Re-enable once that
+// warning is reinstated upstream.
+test.skip('cjs warns about unknown `import.meta` properties', async () => {
+  const fixturePath = __dirname;
+  const { logs, restore } = proxyConsole('warn');
+  await buildAndGetResults({ fixturePath }).finally(restore);
 
   const warnings = logs.map(stripAnsi).join('\n');
   expect(warnings).toContain(


### PR DESCRIPTION
## Summary

Rspack has temporarily reverted the warning emitted when an unknown `import.meta` property is replaced with `undefined`.
