### PR TITLE
docs: refine new URL migration guidance

### DIFF
--- a/website/docs/en/guide/advanced/static-assets.mdx
+++ b/website/docs/en/guide/advanced/static-assets.mdx
@@ -201,7 +201,7 @@ The output retains the standard `new URL(path, import.meta.url)` form. If the re
 
 ##### Ignore a specific reference
 
-To skip processing for a specific `new URL()`, add the [rspackIgnore](https://rspack.rs/api/runtime-api/module-methods#rspackignore) comment before its first argument:
+To skip processing for a specific `new URL()` expression, add the [rspackIgnore](https://rspack.rs/api/runtime-api/module-methods#rspackignore) comment before its first argument. The output then preserves the standard `new URL(path, import.meta.url)` expression:
 
 ```ts title="src/index.ts"
 const logo = new URL(
@@ -209,8 +209,6 @@ const logo = new URL(
   import.meta.url,
 );
 ```
-
-At this point, Rslib uses a runtime variable as the base URL for `new URL()`, and the emitted expression no longer retains `import.meta.url`. This limits downstream bundlers' ability to statically analyze the asset reference when consuming the output.
 
 ## Import assets in CSS file
 

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -197,13 +197,13 @@ Rslib v1 treats statically analyzable `new URL()` references as static assets wh
 const logo = new URL('./assets/logo.svg', import.meta.url);
 ```
 
-For project source, Rslib v0.x preserved the expression and did not emit `logo.svg`. Rslib v1 emits the file and updates the path in `new URL()` to point to the emitted asset.
+For project source, Rslib v0.x preserved the expression and did not emit `logo.svg`. Rslib v1 emits the file and rewrites the path in `new URL()` to a relative path that points to the emitted asset.
 
 ```js title="dist/index.js"
 const logo = new URL('./static/svg/logo.svg', import.meta.url);
 ```
 
-For third-party dependencies bundled into the output, Rslib v0.x rewrote the asset path in `new URL()` as a module reference and injected runtime code to load that module and compute the base URL. Rslib v1 handles these references in the same way as project source, emitting the referenced assets and updating the paths in `new URL()` to point to the emitted files.
+For third-party dependencies bundled into the output, Rslib v0.x rewrote the asset path in `new URL()` as a module reference and injected runtime code to load that module and compute the base URL. Rslib v1 handles these references in the same way as project source, emitting the referenced assets and rewriting the paths in `new URL()` to relative paths that point to the emitted files.
 
 If a project previously copied these assets through [output.copy](/config/rsbuild/output#outputcopy) or a script, and Rslib emits them from `new URL()` references after the upgrade, remove the corresponding configuration or script to avoid duplicate outputs. In bundleless mode ([`bundle: false`](/config/lib/bundle)), if [source.entry](/config/rsbuild/source#sourceentry) also matches these assets, exclude them to avoid generating an additional JavaScript entry for the same file.
 

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -191,65 +191,64 @@ Rslib v1 changes how ESM output ([`format: 'esm'`](/config/lib/format)) handles 
 
 ### Static assets with `new URL()`
 
-When building ESM output, Rslib v1 treats statically analyzable local `new URL()` references as static assets. Consider a source file that references `logo.svg`:
+Rslib v1 treats statically analyzable `new URL()` references as static assets when building ESM output. Consider a source file that references `logo.svg`:
 
 ```ts title="src/index.ts"
 const logo = new URL('./assets/logo.svg', import.meta.url);
 ```
 
-For project source files, Rslib v0.x preserved this expression and did not emit `logo.svg`. Rslib v1 emits the file and rewrites the URL to a relative path that points to it:
+For project source, Rslib v0.x preserved the expression and did not emit `logo.svg`. Rslib v1 emits the file and updates the path in `new URL()` to point to the emitted asset.
 
 ```js title="dist/index.js"
 const logo = new URL('./static/svg/logo.svg', import.meta.url);
 ```
 
-In addition, for third-party dependencies bundled into the output, Rslib v0.x fell back to Rspack's default URL handling and pulled in extra runtime code, while Rslib v1 consistently emits a static relative URL that points to the emitted asset.
+For third-party dependencies bundled into the output, Rslib v0.x rewrote the asset path in `new URL()` as a module reference and injected runtime code to load that module and compute the base URL. Rslib v1 handles these references in the same way as project source, emitting the referenced assets and updating the paths in `new URL()` to point to the emitted files.
 
-If the project previously copied these assets through [output.copy](/config/rsbuild/output#outputcopy) or a script, remove the corresponding configuration after upgrading to avoid duplicate outputs. In bundleless mode ([`bundle: false`](/config/lib/bundle)), also exclude assets referenced through `new URL()` from [source.entry](/config/rsbuild/source#sourceentry) to avoid generating an additional JavaScript entry for the same file.
+If a project previously copied these assets through [output.copy](/config/rsbuild/output#outputcopy) or a script, and Rslib emits them from `new URL()` references after the upgrade, remove the corresponding configuration or script to avoid duplicate outputs. In bundleless mode ([`bundle: false`](/config/lib/bundle)), if [source.entry](/config/rsbuild/source#sourceentry) also matches these assets, exclude them to avoid generating an additional JavaScript entry for the same file.
 
-:::note
+To skip Rslib's static asset processing for `new URL()` references, choose an approach based on the required scope. For details, see [Skip `new URL()` processing](/guide/advanced/static-assets#skip-new-url-processing).
 
-Because Rslib v1 bundles assets referenced through `new URL()` by default, the referenced target must be an existing source file. For references to directories or files that are expected to exist only in the build output:
+- **Skip one reference:** Add the [rspackIgnore](https://rspack.rs/api/runtime-api/module-methods#rspackignore) magic comment before the first argument of `new URL()`.
 
-```ts
+  ```ts title="src/index.ts"
+  const logo = new URL(
+    /* rspackIgnore: true */ './assets/logo.svg',
+    import.meta.url,
+  );
+  ```
+
+- **Skip all references:** Use [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) to set the `url` parser option of the `rslib:new-url` rule to `false`.
+
+  ```ts title="rslib.config.ts"
+  import { defineConfig } from '@rslib/core';
+
+  export default defineConfig({
+    tools: {
+      bundlerChain(chain) {
+        chain.module.rule('rslib:new-url').parser({
+          url: false,
+        });
+      },
+    },
+  });
+  ```
+
+Additionally, Rslib's default handling requires the target of a `new URL()` reference to resolve to an existing file at build time, while directories and files that exist only in the build output cannot be processed as static assets. For example:
+
+```ts title="src/index.ts"
 const currentDirectory = new URL('.', import.meta.url);
 const generatedFile = new URL('./generated.js', import.meta.url);
 ```
 
-You can add the [`rspackIgnore`](https://rspack.rs/api/runtime-api/module-methods#rspackignore) magic comment to skip processing the `new URL()` expression and preserve the expected runtime behavior:
+For these references, use one of the approaches above to skip `new URL()` processing. If they are used only to construct Node.js file system paths, you can also modify the source to use Node.js `path` and `url` APIs:
 
-```ts
-const currentDirectory = new URL(/* rspackIgnore: true */ '.', import.meta.url);
-const generatedFile = new URL(
-  /* rspackIgnore: true */ './generated.js',
-  import.meta.url,
-);
-```
-
-If the target platform is Node.js, you can also use Node.js path APIs:
-
-```ts
+```ts title="src/index.ts"
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 const generatedFile = path.join(currentDirectory, 'generated.js');
-```
-
-:::
-
-To keep the Rslib v0.x behavior—preserving all `new URL()` expressions without having Rslib emit the assets—[disable the URL parser](/guide/advanced/static-assets#disable-the-url-parser):
-
-```ts title="rslib.config.ts"
-export default {
-  tools: {
-    bundlerChain(chain) {
-      chain.module.rule('rslib:new-url').parser({
-        url: false,
-      });
-    },
-  },
-};
 ```
 
 For more details, see [Static assets - `new URL` imports](/guide/advanced/static-assets#new-url-imports).

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -234,14 +234,14 @@ To skip Rslib's static asset processing for `new URL()` references, choose an ap
   });
   ```
 
-Additionally, Rslib's default handling requires the target of a `new URL()` reference to resolve to an existing file at build time, while directories and files that exist only in the build output cannot be processed as static assets. For example:
+Additionally, Rslib's default handling requires the target of a `new URL()` reference to resolve to an existing source file at build time, while directories and files that exist only in the build output cannot be processed as static assets. For example:
 
 ```ts title="src/index.ts"
 const currentDirectory = new URL('.', import.meta.url);
 const generatedFile = new URL('./generated.js', import.meta.url);
 ```
 
-For these references, use one of the approaches above to skip `new URL()` processing. If they are used only to construct Node.js file system paths, you can also modify the source to use Node.js `path` and `url` APIs:
+For these references, use one of the approaches above to skip `new URL()` processing. If these references are only used to obtain file system paths in Node.js, you can also modify the source to use Node.js `path` and `url` APIs:
 
 ```ts title="src/index.ts"
 import path from 'node:path';

--- a/website/docs/zh/guide/advanced/static-assets.mdx
+++ b/website/docs/zh/guide/advanced/static-assets.mdx
@@ -201,7 +201,7 @@ const logo = new URL('./assets/logo.svg', import.meta.url);
 
 ##### 忽略特定引用
 
-如果只需要跳过某个 `new URL()` 的处理，可以在第一个参数前添加 [rspackIgnore](https://rspack.rs/zh/api/runtime-api/module-methods#rspackignore) 注释：
+如果只需要跳过某个 `new URL()` 表达式的处理，可以在第一个参数前添加 [rspackIgnore](https://rspack.rs/zh/api/runtime-api/module-methods#rspackignore) 注释。此时，产物中会保留标准的 `new URL(path, import.meta.url)` 表达式：
 
 ```ts title="src/index.ts"
 const logo = new URL(
@@ -209,8 +209,6 @@ const logo = new URL(
   import.meta.url,
 );
 ```
-
-此时，Rslib 会使用运行时变量作为 `new URL()` 的基准 URL，产物中的表达式将不再保留 `import.meta.url`，这会限制后续打包工具在二次消费产物时对该资源引用的静态分析。
 
 ## 在 CSS 文件中引用
 

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -191,65 +191,64 @@ Rslib v1 调整了 ESM 产物（[`format: 'esm'`](/config/lib/format)）中通�
 
 ### `new URL()` 静态资源
 
-构建 ESM 产物时，Rslib v1 会将可静态分析的本地 `new URL()` 引用作为静态资源处理。以引用 `logo.svg` 为例：
+Rslib v1 会在构建 ESM 产物时将可静态分析的 `new URL()` 引用作为静态资源处理。以引用 `logo.svg` 为例：
 
 ```ts title="src/index.ts"
 const logo = new URL('./assets/logo.svg', import.meta.url);
 ```
 
-对于项目源码，Rslib v0.x 会原样保留该表达式，且不会输出 `logo.svg`。Rslib v1 则会输出该文件，并将 URL 重写为指向该文件的相对路径：
+对于项目源码，Rslib v0.x 会原样保留该表达式，且不会输出 `logo.svg`。Rslib v1 则会输出该文件，并使 `new URL()` 中的路径指向产物中的资源文件。
 
 ```js title="dist/index.js"
 const logo = new URL('./static/svg/logo.svg', import.meta.url);
 ```
 
-此外，对于被打包到产物中的三方依赖，Rslib v0.x 会回退到 Rspack 默认的 URL 处理并引入额外 runtime，Rslib v1 则会统一生成指向输出资源的静态相对 URL。
+对于被打包到产物中的三方依赖，Rslib v0.x 会将 `new URL()` 中的资源路径改写为模块引用，并在产物中注入用于加载该模块和计算基准 URL 的运行时代码。Rslib v1 则会采用与项目源码相同的处理方式，输出引用的资源，并使 `new URL()` 中的路径指向该资源文件。
 
-如果项目此前通过 [output.copy](/config/rsbuild/output#outputcopy) 或脚本复制这类资源，升级后应移除相应配置，避免重复输出。在 bundleless 模式（[`bundle: false`](/config/lib/bundle)）下，还需要在 [source.entry](/config/rsbuild/source#sourceentry) 中排除已通过 `new URL()` 引用的资源，避免为同一文件额外生成 JavaScript 入口。
+如果项目原先通过 [output.copy](/config/rsbuild/output#outputcopy) 配置或脚本复制这些资源，且升级后这些资源会由 Rslib 根据 `new URL()` 引用输出，应移除相应配置或脚本，避免重复输出。在 bundleless 模式（[`bundle: false`](/config/lib/bundle)）下，如果 [source.entry](/config/rsbuild/source#sourceentry) 也会匹配这些资源，还应将它们排除，避免为同一文件额外生成 JavaScript 入口。
 
-:::note
+如果需要跳过 Rslib 对 `new URL()` 引用的静态资源处理，可以根据作用范围选择以下方式，详情可以参考 [跳过 `new URL()` 处理](/guide/advanced/static-assets#跳过-new-url-处理)。
 
-由于 Rslib v1 默认会对 `new URL()` 引用的资源进行打包，因此引用目标需要是现有的源文件。对于目录或预期仅存在于构建产物中的文件等引用：
+- **跳过单个引用**：在 `new URL()` 的第一个参数前添加 [rspackIgnore](https://rspack.rs/zh/api/runtime-api/module-methods#rspackignore) 注释。
 
-```ts
+  ```ts title="src/index.ts"
+  const logo = new URL(
+    /* rspackIgnore: true */ './assets/logo.svg',
+    import.meta.url,
+  );
+  ```
+
+- **跳过所有引用**：通过 [tools.bundlerChain](/config/rsbuild/tools#toolsbundlerchain) 将 `rslib:new-url` 规则中的 `url` parser 选项设置为 `false`。
+
+  ```ts title="rslib.config.ts"
+  import { defineConfig } from '@rslib/core';
+
+  export default defineConfig({
+    tools: {
+      bundlerChain(chain) {
+        chain.module.rule('rslib:new-url').parser({
+          url: false,
+        });
+      },
+    },
+  });
+  ```
+
+此外，Rslib 的默认处理要求 `new URL()` 的引用目标在构建时能够解析为现有文件，目录或仅在构建产物中存在的文件无法作为静态资源处理。例如：
+
+```ts title="src/index.ts"
 const currentDirectory = new URL('.', import.meta.url);
 const generatedFile = new URL('./generated.js', import.meta.url);
 ```
 
-你可以添加 [`rspackIgnore`](https://rspack.rs/zh/api/runtime-api/module-methods#rspackignore) magic comment 跳过对 `new URL()` 表达式的处理，以保留预期的运行时行为：
+对于这类引用，可以使用上述方式跳过 `new URL()` 处理。如果它们仅用于构造 Node.js 文件系统路径，也可以通过修改源码，改用 Node.js 的 `path` 和 `url` API：
 
-```ts
-const currentDirectory = new URL(/* rspackIgnore: true */ '.', import.meta.url);
-const generatedFile = new URL(
-  /* rspackIgnore: true */ './generated.js',
-  import.meta.url,
-);
-```
-
-如果目标平台为 Node.js，你也可以改用 Node.js path API：
-
-```ts
+```ts title="src/index.ts"
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 const generatedFile = path.join(currentDirectory, 'generated.js');
-```
-
-:::
-
-如果希望保留 Rslib v0.x 的行为，原样保留所有 `new URL()` 且不由 Rslib 输出资源，可以[关闭 URL parser](/guide/advanced/static-assets#关闭-url-parser)：
-
-```ts title="rslib.config.ts"
-export default {
-  tools: {
-    bundlerChain(chain) {
-      chain.module.rule('rslib:new-url').parser({
-        url: false,
-      });
-    },
-  },
-};
 ```
 
 更多详情请参考 [静态资源 - `new URL` 引用](/guide/advanced/static-assets#new-url-引用)。

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -234,14 +234,14 @@ const logo = new URL('./static/svg/logo.svg', import.meta.url);
   });
   ```
 
-此外，Rslib 的默认处理要求 `new URL()` 的引用目标在构建时能够解析为现有文件，目录或仅在构建产物中存在的文件无法作为静态资源处理。例如：
+此外，Rslib 的默认处理要求 `new URL()` 的引用目标在构建时能够解析为现有源文件，目录或仅在构建产物中存在的文件无法作为静态资源处理。例如：
 
 ```ts title="src/index.ts"
 const currentDirectory = new URL('.', import.meta.url);
 const generatedFile = new URL('./generated.js', import.meta.url);
 ```
 
-对于这类引用，可以使用上述方式跳过 `new URL()` 处理。如果它们仅用于构造 Node.js 文件系统路径，也可以通过修改源码，改用 Node.js 的 `path` 和 `url` API：
+对于这类引用，可以使用上述方式跳过 `new URL()` 处理。如果这些引用只是为了在 Node.js 中获取文件系统路径，也可以通过修改源码，改用 Node.js 的 `path` 和 `url` API：
 
 ```ts title="src/index.ts"
 import path from 'node:path';

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -197,13 +197,13 @@ Rslib v1 会在构建 ESM 产物时将可静态分析的 `new URL()` 引用作�
 const logo = new URL('./assets/logo.svg', import.meta.url);
 ```
 
-对于项目源码，Rslib v0.x 会原样保留该表达式，且不会输出 `logo.svg`。Rslib v1 则会输出该文件，并使 `new URL()` 中的路径指向产物中的资源文件。
+对于项目源码，Rslib v0.x 会原样保留该表达式，且不会输出 `logo.svg`。Rslib v1 则会输出该文件，并将 `new URL()` 中的路径改写为指向该资源文件的相对路径。
 
 ```js title="dist/index.js"
 const logo = new URL('./static/svg/logo.svg', import.meta.url);
 ```
 
-对于被打包到产物中的三方依赖，Rslib v0.x 会将 `new URL()` 中的资源路径改写为模块引用，并在产物中注入用于加载该模块和计算基准 URL 的运行时代码。Rslib v1 则会采用与项目源码相同的处理方式，输出引用的资源，并使 `new URL()` 中的路径指向该资源文件。
+对于被打包到产物中的三方依赖，Rslib v0.x 会将 `new URL()` 中的资源路径改写为模块引用，并在产物中注入用于加载该模块和计算基准 URL 的运行时代码。Rslib v1 则会采用与项目源码相同的处理方式，输出引用的资源，并将 `new URL()` 中的路径改写为指向该资源文件的相对路径。
 
 如果项目原先通过 [output.copy](/config/rsbuild/output#outputcopy) 配置或脚本复制这些资源，且升级后这些资源会由 Rslib 根据 `new URL()` 引用输出，应移除相应配置或脚本，避免重复输出。在 bundleless 模式（[`bundle: false`](/config/lib/bundle)）下，如果 [source.entry](/config/rsbuild/source#sourceentry) 也会匹配这些资源，还应将它们排除，避免为同一文件额外生成 JavaScript 入口。
 


### PR DESCRIPTION
## Summary

This PR refines the `new URL()` migration guidance added in #1843:

- clarify the differences between Rslib v0.x and v1 for project source and bundled dependencies
- document per-reference and rule-wide opt-out approaches for directory and generated-file references
- correct the `rspackIgnore` output description in the static asset guide

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1843

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).