### PR TITLE
fix(create-rslib): remove redundant agent preamble

### DIFF
--- a/packages/create-rslib/template-common/AGENTS.md
+++ b/packages/create-rslib/template-common/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md
 
-You are an expert in JavaScript, Rspack, Rsbuild, Rslib, and library development. You write maintainable, performant, and accessible code.
-
 ## Commands
 
 - `{{ packageManager }} run build` - Build the library for production


### PR DESCRIPTION
## Summary

This PR removes the generic coding-agent persona from the generated `AGENTS.md` so the file focuses on actionable Rslib commands and documentation links.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8233

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).