### PR TITLE
fix(create-rslib): add pnpm config to Svelte templates

### DIFF
--- a/packages/create-rslib/template-svelte-js/pnpm-workspace.yaml
+++ b/packages/create-rslib/template-svelte-js/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  svelte-preprocess: false

--- a/packages/create-rslib/template-svelte-ts/pnpm-workspace.yaml
+++ b/packages/create-rslib/template-svelte-ts/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  svelte-preprocess: false

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -132,6 +132,9 @@ export const createAndValidate = (
     expect(pkgJson.devDependencies['@rsbuild/plugin-svelte']).toBeTruthy();
     expect(pkgJson.devDependencies.svelte).toBeTruthy();
     expect(pkgJson.peerDependencies.svelte).toBe('^5.0.0');
+    expect(
+      fse.readFileSync(path.join(dir, 'pnpm-workspace.yaml'), 'utf-8'),
+    ).toBe('allowBuilds:\n  svelte-preprocess: false\n');
 
     if (templateCase.lang === 'ts') {
       expect(pkgJson.devDependencies['svelte-check']).toBeTruthy();

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -134,7 +134,7 @@ export const createAndValidate = (
     expect(pkgJson.peerDependencies.svelte).toBe('^5.0.0');
     expect(
       fse.readFileSync(path.join(dir, 'pnpm-workspace.yaml'), 'utf-8'),
-    ).toBe('allowBuilds:\n  svelte-preprocess: false\n');
+    ).toContain('svelte-preprocess: false');
 
     if (templateCase.lang === 'ts') {
       expect(pkgJson.devDependencies['svelte-check']).toBeTruthy();


### PR DESCRIPTION
## Summary

Generated Svelte library projects need an explicit build-script policy for `svelte-preprocess` when using pnpm. This PR adds pnpm-only workspace configuration to both JavaScript and TypeScript Svelte templates and verifies the generated policy; npm and other package managers remain unaffected.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/273

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).