### PR TITLE
chore(lint): enable Rstest lint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@types/node": "catalog:",
     "cspell-ban-words": "catalog:",
     "fs-extra": "catalog:",
-    "globals": "catalog:",
     "heading-case": "catalog:",
     "nano-staged": "catalog:",
     "prettier": "catalog:",

--- a/packages/core/tests/lcp.test.ts
+++ b/packages/core/tests/lcp.test.ts
@@ -20,57 +20,68 @@ describe('LCP calculate correctly', () => {
   it('correct 1', async () => {
     vol.fromJSON({ '/Users/Someone/project-a/src': null });
 
-    if (os.platform() !== 'win32') {
-      const result = await calcLongestCommonPath([
-        '/Users/Someone/project-a/src/helpers',
-        '/Users/Someone/project-a/src',
-        '/Users/Someone/project-a/src/utils',
-      ]);
-      expect(result).toEqual('/Users/Someone/project-a/src');
-    } else {
-      const result = await calcLongestCommonPath([
-        'D:/Users/Someone/project-a/src/helpers',
-        'D:/Users/Someone/project-a/src',
-        'D:/Users/Someone/project-a/src/utils',
-      ]);
-      expect(result).toEqual('D:/Users/Someone/project-a/src');
-    }
+    const [paths, expected] =
+      os.platform() !== 'win32'
+        ? [
+            [
+              '/Users/Someone/project-a/src/helpers',
+              '/Users/Someone/project-a/src',
+              '/Users/Someone/project-a/src/utils',
+            ],
+            '/Users/Someone/project-a/src',
+          ]
+        : [
+            [
+              'D:/Users/Someone/project-a/src/helpers',
+              'D:/Users/Someone/project-a/src',
+              'D:/Users/Someone/project-a/src/utils',
+            ],
+            'D:/Users/Someone/project-a/src',
+          ];
+    const result = await calcLongestCommonPath(paths);
+    expect(result).toEqual(expected);
   });
 
   it('correct 2', async () => {
     vol.fromJSON({ '/Users/Someone/project-monorepo': null });
 
-    if (os.platform() !== 'win32') {
-      const result = await calcLongestCommonPath([
-        '/Users/Someone/project-monorepo/packages-a/src/index.ts',
-        '/Users/Someone/project-monorepo/packages-util/src/index.js',
-        '/Users/Someone/project-monorepo/script.js',
-      ]);
-      expect(result).toEqual('/Users/Someone/project-monorepo');
-    } else {
-      const result = await calcLongestCommonPath([
-        'D:/Users/Someone/project-monorepo/packages-a/src/index.ts',
-        'D:/Users/Someone/project-monorepo/packages-util/src/index.js',
-        'D:/Users/Someone/project-monorepo/script.js',
-      ]);
-      expect(result).toEqual('D:/Users/Someone/project-monorepo');
-    }
+    const [paths, expected] =
+      os.platform() !== 'win32'
+        ? [
+            [
+              '/Users/Someone/project-monorepo/packages-a/src/index.ts',
+              '/Users/Someone/project-monorepo/packages-util/src/index.js',
+              '/Users/Someone/project-monorepo/script.js',
+            ],
+            '/Users/Someone/project-monorepo',
+          ]
+        : [
+            [
+              'D:/Users/Someone/project-monorepo/packages-a/src/index.ts',
+              'D:/Users/Someone/project-monorepo/packages-util/src/index.js',
+              'D:/Users/Someone/project-monorepo/script.js',
+            ],
+            'D:/Users/Someone/project-monorepo',
+          ];
+    const result = await calcLongestCommonPath(paths);
+    expect(result).toEqual(expected);
   });
 
   it('correct 3', async () => {
     vol.fromJSON({
       '/Users/Someone/project/src/index.js': '',
     });
-    if (os.platform() !== 'win32') {
-      const result = await calcLongestCommonPath([
-        '/Users/Someone/project/src/index.js',
-      ]);
-      expect(result).toEqual('/Users/Someone/project/src');
-    } else {
-      const result = await calcLongestCommonPath([
-        'D:/Users/Someone/project/src/index.js',
-      ]);
-      expect(result).toEqual('D:/Users/Someone/project/src');
-    }
+    const [paths, expected] =
+      os.platform() !== 'win32'
+        ? [
+            ['/Users/Someone/project/src/index.js'],
+            '/Users/Someone/project/src',
+          ]
+        : [
+            ['D:/Users/Someone/project/src/index.js'],
+            'D:/Users/Someone/project/src',
+          ];
+    const result = await calcLongestCommonPath(paths);
+    expect(result).toEqual(expected);
   });
 });

--- a/packages/core/tests/syntax.test.ts
+++ b/packages/core/tests/syntax.test.ts
@@ -89,9 +89,10 @@ describe('ESX_TO_BROWSERSLIST', () => {
         const currQuery = (
           ESX_TO_BROWSERSLIST[current] as Record<string, string>
         )[query];
-        if (prevQuery && currQuery) {
-          expect(compareSemver(currQuery, prevQuery)).toBeGreaterThanOrEqual(0);
+        if (!prevQuery || !currQuery) {
+          continue;
         }
+        expect(compareSemver(currQuery, prevQuery)).toBeGreaterThanOrEqual(0);
       }
     }
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,8 +83,8 @@ catalogs:
       specifier: ^2.0.0
       version: 2.0.0
     '@rslint/core':
-      specifier: ^0.8.0
-      version: 0.8.0
+      specifier: ^0.8.1
+      version: 0.8.1
     '@rspress/core':
       specifier: ^2.0.19
       version: 2.0.19
@@ -322,7 +322,7 @@ importers:
     devDependencies:
       '@rslint/core':
         specifier: 'catalog:'
-        version: 0.8.0(jiti@2.7.0)
+        version: 0.8.1(jiti@2.7.0)
       '@rstest/adapter-rslib':
         specifier: 'catalog:'
         version: 0.11.8(@rslib/core@1.0.0-beta.3)(@rstest/core@0.11.8)(typescript@7.0.2)
@@ -3137,8 +3137,8 @@ packages:
       typescript:
         optional: true
 
-  '@rslint/core@0.8.0':
-    resolution: {integrity: sha512-MfMC6lxiXoKPWsYRu9fuAxWA9mCD/I4E5Aa6Sl20a6q5w8r2C12fJM+bceC01AMGYuvWygKHqS3QBJdJHjniRw==}
+  '@rslint/core@0.8.1':
+    resolution: {integrity: sha512-cqpDcgJ8TgBC+I/OZkICze0sSNcsdjtxNCv01fQTYvgIvBkwbhNlg4celD3XEPfA8B2B2H/woYgeaX0IPEeTMA==}
     hasBin: true
     peerDependencies:
       jiti: ^2.7.0
@@ -3146,47 +3146,47 @@ packages:
       jiti:
         optional: true
 
-  '@rslint/native-darwin-arm64@0.8.0':
-    resolution: {integrity: sha512-Bo6kXL1/TkjVUl6maZ3Sw+JEnZUkgpUD35v06jyBTcjpxlXE6yqFj66NAzB/G2CVu220ADp/FEE7l2Kocrefhg==}
+  '@rslint/native-darwin-arm64@0.8.1':
+    resolution: {integrity: sha512-HlucYn3RLELMHRjlvKcr0vPlE/2RUs6BVn5ClRKFcLShON4j+q8NWaIPHwY5zrQjqq7GJxX3b/7G9skU+TrQ2w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rslint/native-darwin-x64@0.8.0':
-    resolution: {integrity: sha512-F5pabdH7dluxoj7PGuQjPYuoNU+yxnctcJzqrb/CZ122FLP3uJPrbiLufh+ZF9e5ui700rNyb7macJqnHlBV2w==}
+  '@rslint/native-darwin-x64@0.8.1':
+    resolution: {integrity: sha512-HV4FOwq3ofuoMkUxjEyGvaOGyr79OzFhAIpMcT9uOO6BxEA/PndepwBAPmkBt33aewm2oPKM2khsC582XTsxew==}
     cpu: [x64]
     os: [darwin]
 
-  '@rslint/native-linux-arm64-gnu@0.8.0':
-    resolution: {integrity: sha512-SSgSjyaeXI032Wk8bq6VmkLQTWOEqHZH5MWAk3831pd/G2rWr2XcoDi5Wf6w0o2rSCeYzkYbIejOePYwIKT4Lg==}
+  '@rslint/native-linux-arm64-gnu@0.8.1':
+    resolution: {integrity: sha512-O9kvvw2O7WAzeBAp7KSfXVbyl4Q4hAY1rUSRpeJp9hOY3yQUipE98qF29QicbXTRsoZZooMTmrjV/0EiYGL8OA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rslint/native-linux-arm64-musl@0.8.0':
-    resolution: {integrity: sha512-50VDZQFAc9kp6rbOUOjyppVjC3d3AdbOJyA6JxlhK3mp8a/8sPIqWG0BlfcN/7ZpwdZrFsQt2Ds+0yMXITfu5A==}
+  '@rslint/native-linux-arm64-musl@0.8.1':
+    resolution: {integrity: sha512-I92YjEMPcdeXz29rGuWR7kKjlek3LG/kcLHaBop6ucYkAXbuwdCwALM/JKxjcnRjoEZA3qR4QCRu92Llbzh+Ig==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rslint/native-linux-x64-gnu@0.8.0':
-    resolution: {integrity: sha512-wfc/UfnuTBAofwLPK5MLB2Hus1YYnsxP2MVchp380fUvMfQuGFPzz1WOAUY66zqrsrDKpUJsh3V1bx7c8DTlJA==}
+  '@rslint/native-linux-x64-gnu@0.8.1':
+    resolution: {integrity: sha512-9uh4XygsKs2lj7JWM2yi92qjrgrXM7slppAgTQnFfkiRoKASVt4M2anSiJfs2v5hU3UhsmVotXAOYtWoV5Hd3g==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rslint/native-linux-x64-musl@0.8.0':
-    resolution: {integrity: sha512-MTYcAMz6IZWb6ZmLo12pakCBA8mS3EW9cOI0jd3At6vs0Yia9YbeOAUiWbIC4Z9yyp75b8ZQCQMRSnY6rDnbaA==}
+  '@rslint/native-linux-x64-musl@0.8.1':
+    resolution: {integrity: sha512-pcWlxs9ZLaETAoDaYcO6f8jeuE+nZliIVrhCJ1eWX+aTB+WPKHVHK6dFMPjxqsvUtwbK1zfpTeo8rOaeGRrSfQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rslint/native-win32-arm64-msvc@0.8.0':
-    resolution: {integrity: sha512-hids2jgNWBxZf2mSBLZJxubWRLWlJapEfeJHVokzjpRpBZZNv7O06enoyXSb4Lswff9WaHssIqu1sfZIc9lC2g==}
+  '@rslint/native-win32-arm64-msvc@0.8.1':
+    resolution: {integrity: sha512-GGRcKGBOQs7WsxSfXWRQnY15nRyikaDajWoefhKnYVj+AMg6BEWWsdH3Q2xOOuVMGNCC/SoXUAGb9cGpV7Smdg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rslint/native-win32-x64-msvc@0.8.0':
-    resolution: {integrity: sha512-bun7uURKl6NdChwmw/i2mk3Yj9klZQyh1uRbIQG0RDEJ9oTIbU5M3c7K5sd/Rukat0TVCGgbBAzR+YB0DAXPZQ==}
+  '@rslint/native-win32-x64-msvc@0.8.1':
+    resolution: {integrity: sha512-rokvuC3MKTNMbGU5eh/p6a715xzl1yZvjh9gQByNPKGHrF3OUmqN1c6QGCtlNU8HGHekvMS9dUNzjTCoMenZjQ==}
     cpu: [x64]
     os: [win32]
 
@@ -9695,42 +9695,42 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rslint/core@0.8.0(jiti@2.7.0)':
+  '@rslint/core@0.8.1(jiti@2.7.0)':
     dependencies:
       picomatch: 4.0.5
     optionalDependencies:
-      '@rslint/native-darwin-arm64': 0.8.0
-      '@rslint/native-darwin-x64': 0.8.0
-      '@rslint/native-linux-arm64-gnu': 0.8.0
-      '@rslint/native-linux-arm64-musl': 0.8.0
-      '@rslint/native-linux-x64-gnu': 0.8.0
-      '@rslint/native-linux-x64-musl': 0.8.0
-      '@rslint/native-win32-arm64-msvc': 0.8.0
-      '@rslint/native-win32-x64-msvc': 0.8.0
+      '@rslint/native-darwin-arm64': 0.8.1
+      '@rslint/native-darwin-x64': 0.8.1
+      '@rslint/native-linux-arm64-gnu': 0.8.1
+      '@rslint/native-linux-arm64-musl': 0.8.1
+      '@rslint/native-linux-x64-gnu': 0.8.1
+      '@rslint/native-linux-x64-musl': 0.8.1
+      '@rslint/native-win32-arm64-msvc': 0.8.1
+      '@rslint/native-win32-x64-msvc': 0.8.1
       jiti: 2.7.0
 
-  '@rslint/native-darwin-arm64@0.8.0':
+  '@rslint/native-darwin-arm64@0.8.1':
     optional: true
 
-  '@rslint/native-darwin-x64@0.8.0':
+  '@rslint/native-darwin-x64@0.8.1':
     optional: true
 
-  '@rslint/native-linux-arm64-gnu@0.8.0':
+  '@rslint/native-linux-arm64-gnu@0.8.1':
     optional: true
 
-  '@rslint/native-linux-arm64-musl@0.8.0':
+  '@rslint/native-linux-arm64-musl@0.8.1':
     optional: true
 
-  '@rslint/native-linux-x64-gnu@0.8.0':
+  '@rslint/native-linux-x64-gnu@0.8.1':
     optional: true
 
-  '@rslint/native-linux-x64-musl@0.8.0':
+  '@rslint/native-linux-x64-musl@0.8.1':
     optional: true
 
-  '@rslint/native-win32-arm64-msvc@0.8.0':
+  '@rslint/native-win32-arm64-msvc@0.8.1':
     optional: true
 
-  '@rslint/native-win32-x64-msvc@0.8.0':
+  '@rslint/native-win32-x64-msvc@0.8.1':
     optional: true
 
   '@rspack/binding-darwin-arm64@2.1.10':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,9 +187,6 @@ catalogs:
     get-tsconfig:
       specifier: 5.0.0-beta.6
       version: 5.0.0-beta.6
-    globals:
-      specifier: ^17.11.0
-      version: 17.11.0
     heading-case:
       specifier: ^1.1.5
       version: 1.1.5
@@ -341,9 +338,6 @@ importers:
       fs-extra:
         specifier: 'catalog:'
         version: 11.4.0
-      globals:
-        specifier: 'catalog:'
-        version: 17.11.0
       heading-case:
         specifier: 'catalog:'
         version: 1.1.5
@@ -5272,10 +5266,6 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  globals@17.11.0:
-    resolution: {integrity: sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==}
-    engines: {node: '>=18'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -11918,8 +11908,6 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
-
-  globals@17.11.0: {}
 
   gopd@1.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,7 +39,7 @@ catalog:
   '@rsbuild/plugin-typed-css-modules': '^1.2.4'
   '@rsbuild/plugin-vue': '^2.0.1'
   '@rsbuild/plugin-yaml': '^2.0.0'
-  '@rslint/core': '^0.8.0'
+  '@rslint/core': '^0.8.1'
   '@rspress/core': '^2.0.19'
   '@rspress/plugin-algolia': '^2.0.19'
   '@rspress/plugin-llms': '^2.0.19'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -74,7 +74,6 @@ catalog:
   'express': '^5.2.1'
   'fs-extra': '^11.4.0'
   'get-tsconfig': '5.0.0-beta.6'
-  'globals': '^17.11.0'
   'heading-case': '^1.1.5'
   'http-server': '^14.1.1'
   'lodash': '^4.18.1'

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -1,5 +1,4 @@
-import { defineConfig, js, rstestPlugin, ts } from '@rslint/core';
-import globals from 'globals';
+import { defineConfig, globals, js, rstestPlugin, ts } from '@rslint/core';
 
 export default defineConfig([
   {

--- a/rslint.config.ts
+++ b/rslint.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, js, ts } from '@rslint/core';
+import { defineConfig, js, rstestPlugin, ts } from '@rslint/core';
 import globals from 'globals';
 
 export default defineConfig([
@@ -43,6 +43,24 @@ export default defineConfig([
     files: ['**/*.cjs'],
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    ...rstestPlugin.configs.recommended,
+    rules: {
+      ...rstestPlugin.configs.recommended.rules,
+      'rstest/expect-expect': [
+        'warn',
+        {
+          assertFunctionNames: [
+            'expect',
+            'assert',
+            'expect*',
+            'createAndValidate',
+          ],
+        },
+      ],
     },
   },
 ]);

--- a/tests/integration/asset/index.test.ts
+++ b/tests/integration/asset/index.test.ts
@@ -520,24 +520,26 @@ test('use Node.js addons', async () => {
   }
 
   // The native fixture is only compatible with Darwin arm64.
-  if (process.platform === 'darwin' && process.arch === 'arm64') {
-    const esmEntries = [
-      'dist/esm/bundle/index.js',
-      'dist/esm/bundleless/index.js',
-    ];
-    for (const entry of esmEntries) {
-      const { addon } = await import(join(fixturePath, entry));
-      expect(typeof addon.readLength).toBe('function');
-    }
+  if (process.platform !== 'darwin' || process.arch !== 'arm64') {
+    return;
+  }
 
-    const cjsEntries = [
-      'dist/cjs/bundle/index.cjs',
-      'dist/cjs/bundleless/index.cjs',
-    ];
-    for (const entry of cjsEntries) {
-      const { addon } = require(join(fixturePath, entry));
-      expect(typeof addon.readLength).toBe('function');
-    }
+  const esmEntries = [
+    'dist/esm/bundle/index.js',
+    'dist/esm/bundleless/index.js',
+  ];
+  for (const entry of esmEntries) {
+    const { addon } = await import(join(fixturePath, entry));
+    expect(typeof addon.readLength).toBe('function');
+  }
+
+  const cjsEntries = [
+    'dist/cjs/bundle/index.cjs',
+    'dist/cjs/bundleless/index.cjs',
+  ];
+  for (const entry of cjsEntries) {
+    const { addon } = require(join(fixturePath, entry));
+    expect(typeof addon.readLength).toBe('function');
   }
 });
 

--- a/tests/integration/banner-footer/index.test.ts
+++ b/tests/integration/banner-footer/index.test.ts
@@ -32,24 +32,25 @@ test('banner and footer should work in js, css and dts', async () => {
     type: 'js' | 'css' | 'dts',
   ) => {
     for (const content of Object.values(contents)) {
-      if (content) {
-        const expectedBanner =
-          type === 'js'
-            ? BannerFooter.JS_BANNER
-            : type === 'css'
-              ? BannerFooter.CSS_BANNER
-              : BannerFooter.DTS_BANNER;
-        const expectedFooter =
-          type === 'js'
-            ? BannerFooter.JS_FOOTER
-            : type === 'css'
-              ? BannerFooter.CSS_FOOTER
-              : BannerFooter.DTS_FOOTER;
+      if (!content) {
+        continue;
+      }
+      const expectedBanner =
+        type === 'js'
+          ? BannerFooter.JS_BANNER
+          : type === 'css'
+            ? BannerFooter.CSS_BANNER
+            : BannerFooter.DTS_BANNER;
+      const expectedFooter =
+        type === 'js'
+          ? BannerFooter.JS_FOOTER
+          : type === 'css'
+            ? BannerFooter.CSS_FOOTER
+            : BannerFooter.DTS_FOOTER;
 
-        for (const value of Object.values(content)) {
-          expect(value).toContain(expectedBanner);
-          expect(value).toContain(expectedFooter);
-        }
+      for (const value of Object.values(content)) {
+        expect(value).toContain(expectedBanner);
+        expect(value).toContain(expectedFooter);
       }
     }
   };

--- a/tests/integration/cli/build/build.test.ts
+++ b/tests/integration/cli/build/build.test.ts
@@ -69,16 +69,14 @@ describe('build command', async () => {
 
   test('--lib should throw error if not found', async () => {
     await fse.remove(path.join(__dirname, 'dist'));
-    try {
-      await buildAndGetResults({
+    await expect(
+      buildAndGetResults({
         fixturePath: __dirname,
         lib: ['not-exist'],
-      });
-    } catch (error) {
-      expect((error as Error).message).toMatchInlineSnapshot(
-        `"The following libs are not found: "not-exist"."`,
-      );
-    }
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: The following libs are not found: "not-exist".]`,
+    );
     expect(fse.existsSync(path.join(__dirname, 'dist'))).toBe(false);
   });
 

--- a/tests/integration/config-check/index.test.ts
+++ b/tests/integration/config-check/index.test.ts
@@ -1,16 +1,11 @@
 import { join } from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expect, test } from '@rstest/core';
-import { buildAndGetResults } from 'test-helper';
+import { buildAndGetResults, expectBuildToFail } from 'test-helper';
 
 test('should throw error when lib array not exists or empty', async () => {
   const fixturePath = join(__dirname, 'lib-array');
-  const error = await buildAndGetResults({ fixturePath }).then(
-    () => {
-      throw new Error('Expected build to throw.');
-    },
-    (error: Error) => error,
-  );
+  const error = await expectBuildToFail(buildAndGetResults({ fixturePath }));
   expect(stripAnsi(error.message)).toMatchInlineSnapshot(
     `"Expect "lib" field to be a non-empty array, but got: []."`,
   );

--- a/tests/integration/config-check/index.test.ts
+++ b/tests/integration/config-check/index.test.ts
@@ -5,11 +5,13 @@ import { buildAndGetResults } from 'test-helper';
 
 test('should throw error when lib array not exists or empty', async () => {
   const fixturePath = join(__dirname, 'lib-array');
-  try {
-    await buildAndGetResults({ fixturePath });
-  } catch (error) {
-    expect(stripAnsi((error as Error).message)).toMatchInlineSnapshot(
-      `"Expect "lib" field to be a non-empty array, but got: []."`,
-    );
-  }
+  const error = await buildAndGetResults({ fixturePath }).then(
+    () => {
+      throw new Error('Expected build to throw.');
+    },
+    (error: Error) => error,
+  );
+  expect(stripAnsi(error.message)).toMatchInlineSnapshot(
+    `"Expect "lib" field to be a non-empty array, but got: []."`,
+  );
 });

--- a/tests/integration/dts-tsgo/bundle-false/index.test.ts
+++ b/tests/integration/dts-tsgo/bundle-false/index.test.ts
@@ -143,13 +143,15 @@ describe('dts with tsgo when bundle: false', () => {
     const fixturePath = join(__dirname, 'tsconfig-path');
     await createTempFiles(fixturePath, false);
 
-    try {
-      await buildAndGetResults({ fixturePath, type: 'dts' });
-    } catch (err: any) {
-      expect(stripAnsi(err.message)).toMatchInlineSnapshot(
-        `"Failed to resolve tsconfig file "<ROOT>/tests/integration/dts-tsgo/bundle-false/tsconfig-path/path_not_exist/tsconfig.json" from <ROOT>/tests/integration/dts-tsgo/bundle-false/tsconfig-path. Please ensure that the file exists."`,
-      );
-    }
+    const err = await buildAndGetResults({ fixturePath, type: 'dts' }).then(
+      () => {
+        throw new Error('Expected build to throw.');
+      },
+      (err: any) => err,
+    );
+    expect(stripAnsi(err.message)).toMatchInlineSnapshot(
+      `"Failed to resolve tsconfig file "<ROOT>/tests/integration/dts-tsgo/bundle-false/tsconfig-path/path_not_exist/tsconfig.json" from <ROOT>/tests/integration/dts-tsgo/bundle-false/tsconfig-path. Please ensure that the file exists."`,
+    );
   });
 
   test('alias', async () => {

--- a/tests/integration/dts-tsgo/bundle-false/index.test.ts
+++ b/tests/integration/dts-tsgo/bundle-false/index.test.ts
@@ -5,6 +5,7 @@ import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import {
   buildAndGetResults,
   createTempFiles,
+  expectBuildToFail,
   globContentJSON,
   queryContent,
   runCliSync,
@@ -143,11 +144,8 @@ describe('dts with tsgo when bundle: false', () => {
     const fixturePath = join(__dirname, 'tsconfig-path');
     await createTempFiles(fixturePath, false);
 
-    const err = await buildAndGetResults({ fixturePath, type: 'dts' }).then(
-      () => {
-        throw new Error('Expected build to throw.');
-      },
-      (err: any) => err,
+    const err = await expectBuildToFail(
+      buildAndGetResults({ fixturePath, type: 'dts' }),
     );
     expect(stripAnsi(err.message)).toMatchInlineSnapshot(
       `"Failed to resolve tsconfig file "<ROOT>/tests/integration/dts-tsgo/bundle-false/tsconfig-path/path_not_exist/tsconfig.json" from <ROOT>/tests/integration/dts-tsgo/bundle-false/tsconfig-path. Please ensure that the file exists."`,

--- a/tests/integration/dts/bundle-false/index.test.ts
+++ b/tests/integration/dts/bundle-false/index.test.ts
@@ -182,13 +182,15 @@ describe('dts when bundle: false', () => {
     const fixturePath = join(__dirname, 'tsconfig-path');
     await createTempFiles(fixturePath, false);
 
-    try {
-      await buildAndGetResults({ fixturePath, type: 'dts' });
-    } catch (err: any) {
-      expect(stripAnsi(err.message)).toMatchInlineSnapshot(
-        `"Failed to resolve tsconfig file "<ROOT>/tests/integration/dts/bundle-false/tsconfig-path/path_not_exist/tsconfig.json" from <ROOT>/tests/integration/dts/bundle-false/tsconfig-path. Please ensure that the file exists."`,
-      );
-    }
+    const err = await buildAndGetResults({ fixturePath, type: 'dts' }).then(
+      () => {
+        throw new Error('Expected build to throw.');
+      },
+      (err: any) => err,
+    );
+    expect(stripAnsi(err.message)).toMatchInlineSnapshot(
+      `"Failed to resolve tsconfig file "<ROOT>/tests/integration/dts/bundle-false/tsconfig-path/path_not_exist/tsconfig.json" from <ROOT>/tests/integration/dts/bundle-false/tsconfig-path. Please ensure that the file exists."`,
+    );
   });
 
   test('alias', async () => {

--- a/tests/integration/dts/bundle-false/index.test.ts
+++ b/tests/integration/dts/bundle-false/index.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from '@rstest/core';
 import {
   buildAndGetResults,
   createTempFiles,
+  expectBuildToFail,
   globContentJSON,
   queryContent,
   runCliSync,
@@ -182,11 +183,8 @@ describe('dts when bundle: false', () => {
     const fixturePath = join(__dirname, 'tsconfig-path');
     await createTempFiles(fixturePath, false);
 
-    const err = await buildAndGetResults({ fixturePath, type: 'dts' }).then(
-      () => {
-        throw new Error('Expected build to throw.');
-      },
-      (err: any) => err,
+    const err = await expectBuildToFail(
+      buildAndGetResults({ fixturePath, type: 'dts' }),
     );
     expect(stripAnsi(err.message)).toMatchInlineSnapshot(
       `"Failed to resolve tsconfig file "<ROOT>/tests/integration/dts/bundle-false/tsconfig-path/path_not_exist/tsconfig.json" from <ROOT>/tests/integration/dts/bundle-false/tsconfig-path. Please ensure that the file exists."`,

--- a/tests/integration/dts/bundle/index.test.ts
+++ b/tests/integration/dts/bundle/index.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from '@rstest/core';
 import {
   buildAndGetResults,
   createTempFiles,
+  expectBuildToFail,
   proxyConsole,
   queryContent,
   runCliSync,
@@ -229,11 +230,8 @@ describe('dts when bundle: true', () => {
     const fixturePath = join(__dirname, 'no-entry');
     const { restore } = proxyConsole();
 
-    const err = await buildAndGetResults({ fixturePath, type: 'dts' }).then(
-      () => {
-        throw new Error('Expected build to throw.');
-      },
-      (err: any) => err,
+    const err = await expectBuildToFail(
+      buildAndGetResults({ fixturePath, type: 'dts' }),
     );
     expect(stripAnsi(err.message)).toMatchInlineSnapshot(
       `"Can not find a valid entry for dts.bundle option, please check your entry config."`,

--- a/tests/integration/dts/bundle/index.test.ts
+++ b/tests/integration/dts/bundle/index.test.ts
@@ -229,13 +229,15 @@ describe('dts when bundle: true', () => {
     const fixturePath = join(__dirname, 'no-entry');
     const { restore } = proxyConsole();
 
-    try {
-      await buildAndGetResults({ fixturePath, type: 'dts' });
-    } catch (err: any) {
-      expect(stripAnsi(err.message)).toMatchInlineSnapshot(
-        `"Can not find a valid entry for dts.bundle option, please check your entry config."`,
-      );
-    }
+    const err = await buildAndGetResults({ fixturePath, type: 'dts' }).then(
+      () => {
+        throw new Error('Expected build to throw.');
+      },
+      (err: any) => err,
+    );
+    expect(stripAnsi(err.message)).toMatchInlineSnapshot(
+      `"Can not find a valid entry for dts.bundle option, please check your entry config."`,
+    );
 
     restore();
   });

--- a/tests/integration/env-define/index.test.ts
+++ b/tests/integration/env-define/index.test.ts
@@ -49,6 +49,7 @@ test('cjs preserves `process.env.*` and replaces `import.meta.env.*` with undefi
 // Rspack has temporarily reverted the warning emitted when an unknown
 // `import.meta` property is replaced with `undefined`. Re-enable once that
 // warning is reinstated upstream.
+// rslint-disable-next-line rstest/no-disabled-tests
 test.skip('cjs warns about unknown `import.meta` properties', async () => {
   const fixturePath = __dirname;
   const { logs, restore } = proxyConsole('warn');

--- a/tests/integration/preserve-jsx/index.test.ts
+++ b/tests/integration/preserve-jsx/index.test.ts
@@ -1,7 +1,12 @@
 import { join } from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expect, test } from '@rstest/core';
-import { buildAndGetResults, proxyConsole, queryContent } from 'test-helper';
+import {
+  buildAndGetResults,
+  expectBuildToFail,
+  proxyConsole,
+  queryContent,
+} from 'test-helper';
 
 test('JSX syntax should be preserved', async () => {
   const fixturePath = join(__dirname, 'default');
@@ -46,13 +51,7 @@ test('throw error when preserve JSX with bundle mode', async () => {
   const fixturePath = join(__dirname, 'forbid-bundle');
   const { logs, restore } = proxyConsole();
 
-  try {
-    await buildAndGetResults({ fixturePath });
-  } catch {
-    // The build error is expected; its log is asserted below.
-  } finally {
-    restore();
-  }
+  await expectBuildToFail(buildAndGetResults({ fixturePath })).finally(restore);
 
   expect(logs.map((l) => stripAnsi(l))).toMatchInlineSnapshot(`
     [

--- a/tests/integration/preserve-jsx/index.test.ts
+++ b/tests/integration/preserve-jsx/index.test.ts
@@ -49,14 +49,16 @@ test('throw error when preserve JSX with bundle mode', async () => {
   try {
     await buildAndGetResults({ fixturePath });
   } catch {
-    expect(logs.map((l) => stripAnsi(l))).toMatchInlineSnapshot(`
-      [
-        "error   Bundle mode does not support preserving JSX syntax. Set "bundle" to "false" or change the JSX runtime to \`automatic\` or \`classic\`. Check out https://rslib.rs/guide/solution/react#jsx-transform for more details.",
-      ]
-    `);
+    // The build error is expected; its log is asserted below.
   } finally {
     restore();
   }
+
+  expect(logs.map((l) => stripAnsi(l))).toMatchInlineSnapshot(`
+    [
+      "error   Bundle mode does not support preserving JSX syntax. Set "bundle" to "false" or change the JSX runtime to \`automatic\` or \`classic\`. Check out https://rslib.rs/guide/solution/react#jsx-transform for more details.",
+    ]
+  `);
 });
 
 test('preserve JSX in bundleless mode should not throw error when coexisting with bundle mode', async () => {

--- a/tests/scripts/helper.ts
+++ b/tests/scripts/helper.ts
@@ -133,3 +133,18 @@ export const expectLog = (child: ChildProcess, log: string) =>
 
 export const expectBuildEnd = (child: ChildProcess) =>
   expectLog(child, 'built in');
+
+/**
+ * Expect a build promise to reject and return its error.
+ */
+export const expectBuildToFail = async (
+  buildPromise: Promise<unknown>,
+): Promise<Error> => {
+  const error = await buildPromise.then(
+    () => undefined,
+    (error: unknown) => error,
+  );
+
+  expect(error).toBeInstanceOf(Error);
+  return error as Error;
+};


### PR DESCRIPTION
## Summary

- Upgrade `@rslint/core` from 0.8.0 to 0.8.1 and enable the recommended Rstest rules for test files.
- Address the most impactful rule, `rstest/no-conditional-expect`, by moving assertions out of conditional branches and using rejection assertions or early returns where appropriate. Keep the rules enabled because they exposed tests that could silently pass when an expected error was not thrown, demonstrating value beyond stylistic enforcement.
- Keep the intentional skipped test for an upstream issue with a targeted `// rslint-disable-next-line rstest/no-disabled-tests` comment.

## Related Links

- https://github.com/web-infra-dev/rslint/releases/tag/v0.8.1

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
