### PR TITLE
chore(deps): upgrade Rslib to 1.0.0-rc.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,8 +251,8 @@ catalogs:
       specifier: ^1.0.0
       version: 1.0.0
     rslib:
-      specifier: npm:@rslib/core@1.0.0-beta.3
-      version: 1.0.0-beta.3
+      specifier: npm:@rslib/core@1.0.0-rc.0
+      version: 1.0.0-rc.0
     rslog:
       specifier: ^2.3.0
       version: 2.3.0
@@ -325,7 +325,7 @@ importers:
         version: 0.8.0(jiti@2.7.0)
       '@rstest/adapter-rslib':
         specifier: 'catalog:'
-        version: 0.11.8(@rslib/core@1.0.0-beta.3)(@rstest/core@0.11.8)(typescript@7.0.2)
+        version: 0.11.8(@rslib/core@1.0.0-rc.0)(@rstest/core@0.11.8)(typescript@7.0.2)
       '@rstest/core':
         specifier: 'catalog:'
         version: 0.11.8(@module-federation/runtime-tools@2.8.2)
@@ -678,7 +678,7 @@ importers:
         version: 1.0.0(@rsbuild/core@2.2.0-beta.1)
       rslib:
         specifier: 'catalog:'
-        version: '@rslib/core@1.0.0-beta.3(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
+        version: '@rslib/core@1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
       rslog:
         specifier: 'catalog:'
         version: 2.3.0
@@ -715,7 +715,7 @@ importers:
         version: 1.0.0(@rsbuild/core@2.1.13)
       rslib:
         specifier: 'catalog:'
-        version: '@rslib/core@1.0.0-beta.3(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
+        version: '@rslib/core@1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
       tsx:
         specifier: 'catalog:'
         version: 4.23.12
@@ -749,7 +749,7 @@ importers:
         version: 1.0.0(@rsbuild/core@2.2.0-beta.1)
       rslib:
         specifier: 'catalog:'
-        version: '@rslib/core@1.0.0-beta.3(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
+        version: '@rslib/core@1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
       tinyglobby:
         specifier: 'catalog:'
         version: 0.2.17
@@ -3124,8 +3124,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@1.0.0-beta.3':
-    resolution: {integrity: sha512-OtfmaBoGlHo1KYvQ3+B0ZLy3zUsAdoRZfWieaxoJMJ9uKAws2//afFgvUqeSDkkSJDlp8TDdgt4hib+QaFOaGQ==}
+  '@rslib/core@1.0.0-rc.0':
+    resolution: {integrity: sha512-JpMVCAILFF9BSB13DbPPLeqGm5My/vCsy3enqBZqnBOUXCJ5d1NuQH+K0d+35DQTsPAMWmGMHCKF8lxxMBWZyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -6873,8 +6873,8 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  rsbuild-plugin-dts@1.0.0-beta.3:
-    resolution: {integrity: sha512-Q8x/yyOsy8sNR8sHn0xuZsul7ErT5kXkTmDwCIxQ8esiMCW7QKjfyXDa4kvTxWn7oSQ5NP/O6qZM2vEA07thKw==}
+  rsbuild-plugin-dts@1.0.0-rc.0:
+    resolution: {integrity: sha512-eQJYXzmEY0YKNadXORdgIk/+t8Cw3+Y6s/haJZUv9pyRuBwAK1XKvkd+ucsYxa6ZsnGpD9ZbPBOW2sqgvCyc6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -9684,10 +9684,10 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
 
-  '@rslib/core@1.0.0-beta.3(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)':
+  '@rslib/core@1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)
-      rsbuild-plugin-dts: 1.0.0-beta.3(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.13)(typescript@7.0.2)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      rsbuild-plugin-dts: 1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.2.0-beta.1)(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2
@@ -10008,9 +10008,9 @@ snapshots:
 
   '@rstackjs/create-toolkit@2.2.3': {}
 
-  '@rstest/adapter-rslib@0.11.8(@rslib/core@1.0.0-beta.3)(@rstest/core@0.11.8)(typescript@7.0.2)':
+  '@rstest/adapter-rslib@0.11.8(@rslib/core@1.0.0-rc.0)(@rstest/core@0.11.8)(typescript@7.0.2)':
     dependencies:
-      '@rslib/core': 1.0.0-beta.3(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)
+      '@rslib/core': 1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)
       '@rstest/core': 0.11.8(@module-federation/runtime-tools@2.8.2)
     optionalDependencies:
       typescript: 7.0.2
@@ -13975,10 +13975,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@1.0.0-beta.3(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.1.13)(typescript@7.0.2):
+  rsbuild-plugin-dts@1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.2.0-beta.1)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,7 +95,7 @@ catalog:
   'rsbuild-plugin-google-analytics': '1.0.6'
   'rsbuild-plugin-open-graph': '^1.1.3'
   'rsbuild-plugin-publint': '^1.0.0'
-  'rslib': 'npm:@rslib/core@1.0.0-beta.3'
+  'rslib': 'npm:@rslib/core@1.0.0-rc.0'
   'rslog': '^2.3.0'
   'rspress-plugin-file-tree': '^1.0.5'
   'rspress-plugin-font-open-sans': '^1.0.4'


### PR DESCRIPTION
## Summary

Upgrade the repository's bootstrap Rslib dependency from 1.0.0-beta.3 to 1.0.0-rc.0 so self-hosted builds use the current release candidate. Generated outputs for @rslib/core, rsbuild-plugin-dts, and create-rslib remain byte-for-byte identical after the upgrade.

## Related Links

https://github.com/web-infra-dev/rslib/releases/tag/v1.0.0-rc.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).