### PR TITLE
fix: keep scheme-less loader requests bundled

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -72,6 +72,17 @@ import {
 import { loadTsconfig } from './utils/tsconfig';
 import { composeWasmConfig, resolveWasmMode } from './wasm/compose';
 
+// Mirrors get_scheme() in rspack's loader runner. `builtin:` is intentionally
+// treated as scheme-less because Rspack uses it for inline builtin loaders.
+const hasScheme = (request: string) =>
+  /^[A-Za-z][A-Za-z0-9+-]*:/.test(request) &&
+  !/^builtin:/i.test(request) &&
+  !/^[A-Za-z]:[\\/#?]/.test(request);
+
+export function isInlineLoaderRequest(request: string): boolean {
+  return request.includes('!') && !hasScheme(request);
+}
+
 export function composeMinifyConfig(config: LibConfig): EnvironmentConfig {
   const minify = config.output?.minify;
   const format = config.format;
@@ -1282,15 +1293,6 @@ const composeBundlelessExternalConfig = (
     typeof request === 'string' &&
     request.includes('rspack-vue-loader') &&
     (suffix ? request.includes(suffix) : true);
-
-  // Mirrors get_scheme() in rspack's loader runner. Requests without a URI
-  // scheme are split on every `!` by NormalModuleFactory, so any `!` in such
-  // a request identifies an inline loader request and must not be externalized.
-  const hasScheme = (request: string) =>
-    /^[A-Za-z][A-Za-z0-9+-]*:/.test(request) &&
-    !/^[A-Za-z]:[\\/#?]/.test(request);
-  const isInlineLoaderRequest = (request: string) =>
-    request.includes('!') && !hasScheme(request);
 
   const isPathInOutBase = (resourcePath: string, outBase: string) => {
     const normalizedOutBase = normalizeSlash(outBase).replace(/\/+$/, '');

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1283,6 +1283,15 @@ const composeBundlelessExternalConfig = (
     request.includes('rspack-vue-loader') &&
     (suffix ? request.includes(suffix) : true);
 
+  // Mirrors get_scheme() in rspack's loader runner. Requests without a URI
+  // scheme are split on every `!` by NormalModuleFactory, so any `!` in such
+  // a request identifies an inline loader request and must not be externalized.
+  const hasScheme = (request: string) =>
+    /^[A-Za-z][A-Za-z0-9+-]*:/.test(request) &&
+    !/^[A-Za-z]:[\\/#?]/.test(request);
+  const isInlineLoaderRequest = (request: string) =>
+    request.includes('!') && !hasScheme(request);
+
   const isPathInOutBase = (resourcePath: string, outBase: string) => {
     const normalizedOutBase = normalizeSlash(outBase).replace(/\/+$/, '');
     const normalizedResourcePath = normalizeSlash(resourcePath);
@@ -1408,12 +1417,11 @@ const composeBundlelessExternalConfig = (
                 return;
               }
 
-              // Keep vue-loader generated virtual block requests and helper
-              // modules bundled so they don't leak loader internals into
-              // bundleless output.
+              // Keep loader requests and vue-loader helper modules bundled so
+              // they don't leak loader internals into bundleless output.
               if (
-                isRspackVueLoaderRequest(request, 'dist/exportHelper.js') ||
-                isRspackVueLoaderRequest(request, '?vue&type=')
+                isInlineLoaderRequest(request) ||
+                isRspackVueLoaderRequest(request, 'dist/exportHelper.js')
               ) {
                 callback();
                 return;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -72,17 +72,6 @@ import {
 import { loadTsconfig } from './utils/tsconfig';
 import { composeWasmConfig, resolveWasmMode } from './wasm/compose';
 
-// Mirrors get_scheme() in rspack's loader runner. `builtin:` is intentionally
-// treated as scheme-less because Rspack uses it for inline builtin loaders.
-const hasScheme = (request: string) =>
-  /^[A-Za-z][A-Za-z0-9+-]*:/.test(request) &&
-  !/^builtin:/i.test(request) &&
-  !/^[A-Za-z]:[\\/#?]/.test(request);
-
-export function isInlineLoaderRequest(request: string): boolean {
-  return request.includes('!') && !hasScheme(request);
-}
-
 export function composeMinifyConfig(config: LibConfig): EnvironmentConfig {
   const minify = config.output?.minify;
   const format = config.format;
@@ -1273,6 +1262,17 @@ const composeEntryConfig = async (
     outBase,
   };
 };
+
+// Mirrors get_scheme() in rspack's loader runner. `builtin:` is intentionally
+// treated as scheme-less because Rspack uses it for inline builtin loaders.
+const hasScheme = (request: string) =>
+  /^[A-Za-z][A-Za-z0-9+-]*:/.test(request) &&
+  !/^builtin:/i.test(request) &&
+  !/^[A-Za-z]:[\\/#?]/.test(request);
+
+export function isInlineLoaderRequest(request: string): boolean {
+  return request.includes('!') && !hasScheme(request);
+}
 
 const composeBundlelessExternalConfig = (
   jsExtension: string,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1263,8 +1263,10 @@ const composeEntryConfig = async (
   };
 };
 
-// Mirrors get_scheme() in rspack's loader runner. `builtin:` is intentionally
-// treated as scheme-less because Rspack uses it for inline builtin loaders.
+// Mirrors get_scheme() in Rspack's loader runner:
+// https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_loader_runner/src/scheme.rs#L38-L42
+// `builtin:` is intentionally treated as scheme-less because Rspack uses it
+// for inline builtin loaders.
 const hasScheme = (request: string) =>
   /^[A-Za-z][A-Za-z0-9+-]*:/.test(request) &&
   !/^builtin:/i.test(request) &&

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -9,6 +9,7 @@ import { init, initCliAction } from '../src/cli/init';
 import {
   composeCreateRsbuildConfig,
   composeRsbuildEnvironments,
+  isInlineLoaderRequest,
 } from '../src/config';
 import { createRslib } from '../src/createRslib';
 import { loadConfig } from '../src/loadConfig';
@@ -18,6 +19,17 @@ import { normalizeSlash } from '../src/utils/helper';
 import { logger } from '../src/utils/logger';
 
 rs.mock('rslog');
+
+describe('bundleless loader request detection', () => {
+  test('matches Rspack scheme handling', () => {
+    expect(isInlineLoaderRequest('builtin:swc-loader!./value.js')).toBe(true);
+    expect(isInlineLoaderRequest('BUILTIN:swc-loader!./value.js')).toBe(true);
+    expect(isInlineLoaderRequest('./value.js!loader')).toBe(true);
+    expect(isInlineLoaderRequest('data:text/javascript!value')).toBe(false);
+    expect(isInlineLoaderRequest('foo-bar:payload!text')).toBe(false);
+    expect(isInlineLoaderRequest('C:/value.js!text')).toBe(true);
+  });
+});
 
 describe('Should load config file correctly', () => {
   test('Load config.js in cjs project', async () => {

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -1394,9 +1394,10 @@ describe('wasm', () => {
 });
 
 describe('bundleless loader request detection', () => {
-  test('matches Rspack scheme handling', () => {
+  test('matches Rspack scheme handling case-insensitively', () => {
     expect(isInlineLoaderRequest('builtin:swc-loader!./value.js')).toBe(true);
     expect(isInlineLoaderRequest('BUILTIN:swc-loader!./value.js')).toBe(true);
+    expect(isInlineLoaderRequest('BuIlTiN:swc-loader!./value.js')).toBe(true);
     expect(isInlineLoaderRequest('./value.js!loader')).toBe(true);
     expect(isInlineLoaderRequest('data:text/javascript!value')).toBe(false);
     expect(isInlineLoaderRequest('foo-bar:payload!text')).toBe(false);

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -20,17 +20,6 @@ import { logger } from '../src/utils/logger';
 
 rs.mock('rslog');
 
-describe('bundleless loader request detection', () => {
-  test('matches Rspack scheme handling', () => {
-    expect(isInlineLoaderRequest('builtin:swc-loader!./value.js')).toBe(true);
-    expect(isInlineLoaderRequest('BUILTIN:swc-loader!./value.js')).toBe(true);
-    expect(isInlineLoaderRequest('./value.js!loader')).toBe(true);
-    expect(isInlineLoaderRequest('data:text/javascript!value')).toBe(false);
-    expect(isInlineLoaderRequest('foo-bar:payload!text')).toBe(false);
-    expect(isInlineLoaderRequest('C:/value.js!text')).toBe(true);
-  });
-});
-
 describe('Should load config file correctly', () => {
   test('Load config.js in cjs project', async () => {
     const fixtureDir = join(__dirname, 'fixtures/config/cjs');
@@ -1402,4 +1391,15 @@ describe('wasm', () => {
       );
     },
   );
+});
+
+describe('bundleless loader request detection', () => {
+  test('matches Rspack scheme handling', () => {
+    expect(isInlineLoaderRequest('builtin:swc-loader!./value.js')).toBe(true);
+    expect(isInlineLoaderRequest('BUILTIN:swc-loader!./value.js')).toBe(true);
+    expect(isInlineLoaderRequest('./value.js!loader')).toBe(true);
+    expect(isInlineLoaderRequest('data:text/javascript!value')).toBe(false);
+    expect(isInlineLoaderRequest('foo-bar:payload!text')).toBe(false);
+    expect(isInlineLoaderRequest('C:/value.js!text')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- Keep requests without a URI scheme and containing `!` bundled, since Rspack treats `!` as a loader separator.
- Preserve externalization for scheme-based requests. For example, `data:text/javascript,export const bang = "a!b!c"` contains `!` as module content rather than loader syntax.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).