### PR TITLE
refactor: migrate to Rsbuild splitChunks config

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -238,10 +238,10 @@ export async function createConstantRsbuildConfig(): Promise<EnvironmentConfig> 
   // When the default configuration is inconsistent with rsbuild, remember to modify the type hints
   // see https://github.com/web-infra-dev/rslib/discussions/856
   return defineRsbuildConfig({
+    splitChunks: {
+      preset: 'none',
+    },
     performance: {
-      chunkSplit: {
-        strategy: 'custom',
-      },
       buildCache: true,
     },
     tools: {

--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -1084,9 +1084,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   optimization: {
     minimize: true,
-    splitChunks: {
-      chunks: 'async'
-    },
     minimizer: [
       /* config.optimization.minimizer('js') */
       new SwcJsMinimizerRspackPlugin(
@@ -1116,6 +1113,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     concatenateModules: false,
     sideEffects: true,
     avoidEntryIife: true,
+    splitChunks: {
+      chunks: 'async'
+    },
     moduleIds: 'named'
   },
   plugins: [
@@ -1943,9 +1943,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   optimization: {
     minimize: true,
-    splitChunks: {
-      chunks: 'async'
-    },
     minimizer: [
       /* config.optimization.minimizer('js') */
       new SwcJsMinimizerRspackPlugin(
@@ -1972,6 +1969,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       )
     ],
     nodeEnv: false,
+    splitChunks: {
+      chunks: 'async'
+    },
     moduleIds: 'named'
   },
   plugins: [
@@ -2713,7 +2713,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   optimization: {
     minimize: true,
-    splitChunks: false,
     minimizer: [
       /* config.optimization.minimizer('js') */
       new SwcJsMinimizerRspackPlugin(
@@ -2740,6 +2739,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       )
     ],
     nodeEnv: 'production',
+    splitChunks: false,
     moduleIds: 'named'
   },
   plugins: [
@@ -3490,7 +3490,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   optimization: {
     minimize: true,
-    splitChunks: false,
     minimizer: [
       /* config.optimization.minimizer('js') */
       new SwcJsMinimizerRspackPlugin(
@@ -3518,6 +3517,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       )
     ],
     nodeEnv: 'production',
+    splitChunks: false,
     moduleIds: 'named'
   },
   plugins: [
@@ -4203,8 +4203,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   optimization: {
     minimize: true,
     splitChunks: {
-      chunks: 'all',
-      cacheGroups: {}
+      chunks: 'all'
     },
     minimizer: [
       /* config.optimization.minimizer('js') */
@@ -4382,9 +4381,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     },
     "performance": {
       "buildCache": true,
-      "chunkSplit": {
-        "strategy": "custom",
-      },
     },
     "plugins": [
       {
@@ -4412,6 +4408,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     "source": {
       "entry": {},
       "preEntry": "./b.js",
+    },
+    "splitChunks": {
+      "preset": "none",
     },
     "tools": {
       "htmlPlugin": false,
@@ -4649,9 +4648,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     },
     "performance": {
       "buildCache": true,
-      "chunkSplit": {
-        "strategy": "custom",
-      },
     },
     "plugins": [
       {
@@ -4687,6 +4683,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
         "./c.js",
         "./d.js",
       ],
+    },
+    "splitChunks": {
+      "preset": "none",
     },
     "tools": {
       "htmlPlugin": false,
@@ -4912,9 +4911,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     },
     "performance": {
       "buildCache": true,
-      "chunkSplit": {
-        "strategy": "custom",
-      },
     },
     "plugins": [
       {
@@ -4935,6 +4931,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     "source": {
       "entry": {},
       "preEntry": "./a.js",
+    },
+    "splitChunks": {
+      "preset": "none",
     },
     "tools": {
       "htmlPlugin": false,
@@ -5149,9 +5148,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     },
     "performance": {
       "buildCache": true,
-      "chunkSplit": {
-        "strategy": "custom",
-      },
     },
     "plugins": [
       {
@@ -5172,6 +5168,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     "source": {
       "entry": {},
       "preEntry": "./a.js",
+    },
+    "splitChunks": {
+      "preset": "none",
     },
     "tools": {
       "htmlPlugin": false,
@@ -5337,9 +5336,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     },
     "performance": {
       "buildCache": true,
-      "chunkSplit": {
-        "strategy": "custom",
-      },
     },
     "plugins": [
       {
@@ -5364,6 +5360,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     "source": {
       "entry": {},
       "preEntry": "./a.js",
+    },
+    "splitChunks": {
+      "preset": "none",
     },
     "tools": {
       "htmlPlugin": false,


### PR DESCRIPTION
## Summary

Rsbuild v2 deprecates `performance.chunkSplit` in favor of the top-level `splitChunks` option. This PR migrates Rslib's built-in custom chunk splitting configuration to `preset: 'none'` and refreshes the existing config snapshots while preserving build cache behavior.

## Related Links

- https://rsbuild.rs/guide/upgrade/v1-to-v2#migrate-performancechunksplit

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).