### PR TITLE
feat(deps): upgrade Rsbuild to 2.2.0-beta.2

### DIFF
--- a/packages/core/tests/__snapshots__/config.test.ts.snap
+++ b/packages/core/tests/__snapshots__/config.test.ts.snap
@@ -308,7 +308,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    nativeWatcher: true,
     sourceImport: true
   },
   devtool: false,
@@ -1084,6 +1083,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   optimization: {
     minimize: true,
+    splitChunks: {
+      chunks: 'async'
+    },
     minimizer: [
       /* config.optimization.minimizer('js') */
       new SwcJsMinimizerRspackPlugin(
@@ -1113,9 +1115,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     concatenateModules: false,
     sideEffects: true,
     avoidEntryIife: true,
-    splitChunks: {
-      chunks: 'async'
-    },
     moduleIds: 'named'
   },
   plugins: [
@@ -1173,7 +1172,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    nativeWatcher: true,
     sourceImport: true
   },
   devtool: false,
@@ -1943,6 +1941,9 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   optimization: {
     minimize: true,
+    splitChunks: {
+      chunks: 'async'
+    },
     minimizer: [
       /* config.optimization.minimizer('js') */
       new SwcJsMinimizerRspackPlugin(
@@ -1969,9 +1970,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       )
     ],
     nodeEnv: false,
-    splitChunks: {
-      chunks: 'async'
-    },
     moduleIds: 'named'
   },
   plugins: [
@@ -2035,7 +2033,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    nativeWatcher: true,
     sourceImport: true
   },
   devtool: false,
@@ -2713,6 +2710,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   optimization: {
     minimize: true,
+    splitChunks: false,
     minimizer: [
       /* config.optimization.minimizer('js') */
       new SwcJsMinimizerRspackPlugin(
@@ -2739,7 +2737,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       )
     ],
     nodeEnv: 'production',
-    splitChunks: false,
     moduleIds: 'named'
   },
   plugins: [
@@ -2808,7 +2805,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    nativeWatcher: true,
     sourceImport: true
   },
   devtool: false,
@@ -3490,6 +3486,7 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
   },
   optimization: {
     minimize: true,
+    splitChunks: false,
     minimizer: [
       /* config.optimization.minimizer('js') */
       new SwcJsMinimizerRspackPlugin(
@@ -3517,7 +3514,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
       )
     ],
     nodeEnv: 'production',
-    splitChunks: false,
     moduleIds: 'named'
   },
   plugins: [
@@ -3586,7 +3582,6 @@ exports[`Should compose create Rsbuild config correctly > Merge Rsbuild config i
     aggregateTimeout: 0
   },
   experiments: {
-    nativeWatcher: true,
     sourceImport: true
   },
   devtool: false,

--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.0-beta.1",
+    "@rsbuild/core": "~2.2.0-beta.2",
     "@storybook/addon-docs": "^10.5.8",
     "@storybook/addon-onboarding": "^10.5.8",
     "@storybook/react": "^10.5.8",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.0-beta.1",
+    "@rsbuild/core": "~2.2.0-beta.2",
     "@storybook/addon-docs": "^10.5.8",
     "@storybook/addon-onboarding": "^10.5.8",
     "@storybook/react": "^10.5.8",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.0-beta.1",
+    "@rsbuild/core": "~2.2.0-beta.2",
     "@storybook/addon-docs": "^10.5.8",
     "@storybook/addon-onboarding": "^10.5.8",
     "@storybook/vue3": "^10.5.8",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.0-beta.1",
+    "@rsbuild/core": "~2.2.0-beta.2",
     "@storybook/addon-docs": "^10.5.8",
     "@storybook/addon-onboarding": "^10.5.8",
     "@storybook/vue3": "^10.5.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ catalogs:
       specifier: ^2.12.0
       version: 2.12.0
     '@rsbuild/core':
-      specifier: ~2.2.0-beta.1
-      version: 2.2.0-beta.1
+      specifier: ~2.2.0-beta.2
+      version: 2.2.0-beta.2
     '@rsbuild/plugin-babel':
       specifier: ^2.0.1
       version: 2.0.1
@@ -391,13 +391,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.10)
+        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.10)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -415,16 +415,16 @@ importers:
         version: 2.8.2(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.10)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.10)
+        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.10)
       '@module-federation/storybook-addon':
         specifier: 'catalog:'
-        version: 6.0.18(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(storybook@10.5.8)(typescript@6.0.3)(vue-tsc@3.3.10)(webpack-virtual-modules@0.6.2)
+        version: 6.0.18(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(storybook@10.5.8)(typescript@6.0.3)(vue-tsc@3.3.10)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -454,10 +454,10 @@ importers:
         version: 10.5.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.0-beta.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
+        version: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(supports-color@9.4.0)(typescript@6.0.3)
+        version: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -473,13 +473,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.10)
+        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.10)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -602,10 +602,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -623,10 +623,10 @@ importers:
         version: 10.5.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.0-beta.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
+        version: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3)(vue@3.5.41)
+        version: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3)(vue@3.5.41)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -641,14 +641,14 @@ importers:
     dependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.10)
+        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.10)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -675,7 +675,7 @@ importers:
         version: 0.6.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.2.0-beta.1)
+        version: 1.0.0(@rsbuild/core@2.2.0-beta.2)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
@@ -734,7 +734,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -746,7 +746,7 @@ importers:
         version: 1.2.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.2.0-beta.1)
+        version: 1.0.0(@rsbuild/core@2.2.0-beta.2)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
@@ -776,34 +776,34 @@ importers:
         version: 4.0.1(debug@4.4.3)(supports-color@9.4.0)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.10)
+        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.10)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2)
       '@rsbuild/plugin-toml':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 'catalog:'
-        version: 1.2.4(@rsbuild/core@2.2.0-beta.1)
+        version: 1.2.4(@rsbuild/core@2.2.0-beta.2)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
       '@rsbuild/plugin-yaml':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.2.0-beta.1)
+        version: 2.0.0(@rsbuild/core@2.2.0-beta.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1320,10 +1320,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.2.0-beta.1)
+        version: 1.4.6(@rsbuild/core@2.2.0-beta.2)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -1333,10 +1333,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.2.0-beta.1)
+        version: 1.4.6(@rsbuild/core@2.2.0-beta.2)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1646,16 +1646,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.10)
+        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.10)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1703,10 +1703,10 @@ importers:
         version: 19.2.8(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: 'catalog:'
-        version: 1.0.6(@rsbuild/core@2.2.0-beta.1)
+        version: 1.0.6(@rsbuild/core@2.2.0-beta.2)
       rsbuild-plugin-open-graph:
         specifier: 'catalog:'
-        version: 1.1.3(@rsbuild/core@2.2.0-beta.1)
+        version: 1.1.3(@rsbuild/core@2.2.0-beta.2)
       rspress-plugin-file-tree:
         specifier: 'catalog:'
         version: 1.0.5(@rspress/core@2.0.19)(supports-color@9.4.0)
@@ -2997,8 +2997,8 @@ packages:
       core-js:
         optional: true
 
-  '@rsbuild/core@2.2.0-beta.1':
-    resolution: {integrity: sha512-P6KOCAA1kgXBCTa4dx/zQV9Wi5uzMxOIledelrm853DJQVGUTs+z3sMII4BHfzLhE6+NsJFq+ohBlAnmyliKHQ==}
+  '@rsbuild/core@2.2.0-beta.2':
+    resolution: {integrity: sha512-Z2Kc0skwc3KWmCN/T7zVqSlSady7Ii+eDNG3+Go7H9XP0oZo7ZN1FXXA0yaV/wJls1swsIKuNhaTU6BeUNIXhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -9146,13 +9146,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.10)':
+  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.10)':
     dependencies:
       '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.10)
       '@module-federation/node': 2.7.49(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.10)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9161,13 +9161,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.10)':
+  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.10)':
     dependencies:
       '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.10)
       '@module-federation/node': 2.7.49(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.10)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9176,13 +9176,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.10)':
+  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.10)':
     dependencies:
       '@module-federation/enhanced': 2.8.2(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.10)
       '@module-federation/node': 2.7.49(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.10)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9260,12 +9260,12 @@ snapshots:
 
   '@module-federation/sdk@2.8.2': {}
 
-  '@module-federation/storybook-addon@6.0.18(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(storybook@10.5.8)(typescript@6.0.3)(vue-tsc@3.3.10)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.18(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(storybook@10.5.8)(typescript@6.0.3)(vue-tsc@3.3.10)(webpack-virtual-modules@0.6.2)':
     dependencies:
       '@module-federation/enhanced': 2.8.2(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.10)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       storybook: 10.5.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -9542,7 +9542,7 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)':
+  '@rsbuild/core@2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)':
     dependencies:
       '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
@@ -9590,19 +9590,19 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
       less-loader: 12.3.3(@rspack/core@2.1.10)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.2.0-beta.1)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.2.0-beta.2)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9628,7 +9628,7 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
 
   '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(preact@10.29.8)':
     dependencies:
@@ -9651,21 +9651,21 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -9679,7 +9679,7 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.0-beta.1)':
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.0-beta.2)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9687,7 +9687,7 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
 
   '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.13)(solid-js@1.9.14)(supports-color@9.4.0)':
     dependencies:
@@ -9756,39 +9756,39 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-toml@2.1.0(@rsbuild/core@2.2.0-beta.1)':
+  '@rsbuild/plugin-toml@2.1.0(@rsbuild/core@2.2.0-beta.2)':
     dependencies:
       toml: 5.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
 
-  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
       ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.1.10)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
       ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.0-beta.1)':
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.0-beta.2)':
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
 
   '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)':
     dependencies:
@@ -9800,26 +9800,26 @@ snapshots:
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)':
     dependencies:
       rspack-vue-loader: 17.5.1(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.2.0-beta.1)':
+  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.2.0-beta.2)':
     dependencies:
       yaml: 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
 
   '@rslib/core@1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
-      rsbuild-plugin-dts: 1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.2.0-beta.1)(typescript@7.0.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      rsbuild-plugin-dts: 1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.2.0-beta.2)(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2
@@ -14129,28 +14129,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.2.0-beta.1)(typescript@7.0.2):
+  rsbuild-plugin-dts@1.0.0-rc.0(@microsoft/api-extractor@7.58.12)(@rsbuild/core@2.2.0-beta.2)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 7.0.2
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.2.0-beta.1):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.2.0-beta.2):
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
 
-  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.2.0-beta.1):
+  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.2.0-beta.2):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.2.0-beta.1):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.2.0-beta.2):
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
 
   rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.13):
     dependencies:
@@ -14158,11 +14158,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.0-beta.1):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.0-beta.2):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
 
   rslog@2.3.0: {}
 
@@ -14538,18 +14538,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.4.2(@rsbuild/core@2.2.0-beta.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3):
+  storybook-addon-rslib@3.4.2(@rsbuild/core@2.2.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
-      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(typescript@6.0.3)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)
       '@vitest/mocker': 3.2.7
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14562,7 +14562,7 @@ snapshots:
       pathe: 2.0.3
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.2.0-beta.1)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.2.0-beta.2)
       sirv: 2.0.4
       storybook: 10.5.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       ts-dedent: 2.3.0
@@ -14579,10 +14579,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-builder-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
-      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)
       '@vitest/mocker': 3.2.7
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14595,7 +14595,7 @@ snapshots:
       pathe: 2.0.3
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.2.0-beta.1)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.2.0-beta.2)
       sirv: 2.0.4
       storybook: 10.5.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       ts-dedent: 2.3.0
@@ -14612,10 +14612,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(supports-color@9.4.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.4.0
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@storybook/react': 10.5.8(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(supports-color@9.4.0)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(supports-color@9.4.0)(typescript@6.0.3)
       find-up: 5.0.0
@@ -14626,7 +14626,7 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
       storybook: 10.5.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14641,12 +14641,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3)(vue@3.5.41):
+  storybook-vue3-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3)(vue@3.5.41):
     dependencies:
-      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
       '@storybook/vue3': 10.5.8(storybook@10.5.8)(vue@3.5.41)
       storybook: 10.5.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(typescript@6.0.3)
       vue: 3.5.41(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.41)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalog:
   '@module-federation/storybook-addon': '^6.0.18'
   '@playwright/test': '1.62.1'
   '@reduxjs/toolkit': '^2.12.0'
-  '@rsbuild/core': '~2.2.0-beta.1'
+  '@rsbuild/core': '~2.2.0-beta.2'
   '@rsbuild/plugin-babel': '^2.0.1'
   '@rsbuild/plugin-less': '^2.0.1'
   '@rsbuild/plugin-node-polyfill': '^1.4.6'


### PR DESCRIPTION
## Summary

This PR keeps Rslib aligned with the latest Rsbuild 2.2 beta by upgrading `@rsbuild/core` to `2.2.0-beta.2`. It also synchronizes the create-rslib Storybook templates, deduplicates the lockfile resolution, and refreshes config snapshots for beta.2 behavior.

## Related Links

- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.2.0-beta.2

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).