### PR TITLE
chore(ci): allow ecosystem CI to update PR comments

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -42,8 +42,7 @@ jobs:
     if: github.repository == 'web-infra-dev/rslib' && github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Trigger Ecosystem CI
         uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_dispatch@4b0ec855ccbd27595a0df4781ed58b77e64d25ee # v0.3.5


### PR DESCRIPTION
## Summary

This PR allows the manually dispatched ecosystem CI job to update pull request comments by granting the required `pull-requests: write` permission and removing the no-longer-needed issue permission.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).