### PR TITLE
feat(deps): upgrade Rsbuild to 2.2.0-rc.0

### DIFF
--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.0-beta.2",
+    "@rsbuild/core": "2.2.0-rc.0",
     "@storybook/addon-docs": "^10.5.10",
     "@storybook/addon-onboarding": "^10.5.10",
     "@storybook/react": "^10.5.10",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.0-beta.2",
+    "@rsbuild/core": "2.2.0-rc.0",
     "@storybook/addon-docs": "^10.5.10",
     "@storybook/addon-onboarding": "^10.5.10",
     "@storybook/react": "^10.5.10",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.0-beta.2",
+    "@rsbuild/core": "2.2.0-rc.0",
     "@storybook/addon-docs": "^10.5.10",
     "@storybook/addon-onboarding": "^10.5.10",
     "@storybook/vue3": "^10.5.10",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.0-beta.2",
+    "@rsbuild/core": "2.2.0-rc.0",
     "@storybook/addon-docs": "^10.5.10",
     "@storybook/addon-onboarding": "^10.5.10",
     "@storybook/vue3": "^10.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ catalogs:
       specifier: ^2.12.0
       version: 2.12.0
     '@rsbuild/core':
-      specifier: ~2.2.0-beta.2
-      version: 2.2.0-beta.2
+      specifier: 2.2.0-rc.0
+      version: 2.2.0-rc.0
     '@rsbuild/plugin-babel':
       specifier: ^2.1.0
       version: 2.1.0
@@ -391,13 +391,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.11)
+        version: 2.8.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)
+        version: 2.1.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -412,19 +412,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 'catalog:'
-        version: 2.8.2(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+        version: 2.8.2(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+        version: 2.8.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/storybook-addon':
         specifier: 'catalog:'
-        version: 6.0.18(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(storybook@10.5.10)(typescript@6.0.3)(vue-tsc@3.3.11)(webpack-virtual-modules@0.6.2)
+        version: 6.0.18(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(storybook@10.5.10)(typescript@6.0.3)(vue-tsc@3.3.11)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)
+        version: 2.1.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -454,10 +454,10 @@ importers:
         version: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
+        version: 3.4.2(@rsbuild/core@2.2.0-rc.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3)
+        version: 3.4.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -473,13 +473,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.11)
+        version: 2.8.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)
+        version: 2.1.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -602,10 +602,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
+        version: 2.0.1(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -623,10 +623,10 @@ importers:
         version: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
+        version: 3.4.2(@rsbuild/core@2.2.0-rc.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)(vue@3.5.41)
+        version: 3.4.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)(vue@3.5.41)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -641,14 +641,14 @@ importers:
     dependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.11)
+        version: 2.8.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -675,7 +675,7 @@ importers:
         version: 0.6.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.2.0-beta.2)
+        version: 1.0.0(@rsbuild/core@2.2.0-rc.0)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-rc.0(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
@@ -734,7 +734,7 @@ importers:
         version: 7.59.0(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -746,7 +746,7 @@ importers:
         version: 1.2.2
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.2.0-beta.2)
+        version: 1.0.0(@rsbuild/core@2.2.0-rc.0)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-rc.0(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)'
@@ -776,34 +776,34 @@ importers:
         version: 4.0.1(debug@4.4.3)(supports-color@9.4.0)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.11)
+        version: 2.8.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)
+        version: 2.0.1(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)
+        version: 2.1.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2)
+        version: 2.0.1(@rsbuild/core@2.2.0-rc.0)
       '@rsbuild/plugin-toml':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)
+        version: 2.1.0(@rsbuild/core@2.2.0-rc.0)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 'catalog:'
-        version: 1.2.4(@rsbuild/core@2.2.0-beta.2)
+        version: 1.2.4(@rsbuild/core@2.2.0-rc.0)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
+        version: 2.0.1(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
       '@rsbuild/plugin-yaml':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.2.0-beta.2)
+        version: 2.0.0(@rsbuild/core@2.2.0-rc.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1320,10 +1320,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.2.0-beta.2)
+        version: 1.4.6(@rsbuild/core@2.2.0-rc.0)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -1333,10 +1333,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.2.0-beta.2)
+        version: 1.4.6(@rsbuild/core@2.2.0-rc.0)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1646,16 +1646,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.11)
+        version: 2.8.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+        version: 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)
+        version: 2.1.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.0-beta.2)
+        version: 2.0.1(@rsbuild/core@2.2.0-rc.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1703,10 +1703,10 @@ importers:
         version: 19.2.8(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: 'catalog:'
-        version: 1.0.6(@rsbuild/core@2.2.0-beta.2)
+        version: 1.0.6(@rsbuild/core@2.2.0-rc.0)
       rsbuild-plugin-open-graph:
         specifier: 'catalog:'
-        version: 1.1.3(@rsbuild/core@2.2.0-beta.2)
+        version: 1.1.3(@rsbuild/core@2.2.0-rc.0)
       rspress-plugin-file-tree:
         specifier: 'catalog:'
         version: 1.0.5(@rspress/core@2.0.19)(supports-color@9.4.0)
@@ -3013,6 +3013,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.2.0-rc.0':
+    resolution: {integrity: sha512-f6orjv+wOR1u7KchE/vANGP0Eg7AP0UaiM0qn4n+5I0HOUdkVVbNCA1eZSpyX+TJ9bIdZtkbR6T47vBdoFr1MA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.2.1':
     resolution: {integrity: sha512-6Zad7Ff/RUNc91AtftemJcJ1wcZRGOiwuJy349qlLJl9F++oRYwUhx+MxLSpNnVeIywWx2mKdZZBtD1hLqfj9w==}
     peerDependencies:
@@ -3229,6 +3239,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.2.0-rc.0':
+    resolution: {integrity: sha512-Uvy3YnN1pCLe+2/8hF06KiCPegf8ztOuM3VE/p0MJKRitkL5DPoZVHyc40zl6e+O5WB/9tJ5tnEgRG9pDWxFng==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.1.10':
     resolution: {integrity: sha512-my/0h2LwxCRT6cg3oDDC2e0ZOxQLVajAdIcv0fqnQk5JRNvVuL89PuTutitnSqie1A0/JSL8OQz5XHwmoS3kow==}
     cpu: [x64]
@@ -3236,6 +3251,11 @@ packages:
 
   '@rspack/binding-darwin-x64@2.2.0-beta.1':
     resolution: {integrity: sha512-jmg+2GlW3W72I4n5UjOlQNcuq81FJnSIX1UB9+WYcSPZq7F0GBspFKZIiFXawA91H/YUPw7bwzbABV9ZZcv/DQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.2.0-rc.0':
+    resolution: {integrity: sha512-UQO0PgLarsA0lv96uqCTAH1eAnAIPHb+qhMfds5ubWKZgKlr0taGQl253C3DN5pfzbHWfNQgAfVUaVMydm9czw==}
     cpu: [x64]
     os: [darwin]
 
@@ -3247,6 +3267,12 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@2.2.0-beta.1':
     resolution: {integrity: sha512-ZzVCnZKiG4HrbvsLIRi/PIfAXdO77csafU51vcH0a1OHic46KJLjo++A1nCH19QJ6fmelD4ZW5Ozd4pXdugGIg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.2.0-rc.0':
+    resolution: {integrity: sha512-ZggL6W9ckpvhqIPi7K3zDRiEaQd5Co2qRnN5J8OMmBkQlvYQek0CE/SZHFcZsDM0//6+0mkI+VjaTeWdvqJsaQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3263,6 +3289,12 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.2.0-rc.0':
+    resolution: {integrity: sha512-MfDTg9fn/17lRtGMsHLK8BQJs+AEtTsVMWOg1CMou/ls8IrucXoFZ9Ux0i2Jq1ph1ZiKgr4l7pMzdk3SXpNiQg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-ppc64-gnu@2.1.10':
     resolution: {integrity: sha512-U7HlNzHcDtZ+LYOtOJmtx67kHEybZzUUAaP7aEXjGYO5WTCgh/176sW2UYP0rmZLrgUNFUuzn+B98RLaClNaVg==}
     cpu: [ppc64]
@@ -3271,6 +3303,12 @@ packages:
 
   '@rspack/binding-linux-ppc64-gnu@2.2.0-beta.1':
     resolution: {integrity: sha512-duACKIuwYQg1/N6c9NrOcFJGa/Qb9XX48sxGSr1vk380UNyX0tHC9rs7kh/udtMgv8NfNrz91fSvVAR+VRT4Uw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-ppc64-gnu@2.2.0-rc.0':
+    resolution: {integrity: sha512-n84s99eIMr/4xQ1XCctxtu4AnchukynuyJ4DaJ4vlcRKVdFAnPSpUH669rAxztsby5xa3ftAASmxwXhMUFzMsg==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -3287,6 +3325,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rspack/binding-linux-riscv64-gnu@2.2.0-rc.0':
+    resolution: {integrity: sha512-s5bg/LlwnMSVXZfR16KGO3jVWUpobbPp90qE2DXwfaFpcLmMweUnANERM2mCpIiW3MuVnTAXTEjvEcxfB4mXEw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-riscv64-musl@2.1.10':
     resolution: {integrity: sha512-rkurnAWc04vIbzG1QCrPBWSJadZvaOt1mazFH3EdiJO8VUiu0I1T9zdiwuDOPrd50lOKIZlcTXbd5aaAkWEnvQ==}
     cpu: [riscv64]
@@ -3295,6 +3339,12 @@ packages:
 
   '@rspack/binding-linux-riscv64-musl@2.2.0-beta.1':
     resolution: {integrity: sha512-Q21lN9uL5Rw2FsBE4lTLXIFbbGca708JdlQnmKzuU3PxWTgPo+ntVMdjoLFLlkYZ10o+dQKzC4ucdQERrZKuug==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-musl@2.2.0-rc.0':
+    resolution: {integrity: sha512-XNjEnkrNv67CZ4/IhkPQVfNkz9JHevelgZspzuuJOOyn+Z9b1m8JN+shv5Kq06sSudN9aQpLLa6slbHlKGv9lA==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -3311,6 +3361,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rspack/binding-linux-s390x-gnu@2.2.0-rc.0':
+    resolution: {integrity: sha512-OQpj1j6Jfy+YBYDSGwJisZZEXS3g0Y/M5xlb26yqlZBKA/7kamCMDccUPTKNpuJaRQXK1DUerBsA+AK8TELG3g==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-x64-gnu@2.1.10':
     resolution: {integrity: sha512-Fat09V6jUuyo9qG7Wyj9cQ31VDfLmokXyBtGqKxY5OvSWHereB7QUub5btbPXHwbp6Iq4aAQyUbbLTzvR1YaBw==}
     cpu: [x64]
@@ -3319,6 +3375,12 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@2.2.0-beta.1':
     resolution: {integrity: sha512-KCTKFrsO9zN8qR64KkJhJJeB6djFGZ4Cu6fH1rMhfNztJtQxpKXS6oUJRbQZ4AvBxJs4qywIwxToKqVwlu1A8A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.2.0-rc.0':
+    resolution: {integrity: sha512-1QoW+7zjApCgL4v5P14AmnxfvOMCk131abSBCl/+u6h/aIainSwpf+O3ar0FqvkQaSPPOQJrg03ys57WyEwlAQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3335,12 +3397,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.2.0-rc.0':
+    resolution: {integrity: sha512-KLN4bIC3M1dSEuPBX1SPOEkBRyZnnIx8vBjfIFFpKa1bw/CsOHDF7Y6IAAsf9hir7dH3cUd4vaPSCVRM4KiTDw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.1.10':
     resolution: {integrity: sha512-KY5YbWbuvYcoaLXnV+vzZOvGRCeb6jt4EpVpKdph1h1IJjwX/ju15EQ+GOe3iecZEdf0OttQcNVcwBkLkFT9ag==}
     cpu: [wasm32]
 
   '@rspack/binding-wasm32-wasi@2.2.0-beta.1':
     resolution: {integrity: sha512-IYjRonL0MS4Tn0jjFpTSY4bFJHSRiFyj/fFoTZKdweBRDEpZ/AEPfTGRPwjhR6loyK+Uzrv7BY2N6QZo500hmg==}
+    cpu: [wasm32]
+
+  '@rspack/binding-wasm32-wasi@2.2.0-rc.0':
+    resolution: {integrity: sha512-2Vvtckz5DNghQKQKwghfM4j30MOu7t9J7mbUCCi7mTUccpy7Cnr0HPmSV9Jx4sUj6vgQEV+8lIAIxNDNtr0Vhg==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@2.1.10':
@@ -3350,6 +3422,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@2.2.0-beta.1':
     resolution: {integrity: sha512-BHQQ/UOBsiuf0A4+ihsN8/yb0FhFYBgdd3t8OX8LWi1BjKM3NxcX1Al/NYKBjb/ZmI+SWc9prAC1bpAKIXvizw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.2.0-rc.0':
+    resolution: {integrity: sha512-enPqTT2sdt6HgItyk6SA6ubvZ2UXkFIpwhsCuoL83z9vHoDw/Y8obC8L92nIuK6FDP17tokm/r1SFPhDZJIYcg==}
     cpu: [arm64]
     os: [win32]
 
@@ -3363,6 +3440,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.2.0-rc.0':
+    resolution: {integrity: sha512-qYeZLJDfboqkWmNcqazjUcld2QegyErDJVaCfAPm2mnneMmKhQWsOs/DmlqRfC4ePaQN9uOtu26iLwKy2o1sgw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.1.10':
     resolution: {integrity: sha512-pgp23pLrzfhGnKycxzr7ifP17lAbWZEfnx1bX8gXtYrnpJ66DRNyTKSzxB6sa/HBWjS1L8PX5TjMZ44WfPydqQ==}
     cpu: [x64]
@@ -3373,11 +3455,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.2.0-rc.0':
+    resolution: {integrity: sha512-bvzp27ZvpZW1vcCG/srk/K/6cffcR/kqDUcW8dWEMFlntPSBTml9lOC4ouSBpU7n/qIwG6hKE56FaTWWapc3Lw==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@2.1.10':
     resolution: {integrity: sha512-vnu/UP5HnrND15lO9+VeG6eUrbTyycHNQNQ3XEiRiFojuoiGZkIZC3Hbzr8qQH44C6vScPODEPvvIVvLcO2LpQ==}
 
   '@rspack/binding@2.2.0-beta.1':
     resolution: {integrity: sha512-yPjiUiM3nFEWlOFJmcFfMkSAavkPxjzSgfSpJNm07v1VvNCMG68sapcvN6bm7ZjMUV2NIPePqfJzjB6Rt1xpsQ==}
+
+  '@rspack/binding@2.2.0-rc.0':
+    resolution: {integrity: sha512-/Q9ysTd5ajEbIS+Sv61trElR7pWAa5LvcWNrYT+AKI9APsVwy4Y3CIPjEkd7jYeNHl1PJWSLCOUy+BzRUICDUg==}
 
   '@rspack/core@2.1.10':
     resolution: {integrity: sha512-YSS2/Xxz8uiG/KXDkqOoA3dTetNo/vysk7bAexQOrU8iuq7JuzDTTAwLKvWZnwmvME8M8m5wcM4YvfIwYmidHA==}
@@ -3393,6 +3483,18 @@ packages:
 
   '@rspack/core@2.2.0-beta.1':
     resolution: {integrity: sha512-nKecuncGsg+Ay3nrgmqB/hfvNe4d95qHn4qr9neAOIGTcHmMF4ZZU6PtoNqKO6wCspTsvJN6OhsosIV7RQgwZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.2.0-rc.0':
+    resolution: {integrity: sha512-2LAdAFF/ZdnBRltI+IievGhysby9LESxvELxS1ZVkPc1F6ZAJ1skIcCNOLmfZeoYwQ5nXZjdUCbCf9MFDMWJjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -9071,7 +9173,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.8.2(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)':
+  '@module-federation/enhanced@2.8.2(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.2
       '@module-federation/cli': 2.8.2(typescript@6.0.3)(vue-tsc@3.3.11)
@@ -9080,7 +9182,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.8.2(@module-federation/runtime-tools@2.8.2)
       '@module-federation/managers': 2.8.2
       '@module-federation/manifest': 2.8.2(typescript@6.0.3)(vue-tsc@3.3.11)
-      '@module-federation/rspack': 2.8.2(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+      '@module-federation/rspack': 2.8.2(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/runtime-tools': 2.8.2
       '@module-federation/sdk': 2.8.2
       '@module-federation/webpack-bundler-runtime': 2.8.2
@@ -9156,9 +9258,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.49(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)':
+  '@module-federation/node@2.7.49(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)':
     dependencies:
-      '@module-federation/enhanced': 2.8.2(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+      '@module-federation/enhanced': 2.8.2(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/runtime': 2.8.2
       '@module-federation/sdk': 2.8.2
       encoding: 0.1.13
@@ -9171,13 +9273,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.11)':
+  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.11)':
     dependencies:
       '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/node': 2.7.49(@rspack/core@2.1.10)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9186,13 +9288,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.11)':
+  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.11)':
     dependencies:
       '@module-federation/enhanced': 2.8.2(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@module-federation/node': 2.7.49(@rspack/core@2.1.10)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9201,13 +9303,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)':
+  '@module-federation/rsbuild-plugin@2.8.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)':
     dependencies:
-      '@module-federation/enhanced': 2.8.2(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)
-      '@module-federation/node': 2.7.49(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+      '@module-federation/enhanced': 2.8.2(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)
+      '@module-federation/node': 2.7.49(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9250,7 +9352,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rspack@2.8.2(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)':
+  '@module-federation/rspack@2.8.2(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.8.2
       '@module-federation/dts-plugin': 2.8.2(typescript@6.0.3)(vue-tsc@3.3.11)
@@ -9259,7 +9361,7 @@ snapshots:
       '@module-federation/manifest': 2.8.2(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/runtime-tools': 2.8.2
       '@module-federation/sdk': 2.8.2
-      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.11(typescript@6.0.3)
@@ -9285,12 +9387,12 @@ snapshots:
 
   '@module-federation/sdk@2.8.2': {}
 
-  '@module-federation/storybook-addon@6.0.18(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(storybook@10.5.10)(typescript@6.0.3)(vue-tsc@3.3.11)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.18(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(storybook@10.5.10)(typescript@6.0.3)(vue-tsc@3.3.11)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.8.2(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+      '@module-federation/enhanced': 2.8.2(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/sdk': 2.8.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       storybook: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -9577,6 +9679,13 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
+  '@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)':
+    dependencies:
+      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.13)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
@@ -9618,19 +9727,19 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
       less-loader: 12.3.3(@rspack/core@2.1.10)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.2.0-beta.2)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.2.0-rc.0)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9656,7 +9765,7 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
 
   '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(preact@10.29.8)':
     dependencies:
@@ -9679,21 +9788,21 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.0-rc.0)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -9707,7 +9816,7 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.0-beta.2)':
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.0-rc.0)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9715,7 +9824,7 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
 
   '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.1.13)(solid-js@1.9.15)(supports-color@9.4.0)':
     dependencies:
@@ -9784,39 +9893,39 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-toml@2.1.0(@rsbuild/core@2.2.0-beta.2)':
+  '@rsbuild/plugin-toml@2.1.0(@rsbuild/core@2.2.0-rc.0)':
     dependencies:
       toml: 5.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
 
-  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
       ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.1.10)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.0-beta.2)':
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.0-rc.0)':
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
 
   '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)':
     dependencies:
@@ -9828,21 +9937,21 @@ snapshots:
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)':
     dependencies:
       rspack-vue-loader: 17.5.1(@rspack/core@2.1.10)(@vue/compiler-sfc@3.5.41)(vue@3.5.41)
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.2.0-beta.2)':
+  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.2.0-rc.0)':
     dependencies:
       yaml: 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
 
   '@rslib/core@1.0.0-rc.0(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.8.2)(typescript@7.0.2)':
     dependencies:
@@ -9899,10 +10008,16 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.2.0-beta.1':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.2.0-rc.0':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.1.10':
     optional: true
 
   '@rspack/binding-darwin-x64@2.2.0-beta.1':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.2.0-rc.0':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.1.10':
@@ -9911,10 +10026,16 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.2.0-beta.1':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.2.0-rc.0':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.1.10':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.2.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.2.0-rc.0':
     optional: true
 
   '@rspack/binding-linux-ppc64-gnu@2.1.10':
@@ -9923,10 +10044,16 @@ snapshots:
   '@rspack/binding-linux-ppc64-gnu@2.2.0-beta.1':
     optional: true
 
+  '@rspack/binding-linux-ppc64-gnu@2.2.0-rc.0':
+    optional: true
+
   '@rspack/binding-linux-riscv64-gnu@2.1.10':
     optional: true
 
   '@rspack/binding-linux-riscv64-gnu@2.2.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-gnu@2.2.0-rc.0':
     optional: true
 
   '@rspack/binding-linux-riscv64-musl@2.1.10':
@@ -9935,10 +10062,16 @@ snapshots:
   '@rspack/binding-linux-riscv64-musl@2.2.0-beta.1':
     optional: true
 
+  '@rspack/binding-linux-riscv64-musl@2.2.0-rc.0':
+    optional: true
+
   '@rspack/binding-linux-s390x-gnu@2.1.10':
     optional: true
 
   '@rspack/binding-linux-s390x-gnu@2.2.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-s390x-gnu@2.2.0-rc.0':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.1.10':
@@ -9947,10 +10080,16 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.2.0-beta.1':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.2.0-rc.0':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.1.10':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.2.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.2.0-rc.0':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.1.10':
@@ -9967,10 +10106,20 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.2.0-rc.0':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.1.10':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.2.0-beta.1':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.2.0-rc.0':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.1.10':
@@ -9979,10 +10128,16 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@2.2.0-beta.1':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.2.0-rc.0':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.1.10':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.2.0-beta.1':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.2.0-rc.0':
     optional: true
 
   '@rspack/binding@2.1.10':
@@ -10019,6 +10174,23 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.2.0-beta.1
       '@rspack/binding-win32-x64-msvc': 2.2.0-beta.1
 
+  '@rspack/binding@2.2.0-rc.0':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.2.0-rc.0
+      '@rspack/binding-darwin-x64': 2.2.0-rc.0
+      '@rspack/binding-linux-arm64-gnu': 2.2.0-rc.0
+      '@rspack/binding-linux-arm64-musl': 2.2.0-rc.0
+      '@rspack/binding-linux-ppc64-gnu': 2.2.0-rc.0
+      '@rspack/binding-linux-riscv64-gnu': 2.2.0-rc.0
+      '@rspack/binding-linux-riscv64-musl': 2.2.0-rc.0
+      '@rspack/binding-linux-s390x-gnu': 2.2.0-rc.0
+      '@rspack/binding-linux-x64-gnu': 2.2.0-rc.0
+      '@rspack/binding-linux-x64-musl': 2.2.0-rc.0
+      '@rspack/binding-wasm32-wasi': 2.2.0-rc.0
+      '@rspack/binding-win32-arm64-msvc': 2.2.0-rc.0
+      '@rspack/binding-win32-ia32-msvc': 2.2.0-rc.0
+      '@rspack/binding-win32-x64-msvc': 2.2.0-rc.0
+
   '@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.1.10
@@ -10029,6 +10201,13 @@ snapshots:
   '@rspack/core@2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.2.0-beta.1
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.8.2
+      '@swc/helpers': 0.5.23
+
+  '@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.2.0-rc.0
     optionalDependencies:
       '@module-federation/runtime-tools': 2.8.2
       '@swc/helpers': 0.5.23
@@ -10048,11 +10227,11 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.0-rc.0)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
   '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
     dependencies:
@@ -14161,20 +14340,20 @@ snapshots:
       '@microsoft/api-extractor': 7.59.0(@types/node@24.13.3)
       typescript: 7.0.2
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.2.0-beta.2):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.2.0-rc.0):
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
 
-  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.2.0-beta.2):
+  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.2.0-rc.0):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.2.0-beta.2):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.2.0-rc.0):
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
 
   rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.1.13):
     dependencies:
@@ -14182,11 +14361,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.0-beta.2):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.0-rc.0):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
 
   rslog@2.3.0: {}
 
@@ -14562,18 +14741,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.4.2(@rsbuild/core@2.2.0-beta.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3):
+  storybook-addon-rslib@3.4.2(@rsbuild/core@2.2.0-rc.0)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.4.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
-      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(typescript@6.0.3)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(typescript@6.0.3)
       '@vitest/mocker': 3.2.7
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14586,7 +14765,7 @@ snapshots:
       pathe: 2.0.3
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.2.0-beta.2)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.2.0-rc.0)
       sirv: 2.0.4
       storybook: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       ts-dedent: 2.3.0
@@ -14603,10 +14782,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-builder-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.4.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
-      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(typescript@6.0.3)
       '@vitest/mocker': 3.2.7
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14619,7 +14798,7 @@ snapshots:
       pathe: 2.0.3
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.2.0-beta.2)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.2.0-rc.0)
       sirv: 2.0.4
       storybook: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       ts-dedent: 2.3.0
@@ -14636,10 +14815,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.4.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.4.0
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@storybook/react': 10.5.10(@types/react-dom@19.2.4)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(supports-color@9.4.0)(typescript@6.0.3)
       find-up: 5.0.0
@@ -14650,7 +14829,7 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
       storybook: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.2.0-rc.0)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14665,12 +14844,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)(vue@3.5.41):
+  storybook-vue3-rsbuild@3.4.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)(vue@3.5.41):
     dependencies:
-      '@rsbuild/core': 2.2.0-beta.2(@module-federation/runtime-tools@2.8.2)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)
       '@storybook/vue3': 10.5.10(storybook@10.5.10)(vue@3.5.41)
       storybook: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-beta.2)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.0-rc.0)(@rspack/core@2.1.10)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
       vue: 3.5.41(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.41)
       vue-docgen-loader: 2.0.1(vue-docgen-api@4.79.2)
@@ -14966,7 +15145,7 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
-  ts-checker-rspack-plugin@1.6.0(@rspack/core@2.2.0-beta.1)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.6.0(@rspack/core@2.2.0-rc.0)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
@@ -14974,7 +15153,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
   ts-dedent@2.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalog:
   '@module-federation/storybook-addon': '^6.0.18'
   '@playwright/test': '1.62.1'
   '@reduxjs/toolkit': '^2.12.0'
-  '@rsbuild/core': '~2.2.0-beta.2'
+  '@rsbuild/core': '2.2.0-rc.0'
   '@rsbuild/plugin-babel': '^2.1.0'
   '@rsbuild/plugin-less': '^2.0.1'
   '@rsbuild/plugin-node-polyfill': '^1.4.6'


### PR DESCRIPTION
## Summary

Pin Rsbuild to 2.2.0-rc.0 across the workspace catalog and Storybook templates to keep generated projects aligned with the latest release candidate.

## Related Links

- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.2.0-rc.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).