### PR TITLE
fix(core): avoid extracting unused Node archive files

### DIFF
--- a/packages/core/src/exe/download.ts
+++ b/packages/core/src/exe/download.ts
@@ -240,6 +240,7 @@ const extractArchive = async ({
     archivePath,
     '-C',
     path.dirname(extractDir),
+    `${path.basename(extractDir)}/bin/node`,
   ]);
 };
 


### PR DESCRIPTION
## Summary

- extract only the Node executable from Unix target archives
- avoid unrelated `npm` and `npx` symlink creation on Windows
- reduce cross-target archive extraction work

## Related Links

Fixes #1871

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `pnpm --filter @rslib/core run build`
- `pnpm exec rslint packages/core/src/exe/download.ts`
- `pnpm dlx node@25.9.0 ..\node_modules\@rstest\core\bin\rstest.js run --project integration-exe` from `tests` (5/5 passed)
- exact single-member `tar` extraction on Windows without symlink privileges (1 file extracted)