### PR TITLE
docs: fix outdated external links

### DIFF
--- a/examples/vue-component-bundleless/stories/Button.stories.ts
+++ b/examples/vue-component-bundleless/stories/Button.stories.ts
@@ -12,7 +12,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/packages/create-rslib/template-storybook/react-js/stories/Button.stories.jsx
+++ b/packages/create-rslib/template-storybook/react-js/stories/Button.stories.jsx
@@ -11,7 +11,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/packages/create-rslib/template-storybook/react-ts/stories/Button.stories.ts
+++ b/packages/create-rslib/template-storybook/react-ts/stories/Button.stories.ts
@@ -12,7 +12,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/packages/create-rslib/template-storybook/vue-js/stories/Button.stories.js
+++ b/packages/create-rslib/template-storybook/vue-js/stories/Button.stories.js
@@ -11,7 +11,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/packages/create-rslib/template-storybook/vue-ts/stories/Button.stories.js
+++ b/packages/create-rslib/template-storybook/vue-ts/stories/Button.stories.js
@@ -11,7 +11,7 @@ const meta = {
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  // More on argTypes: https://storybook.js.org/docs/api/arg-types
   argTypes: {
     backgroundColor: { control: 'color' },
   },

--- a/website/docs/en/config/rsbuild/plugins.mdx
+++ b/website/docs/en/config/rsbuild/plugins.mdx
@@ -69,7 +69,7 @@ The following are common framework-agnostic plugins:
 - [Babel Plugin](https://rsbuild.rs/plugins/list/plugin-babel): Provides support for Babel transpilation capabilities.
 - [Sass Plugin](https://rsbuild.rs/plugins/list/plugin-sass): Use Sass as the CSS preprocessor.
 - [Less Plugin](https://rsbuild.rs/plugins/list/plugin-less): Use Less as the CSS preprocessor.
-- [Stylus Plugin](https://rsbuild.rs/plugins/list/plugin-stylus): Use Stylus as the CSS preprocessor.
+- [Stylus Plugin](https://github.com/rstackjs/rsbuild-plugin-stylus): Use Stylus as the CSS preprocessor.
 - [Tailwind CSS Plugin](https://rsbuild.rs/plugins/list/plugin-tailwindcss): Use Tailwind CSS v4.
 - [ESLint Plugin](https://github.com/rstackjs/rsbuild-plugin-eslint): Run ESLint checks during the compilation.
 - [Type Check Plugin](https://github.com/rstackjs/rsbuild-plugin-type-check): Run TypeScript type checker on a separate process.

--- a/website/docs/en/guide/advanced/css.mdx
+++ b/website/docs/en/guide/advanced/css.mdx
@@ -260,7 +260,7 @@ Rslib supports popular CSS preprocessors through plugins, including Sass, Less, 
 
 - [Sass Plugin](https://rsbuild.rs/plugins/list/plugin-sass)
 - [Less Plugin](https://rsbuild.rs/plugins/list/plugin-less)
-- [Stylus Plugin](https://rsbuild.rs/plugins/list/plugin-stylus)
+- [Stylus Plugin](https://github.com/rstackjs/rsbuild-plugin-stylus)
 
 Taking the Sass plugin as an example, you can install the plugin via the following command:
 

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -274,7 +274,7 @@ There you go, start Storybook with `npx storybook dev`.
 
 ## Consume other Module Federation modules
 
-Because there are multiple formats in Rslib, if you configure the `remote` parameter to consume other modules during construction, it may not work properly in all formats. It is recommended to access through the [Module Federation Runtime](https://module-federation.io/guide/basic/runtime.html)
+Because there are multiple formats in Rslib, if you configure the `remote` parameter to consume other modules during construction, it may not work properly in all formats. It is recommended to access through the [Module Federation Runtime](https://module-federation.io/guide/runtime/)
 
 First install the runtime dependencies
 

--- a/website/docs/zh/config/rsbuild/plugins.mdx
+++ b/website/docs/zh/config/rsbuild/plugins.mdx
@@ -69,7 +69,7 @@ export default defineConfig({
 - [Babel 插件](https://rsbuild.rs/zh/plugins/list/plugin-babel)：提供对 Babel 转译能力的支持。
 - [Sass 插件](https://rsbuild.rs/zh/plugins/list/plugin-sass)：使用 Sass 作为 CSS 预处理器。
 - [Less 插件](https://rsbuild.rs/zh/plugins/list/plugin-less)：使用 Less 作为 CSS 预处理器。
-- [Stylus 插件](https://rsbuild.rs/zh/plugins/list/plugin-stylus)：使用 Stylus 作为 CSS 预处理器。
+- [Stylus 插件](https://github.com/rstackjs/rsbuild-plugin-stylus)：使用 Stylus 作为 CSS 预处理器。
 - [Tailwind CSS 插件](https://rsbuild.rs/zh/plugins/list/plugin-tailwindcss)：使用 Tailwind CSS v4。
 - [ESLint 插件](https://github.com/rstackjs/rsbuild-plugin-eslint)：用于在编译过程中运行 ESLint 检查。
 - [publint 插件](https://github.com/rstackjs/rsbuild-plugin-publint)：在构建后运行 [`publint`](https://github.com/bluwy/publint) 来检查 npm 包。

--- a/website/docs/zh/guide/advanced/css.mdx
+++ b/website/docs/zh/guide/advanced/css.mdx
@@ -260,7 +260,7 @@ Rslib 通过插件来支持社区流行的 CSS 预处理器，包括 Sass、Less
 
 - [Sass 插件](https://rsbuild.rs/zh/plugins/list/plugin-sass)
 - [Less 插件](https://rsbuild.rs/zh/plugins/list/plugin-less)
-- [Stylus 插件](https://rsbuild.rs/zh/plugins/list/plugin-stylus)
+- [Stylus 插件](https://github.com/rstackjs/rsbuild-plugin-stylus)
 
 以 Sass 插件为例，你可以通过如下的命令安装插件:
 

--- a/website/docs/zh/guide/advanced/module-federation.mdx
+++ b/website/docs/zh/guide/advanced/module-federation.mdx
@@ -273,7 +273,7 @@ export const Primary = {};
 
 ## 使用其他模块联合模块
 
-由于 Rslib 中有多种格式，如果在构建时配置 `remote` 参数来消耗其他模块，则可能无法在所有格式下正常工作。建议通过以下方式访问 [Module Federation Runtime](https://module-federation.io/zh/guide/basic/runtime.html)
+由于 Rslib 中有多种格式，如果在构建时配置 `remote` 参数来消耗其他模块，则可能无法在所有格式下正常工作。建议通过以下方式访问 [Module Federation Runtime](https://module-federation.io/zh/guide/runtime/)
 
 首先安装运行时依赖
 


### PR DESCRIPTION
## Summary

- update English and Chinese Module Federation Runtime links
- point Stylus references to the maintained Rsbuild plugin repository
- update ArgTypes links in the example and generated Storybook templates

## Related Links

Fixes #1873

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `pnpm --dir website run build`
- `pnpm --filter create-rslib run test` (38/38 passed)
- Rslint on the five changed Storybook source/template files
- all four replacement destinations return HTTP 200; all stale URL forms are absent