### PR TITLE
docs: move LLMs UI to page outline

### DIFF
--- a/website/docs/en/guide/start/ai.mdx
+++ b/website/docs/en/guide/start/ai.mdx
@@ -58,7 +58,7 @@ You can choose the file that best fits your use case:
 
 ## Markdown docs
 
-Every Rslib documentation page has a corresponding `.md` plain-text version that can be provided directly to AI. On any doc page, you can click “Copy Markdown” or “Copy Markdown Link” under the title to get the Markdown content or link.
+Every Rslib documentation page has a corresponding `.md` plain-text version that can be provided directly to AI. On any doc page, you can click “Copy Markdown” or “Copy Markdown Link” in the page outline to get the Markdown content or link.
 
 ```
 https://rslib.rs/guide/start/index.md

--- a/website/docs/zh/guide/start/ai.mdx
+++ b/website/docs/zh/guide/start/ai.mdx
@@ -58,7 +58,7 @@ https://rslib.rs/llms-full.txt
 
 ## Markdown 文档
 
-Rslib 文档的每个页面都提供对应的 `.md` 纯文本版本，可直接作为上下文提供给 AI。你可以在文档任意页面的标题下方点击「复制 Markdown」或 「复制 Markdown 链接」按钮，获取该页面对应的 Markdown 文件内容或链接。
+Rslib 文档的每个页面都提供对应的 `.md` 纯文本版本，可直接作为上下文提供给 AI。你可以在任意文档页面的大纲中点击「复制 Markdown」或 「复制 Markdown 链接」按钮，获取该页面对应的 Markdown 文件内容或链接。
 
 ```
 https://rslib.rs/guide/start/index.md

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -92,6 +92,9 @@ export default defineConfig({
     },
   ],
   themeConfig: {
+    llmsUI: {
+      placement: 'outline',
+    },
     socialLinks: [
       {
         icon: 'github',


### PR DESCRIPTION
## Summary

This PR ports rstack-cli #414 by moving the LLMs UI actions from below page titles into the page outline, keeping AI shortcuts alongside page navigation. It sets `themeConfig.llmsUI.placement` to `outline` and updates the English and Chinese AI guides to match.

## Related Links

- https://github.com/rstackjs/rstack-cli/pull/414

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).