### PR TITLE
chore(deps): migrate to @rstackjs/doc-ui v1.14.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,12 +106,12 @@ catalogs:
     '@rspress/plugin-twoslash':
       specifier: ^2.0.19
       version: 2.0.19
-    '@rstack-dev/doc-ui':
-      specifier: 1.14.8
-      version: 1.14.8
     '@rstackjs/create-toolkit':
       specifier: 2.2.4
       version: 2.2.4
+    '@rstackjs/doc-ui':
+      specifier: 1.14.9
+      version: 1.14.9
     '@rstest/adapter-rslib':
       specifier: ^0.11.9
       version: 0.11.9
@@ -1680,9 +1680,9 @@ importers:
       '@rspress/plugin-twoslash':
         specifier: 'catalog:'
         version: 2.0.19(@rspress/core@2.0.19)(react@19.2.8)(supports-color@9.4.0)(typescript@6.0.3)
-      '@rstack-dev/doc-ui':
+      '@rstackjs/doc-ui':
         specifier: 'catalog:'
-        version: 1.14.8(@rspress/core@2.0.19)
+        version: 1.14.9(@rspress/core@2.0.19)
       '@shikijs/transformers':
         specifier: 'catalog:'
         version: 4.4.3
@@ -3467,17 +3467,17 @@ packages:
   '@rspress/shared@2.0.19':
     resolution: {integrity: sha512-INrETllWuR49lksqCz+xeLSO6rKtHA+5Ix2YQWcP9nerCuTSyGYwH8eBC0HrIacJkGHxB8wkkbV99tyzGtY8Wg==}
 
-  '@rstack-dev/doc-ui@1.14.8':
-    resolution: {integrity: sha512-CAibkpvCnJEcxsypu3ZE9JjtQw+1+iJGv9X09Yg4//9FevHpfaHW+b2onFG+Z/xOlUXGg83rJTb7CO6YbToP0w==}
+  '@rstackjs/create-toolkit@2.2.4':
+    resolution: {integrity: sha512-YVnA9aTZKPTql8Hzyf9o5chWAICNJ46CYoPwADrSObyBxF1jlvB5gO5M+yXYoZT/VNWh1Abm0TvTtmAh4EeT3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@rstackjs/doc-ui@1.14.9':
+    resolution: {integrity: sha512-Te7Wx4K9JuvluP7HsH/Dpdju5QhClUe17/9YBzHlul+x2wg63jOkngv79DlMXyYDJgHQ+11vZfz18B+bnPhttw==}
     peerDependencies:
       '@rspress/core': '>=2.0.0'
     peerDependenciesMeta:
       '@rspress/core':
         optional: true
-
-  '@rstackjs/create-toolkit@2.2.4':
-    resolution: {integrity: sha512-YVnA9aTZKPTql8Hzyf9o5chWAICNJ46CYoPwADrSObyBxF1jlvB5gO5M+yXYoZT/VNWh1Abm0TvTtmAh4EeT3A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@rstest/adapter-rslib@0.11.9':
     resolution: {integrity: sha512-qdkgl3bxgb1twAEAcNK1yB+ZoheGAlQd1O1Ziuk+AtTQxqPZN82y5dctlMn/gsbNHZxezMWs+5i+xWHJC9iMGg==}
@@ -10024,11 +10024,11 @@ snapshots:
       - core-js
       - supports-color
 
-  '@rstack-dev/doc-ui@1.14.8(@rspress/core@2.0.19)':
+  '@rstackjs/create-toolkit@2.2.4': {}
+
+  '@rstackjs/doc-ui@1.14.9(@rspress/core@2.0.19)':
     optionalDependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.2.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
-
-  '@rstackjs/create-toolkit@2.2.4': {}
 
   '@rstest/adapter-rslib@0.11.9(@rslib/core@1.0.0-rc.2)(@rstest/core@0.11.9)(typescript@7.0.2)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,7 @@ catalog:
   '@rspress/plugin-rss': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rspress/plugin-twoslash': '^2.0.19'
-  '@rstack-dev/doc-ui': '1.14.8'
+  '@rstackjs/doc-ui': '1.14.9'
   '@rstackjs/create-toolkit': '2.2.4'
   '@rstest/adapter-rslib': '^0.11.9'
   '@rstest/core': '^0.11.9'
@@ -144,7 +144,7 @@ minimumReleaseAgeExclude:
   - '@rsdoctor/*'
   - '@rslint/*'
   - reduce-configs
-  - '@rstack-dev/doc-ui'
+  - '@rstackjs/doc-ui'
   - '@rstackjs/create-toolkit'
   - 'rsbuild-plugin-*'
   - storybook-addon-rslib

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
     "@rspress/plugin-rss": "catalog:",
     "@rspress/plugin-sitemap": "catalog:",
     "@rspress/plugin-twoslash": "catalog:",
-    "@rstack-dev/doc-ui": "catalog:",
+    "@rstackjs/doc-ui": "catalog:",
     "@shikijs/transformers": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/website/theme/components/Hero.tsx
+++ b/website/theme/components/Hero.tsx
@@ -1,5 +1,5 @@
 import { useI18n, useNavigate } from '@rspress/core/runtime';
-import { Hero as BaseHero } from '@rstack-dev/doc-ui/hero';
+import { Hero as BaseHero } from '@rstackjs/doc-ui/hero';
 import { useI18nUrl } from './utils';
 import './Hero.module.scss';
 

--- a/website/theme/components/ToolStack.tsx
+++ b/website/theme/components/ToolStack.tsx
@@ -1,6 +1,6 @@
 import { useLang } from '@rspress/core/runtime';
-import { containerStyle } from '@rstack-dev/doc-ui/section-style';
-import { ToolStack as BaseToolStack } from '@rstack-dev/doc-ui/tool-stack';
+import { containerStyle } from '@rstackjs/doc-ui/section-style';
+import { ToolStack as BaseToolStack } from '@rstackjs/doc-ui/tool-stack';
 
 export function ToolStack() {
   const lang = useLang();

--- a/website/theme/index.scss
+++ b/website/theme/index.scss
@@ -1,15 +1,5 @@
 :root {
-  --rp-c-brand: #ff5e00;
-  --rp-c-brand-dark: #ff704d;
-  --rp-c-brand-darker: #ff704d;
-  --rp-c-brand-light: #ff7524;
-  --rp-c-brand-lighter: #ff7524;
   --rp-c-link: var(--rp-c-brand);
-  --rp-c-brand-tint: rgba(255, 94, 0, 0.07);
-}
-
-.dark {
-  --rp-c-link: var(--rp-c-brand-light);
 }
 
 /* Simulate the centering behavior when sidebar: false  */

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -3,8 +3,9 @@ import {
   Search as PluginAlgoliaSearch,
   ZH_LOCALES,
 } from '@rspress/plugin-algolia/runtime';
-import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
+import { NavIcon } from '@rstackjs/doc-ui/nav-icon';
 import { HomeLayout } from './pages';
+import '@rstackjs/doc-ui/theme.css';
 import './index.scss';
 import { useLang } from '@rspress/core/runtime';
 

--- a/website/theme/pages/index.tsx
+++ b/website/theme/pages/index.tsx
@@ -1,4 +1,4 @@
-import { BackgroundImage } from '@rstack-dev/doc-ui/background-image';
+import { BackgroundImage } from '@rstackjs/doc-ui/background-image';
 import { CopyRight } from '../components/Copyright';
 import { Hero } from '../components/Hero';
 import { ToolStack } from '../components/ToolStack';


### PR DESCRIPTION
## Summary

`@rstackjs/doc-ui` replaces the old `@rstack-dev/doc-ui` package and now exposes shared Rspress theme styles. This PR migrates all Rslib website imports to v1.14.9, loads the shared `theme.css`, and keeps only Rslib-specific theme overrides locally.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8382
- https://github.com/rstackjs/rstack-doc-ui/releases/tag/v1.14.9

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
