### PR TITLE
docs: refresh Rslib introduction content

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ English | [简体中文](./README.zh-CN.md)
 > The `main` branch is under active development for **Rslib 1.0**.
 >
 > The stable **0.x** releases are maintained in the [v0.x](https://github.com/web-infra-dev/rslib/tree/v0.x) branch.
->
-> The documentation for Rslib v1 is available at [v1.rslib.rs](https://v1.rslib.rs).
 
 Rslib is a library development tool based on [Rsbuild](https://rsbuild.rs).
 
@@ -42,19 +40,8 @@ Rslib has the following features:
 
 ## 📚 Documentation
 
-- [Rslib docs](https://rslib.rs)
-
-## 🎯 Ecosystem
-
-Rslib is implemented based on Rsbuild and fully reuses the capabilities and ecosystem of Rsbuild.
-
-The following diagram illustrates the relationship between Rslib and other tools in the ecosystem:
-
-<img src="https://assets.rspack.rs/rsbuild/assets/rspack-stack-layers.png" alt="Rspack stack layers" width="760" />
-
-## 📚 Getting started
-
-To get started with Rslib, see the [Quick start](https://rslib.rs/guide/start/quick-start).
+- [Rslib v1 docs](https://v1.rslib.rs)
+- [Rslib v0 docs](https://rslib.rs)
 
 ## 🦀 Rstack
 
@@ -74,7 +61,7 @@ Rslib is part of Rstack, the fast, unified JavaScript toolchain for developers a
 
 - [awesome-rstack](https://github.com/rstackjs/awesome-rstack): A curated list of awesome things related to Rstack.
 - [agent-skills](https://github.com/rstackjs/agent-skills): A collection of Agent Skills for Rstack.
-- [rstack-examples](https://github.com/rstackjs/rstack-examples): Examples for Rstack.
+- [rstack-examples](https://github.com/rstackjs/rstack-examples): Examples showcasing Rstack.
 - [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild): Storybook builder powered by Rsbuild.
 - [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template): Use this template to create your own Rsbuild plugin.
 - [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources): Design resources for Rstack.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,19 +35,8 @@ Rslib 具备以下特性：
 
 ## 📚 文档
 
-- [Rslib 文档](https://rslib.rs/zh)
-
-## 🎯 生态
-
-Rslib 基于 Rsbuild 实现，并完全复用 Rsbuild 的能力和生态系统。
-
-下图说明了 Rsbuild 与生态中其他工具之间的关系：
-
-<img src="https://assets.rspack.rs/rsbuild/assets/rspack-stack-layers.png" alt="Rspack stack layers" width="760" />
-
-## 📚 快速上手
-
-你可以参考 [快速上手](https://rslib.rs/zh/guide/start/quick-start) 来开始体验 Rslib。
+- [Rslib v1 文档](https://v1.rslib.rs/zh/)
+- [Rslib v0 文档](https://rslib.rs/zh/)
 
 ## 🦀 Rstack
 
@@ -65,12 +54,12 @@ Rslib 是 Rstack 的一员。Rstack 是为开发者与 Agent 打造的高性能�
 
 ## 🔗 链接
 
-- [awesome-rstack](https://github.com/rstackjs/awesome-rstack): 与 Rstack 相关的精彩内容列表。
-- [agent-skills](https://github.com/rstackjs/agent-skills): Rstack 的 Agent Skills 集合。
-- [rstack-examples](https://github.com/rstackjs/rstack-examples): Rstack 的示例项目。
-- [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild): 基于 Rsbuild 构建的 Storybook。
-- [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template): 使用此模板创建你的 Rsbuild 插件。
-- [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources): Rstack 的设计资源。
+- [awesome-rstack](https://github.com/rstackjs/awesome-rstack)：与 Rstack 相关的精彩内容列表。
+- [agent-skills](https://github.com/rstackjs/agent-skills)：Rstack 的 Agent Skills 合集。
+- [rstack-examples](https://github.com/rstackjs/rstack-examples)：Rstack 的示例项目。
+- [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild)：基于 Rsbuild 构建的 Storybook。
+- [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template)：使用此模板创建你的 Rsbuild 插件。
+- [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources)：Rstack 的设计资源。
 
 ## 🤝 参与贡献
 

--- a/website/docs/en/blog/introducing-rslib.mdx
+++ b/website/docs/en/blog/introducing-rslib.mdx
@@ -165,6 +165,6 @@ You can track the progress by checking v1.0 [Milestone](https://github.com/web-i
 
 ## Start using Rslib
 
-We provide the scaffold tool [create-rslib](/guide/start/quick-start) for quickly creating Rslib projects. This scaffold supports creating Node.js / React library projects and supporting development tools. Additionally, we provide [migration documentation](/guide/migration/tsup) to help users migrate from other build tools to Rslib. You can experience developing React component libraries with Rslib in this [CodeSandbox](https://codesandbox.io/p/devbox/rslib-demo-react-ts-7mqjsd).
+We provide the scaffold tool [create-rslib](/guide/start/quick-start) for quickly creating Rslib projects. This scaffold supports creating Node.js / React library projects and supporting development tools. Additionally, we provide [migration documentation](/guide/migration/tsup) to help users migrate from other build tools to Rslib. Read [Quick start](/guide/start/quick-start) to learn how to get started with Rslib.
 
 We believe that a unified toolchain based on Rspack will provide developers with more possibilities. Looking forward to your feedback and contributions to help us build a more complete frontend toolchain ecosystem together.

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: 'Discover Rslib features, its integration with Rsbuild and Rspack, supported output formats, and the wider Rstack ecosystem.'
+description: 'Introduction to Rslib, including its core features, the Rstack toolchain, community resources, and online examples.'
 ---
 
 # Introduction
@@ -8,7 +8,7 @@ Rslib is a library development tool based on [Rsbuild](https://rsbuild.rs).
 
 It gives developers a simple way to create JavaScript libraries and UI component libraries, and provides tool integrations and best practices for building, debugging, documentation, and testing throughout library development.
 
-## ✨ Why Rslib
+## Why Rslib
 
 During the development of component or utility libraries, developers need to focus not only on implementing project logic, but also on handling tasks that are separate from the code itself, such as building, debugging, documentation, and testing. Although many community tools and solutions can address some of these needs, developers who are not familiar with them often face cumbersome configuration requirements or need to coordinate multiple tools to meet these demands.
 
@@ -18,7 +18,7 @@ Furthermore, Rslib utilizes Rsbuild's out-of-the-box configuration to facilitate
 
 In the future, Rslib will explore additional possibilities by leveraging the new features of Rspack.
 
-## 🔥 Features
+## Features
 
 Rslib has the following features:
 
@@ -32,17 +32,17 @@ Rslib has the following features:
 
 - **Framework agnostic**: Rslib is not coupled to frontend UI frameworks. It supports React, Vue, Svelte, Solid, and other frameworks through plugins, allowing developers to build component libraries for different frameworks with a consistent configuration and development workflow.
 
-## 🎯 Ecosystem
-
-Rslib is implemented based on Rsbuild and fully reuses the capabilities and ecosystem of Rsbuild.
-
-The following diagram illustrates the relationship between Rslib and other tools in the ecosystem:
-
-![Rspack stack layers](https://assets.rspack.rs/rsbuild/assets/rspack-stack-layers.png)
-
-## 🦀 Rstack
+## Rstack
 
 Rslib is part of Rstack, the fast, unified JavaScript toolchain for developers and agents.
+
+<img
+  src="https://assets.rspack.rs/rstack/rstack-overview.png"
+  alt="Rstack"
+  width="820"
+/>
+
+Rstack includes the following tools:
 
 | Name                                                  | Description              | Version                                                                                                                                                                          |
 | ----------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -54,14 +54,23 @@ Rslib is part of Rstack, the fast, unified JavaScript toolchain for developers a
 | [Rstest](https://github.com/web-infra-dev/rstest)     | Testing framework        | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 | [Rslint](https://github.com/web-infra-dev/rslint)     | Linter                   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 
-## 🔗 Links
+## Links
 
 - [awesome-rstack](https://github.com/rstackjs/awesome-rstack): A curated list of awesome things related to Rstack.
-- [rstack-examples](https://github.com/rstackjs/rstack-examples): Examples for Rstack.
+- [agent-skills](https://github.com/rstackjs/agent-skills): A collection of Agent Skills for Rstack.
+- [rstack-examples](https://github.com/rstackjs/rstack-examples): Examples showcasing Rstack tools.
 - [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild): Storybook builder powered by Rsbuild.
 - [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template): Use this template to create your own Rsbuild plugin.
 - [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources): Design resources for Rstack.
 
-## 🧑‍💻 Community
+## Community
 
 Come and chat with us on [Discord](https://discord.gg/XsaKEEk4mW)! The Rstack team and users are active there, and we're always looking for contributions.
+
+## Online example
+
+Try Rslib online with the [StackBlitz example](https://stackblitz.com/~/github.com/rstackjs/rslib-stackblitz-example).
+
+## Next steps
+
+Please read [Quick start](/guide/start/quick-start) to start using Rslib.

--- a/website/docs/zh/blog/introducing-rslib.mdx
+++ b/website/docs/zh/blog/introducing-rslib.mdx
@@ -165,6 +165,6 @@ Rslib 目前处于 0.x 阶段，我们计划在达成以下关键目标后发布
 
 ## 开始使用 Rslib
 
-我们提供了脚手架工具 [create-rslib](/guide/start/quick-start) 用于快速创建 Rslib 项目。该脚手架支持创建 Node.js / React 库项目及配套的开发工具。此外，我们还提供了 [迁移文档](/guide/migration/tsup)，帮助用户从其他构建工具迁移到 Rslib。你可以在这个 [CodeSandbox](https://codesandbox.io/p/devbox/rslib-demo-react-ts-7mqjsd) 中体验使用 Rslib 开发 React 组件库。
+我们提供了脚手架工具 [create-rslib](/guide/start/quick-start) 用于快速创建 Rslib 项目。该脚手架支持创建 Node.js / React 库项目及配套的开发工具。此外，我们还提供了 [迁移文档](/guide/migration/tsup)，帮助用户从其他构建工具迁移到 Rslib。阅读 [快速上手](/guide/start/quick-start)，进一步了解如何开始使用 Rslib。
 
 我们相信，基于 Rspack 的统一工具链，将为开发者提供更多的可能性。期待你的反馈与贡献，帮助我们共同构建更完善的前端工具链生态。

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: '了解 Rslib 的核心特性、与 Rsbuild 和 Rspack 的关系、支持的输出格式与更完整的 Rstack 生态。'
+description: 'Rslib 入门指南，介绍核心特性、Rstack 工具链、社区资源与在线示例。'
 ---
 
 # 介绍
@@ -8,7 +8,7 @@ Rslib 是一个基于 [Rsbuild](https://rsbuild.rs/zh/) 的库开发工具。
 
 它帮助开发者以简单的方式创建 JavaScript 库和 UI 组件库，并为库开发中的构建、调试、文档编写和测试等环节提供工具集成与最佳实践。
 
-## ✨ 为什么选择 Rslib
+## 为什么选择 Rslib
 
 在开发组件库或工具库时，开发者不仅需要关注项目逻辑的实现，还需考虑项目的构建、调试、文档和测试等与代码逻辑无关的工作。现有许多社区工具与方案通常能较好地满足其中部分需求，但对于不熟悉这些工具与方案的开发者来说，往往需要繁琐的配置工作或多种工具配合使用，以满足这些需求。
 
@@ -18,7 +18,7 @@ Rslib 基于 Rspack 与 Rsbuild 实现，针对库开发场景的多样化需求
 
 未来，Rslib 将基于 Rspack 的新特性，探索更多的可能性。
 
-## 🔥 特性
+## 特性
 
 Rslib 具备以下特性：
 
@@ -32,17 +32,17 @@ Rslib 具备以下特性：
 
 - **框架无关**：Rslib 不与前端 UI 框架耦合，并通过插件支持 React、Vue、Svelte、Solid 等框架，让开发者能够以一致的配置和开发方式构建不同框架的组件库。
 
-## 🎯 生态
-
-Rslib 基于 Rsbuild 实现，并完全复用 Rsbuild 的能力和生态系统。
-
-下图说明了 Rsbuild 与生态中其他工具之间的关系：
-
-![Rspack stack layers](https://assets.rspack.rs/rsbuild/assets/rspack-stack-layers.png)
-
-## 🦀 Rstack
+## Rstack
 
 Rslib 是 Rstack 的一员。Rstack 是为开发者与 Agent 打造的高性能、一体化 JavaScript 工具链。
+
+<img
+  src="https://assets.rspack.rs/rstack/rstack-overview.png"
+  alt="Rstack"
+  width="820"
+/>
+
+Rstack 包含以下工具：
 
 | 名称                                                  | 描述           | 版本                                                                                                                                                                             |
 | ----------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -54,16 +54,25 @@ Rslib 是 Rstack 的一员。Rstack 是为开发者与 Agent 打造的高性能�
 | [Rstest](https://github.com/web-infra-dev/rstest)     | 测试框架       | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 | [Rslint](https://github.com/web-infra-dev/rslint)     | 代码检查工具   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 
-## 🔗 链接
+## 链接
 
-- [awesome-rstack](https://github.com/rstackjs/awesome-rstack): 与 Rstack 相关的精彩内容列表。
-- [rstack-examples](https://github.com/rstackjs/rstack-examples): Rstack 的示例项目。
-- [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild): 基于 Rsbuild 构建的 Storybook。
-- [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template): 使用此模板创建你的 Rsbuild 插件。
-- [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources): Rstack 的设计资源。
+- [awesome-rstack](https://github.com/rstackjs/awesome-rstack)：与 Rstack 相关的精彩内容列表。
+- [agent-skills](https://github.com/rstackjs/agent-skills)：Rstack 的 Agent Skills 合集。
+- [rstack-examples](https://github.com/rstackjs/rstack-examples)：Rstack 的示例项目。
+- [storybook-rsbuild](https://github.com/rstackjs/storybook-rsbuild)：基于 Rsbuild 构建的 Storybook。
+- [rsbuild-plugin-template](https://github.com/rstackjs/rsbuild-plugin-template)：使用此模板创建你的 Rsbuild 插件。
+- [rstack-design-resources](https://github.com/rstackjs/rstack-design-resources)：Rstack 的设计资源。
 
-## 🧑‍💻 社区
+## 社区
 
 欢迎加入我们的 [Discord](https://discord.gg/XsaKEEk4mW) 交流频道！Rstack 团队和用户都在那里活跃，并且我们一直期待着各种贡献。
 
 你也可以加入 [飞书群](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=3c3vca77-bfc0-4ef5-b62b-9c5c9c92f1b4) 与大家一起交流。
+
+## 在线示例
+
+通过 [StackBlitz 示例](https://stackblitz.com/~/github.com/rstackjs/rslib-stackblitz-example) 在线体验 Rslib。
+
+## 下一步
+
+请阅读 [快速上手](/guide/start/quick-start) 来开始使用 Rslib。


### PR DESCRIPTION
## Summary

- Update the English and Chinese READMEs with versioned documentation links and refreshed Rstack resources.
- Consolidate and expand the Rslib introduction pages with Rstack information, an online example, and next-step guidance.
- Replace the outdated CodeSandbox reference in the launch blog with the Rslib quick-start guide.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).