### PR TITLE
docs: update blog UI

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -10,6 +10,7 @@ browserslistrc
 bundleless
 caniuse
 CEHQ
+Chenwei
 chunkhash
 Chunktmp
 cjsx
@@ -37,6 +38,7 @@ envinfo
 esbuild
 estree
 facti
+fi3ework
 filenaming
 flac
 flexbox

--- a/website/docs/en/blog/index.mdx
+++ b/website/docs/en/blog/index.mdx
@@ -1,15 +1,11 @@
 ---
-title: Overview
-description: 'Browse Rslib release announcements, project updates, and articles about library development with Rspack and Rsbuild.'
+title: Rslib blogs
+description: 'This page collects blog posts about Rslib.'
 sidebar: false
 ---
 
-# Rslib blogs
-
 Check here for the latest articles and release announcements about Rslib.
 
-## [Rslib: Build library with Rspack](/blog/introducing-rslib)
+import { BlogList } from '@components/BlogList';
 
-> May 14, 2025
-
-We are excited to introduce Rslib — **a library development tool based on Rspack**. Developed by ByteDance Web Infra Team, Rslib helps developers create JavaScript libraries and UI component libraries in a simple and intuitive way while enjoying the ultimate development experience brought by [Rspack](https://rspack.rs/) and [Rsbuild](https://rsbuild.rs/).
+<BlogList />

--- a/website/docs/en/blog/introducing-rslib.mdx
+++ b/website/docs/en/blog/introducing-rslib.mdx
@@ -1,14 +1,24 @@
 ---
-description: 'Learn why Rslib was built on Rspack and Rsbuild, and how it delivers multiple output formats, ecosystem reuse, and performance.'
+description: 'Rslib is officially released, helping developers create JavaScript libraries and UI component libraries in a simple and intuitive way.'
 date: 2025-05-14 10:00:00
 sidebar: false
+authors:
+  - name: fi3ework
+    avatar: 'https://github.com/fi3ework.png'
+    github: 'fi3ework'
+  - name: Chenwei Dai
+    avatar: 'https://github.com/Timeless0911.png'
+    github: 'Timeless0911'
 ---
+
+import { ImageAlt } from '../../../theme/components/ImageAlt';
+import { BlogAuthors } from '@rstackjs/doc-ui/blog-authors';
+
+# Rslib: Build library with Rspack
 
 _May 14, 2025_
 
-import { ImageAlt } from '../../../theme/components/ImageAlt';
-
-# Rslib: Build library with Rspack
+<BlogAuthors />
 
 ![banner](https://assets.rspack.rs/rslib/rslib-banner.png)
 

--- a/website/docs/zh/blog/index.mdx
+++ b/website/docs/zh/blog/index.mdx
@@ -1,15 +1,11 @@
 ---
-title: 总览
-description: '浏览 Rslib 的版本发布、项目动态，以及基于 Rspack 和 Rsbuild 的库开发文章与实践内容。'
+title: Rslib 博客
+description: '汇总了与 Rslib 相关的博客文章'
 sidebar: false
 ---
 
-# Rslib 博客
-
 在此查看有关 Rslib 的最新文章和发布公告。
 
-## [Rspack 生态升级！全新库开发工具 Rslib 发布](/blog/introducing-rslib)
+import { BlogList } from '@components/BlogList';
 
-> 2025 年 5 月 14 日
-
-我们很高兴地向大家介绍 Rslib —— **一款基于 Rspack 的库开发工具**。Rslib 由字节跳动 Web Infra 团队开发，能够帮助开发者以简单直观的方式创建 JavaScript 库和 UI 组件库，并享受 [Rspack](https://rspack.rs/zh/) 和 [Rsbuild](https://rsbuild.rs/zh/) 带来的极致开发体验。
+<BlogList />

--- a/website/docs/zh/blog/introducing-rslib.mdx
+++ b/website/docs/zh/blog/introducing-rslib.mdx
@@ -1,14 +1,24 @@
 ---
-description: '了解 Rslib 为何基于 Rspack 与 Rsbuild 构建，以及它如何提供多格式输出、生态复用与高性能体验。'
+description: 'Rslib 正式发布，帮助开发者以简单直观的方式创建 JavaScript 库和 UI 组件库。'
 date: 2025-05-14 10:00:00
 sidebar: false
+authors:
+  - name: fi3ework
+    avatar: 'https://github.com/fi3ework.png'
+    github: 'fi3ework'
+  - name: Chenwei Dai
+    avatar: 'https://github.com/Timeless0911.png'
+    github: 'Timeless0911'
 ---
+
+import { ImageAlt } from '../../../theme/components/ImageAlt';
+import { BlogAuthors } from '@rstackjs/doc-ui/blog-authors';
+
+# Rspack 生态升级！全新库开发工具 Rslib 发布
 
 _2025 年 5 月 14 日_
 
-import { ImageAlt } from '../../../theme/components/ImageAlt';
-
-# Rspack 生态升级！全新库开发工具 Rslib 发布
+<BlogAuthors />
 
 ![banner](https://assets.rspack.rs/rslib/rslib-banner.png)
 

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { defineConfig } from '@rspress/core';
 import { pluginAlgolia } from '@rspress/plugin-algolia';
@@ -9,6 +8,7 @@ import {
   transformerNotationDiff,
   transformerNotationHighlight,
 } from '@shikijs/transformers';
+import path from 'node:path';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
 import pluginFileTree from 'rspress-plugin-file-tree';
@@ -134,7 +134,7 @@ export default defineConfig({
   builderConfig: {
     resolve: {
       alias: {
-        '@components': path.join(__dirname, '@components'),
+        '@components': path.join(__dirname, 'theme/components'),
         '@en': path.join(__dirname, 'docs/en'),
         '@zh': path.join(__dirname, 'docs/zh'),
       },

--- a/website/theme/components/BlogList.tsx
+++ b/website/theme/components/BlogList.tsx
@@ -1,0 +1,80 @@
+import { Link, renderInlineMarkdown } from '@rspress/core/theme';
+import {
+  BlogList as BaseBlogList,
+  type BlogListItem,
+} from '@rstackjs/doc-ui/blog-list';
+import { BlogBackground } from '@rstackjs/doc-ui/blog-background';
+import type { BlogAvatarAuthor } from '@rstackjs/doc-ui/blog-avatar';
+import { useLang, usePages } from '@rspress/core/runtime';
+
+const DEFAULT_AUTHOR: BlogAvatarAuthor = {
+  name: 'Rstack Team',
+  avatar: 'https://assets.rspack.rs/rspack/rspack-logo-with-background.png',
+  github: 'https://github.com/web-infra-dev',
+  x: 'https://x.com/rspack_dev',
+};
+
+type BlogFrontmatter = {
+  description?: string;
+  date?: string;
+  authors?: BlogAvatarAuthor[];
+};
+
+const getDateValue = (date?: BlogListItem['date']): number => {
+  if (!date) {
+    return 0;
+  }
+
+  const timestamp = new Date(date).getTime();
+
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+};
+
+const withDefaultAuthor = (page: BlogListItem): BlogListItem => ({
+  ...page,
+  authors: page.authors?.length ? page.authors : [DEFAULT_AUTHOR],
+});
+
+export const useBlogPages = (): BlogListItem[] => {
+  const { pages } = usePages();
+  const lang = useLang();
+
+  const localBlogPages = pages
+    .filter((page) => page.lang === lang)
+    .filter(
+      (page) =>
+        page.routePath.includes('/blog/') && !page.routePath.endsWith('/blog/'),
+    )
+    .map((page) => {
+      const frontmatter = (page.frontmatter ?? {}) as BlogFrontmatter;
+
+      return withDefaultAuthor({
+        title: page.title,
+        description: frontmatter.description,
+        date: frontmatter.date,
+        href: page.routePath,
+        authors: frontmatter.authors,
+      });
+    });
+
+  return localBlogPages.sort(
+    (a, b) => getDateValue(b.date) - getDateValue(a.date),
+  );
+};
+
+export function BlogList() {
+  const lang = useLang();
+  const posts = useBlogPages();
+
+  return (
+    <>
+      <BaseBlogList
+        posts={posts}
+        lang={lang}
+        LinkComp={Link}
+        renderInlineMarkdown={renderInlineMarkdown}
+      />
+      <BlogBackground />
+    </>
+  );
+}

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,17 +1,42 @@
-import { Layout as BaseLayout } from '@rspress/core/theme-original';
 import {
-  Search as PluginAlgoliaSearch,
-  ZH_LOCALES,
-} from '@rspress/plugin-algolia/runtime';
+  Layout as BaseLayout,
+  DocLayout as BasicDocLayout,
+  Link,
+  type DocLayoutProps,
+} from '@rspress/core/theme-original';
+import { BlogBackButton } from '@rstackjs/doc-ui/blog-back-button';
 import { NavIcon } from '@rstackjs/doc-ui/nav-icon';
 import { HomeLayout } from './pages';
 import '@rstackjs/doc-ui/theme.css';
 import './index.scss';
-import { useLang } from '@rspress/core/runtime';
+import { useLang, usePage } from '@rspress/core/runtime';
+import {
+  Search as PluginAlgoliaSearch,
+  ZH_LOCALES,
+} from '@rspress/plugin-algolia/runtime';
 
-const Layout = () => {
-  return <BaseLayout beforeNavTitle={<NavIcon />} />;
+const DocLayout = (props: DocLayoutProps) => {
+  const { page } = usePage();
+  const lang = useLang();
+
+  return (
+    <BasicDocLayout
+      {...props}
+      beforeDocContent={
+        <>
+          <BlogBackButton
+            pathname={page.routePath}
+            lang={lang}
+            LinkComp={Link}
+          />
+          {props.beforeDocContent}
+        </>
+      }
+    />
+  );
 };
+
+const Layout = () => <BaseLayout beforeNavTitle={<NavIcon />} />;
 
 const Search = () => {
   const lang = useLang();
@@ -30,6 +55,6 @@ const Search = () => {
   );
 };
 
-export { Layout, HomeLayout, Search };
+export { DocLayout, Layout, HomeLayout, Search };
 
 export * from '@rspress/core/theme-original';


### PR DESCRIPTION
## Summary

This PR aligns the Rslib blog with the current Rsbuild blog UI so posts use consistent cards, metadata, and navigation.

- Replace the hand-written localized blog indexes with shared blog cards generated from page frontmatter.
- Add localized author metadata and blog back navigation to the introduction post.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).