### PR TITLE
chore: migrate hooks and staged tasks to Rstack CLI

### DIFF
--- a/.rstack/hooks/pre-commit
+++ b/.rstack/hooks/pre-commit
@@ -1,0 +1,1 @@
+rs staged

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check-spell": "pnpx cspell && heading-case",
     "format": "rs fmt && heading-case --write",
     "lint": "rs lint --type-check",
-    "prepare": "simple-git-hooks",
+    "prepare": "rs hooks",
     "sort-package-json": "rs fmt \"packages/*/package.json\"",
     "test": "pnpm run test:unit && pnpm run test:integration && pnpm run test:e2e",
     "test:benchmark": "cd ./tests && pnpm run test:benchmark",
@@ -20,16 +20,6 @@
     "update:rsbuild": "npx taze minor --include /rsbuild/ -w -r -l",
     "watch": "pnpm build --watch"
   },
-  "simple-git-hooks": {
-    "pre-commit": "pnpm exec nano-staged"
-  },
-  "nano-staged": {
-    "*.{md,mdx,css,less,scss,json,jsonc,json5}": "rs fmt",
-    "*.{js,jsx,ts,tsx,mjs,mjsx,cjs,cjsx,mts,mtsx,cts,ctsx}": [
-      "rs lint --type-check",
-      "rs fmt"
-    ]
-  },
   "devDependencies": {
     "@rstest/adapter-rslib": "catalog:",
     "@rstest/core": "catalog:",
@@ -38,10 +28,8 @@
     "cspell-ban-words": "catalog:",
     "fs-extra": "catalog:",
     "heading-case": "catalog:",
-    "nano-staged": "catalog:",
     "prettier": "catalog:",
     "rstack": "catalog:",
-    "simple-git-hooks": "catalog:",
     "typescript": "catalog:"
   },
   "packageManager": "pnpm@11.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,9 +205,6 @@ catalogs:
     memfs:
       specifier: ^4.68.1
       version: 4.68.1
-    nano-staged:
-      specifier: ^1.0.2
-      version: 1.0.2
     ora:
       specifier: 9.4.1
       version: 9.4.1
@@ -262,9 +259,6 @@ catalogs:
     semver:
       specifier: ^7.8.5
       version: 7.8.5
-    simple-git-hooks:
-      specifier: ^2.13.1
-      version: 2.13.1
     solid-js:
       specifier: ^1.9.15
       version: 1.9.15
@@ -341,18 +335,12 @@ importers:
       heading-case:
         specifier: 'catalog:'
         version: 1.1.5
-      nano-staged:
-        specifier: 'catalog:'
-        version: 1.0.2
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
       rstack:
         specifier: 'catalog:'
         version: 0.6.5(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.8.2)(@rspress/core@2.0.19)(jiti@2.7.0)(typescript@7.0.2)
-      simple-git-hooks:
-        specifier: 'catalog:'
-        version: 2.13.1
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -6399,11 +6387,6 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nano-staged@1.0.2:
-    resolution: {integrity: sha512-Fytar3zHLY99nlMfqPPbraxZodqQAHPpdPRyYaplL+lB9DCR6pUrafxbG+Btz4+7fO5Rm/+DO4ZeDO/nLSUMhw==}
-    engines: {node: ^22 || >= 24}
-    hasBin: true
-
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -7439,10 +7422,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-git-hooks@2.13.1:
-    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
-    hasBin: true
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -13322,8 +13301,6 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nano-staged@1.0.2: {}
-
   nanoid@3.3.15: {}
 
   needle@3.5.0:
@@ -14526,8 +14503,6 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   signal-exit@4.1.0: {}
-
-  simple-git-hooks@2.13.1: {}
 
   simple-swizzle@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,7 +80,6 @@ catalog:
   'lodash.merge': '^4.6.2'
   'magic-string': '^1.2.2'
   'memfs': '^4.68.1'
-  'nano-staged': '^1.0.2'
   'ora': '9.4.1'
   'path-serializer': '0.6.0'
   'postcss-alias': '2.0.0'
@@ -99,7 +98,6 @@ catalog:
   'rspress-plugin-font-open-sans': '^1.0.4'
   'rstack': '^0.6.5'
   'semver': '^7.8.5'
-  'simple-git-hooks': '^2.13.1'
   'solid-js': '^1.9.15'
   'storybook': '^10.5.10'
   'storybook-addon-rslib': '^3.4.2'
@@ -125,7 +123,6 @@ allowBuilds:
   '@parcel/watcher': false
   core-js-pure: false
   esbuild: true
-  simple-git-hooks: false
   svelte-preprocess: false
 
 autoInstallPeers: false

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -68,3 +68,11 @@ define.fmt({
   singleQuote: true,
   sortPackageJson: true,
 });
+
+define.staged({
+  '*.{md,mdx,css,less,scss,json,jsonc,json5}': 'rs fmt',
+  '*.{js,jsx,ts,tsx,mjs,mjsx,cjs,cjsx,mts,mtsx,cts,ctsx}': [
+    'rs lint --type-check',
+    'rs fmt',
+  ],
+});


### PR DESCRIPTION
## Summary

This PR moves repository-level Git hooks and staged-file tasks to Rstack CLI so they use the same unified tooling as linting and formatting.

- Install hooks with `rs hooks` and invoke `rs staged` from the pre-commit hook.
- Preserve the existing staged globs and commands through `define.staged()`, while removing `simple-git-hooks` and `nano-staged`.

## Related Links

- https://rstack.rs/guide/migration

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).