### PR TITLE
chore: check formatting in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Lint
-        run: pnpm run lint
+      - name: Check
+        run: pnpm run check
 
       - name: Check Spell
         run: pnpm run check-spell

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "scripts": {
     "build": "pnpm --filter \"./packages/*\" run build",
     "build:examples": "pnpm --filter \"@examples/*\" run build",
+    "check": "rs check --type-check",
     "check-spell": "pnpx cspell && heading-case",
     "format": "rs fmt && heading-case --write",
     "lint": "rs lint --type-check",
     "prepare": "rs hooks",
-    "sort-package-json": "rs fmt \"packages/*/package.json\"",
     "test": "pnpm run test:unit && pnpm run test:integration && pnpm run test:e2e",
     "test:benchmark": "cd ./tests && pnpm run test:benchmark",
     "test:e2e": "pnpm run build:examples && cd tests && pnpm run test:e2e",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -585,12 +585,9 @@ const modifyRsbuildDefaultPlugin = ({
 
       // Part 2: configure URL parsing for library output.
       if (urlParserMode !== undefined) {
-        chain.module
-          .rule(NEW_URL_RULE)
-          .test(JS_EXTENSIONS_PATTERN)
-          .parser({
-            url: urlParserMode
-          });
+        chain.module.rule(NEW_URL_RULE).test(JS_EXTENSIONS_PATTERN).parser({
+          url: urlParserMode,
+        });
       }
 
       // Part 3: remove Rsbuild's `type: 'javascript/auto'` override.

--- a/packages/core/src/css/libCssExtractLoader.ts
+++ b/packages/core/src/css/libCssExtractLoader.ts
@@ -123,8 +123,7 @@ export const pitch: Rspack.LoaderDefinition['pitch'] = function (
 
   const handleExports = (
     originalExports:
-      | { default: Record<string, any>; __esModule: true }
-      | Record<string, any>,
+      { default: Record<string, any>; __esModule: true } | Record<string, any>,
   ) => {
     let locals: Record<string, string> | undefined;
     let namedExport: boolean;

--- a/packages/core/src/utils/syntax.ts
+++ b/packages/core/src/utils/syntax.ts
@@ -235,7 +235,7 @@ export async function resolveMinNodeVersion(
   try {
     const { default: minVersion } = await import('semver/ranges/min-version');
     const minVer = minVersion(range);
-    return minVer?.version === '0.0.0' ? null : minVer?.version ?? null;
+    return minVer?.version === '0.0.0' ? null : (minVer?.version ?? null);
   } catch {
     return null;
   }

--- a/packages/core/tests/syntax.test.ts
+++ b/packages/core/tests/syntax.test.ts
@@ -281,7 +281,10 @@ describe('transformSyntaxToRspackTarget', () => {
 });
 
 describe('resolveMinNodeVersion', () => {
-  const expectMinNodeVersion = async (range: string, expected: string | null) => {
+  const expectMinNodeVersion = async (
+    range: string,
+    expected: string | null,
+  ) => {
     await expect(resolveMinNodeVersion(range)).resolves.toBe(expected);
   };
   test('extracts minimum versions from common range operators', async () => {
@@ -298,10 +301,7 @@ describe('resolveMinNodeVersion', () => {
     await expectMinNodeVersion('18', '18.0.0');
     await expectMinNodeVersion('18.12', '18.12.0');
     await expectMinNodeVersion('v20.19.0', '20.19.0');
-    await expectMinNodeVersion(
-      '>=20.19.0-alpha.1',
-      '20.19.0-alpha.1',
-    );
+    await expectMinNodeVersion('>=20.19.0-alpha.1', '20.19.0-alpha.1');
     await expectMinNodeVersion('^20.19.0-alpha.1', '20.19.0-alpha.1');
   });
 
@@ -335,10 +335,7 @@ describe('resolveMinNodeVersion', () => {
   test('uses the lowest satisfiable set from OR ranges', async () => {
     await expectMinNodeVersion('^20.19.0 || >=22.12.0', '20.19.0');
     await expectMinNodeVersion('>=22.12.0 || >=20.19.0', '20.19.0');
-    await expectMinNodeVersion(
-      '>=18.12.0 <19 || >=20.0.0',
-      '18.12.0',
-    );
+    await expectMinNodeVersion('>=18.12.0 <19 || >=20.0.0', '18.12.0');
   });
 
   test('returns null for impractical lower bounds', async () => {

--- a/website/docs/en/guide/migration/tsup.mdx
+++ b/website/docs/en/guide/migration/tsup.mdx
@@ -60,24 +60,24 @@ export default defineConfig({});
 
 Here is the corresponding Rslib configuration for tsup configuration:
 
-| tsup          | Rslib                                                                                                      |
-| ------------- | ---------------------------------------------------------------------------------------------------------- |
-| banner        | [lib.banner](/config/lib/banner)                                                                           |
-| bundle        | [lib.bundle](/config/lib/bundle)                                                                           |
-| clean         | [output.cleanDistPath](/config/rsbuild/output#outputcleandistpath)                                         |
-| define        | [source.define](/config/rsbuild/source#sourcedefine)                                                       |
-| dts           | [lib.dts](/config/lib/dts)                                                                                 |
-| entry         | [source.entry](/config/rsbuild/source#sourceentry)                                                         |
+| tsup          | Rslib                                                                                                                         |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| banner        | [lib.banner](/config/lib/banner)                                                                                              |
+| bundle        | [lib.bundle](/config/lib/bundle)                                                                                              |
+| clean         | [output.cleanDistPath](/config/rsbuild/output#outputcleandistpath)                                                            |
+| define        | [source.define](/config/rsbuild/source#sourcedefine)                                                                          |
+| dts           | [lib.dts](/config/lib/dts)                                                                                                    |
+| entry         | [source.entry](/config/rsbuild/source#sourceentry)                                                                            |
 | external      | [output.externals](/config/rsbuild/output#outputexternals) / [output.autoExternal](/config/rsbuild/output#outputautoexternal) |
-| format        | [lib.format](/config/lib/format)                                                                           |
-| footer        | [lib.footer](/config/lib/footer)                                                                           |
-| minify        | [output.minify](/config/rsbuild/output#outputminify)                                                       |
-| platform      | [output.target](/config/rsbuild/output#outputtarget)                                                       |
-| plugins       | [plugins](/config/rsbuild/plugins)                                                                         |
-| sourcemap     | [output.sourceMap](/config/rsbuild/output#outputsourcemap)                                                 |
-| shims         | [lib.shims](/config/lib/shims)                                                                             |
-| terserOptions | [output.minify](/config/rsbuild/output#outputminify)                                                       |
-| tsconfig      | [source.tsconfigPath](/config/rsbuild/source#sourcetsconfigpath)                                           |
+| format        | [lib.format](/config/lib/format)                                                                                              |
+| footer        | [lib.footer](/config/lib/footer)                                                                                              |
+| minify        | [output.minify](/config/rsbuild/output#outputminify)                                                                          |
+| platform      | [output.target](/config/rsbuild/output#outputtarget)                                                                          |
+| plugins       | [plugins](/config/rsbuild/plugins)                                                                                            |
+| sourcemap     | [output.sourceMap](/config/rsbuild/output#outputsourcemap)                                                                    |
+| shims         | [lib.shims](/config/lib/shims)                                                                                                |
+| terserOptions | [output.minify](/config/rsbuild/output#outputminify)                                                                          |
+| tsconfig      | [source.tsconfigPath](/config/rsbuild/source#sourcetsconfigpath)                                                              |
 
 ## Example
 

--- a/website/docs/zh/guide/migration/tsup.mdx
+++ b/website/docs/zh/guide/migration/tsup.mdx
@@ -60,24 +60,24 @@ export default defineConfig({});
 
 以下是 tsup 配置对应的 Rslib 配置：
 
-| tsup          | Rslib                                                                                                      |
-| ------------- | ---------------------------------------------------------------------------------------------------------- |
-| banner        | [lib.banner](/config/lib/banner)                                                                           |
-| bundle        | [lib.bundle](/config/lib/bundle)                                                                           |
-| clean         | [output.cleanDistPath](/config/rsbuild/output#outputcleandistpath)                                         |
-| define        | [source.define](/config/rsbuild/source#sourcedefine)                                                       |
-| dts           | [lib.dts](/config/lib/dts)                                                                                 |
-| entry         | [source.entry](/config/rsbuild/source#sourceentry)                                                         |
+| tsup          | Rslib                                                                                                                         |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| banner        | [lib.banner](/config/lib/banner)                                                                                              |
+| bundle        | [lib.bundle](/config/lib/bundle)                                                                                              |
+| clean         | [output.cleanDistPath](/config/rsbuild/output#outputcleandistpath)                                                            |
+| define        | [source.define](/config/rsbuild/source#sourcedefine)                                                                          |
+| dts           | [lib.dts](/config/lib/dts)                                                                                                    |
+| entry         | [source.entry](/config/rsbuild/source#sourceentry)                                                                            |
 | external      | [output.externals](/config/rsbuild/output#outputexternals) / [output.autoExternal](/config/rsbuild/output#outputautoexternal) |
-| format        | [lib.format](/config/lib/format)                                                                           |
-| footer        | [lib.footer](/config/lib/footer)                                                                           |
-| minify        | [output.minify](/config/rsbuild/output#outputminify)                                                       |
-| platform      | [output.target](/config/rsbuild/output#outputtarget)                                                       |
-| plugins       | [plugins](/config/rsbuild/plugins)                                                                         |
-| sourcemap     | [output.sourceMap](/config/rsbuild/output#outputsourcemap)                                                 |
-| shims         | [lib.shims](/config/lib/shims)                                                                             |
-| terserOptions | [output.minify](/config/rsbuild/output#outputminify)                                                       |
-| tsconfig      | [source.tsconfigPath](/config/rsbuild/source#sourcetsconfigpath)                                           |
+| format        | [lib.format](/config/lib/format)                                                                                              |
+| footer        | [lib.footer](/config/lib/footer)                                                                                              |
+| minify        | [output.minify](/config/rsbuild/output#outputminify)                                                                          |
+| platform      | [output.target](/config/rsbuild/output#outputtarget)                                                                          |
+| plugins       | [plugins](/config/rsbuild/plugins)                                                                                            |
+| sourcemap     | [output.sourceMap](/config/rsbuild/output#outputsourcemap)                                                                    |
+| shims         | [lib.shims](/config/lib/shims)                                                                                                |
+| terserOptions | [output.minify](/config/rsbuild/output#outputminify)                                                                          |
+| tsconfig      | [source.tsconfigPath](/config/rsbuild/source#sourcetsconfigpath)                                                              |
 
 ## 示例
 


### PR DESCRIPTION
## Summary

This PR adds formatting verification to CI so formatting regressions fail before merge.

- Add a `check` script backed by `rs check --type-check`, and run it in CI to preserve lint and type checking while adding `rs fmt --check`.
- Apply the existing Rstack formatting rules so the repository passes the new check, and remove the redundant `sort-package-json` script.

## Related Links

- https://rstack.rs/guide/cli/check
- https://github.com/web-infra-dev/rslib/pull/1884

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).