### PR TITLE
feat(deps): upgrade Rsbuild to 2.2.2

### DIFF
--- a/packages/create-rslib/template-storybook/react-js/package.json
+++ b/packages/create-rslib/template-storybook/react-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.1",
+    "@rsbuild/core": "~2.2.2",
     "@storybook/addon-docs": "^10.5.10",
     "@storybook/addon-onboarding": "^10.5.10",
     "@storybook/react": "^10.5.10",

--- a/packages/create-rslib/template-storybook/react-ts/package.json
+++ b/packages/create-rslib/template-storybook/react-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.1",
+    "@rsbuild/core": "~2.2.2",
     "@storybook/addon-docs": "^10.5.10",
     "@storybook/addon-onboarding": "^10.5.10",
     "@storybook/react": "^10.5.10",

--- a/packages/create-rslib/template-storybook/vue-js/package.json
+++ b/packages/create-rslib/template-storybook/vue-js/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.1",
+    "@rsbuild/core": "~2.2.2",
     "@storybook/addon-docs": "^10.5.10",
     "@storybook/addon-onboarding": "^10.5.10",
     "@storybook/vue3": "^10.5.10",

--- a/packages/create-rslib/template-storybook/vue-ts/package.json
+++ b/packages/create-rslib/template-storybook/vue-ts/package.json
@@ -4,7 +4,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.2.1",
+    "@rsbuild/core": "~2.2.2",
     "@storybook/addon-docs": "^10.5.10",
     "@storybook/addon-onboarding": "^10.5.10",
     "@storybook/vue3": "^10.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,7 +319,7 @@ importers:
         version: 0.11.10(@rslib/core@1.0.0-rc.2)(@rstest/core@0.11.10)(typescript@7.0.2)
       '@rstest/core':
         specifier: 'catalog:'
-        version: 0.11.10(@module-federation/runtime-tools@2.9.0)
+        version: 0.11.10
       '@types/fs-extra':
         specifier: 'catalog:'
         version: 11.0.4
@@ -340,7 +340,7 @@ importers:
         version: 3.9.6
       rstack:
         specifier: 'catalog:'
-        version: 0.6.5(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(jiti@2.7.0)(typescript@7.0.2)
+        version: 0.6.5(@microsoft/api-extractor@7.59.0)(@rspress/core@2.0.21)(jiti@2.7.0)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -630,7 +630,7 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.9.0(@rsbuild/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
+        version: 2.9.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -3037,16 +3037,6 @@ packages:
       rollup:
         optional: true
 
-  '@rsbuild/core@2.2.1':
-    resolution: {integrity: sha512-JcGtG4bo7PBihj6fBL6gaxaJihqLf7nGWW/t4zEmXpMJkV6XNdr1jAo9B0xI4mLAOmtFeva8cUbn9SE2ZEmAIw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
   '@rsbuild/core@2.2.2':
     resolution: {integrity: sha512-T82jUaeMUFhcBqpmKvRiNAcWMp6abxkvMEwiZi4x+gf7NAbyiF5jrbLnQLm1y4909eANsTSHenp99HlRPIByLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3263,19 +3253,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@2.2.1':
-    resolution: {integrity: sha512-Y/Naw/7V76QiUYdYRuBzBZtzRjt/3fjDUuF8GK0+/BO7BP1RrpY4tk1ln+iiqegRUD8u9uGn08fi8No1rwfyUg==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@2.2.2':
     resolution: {integrity: sha512-/le/AvV4HSinXTPs2Lqpujxt189Z5T10Ggt96QzckLRPvIchzqoavVDDjltzC7XcaZ87XCH/X06jNKgzkcBBNA==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@2.2.1':
-    resolution: {integrity: sha512-rTIG/xZIW7RbEEuMR9hnNn5dv3fDBpX0N4FAQUwfhUYy3tN2+3vibTTq/Nj1Sd9Vn4yWydbWIEwBX6m/aGejig==}
-    cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@2.2.2':
@@ -3283,23 +3263,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.2.1':
-    resolution: {integrity: sha512-53rAMU6Hqiat21IMU1hTt4Si2F33h+ZbXOt+Y18W39AFjcwmleIBId2u7beqJeGXLJuBgIAm31jcbJj/PN7mWQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-arm64-gnu@2.2.2':
     resolution: {integrity: sha512-Pjby4pDSMNJQK2VBzpgCj6lb+DGuenS1fEDb6xi5/apbJb9v5WE+e43Mz7i+XqgXS8e846pjaONV3KM5WKB1LQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rspack/binding-linux-arm64-musl@2.2.1':
-    resolution: {integrity: sha512-o7zFiWkt4MqSfSdTbxUdF27fcrWKpRizcuVB8H3yd2G6xW9V2OfYbhVGQnOlbKi+GK74RkCmoJtANB+QboIqKQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-arm64-musl@2.2.2':
     resolution: {integrity: sha512-0u9O7tTVT2z+F6o/eEY6f6+My8Jn9U56QiBwkfy90ZaoAfZyQSSTxqaK/zA7W43oFxQefeCpiPas27VUzrSakw==}
@@ -3307,21 +3275,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-ppc64-gnu@2.2.1':
-    resolution: {integrity: sha512-pvx1oeg1z7cr8OcNt7PAt1SJTHzdsN/pvu7HkGnfks2fWE7GDs9DLL2KvN7tUkzQvJm6bGgUwqSCOrqV4uSwAg==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-ppc64-gnu@2.2.2':
     resolution: {integrity: sha512-N3lVnhq5qOvpmP5n386JzR1GcE8HzAqq4/r440Z6yle9m7PhVFJ6oXVWxgaDTYV0mtv9YLJmaG+YrjYfUa1vuA==}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-riscv64-gnu@2.2.1':
-    resolution: {integrity: sha512-WQ6P94Wz2tgwOsgifTWP2/bV63iZH5+rkxngQwF22FC8KmIXXy/Yug7lyMH1ld8Hzg4p1qXjBBr4i1cCyJTR+w==}
-    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -3331,33 +3287,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.2.1':
-    resolution: {integrity: sha512-GEFUFHQkjKU7OYyHXnrIo8wWcUHM7jeKov5z6Lxd3i+3hKo11yBOgb7b+uD94Rx2tPuWF4jyFdWmcNu46Njb/A==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
   '@rspack/binding-linux-riscv64-musl@2.2.2':
     resolution: {integrity: sha512-mqsorvTNerr3r8zI35NFTPYATPDlhepdiUhZjKT6ylqpHlP7vLU9fp4aEMK/CuTv2f+IVsa0+iZqtMxHs2tSjw==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-s390x-gnu@2.2.1':
-    resolution: {integrity: sha512-Cqw2UjSmFGZaw1EjQXClKDud86ThynGEEIazy2PZfPzZG4WjICK1WjdeFCJd7xWsSbUQ3jGyzb7/EHiDVa+sKA==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-s390x-gnu@2.2.2':
     resolution: {integrity: sha512-ql2Jub8QYWSugBppmj2u0SjcIj6fOQuAaLCYQOqU7zbvz/uuWTfoqmdWKExwrxeCU9Tzt7emVM0ETuVEpoca+A==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-x64-gnu@2.2.1':
-    resolution: {integrity: sha512-QX+gRxg2CS9ri2fUG5eNurdsrOCWoJ56SsD2O7kcVGiRm+S2+muNb/QhkdkAdt/u/m++7Ve5TMIpHTnaKYCpCw==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -3367,39 +3305,19 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.2.1':
-    resolution: {integrity: sha512-mBZQl1NdGbEB3y5M9d0tkuF7RL1GLz3Hb3gqFa3QRZBymP9PCV83Jiji8s2PJimNUJIVcdZRIw8+VGYs/35c2A==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rspack/binding-linux-x64-musl@2.2.2':
     resolution: {integrity: sha512-y9/9CmE8lrECaF17GAhacibTL+SvlEPEotQnUuBFC/WFtXh8hU2E7a7bAkpYGSLH6kM0nrJZHO3hTvM1wdWOJw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.2.1':
-    resolution: {integrity: sha512-/d2ImKDS+lT+FJ07MxKBeUkTat84tr2Nm2+nIRt8HmZK7/N8odkQml9vb4MHr8E7oYOp4B+jm6W5frdRzKrkJQ==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@2.2.2':
     resolution: {integrity: sha512-VbDIjjeFwZvMSKAOGY5IbU6lLzt6AHHHncTdMMkZ94Xk7O2BOHe9BXDV32Ln29TIW2C8m1fdxfPZWDiecVghUQ==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.2.1':
-    resolution: {integrity: sha512-TfmaKPF3KC7uoZb6A+8ZUbLS8g8P5EdeXFGLCaJ+UgdkJ20TsapcfJXZXWNnKzFEkV8dUO/t5oNxNLYy2URusw==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rspack/binding-win32-arm64-msvc@2.2.2':
     resolution: {integrity: sha512-rfcNg0W3ZPZvXma1gTyEt9/Z8FxASIaQr+sMWTSaTPPaeU3xY1+0hYcrD0kUFNs3/5L4u63myI4R8qRXiuW3pA==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@2.2.1':
-    resolution: {integrity: sha512-rdBXayngvpQFMSUIC4b71FDZrSBJszSHNEkln/Nis3a17DMAE7IkgJcqe7SqLWbk2OPF/N920AOWmBEDQQCaMg==}
-    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@2.2.2':
@@ -3407,33 +3325,13 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.2.1':
-    resolution: {integrity: sha512-l3K4s7nrQJc+3LacPFjZGjX8Jk1sf8Q4TK6IXAsdSucOjTqYSpD8PMl2NUXCBDXOl8T2V4v323z1LfxwW8BPmA==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@2.2.2':
     resolution: {integrity: sha512-GvEGyL594dtWN9SoVnKWh0exrM8WLInaUjwcuA2JKbCi1ak/9iHxip/U1dY3DuVqBYBhmvYq96JPbl91xnzFjg==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.2.1':
-    resolution: {integrity: sha512-56TqztuEMd+aHGv1jDXnkJQGSLTb4NoO146flFxJqPG8931UdXPO2pNR9M0Q2Pz+GvmO0fLHGPLYBHoRVrRlHw==}
-
   '@rspack/binding@2.2.2':
     resolution: {integrity: sha512-gWjKDQfVQJSBh/I+y9WTlyERsiShSJ7eI6Yl0SJs/6gjx8t4ixuwWCsaEFFjwSL4nSn6ML5hNQ7UFY3gj72BWA==}
-
-  '@rspack/core@2.2.1':
-    resolution: {integrity: sha512-EHFX2oWCY1HkHJkG/Ev8HXCcl4gQzgETyairdIlBkKaypuW8i7kowBxUFzpHHg/ObF70vB3focToel9Wwg4MRA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
 
   '@rspack/core@2.2.2':
     resolution: {integrity: sha512-/yztfDZR5syIPBrUpzBpL+6fhhl0IHBPcXlNr4tOMBULbocFIz7Z4/cqvf1ix0DBbKpIGx99v6N1IDbk2gi8hw==}
@@ -9203,29 +9101,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)':
-    dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 2.9.0
-      '@module-federation/cli': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
-      '@module-federation/dts-plugin': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
-      '@module-federation/error-codes': 2.9.0
-      '@module-federation/inject-external-runtime-core-plugin': 2.9.0(@module-federation/runtime-tools@2.9.0)
-      '@module-federation/managers': 2.9.0
-      '@module-federation/manifest': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
-      '@module-federation/rspack': 2.9.0(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
-      '@module-federation/runtime-tools': 2.9.0
-      '@module-federation/sdk': 2.9.0
-      '@module-federation/webpack-bundler-runtime': 2.9.0
-      schema-utils: 4.3.0
-      tapable: 2.3.0
-    optionalDependencies:
-      typescript: 7.0.2
-      vue-tsc: 3.3.11(typescript@7.0.2)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - utf-8-validate
-
   '@module-federation/error-codes@2.9.0': {}
 
   '@module-federation/inject-external-runtime-core-plugin@2.9.0(@module-federation/runtime-tools@2.9.0)':
@@ -9288,21 +9163,6 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.50(typescript@7.0.2)(vue-tsc@3.3.11)':
-    dependencies:
-      '@module-federation/enhanced': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
-      '@module-federation/runtime': 2.9.0
-      '@module-federation/sdk': 2.9.0
-      encoding: 0.1.13
-      node-fetch: 2.7.0(encoding@0.1.13)
-      tapable: 2.3.0
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-
   '@module-federation/rsbuild-plugin@2.9.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)':
     dependencies:
       '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
@@ -9322,21 +9182,6 @@ snapshots:
     dependencies:
       '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@module-federation/node': 2.7.50(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
-      '@module-federation/sdk': 2.9.0
-    optionalDependencies:
-      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-      - webpack
-
-  '@module-federation/rsbuild-plugin@2.9.0(@rsbuild/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)':
-    dependencies:
-      '@module-federation/enhanced': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
-      '@module-federation/node': 2.7.50(typescript@7.0.2)(vue-tsc@3.3.11)
       '@module-federation/sdk': 2.9.0
     optionalDependencies:
       '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
@@ -9678,13 +9523,6 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.5
 
-  '@rsbuild/core@2.2.1(@module-federation/runtime-tools@2.9.0)':
-    dependencies:
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
   '@rsbuild/core@2.2.2(@module-federation/runtime-tools@2.9.0)':
     dependencies:
       '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
@@ -9772,25 +9610,6 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
       - preact
-
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.1)':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.2)(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-    optional: true
-
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.2)':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.2)(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
 
   '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)':
     dependencies:
@@ -9918,8 +9737,8 @@ snapshots:
 
   '@rslib/core@1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
-      rsbuild-plugin-dts: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@rsbuild/core@2.2.1)(typescript@7.0.2)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
+      rsbuild-plugin-dts: 1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@rsbuild/core@2.2.2)(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.59.0(@types/node@24.13.3)
       typescript: 7.0.2
@@ -9965,71 +9784,34 @@ snapshots:
   '@rslint/native-win32-x64-msvc@0.8.1':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.2.1':
-    optional: true
-
   '@rspack/binding-darwin-arm64@2.2.2':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.2.1':
     optional: true
 
   '@rspack/binding-darwin-x64@2.2.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.2.1':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@2.2.2':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@2.2.1':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.2.2':
     optional: true
 
-  '@rspack/binding-linux-ppc64-gnu@2.2.1':
-    optional: true
-
   '@rspack/binding-linux-ppc64-gnu@2.2.2':
-    optional: true
-
-  '@rspack/binding-linux-riscv64-gnu@2.2.1':
     optional: true
 
   '@rspack/binding-linux-riscv64-gnu@2.2.2':
     optional: true
 
-  '@rspack/binding-linux-riscv64-musl@2.2.1':
-    optional: true
-
   '@rspack/binding-linux-riscv64-musl@2.2.2':
-    optional: true
-
-  '@rspack/binding-linux-s390x-gnu@2.2.1':
     optional: true
 
   '@rspack/binding-linux-s390x-gnu@2.2.2':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.2.1':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@2.2.2':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.2.1':
-    optional: true
-
   '@rspack/binding-linux-x64-musl@2.2.2':
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.2.1':
-    dependencies:
-      '@emnapi/core': 1.11.3
-      '@emnapi/runtime': 1.11.3
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.2.2':
@@ -10039,40 +9821,14 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.2.1':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@2.2.2':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@2.2.1':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.2.2':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.2.1':
-    optional: true
-
   '@rspack/binding-win32-x64-msvc@2.2.2':
     optional: true
-
-  '@rspack/binding@2.2.1':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.2.1
-      '@rspack/binding-darwin-x64': 2.2.1
-      '@rspack/binding-linux-arm64-gnu': 2.2.1
-      '@rspack/binding-linux-arm64-musl': 2.2.1
-      '@rspack/binding-linux-ppc64-gnu': 2.2.1
-      '@rspack/binding-linux-riscv64-gnu': 2.2.1
-      '@rspack/binding-linux-riscv64-musl': 2.2.1
-      '@rspack/binding-linux-s390x-gnu': 2.2.1
-      '@rspack/binding-linux-x64-gnu': 2.2.1
-      '@rspack/binding-linux-x64-musl': 2.2.1
-      '@rspack/binding-wasm32-wasi': 2.2.1
-      '@rspack/binding-win32-arm64-msvc': 2.2.1
-      '@rspack/binding-win32-ia32-msvc': 2.2.1
-      '@rspack/binding-win32-x64-msvc': 2.2.1
 
   '@rspack/binding@2.2.2':
     optionalDependencies:
@@ -10090,13 +9846,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 2.2.2
       '@rspack/binding-win32-ia32-msvc': 2.2.2
       '@rspack/binding-win32-x64-msvc': 2.2.2
-
-  '@rspack/core@2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)':
-    dependencies:
-      '@rspack/binding': 2.2.1
-    optionalDependencies:
-      '@module-federation/runtime-tools': 2.9.0
-      '@swc/helpers': 0.5.23
 
   '@rspack/core@2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)':
     dependencies:
@@ -10124,8 +9873,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.2)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rspress/shared': 2.0.21(@module-federation/runtime-tools@2.9.0)(supports-color@9.4.0)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -10167,55 +9916,6 @@ snapshots:
       - micromark
       - micromark-util-types
       - supports-color
-
-  '@rspress/core@2.0.21(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
-    dependencies:
-      '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
-      '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.1)
-      '@rspress/shared': 2.0.21(@module-federation/runtime-tools@2.9.0)(supports-color@9.4.0)
-      '@shikijs/rehype': 4.3.0
-      '@types/mdast': 4.0.4
-      '@types/react': 19.2.18
-      '@unhead/react': 2.1.17(react@19.2.8)
-      body-scroll-lock: 4.0.0-beta.0
-      clsx: 2.1.1
-      copy-to-clipboard: 3.3.3
-      flexsearch: 0.8.212
-      hast-util-heading-rank: 3.0.0
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@9.4.0)
-      mdast-util-mdx: 3.0.0(supports-color@9.4.0)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@9.4.0)
-      medium-zoom: 1.1.0
-      nprogress: 0.2.0
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-lazy-with-preload: 2.2.1
-      react-render-to-markdown: 19.1.0(react@19.2.8)
-      react-router-dom: 7.18.3(react-dom@19.2.8)(react@19.2.8)
-      rehype-external-links: 3.0.0
-      rehype-raw: 7.0.0
-      remark-cjk-friendly: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
-      remark-cjk-friendly-gfm-strikethrough: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)(unified@11.0.5)
-      remark-gfm: 4.0.1(supports-color@9.4.0)
-      remark-mdx: 3.1.1(supports-color@9.4.0)
-      remark-parse: 11.0.0(supports-color@9.4.0)
-      remark-stringify: 11.0.0
-      scroll-into-view-if-needed: 3.1.0
-      shiki: 4.3.0
-      unified: 11.0.5
-      unist-util-visit: 5.1.0
-      unist-util-visit-children: 3.0.0
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - '@rspack/core'
-      - core-js
-      - micromark
-      - micromark-util-types
-      - supports-color
-    optional: true
 
   '@rspress/plugin-algolia@2.0.21(@rspress/core@2.0.21)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)':
     dependencies:
@@ -10267,7 +9967,7 @@ snapshots:
 
   '@rspress/shared@2.0.21(@module-federation/runtime-tools@2.9.0)(supports-color@9.4.0)':
     dependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@shikijs/rehype': 4.3.0
       '@types/react': 19.2.18
       mdast-util-mdx-jsx: 3.2.0(supports-color@9.4.0)
@@ -10325,13 +10025,13 @@ snapshots:
   '@rstest/adapter-rslib@0.11.10(@rslib/core@1.0.0-rc.2)(@rstest/core@0.11.10)(typescript@7.0.2)':
     dependencies:
       '@rslib/core': 1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(typescript@7.0.2)
-      '@rstest/core': 0.11.10(@module-federation/runtime-tools@2.9.0)
+      '@rstest/core': 0.11.10
     optionalDependencies:
       typescript: 7.0.2
 
-  '@rstest/core@0.11.10(@module-federation/runtime-tools@2.9.0)':
+  '@rstest/core@0.11.10':
     dependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@types/chai': 5.2.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -14331,10 +14031,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@rsbuild/core@2.2.1)(typescript@7.0.2):
+  rsbuild-plugin-dts@1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@rsbuild/core@2.2.2)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.45.1
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.59.0(@types/node@24.13.3)
       typescript: 7.0.2
@@ -14407,17 +14107,17 @@ snapshots:
     dependencies:
       '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
-  rstack@0.6.5(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(jiti@2.7.0)(typescript@7.0.2):
+  rstack@0.6.5(@microsoft/api-extractor@7.59.0)(@rspress/core@2.0.21)(jiti@2.7.0)(typescript@7.0.2):
     dependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core': 1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(typescript@7.0.2)
       '@rslint/core': 0.8.1(jiti@2.7.0)
-      '@rstest/core': 0.11.10(@module-federation/runtime-tools@2.9.0)
+      '@rstest/core': 0.11.10
       prettier: 3.9.6
       tinypool: 2.1.2
       yuku-parser: 0.9.1
     optionalDependencies:
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@rstackjs/cli-darwin-arm64': 0.6.5
       '@rstackjs/cli-darwin-x64': 0.6.5
       '@rstackjs/cli-linux-arm64-gnu': 0.6.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ catalogs:
       specifier: ^2.12.0
       version: 2.12.0
     '@rsbuild/core':
-      specifier: ~2.2.1
-      version: 2.2.1
+      specifier: ~2.2.2
+      version: 2.2.2
     '@rsbuild/plugin-babel':
       specifier: ^2.1.0
       version: 2.1.0
@@ -319,7 +319,7 @@ importers:
         version: 0.11.10(@rslib/core@1.0.0-rc.2)(@rstest/core@0.11.10)(typescript@7.0.2)
       '@rstest/core':
         specifier: 'catalog:'
-        version: 0.11.10
+        version: 0.11.10(@module-federation/runtime-tools@2.9.0)
       '@types/fs-extra':
         specifier: 'catalog:'
         version: 11.0.4
@@ -340,7 +340,7 @@ importers:
         version: 3.9.6
       rstack:
         specifier: 'catalog:'
-        version: 0.6.5(@microsoft/api-extractor@7.59.0)(@rspress/core@2.0.21)(jiti@2.7.0)(typescript@7.0.2)
+        version: 0.6.5(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(jiti@2.7.0)(typescript@7.0.2)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -373,13 +373,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.9.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+        version: 2.9.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.1(@module-federation/runtime-tools@2.9.0)
+        version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -394,19 +394,19 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 'catalog:'
-        version: 2.9.0(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+        version: 2.9.0(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.9.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+        version: 2.9.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/storybook-addon':
         specifier: 'catalog:'
-        version: 6.0.19(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(storybook@10.5.10)(typescript@6.0.3)(vue-tsc@3.3.11)(webpack-virtual-modules@0.6.2)
+        version: 6.0.19(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(storybook@10.5.10)(typescript@6.0.3)(vue-tsc@3.3.11)(webpack-virtual-modules@0.6.2)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.1(@module-federation/runtime-tools@2.9.0)
+        version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -436,10 +436,10 @@ importers:
         version: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
+        version: 3.4.2(@rsbuild/core@2.2.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(@types/react-dom@19.2.5)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3)
+        version: 3.4.2(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(@types/react-dom@19.2.5)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -455,13 +455,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.9.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+        version: 2.9.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.1(@module-federation/runtime-tools@2.9.0)
+        version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -476,10 +476,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(preact@10.29.8)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(preact@10.29.8)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)
+        version: 2.0.1(@rsbuild/core@2.2.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -491,10 +491,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)
+        version: 2.0.1(@rsbuild/core@2.2.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -509,10 +509,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)
+        version: 2.0.1(@rsbuild/core@2.2.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -527,10 +527,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)
+        version: 2.0.1(@rsbuild/core@2.2.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -545,13 +545,13 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(supports-color@9.4.0)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(supports-color@9.4.0)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)
+        version: 2.0.1(@rsbuild/core@2.2.2)
       '@rsbuild/plugin-solid':
         specifier: 'catalog:'
-        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.2.1)(solid-js@1.9.15)(supports-color@9.4.0)
+        version: 1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.2.2)(solid-js@1.9.15)(supports-color@9.4.0)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -566,7 +566,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)
+        version: 2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -584,10 +584,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.1(@module-federation/runtime-tools@2.9.0)
+        version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)
+        version: 2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)
       '@rslib/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -605,10 +605,10 @@ importers:
         version: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       storybook-addon-rslib:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
+        version: 3.4.2(@rsbuild/core@2.2.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3)
       storybook-vue3-rsbuild:
         specifier: 'catalog:'
-        version: 3.4.2(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3)(vue@3.5.42)
+        version: 3.4.2(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3)(vue@3.5.42)
       typescript:
         specifier: catalog:typescript-6
         version: 6.0.3
@@ -623,14 +623,14 @@ importers:
     dependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.1(@module-federation/runtime-tools@2.9.0)
+        version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       rsbuild-plugin-dts:
         specifier: workspace:*
         version: link:../plugin-dts
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.9.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(typescript@7.0.2)(vue-tsc@3.3.11)
+        version: 2.9.0(@rsbuild/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -657,7 +657,7 @@ importers:
         version: 0.6.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.2.1)
+        version: 1.0.0(@rsbuild/core@2.2.2)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(typescript@7.0.2)'
@@ -694,7 +694,7 @@ importers:
         version: 11.4.0
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.2.1)
+        version: 1.0.0(@rsbuild/core@2.2.2)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(typescript@7.0.2)'
@@ -716,7 +716,7 @@ importers:
         version: 7.59.0(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.1(@module-federation/runtime-tools@2.9.0)
+        version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -728,7 +728,7 @@ importers:
         version: 1.2.3
       rsbuild-plugin-publint:
         specifier: 'catalog:'
-        version: 1.0.0(@rsbuild/core@2.2.1)
+        version: 1.0.0(@rsbuild/core@2.2.2)
       rslib:
         specifier: 'catalog:'
         version: '@rslib/core@1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(typescript@7.0.2)'
@@ -758,34 +758,34 @@ importers:
         version: 4.0.1(debug@4.4.3)(supports-color@9.4.0)
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.9.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(typescript@7.0.2)(vue-tsc@3.3.11)
+        version: 2.9.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.1(@module-federation/runtime-tools@2.9.0)
+        version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)
+        version: 2.0.1(@rsbuild/core@2.2.2)
       '@rsbuild/plugin-toml':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 'catalog:'
-        version: 1.2.4(@rsbuild/core@2.2.1)
+        version: 1.2.4(@rsbuild/core@2.2.2)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)
+        version: 2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)
       '@rsbuild/plugin-yaml':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.2.1)
+        version: 2.0.0(@rsbuild/core@2.2.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -862,7 +862,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
 
   tests/integration/asset/json: {}
 
@@ -884,10 +884,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/async-chunks/default: {}
 
@@ -972,10 +972,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(supports-color@9.4.0)(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(supports-color@9.4.0)(typescript@7.0.2)
 
   tests/integration/cli/build: {}
 
@@ -1302,10 +1302,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.1(@module-federation/runtime-tools@2.9.0)
+        version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.2.1)
+        version: 1.4.6(@rsbuild/core@2.2.2)
 
   tests/integration/node-polyfill/bundle-false:
     dependencies:
@@ -1315,10 +1315,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.1(@module-federation/runtime-tools@2.9.0)
+        version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.2.1)
+        version: 1.4.6(@rsbuild/core@2.2.2)
 
   tests/integration/outBase/custom-entry: {}
 
@@ -1355,7 +1355,7 @@ importers:
         version: 8.0.1
       '@rsbuild/plugin-babel':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(supports-color@9.4.0)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(supports-color@9.4.0)
       babel-plugin-polyfill-corejs3:
         specifier: 'catalog:'
         version: 1.0.0(@babel/core@8.0.1)
@@ -1368,7 +1368,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
 
   tests/integration/preserve-jsx/forbid-bundle: {}
 
@@ -1509,19 +1509,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(supports-color@9.4.0)
 
   tests/integration/style/stylus/bundle-false:
     devDependencies:
       '@rsbuild/plugin-stylus':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(supports-color@9.4.0)
+        version: 2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(supports-color@9.4.0)
 
   tests/integration/style/tailwindcss/bundle:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.0.3(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1530,7 +1530,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.0.3(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -1539,10 +1539,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rsbuild/plugin-svelte':
         specifier: 'catalog:'
-        version: 2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.2.1)(less@4.6.7)(postcss@8.5.19)(pug@3.0.3)(sass@1.100.0)(stylus@0.64.0)(svelte@5.57.0)(typescript@7.0.2)
+        version: 2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.2.2)(less@4.6.7)(postcss@8.5.19)(pug@3.0.3)(sass@1.100.0)(stylus@0.64.0)(svelte@5.57.0)(typescript@7.0.2)
       svelte:
         specifier: 'catalog:'
         version: 5.57.0
@@ -1590,10 +1590,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rsbuild/plugin-vue':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)
+        version: 2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)
       vue:
         specifier: 'catalog:'
         version: 3.5.42(typescript@7.0.2)
@@ -1628,16 +1628,16 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: 'catalog:'
-        version: 2.9.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+        version: 2.9.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.2.1(@module-federation/runtime-tools@2.9.0)
+        version: 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+        version: 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.2.1)
+        version: 2.0.1(@rsbuild/core@2.2.2)
       '@rslib/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -1646,7 +1646,7 @@ importers:
         version: link:../scripts/tsconfig
       '@rspress/core':
         specifier: 'catalog:'
-        version: 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+        version: 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@rspress/plugin-algolia':
         specifier: 'catalog:'
         version: 2.0.21(@rspress/core@2.0.21)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
@@ -1685,10 +1685,10 @@ importers:
         version: 19.2.8(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: 'catalog:'
-        version: 1.0.6(@rsbuild/core@2.2.1)
+        version: 1.0.6(@rsbuild/core@2.2.2)
       rsbuild-plugin-open-graph:
         specifier: 'catalog:'
-        version: 1.1.3(@rsbuild/core@2.2.1)
+        version: 1.1.3(@rsbuild/core@2.2.2)
       rspress-plugin-file-tree:
         specifier: 'catalog:'
         version: 1.0.5(@rspress/core@2.0.21)(supports-color@9.4.0)
@@ -3047,6 +3047,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.2.2':
+    resolution: {integrity: sha512-T82jUaeMUFhcBqpmKvRiNAcWMp6abxkvMEwiZi4x+gf7NAbyiF5jrbLnQLm1y4909eANsTSHenp99HlRPIByLw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.2.1':
     resolution: {integrity: sha512-6Zad7Ff/RUNc91AtftemJcJ1wcZRGOiwuJy349qlLJl9F++oRYwUhx+MxLSpNnVeIywWx2mKdZZBtD1hLqfj9w==}
     peerDependencies:
@@ -3258,13 +3268,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.2.2':
+    resolution: {integrity: sha512-/le/AvV4HSinXTPs2Lqpujxt189Z5T10Ggt96QzckLRPvIchzqoavVDDjltzC7XcaZ87XCH/X06jNKgzkcBBNA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.2.1':
     resolution: {integrity: sha512-rTIG/xZIW7RbEEuMR9hnNn5dv3fDBpX0N4FAQUwfhUYy3tN2+3vibTTq/Nj1Sd9Vn4yWydbWIEwBX6m/aGejig==}
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.2.2':
+    resolution: {integrity: sha512-uFIcUPUXiPxM6ljenLafp5TemT8eLZm1riRn8fJYmpqNCK+aCcTaud18XHZpI5SjzzcY+xUHfVShgvNzKXuf2g==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.2.1':
     resolution: {integrity: sha512-53rAMU6Hqiat21IMU1hTt4Si2F33h+ZbXOt+Y18W39AFjcwmleIBId2u7beqJeGXLJuBgIAm31jcbJj/PN7mWQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.2.2':
+    resolution: {integrity: sha512-Pjby4pDSMNJQK2VBzpgCj6lb+DGuenS1fEDb6xi5/apbJb9v5WE+e43Mz7i+XqgXS8e846pjaONV3KM5WKB1LQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3275,8 +3301,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.2.2':
+    resolution: {integrity: sha512-0u9O7tTVT2z+F6o/eEY6f6+My8Jn9U56QiBwkfy90ZaoAfZyQSSTxqaK/zA7W43oFxQefeCpiPas27VUzrSakw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-ppc64-gnu@2.2.1':
     resolution: {integrity: sha512-pvx1oeg1z7cr8OcNt7PAt1SJTHzdsN/pvu7HkGnfks2fWE7GDs9DLL2KvN7tUkzQvJm6bGgUwqSCOrqV4uSwAg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-ppc64-gnu@2.2.2':
+    resolution: {integrity: sha512-N3lVnhq5qOvpmP5n386JzR1GcE8HzAqq4/r440Z6yle9m7PhVFJ6oXVWxgaDTYV0mtv9YLJmaG+YrjYfUa1vuA==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -3287,8 +3325,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rspack/binding-linux-riscv64-gnu@2.2.2':
+    resolution: {integrity: sha512-ReClZyp32/rJkUDV/oGDU0X6BCFyEkTR6r4stFwm/qOOaG6mUMRzZe4gur8Yh979p4Hiz9EdkmfEHY02GBXcaQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-riscv64-musl@2.2.1':
     resolution: {integrity: sha512-GEFUFHQkjKU7OYyHXnrIo8wWcUHM7jeKov5z6Lxd3i+3hKo11yBOgb7b+uD94Rx2tPuWF4jyFdWmcNu46Njb/A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-musl@2.2.2':
+    resolution: {integrity: sha512-mqsorvTNerr3r8zI35NFTPYATPDlhepdiUhZjKT6ylqpHlP7vLU9fp4aEMK/CuTv2f+IVsa0+iZqtMxHs2tSjw==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -3299,8 +3349,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rspack/binding-linux-s390x-gnu@2.2.2':
+    resolution: {integrity: sha512-ql2Jub8QYWSugBppmj2u0SjcIj6fOQuAaLCYQOqU7zbvz/uuWTfoqmdWKExwrxeCU9Tzt7emVM0ETuVEpoca+A==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-x64-gnu@2.2.1':
     resolution: {integrity: sha512-QX+gRxg2CS9ri2fUG5eNurdsrOCWoJ56SsD2O7kcVGiRm+S2+muNb/QhkdkAdt/u/m++7Ve5TMIpHTnaKYCpCw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.2.2':
+    resolution: {integrity: sha512-MNYKYEHrtIVEno2q5rgpou/JVffRwn109xPK3kxct95EojHsniNa8jwy6eEHeOazP4EN60Si7NElE3aQ6JssHw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3311,12 +3373,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.2.2':
+    resolution: {integrity: sha512-y9/9CmE8lrECaF17GAhacibTL+SvlEPEotQnUuBFC/WFtXh8hU2E7a7bAkpYGSLH6kM0nrJZHO3hTvM1wdWOJw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.2.1':
     resolution: {integrity: sha512-/d2ImKDS+lT+FJ07MxKBeUkTat84tr2Nm2+nIRt8HmZK7/N8odkQml9vb4MHr8E7oYOp4B+jm6W5frdRzKrkJQ==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.2.2':
+    resolution: {integrity: sha512-VbDIjjeFwZvMSKAOGY5IbU6lLzt6AHHHncTdMMkZ94Xk7O2BOHe9BXDV32Ln29TIW2C8m1fdxfPZWDiecVghUQ==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.2.1':
     resolution: {integrity: sha512-TfmaKPF3KC7uoZb6A+8ZUbLS8g8P5EdeXFGLCaJ+UgdkJ20TsapcfJXZXWNnKzFEkV8dUO/t5oNxNLYy2URusw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.2.2':
+    resolution: {integrity: sha512-rfcNg0W3ZPZvXma1gTyEt9/Z8FxASIaQr+sMWTSaTPPaeU3xY1+0hYcrD0kUFNs3/5L4u63myI4R8qRXiuW3pA==}
     cpu: [arm64]
     os: [win32]
 
@@ -3325,16 +3402,41 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.2.2':
+    resolution: {integrity: sha512-TFPvr9RZw9oHIhooDhXHzWjKcHpGPTxkznSeM2poIWU0CdEuua2rVUfsrriTF1Dmx+9kMly61DQmyOHCbb+b2g==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.2.1':
     resolution: {integrity: sha512-l3K4s7nrQJc+3LacPFjZGjX8Jk1sf8Q4TK6IXAsdSucOjTqYSpD8PMl2NUXCBDXOl8T2V4v323z1LfxwW8BPmA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.2.2':
+    resolution: {integrity: sha512-GvEGyL594dtWN9SoVnKWh0exrM8WLInaUjwcuA2JKbCi1ak/9iHxip/U1dY3DuVqBYBhmvYq96JPbl91xnzFjg==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@2.2.1':
     resolution: {integrity: sha512-56TqztuEMd+aHGv1jDXnkJQGSLTb4NoO146flFxJqPG8931UdXPO2pNR9M0Q2Pz+GvmO0fLHGPLYBHoRVrRlHw==}
 
+  '@rspack/binding@2.2.2':
+    resolution: {integrity: sha512-gWjKDQfVQJSBh/I+y9WTlyERsiShSJ7eI6Yl0SJs/6gjx8t4ixuwWCsaEFFjwSL4nSn6ML5hNQ7UFY3gj72BWA==}
+
   '@rspack/core@2.2.1':
     resolution: {integrity: sha512-EHFX2oWCY1HkHJkG/Ev8HXCcl4gQzgETyairdIlBkKaypuW8i7kowBxUFzpHHg/ObF70vB3focToel9Wwg4MRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.2.2':
+    resolution: {integrity: sha512-/yztfDZR5syIPBrUpzBpL+6fhhl0IHBPcXlNr4tOMBULbocFIz7Z4/cqvf1ix0DBbKpIGx99v6N1IDbk2gi8hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -9055,7 +9157,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.9.0(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)':
+  '@module-federation/enhanced@2.9.0(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.9.0
       '@module-federation/cli': 2.9.0(typescript@6.0.3)(vue-tsc@3.3.11)
@@ -9064,7 +9166,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.9.0(@module-federation/runtime-tools@2.9.0)
       '@module-federation/managers': 2.9.0
       '@module-federation/manifest': 2.9.0(typescript@6.0.3)(vue-tsc@3.3.11)
-      '@module-federation/rspack': 2.9.0(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+      '@module-federation/rspack': 2.9.0(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/runtime-tools': 2.9.0
       '@module-federation/sdk': 2.9.0
       '@module-federation/webpack-bundler-runtime': 2.9.0
@@ -9078,7 +9180,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/enhanced@2.9.0(@rspack/core@2.2.1)(typescript@7.0.2)(vue-tsc@3.3.11)':
+  '@module-federation/enhanced@2.9.0(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.9.0
       '@module-federation/cli': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
@@ -9087,7 +9189,30 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.9.0(@module-federation/runtime-tools@2.9.0)
       '@module-federation/managers': 2.9.0
       '@module-federation/manifest': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
-      '@module-federation/rspack': 2.9.0(@rspack/core@2.2.1)(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/rspack': 2.9.0(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/runtime-tools': 2.9.0
+      '@module-federation/sdk': 2.9.0
+      '@module-federation/webpack-bundler-runtime': 2.9.0
+      schema-utils: 4.3.0
+      tapable: 2.3.0
+    optionalDependencies:
+      typescript: 7.0.2
+      vue-tsc: 3.3.11(typescript@7.0.2)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - utf-8-validate
+
+  '@module-federation/enhanced@2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)':
+    dependencies:
+      '@module-federation/bridge-react-webpack-plugin': 2.9.0
+      '@module-federation/cli': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/dts-plugin': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/error-codes': 2.9.0
+      '@module-federation/inject-external-runtime-core-plugin': 2.9.0(@module-federation/runtime-tools@2.9.0)
+      '@module-federation/managers': 2.9.0
+      '@module-federation/manifest': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/rspack': 2.9.0(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@module-federation/runtime-tools': 2.9.0
       '@module-federation/sdk': 2.9.0
       '@module-federation/webpack-bundler-runtime': 2.9.0
@@ -9133,9 +9258,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.50(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)':
+  '@module-federation/node@2.7.50(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)':
     dependencies:
-      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/runtime': 2.9.0
       '@module-federation/sdk': 2.9.0
       encoding: 0.1.13
@@ -9148,9 +9273,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.50(@rspack/core@2.2.1)(typescript@7.0.2)(vue-tsc@3.3.11)':
+  '@module-federation/node@2.7.50(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)':
     dependencies:
-      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.1)(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@module-federation/runtime': 2.9.0
       '@module-federation/sdk': 2.9.0
       encoding: 0.1.13
@@ -9163,13 +9288,28 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.9.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)':
+  '@module-federation/node@2.7.50(typescript@7.0.2)(vue-tsc@3.3.11)':
     dependencies:
-      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)
-      '@module-federation/node': 2.7.50(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+      '@module-federation/enhanced': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/runtime': 2.9.0
+      '@module-federation/sdk': 2.9.0
+      encoding: 0.1.13
+      node-fetch: 2.7.0(encoding@0.1.13)
+      tapable: 2.3.0
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
+  '@module-federation/rsbuild-plugin@2.9.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)':
+    dependencies:
+      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
+      '@module-federation/node': 2.7.50(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/sdk': 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9178,13 +9318,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.9.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(typescript@7.0.2)(vue-tsc@3.3.11)':
+  '@module-federation/rsbuild-plugin@2.9.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)':
     dependencies:
-      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.1)(typescript@7.0.2)(vue-tsc@3.3.11)
-      '@module-federation/node': 2.7.50(@rspack/core@2.2.1)(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/node': 2.7.50(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)
       '@module-federation/sdk': 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9193,7 +9333,22 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.9.0(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)':
+  '@module-federation/rsbuild-plugin@2.9.0(@rsbuild/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)':
+    dependencies:
+      '@module-federation/enhanced': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/node': 2.7.50(typescript@7.0.2)(vue-tsc@3.3.11)
+      '@module-federation/sdk': 2.9.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - webpack
+
+  '@module-federation/rspack@2.9.0(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.9.0
       '@module-federation/dts-plugin': 2.9.0(typescript@6.0.3)(vue-tsc@3.3.11)
@@ -9202,7 +9357,7 @@ snapshots:
       '@module-federation/manifest': 2.9.0(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/runtime-tools': 2.9.0
       '@module-federation/sdk': 2.9.0
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.11(typescript@6.0.3)
@@ -9210,7 +9365,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@module-federation/rspack@2.9.0(@rspack/core@2.2.1)(typescript@7.0.2)(vue-tsc@3.3.11)':
+  '@module-federation/rspack@2.9.0(@rspack/core@2.2.2)(typescript@7.0.2)(vue-tsc@3.3.11)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.9.0
       '@module-federation/dts-plugin': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
@@ -9219,7 +9374,7 @@ snapshots:
       '@module-federation/manifest': 2.9.0(typescript@7.0.2)(vue-tsc@3.3.11)
       '@module-federation/runtime-tools': 2.9.0
       '@module-federation/sdk': 2.9.0
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 7.0.2
       vue-tsc: 3.3.11(typescript@7.0.2)
@@ -9245,12 +9400,12 @@ snapshots:
 
   '@module-federation/sdk@2.9.0': {}
 
-  '@module-federation/storybook-addon@6.0.19(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(storybook@10.5.10)(typescript@6.0.3)(vue-tsc@3.3.11)(webpack-virtual-modules@0.6.2)':
+  '@module-federation/storybook-addon@6.0.19(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(storybook@10.5.10)(typescript@6.0.3)(vue-tsc@3.3.11)(webpack-virtual-modules@0.6.2)':
     dependencies:
-      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.1)(typescript@6.0.3)(vue-tsc@3.3.11)
+      '@module-federation/enhanced': 2.9.0(@rspack/core@2.2.2)(typescript@6.0.3)(vue-tsc@3.3.11)
       '@module-federation/sdk': 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
       storybook: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -9530,7 +9685,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.2.1)(supports-color@9.4.0)':
+  '@rsbuild/core@2.2.2(@module-federation/runtime-tools@2.9.0)':
+    dependencies:
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.2.2)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
@@ -9539,39 +9701,39 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-babel@2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(supports-color@9.4.0)':
+  '@rsbuild/plugin-babel@2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(supports-color@9.4.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)(supports-color@9.4.0)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.1)
+      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.2)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)':
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.2.1)(less@4.6.7)
+      less-loader: 12.3.3(@rspack/core@2.2.2)(less@4.6.7)
       reduce-configs: 2.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.2.1)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.2.2)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -9597,30 +9759,49 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-preact@2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(preact@10.29.8)':
+  '@rsbuild/plugin-preact@2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(preact@10.29.8)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.2.1)
+      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.2.2)
       '@swc/plugin-prefresh': 13.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - preact
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.1)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.1)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.2)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+    optional: true
+
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.2)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.2)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.1)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.2)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.2.2)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -9628,39 +9809,39 @@ snapshots:
       reduce-configs: 2.0.1
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.2.1)(solid-js@1.9.15)(supports-color@9.4.0)':
+  '@rsbuild/plugin-solid@1.2.2(@babel/core@7.29.7)(@rsbuild/core@2.2.2)(solid-js@1.9.15)(supports-color@9.4.0)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.2.1)(supports-color@9.4.0)
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.2.2)(supports-color@9.4.0)
       babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.15)
       solid-refresh: 0.6.3(solid-js@1.9.15)(supports-color@9.4.0)
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(supports-color@9.4.0)':
+  '@rsbuild/plugin-stylus@2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(supports-color@9.4.0)':
     dependencies:
       deepmerge: 4.3.1
       stylus: 0.64.0(supports-color@9.4.0)
-      stylus-loader: 8.1.3(@rspack/core@2.2.1)(stylus@0.64.0)
+      stylus-loader: 8.1.3(@rspack/core@2.2.2)(stylus@0.64.0)
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-svelte@2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.2.1)(less@4.6.7)(postcss@8.5.19)(pug@3.0.3)(sass@1.100.0)(stylus@0.64.0)(svelte@5.57.0)(typescript@7.0.2)':
+  '@rsbuild/plugin-svelte@2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.2.2)(less@4.6.7)(postcss@8.5.19)(pug@3.0.3)(sass@1.100.0)(stylus@0.64.0)(svelte@5.57.0)(typescript@7.0.2)':
     dependencies:
       svelte: 5.57.0
       svelte-loader: 3.2.4(svelte@5.57.0)
       svelte-preprocess: 6.0.5(@babel/core@7.29.7)(less@4.6.7)(postcss@8.5.19)(pug@3.0.3)(sass@1.100.0)(stylus@0.64.0)(svelte@5.57.0)(typescript@7.0.2)
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -9673,67 +9854,67 @@ snapshots:
       - sugarss
       - typescript
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(supports-color@9.4.0)(typescript@7.0.2)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(supports-color@9.4.0)(typescript@7.0.2)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)
       '@svgr/core': 8.1.0(supports-color@9.4.0)(typescript@7.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)(supports-color@9.4.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@7.0.2)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.2.1)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.2.2)
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-toml@2.1.0(@rsbuild/core@2.2.1)':
+  '@rsbuild/plugin-toml@2.1.0(@rsbuild/core@2.2.2)':
     dependencies:
       toml: 5.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.2.1)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.6.0(@rspack/core@2.2.2)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
 
-  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.1)':
+  '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.2)':
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.2.1)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.2.2)(@vue/compiler-sfc@3.5.42)(vue@3.5.42)
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.2.1)':
+  '@rsbuild/plugin-yaml@2.0.0(@rsbuild/core@2.2.2)':
     dependencies:
       yaml: 2.9.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
 
   '@rslib/core@1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(typescript@7.0.2)':
     dependencies:
@@ -9787,31 +9968,61 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.2.1':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.2.2':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.2.1':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.2.2':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.2.1':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.2.2':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.2.1':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.2.2':
     optional: true
 
   '@rspack/binding-linux-ppc64-gnu@2.2.1':
     optional: true
 
+  '@rspack/binding-linux-ppc64-gnu@2.2.2':
+    optional: true
+
   '@rspack/binding-linux-riscv64-gnu@2.2.1':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-gnu@2.2.2':
     optional: true
 
   '@rspack/binding-linux-riscv64-musl@2.2.1':
     optional: true
 
+  '@rspack/binding-linux-riscv64-musl@2.2.2':
+    optional: true
+
   '@rspack/binding-linux-s390x-gnu@2.2.1':
+    optional: true
+
+  '@rspack/binding-linux-s390x-gnu@2.2.2':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.2.1':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.2.2':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.2.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.2.2':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.2.1':
@@ -9821,13 +10032,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.2.2':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.2.1':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.2.2':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.2.1':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.2.2':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.2.1':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.2.2':
     optional: true
 
   '@rspack/binding@2.2.1':
@@ -9847,6 +10074,23 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.2.1
       '@rspack/binding-win32-x64-msvc': 2.2.1
 
+  '@rspack/binding@2.2.2':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.2.2
+      '@rspack/binding-darwin-x64': 2.2.2
+      '@rspack/binding-linux-arm64-gnu': 2.2.2
+      '@rspack/binding-linux-arm64-musl': 2.2.2
+      '@rspack/binding-linux-ppc64-gnu': 2.2.2
+      '@rspack/binding-linux-riscv64-gnu': 2.2.2
+      '@rspack/binding-linux-riscv64-musl': 2.2.2
+      '@rspack/binding-linux-s390x-gnu': 2.2.2
+      '@rspack/binding-linux-x64-gnu': 2.2.2
+      '@rspack/binding-linux-x64-musl': 2.2.2
+      '@rspack/binding-wasm32-wasi': 2.2.2
+      '@rspack/binding-win32-arm64-msvc': 2.2.2
+      '@rspack/binding-win32-ia32-msvc': 2.2.2
+      '@rspack/binding-win32-x64-msvc': 2.2.2
+
   '@rspack/core@2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.2.1
@@ -9854,27 +10098,34 @@ snapshots:
       '@module-federation/runtime-tools': 2.9.0
       '@swc/helpers': 0.5.23
 
+  '@rspack/core@2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.2.2
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.9.0
+      '@swc/helpers': 0.5.23
+
   '@rspack/lite-tapable@1.1.2': {}
 
-  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.2.1)':
+  '@rspack/plugin-preact-refresh@2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.2.2)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.8)
       '@prefresh/utils': 1.2.1
     optionalDependencies:
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.1)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.2)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
+  '@rspress/core@2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.2)
       '@rspress/shared': 2.0.21(@module-federation/runtime-tools@2.9.0)(supports-color@9.4.0)
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -9917,11 +10168,60 @@ snapshots:
       - micromark-util-types
       - supports-color
 
+  '@rspress/core@2.0.21(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)':
+    dependencies:
+      '@mdx-js/mdx': 3.1.1(supports-color@9.4.0)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
+      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.1)
+      '@rspress/shared': 2.0.21(@module-federation/runtime-tools@2.9.0)(supports-color@9.4.0)
+      '@shikijs/rehype': 4.3.0
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.18
+      '@unhead/react': 2.1.17(react@19.2.8)
+      body-scroll-lock: 4.0.0-beta.0
+      clsx: 2.1.1
+      copy-to-clipboard: 3.3.3
+      flexsearch: 0.8.212
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@9.4.0)
+      mdast-util-mdx: 3.0.0(supports-color@9.4.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@9.4.0)
+      medium-zoom: 1.1.0
+      nprogress: 0.2.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-lazy-with-preload: 2.2.1
+      react-render-to-markdown: 19.1.0(react@19.2.8)
+      react-router-dom: 7.18.3(react-dom@19.2.8)(react@19.2.8)
+      rehype-external-links: 3.0.0
+      rehype-raw: 7.0.0
+      remark-cjk-friendly: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
+      remark-cjk-friendly-gfm-strikethrough: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)(unified@11.0.5)
+      remark-gfm: 4.0.1(supports-color@9.4.0)
+      remark-mdx: 3.1.1(supports-color@9.4.0)
+      remark-parse: 11.0.0(supports-color@9.4.0)
+      remark-stringify: 11.0.0
+      scroll-into-view-if-needed: 3.1.0
+      shiki: 4.3.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      unist-util-visit-children: 3.0.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@rspack/core'
+      - core-js
+      - micromark
+      - micromark-util-types
+      - supports-color
+    optional: true
+
   '@rspress/plugin-algolia@2.0.21(@rspress/core@2.0.21)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)':
     dependencies:
       '@docsearch/css': 4.7.0
       '@docsearch/react': 4.7.0(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
@@ -9932,7 +10232,7 @@ snapshots:
 
   '@rspress/plugin-llms@2.0.21(@rspress/core@2.0.21)(supports-color@9.4.0)':
     dependencies:
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       remark-mdx: 3.1.1(supports-color@9.4.0)
       remark-parse: 11.0.0(supports-color@9.4.0)
       remark-stringify: 11.0.0
@@ -9943,17 +10243,17 @@ snapshots:
 
   '@rspress/plugin-rss@2.0.21(@rspress/core@2.0.21)':
     dependencies:
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.21(@rspress/core@2.0.21)':
     dependencies:
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rspress/plugin-twoslash@2.0.21(@rspress/core@2.0.21)(react@19.2.8)(supports-color@9.4.0)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@shikijs/twoslash': 4.3.0(supports-color@9.4.0)(typescript@6.0.3)
       mdast-util-from-markdown: 2.0.3(supports-color@9.4.0)
       mdast-util-gfm: 3.1.0(supports-color@9.4.0)
@@ -10020,16 +10320,16 @@ snapshots:
 
   '@rstackjs/doc-ui@1.14.11(@rspress/core@2.0.21)':
     optionalDependencies:
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
   '@rstest/adapter-rslib@0.11.10(@rslib/core@1.0.0-rc.2)(@rstest/core@0.11.10)(typescript@7.0.2)':
     dependencies:
       '@rslib/core': 1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(typescript@7.0.2)
-      '@rstest/core': 0.11.10
+      '@rstest/core': 0.11.10(@module-federation/runtime-tools@2.9.0)
     optionalDependencies:
       typescript: 7.0.2
 
-  '@rstest/core@0.11.10':
+  '@rstest/core@0.11.10(@module-federation/runtime-tools@2.9.0)':
     dependencies:
       '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
       '@types/chai': 5.2.3
@@ -10399,14 +10699,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.2.1)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.2.2)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
     optionalDependencies:
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10987,12 +11287,12 @@ snapshots:
 
   b-validate@1.5.3: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.1):
+  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@9.4.0)
       find-up: 5.0.0
     optionalDependencies:
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 
   babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
     dependencies:
@@ -12455,11 +12755,11 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  less-loader@12.3.3(@rspack/core@2.2.1)(less@4.6.7):
+  less-loader@12.3.3(@rspack/core@2.2.2)(less@4.6.7):
     dependencies:
       less: 4.6.7
     optionalDependencies:
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 
   less@4.6.7:
     dependencies:
@@ -14039,41 +14339,41 @@ snapshots:
       '@microsoft/api-extractor': 7.59.0(@types/node@24.13.3)
       typescript: 7.0.2
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.2.1):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.2.2):
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
 
-  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.2.1):
+  rsbuild-plugin-html-minifier-terser@1.1.5(@rsbuild/core@2.2.2):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.2.1):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.2.2):
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.1):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.2.2):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
 
   rslog@2.3.0: {}
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.2.1)(@vue/compiler-sfc@3.5.42)(vue@3.5.42):
+  rspack-vue-loader@17.5.1(@rspack/core@2.2.2)(@vue/compiler-sfc@3.5.42)(vue@3.5.42):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
       '@vue/compiler-sfc': 3.5.42
       vue: 3.5.42(typescript@6.0.3)
 
   rspress-plugin-devkit@1.0.0(@rspress/core@2.0.21)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
@@ -14098,26 +14398,26 @@ snapshots:
 
   rspress-plugin-file-tree@1.0.5(@rspress/core@2.0.21)(supports-color@9.4.0):
     dependencies:
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       rspress-plugin-devkit: 1.0.0(@rspress/core@2.0.21)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.21):
     dependencies:
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
 
-  rstack@0.6.5(@microsoft/api-extractor@7.59.0)(@rspress/core@2.0.21)(jiti@2.7.0)(typescript@7.0.2):
+  rstack@0.6.5(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(@rspress/core@2.0.21)(jiti@2.7.0)(typescript@7.0.2):
     dependencies:
       '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
       '@rslib/core': 1.0.0-rc.2(@microsoft/api-extractor@7.59.0)(@module-federation/runtime-tools@2.9.0)(typescript@7.0.2)
       '@rslint/core': 0.8.1(jiti@2.7.0)
-      '@rstest/core': 0.11.10
+      '@rstest/core': 0.11.10(@module-federation/runtime-tools@2.9.0)
       prettier: 3.9.6
       tinypool: 2.1.2
       yuku-parser: 0.9.1
     optionalDependencies:
-      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(@rspack/core@2.2.1)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
+      '@rspress/core': 2.0.21(@module-federation/runtime-tools@2.9.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(supports-color@9.4.0)
       '@rstackjs/cli-darwin-arm64': 0.6.5
       '@rstackjs/cli-darwin-x64': 0.6.5
       '@rstackjs/cli-linux-arm64-gnu': 0.6.5
@@ -14453,18 +14753,18 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
-  storybook-addon-rslib@3.4.2(@rsbuild/core@2.2.1)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3):
+  storybook-addon-rslib@3.4.2(@rsbuild/core@2.2.2)(@rslib/core@packages+core)(storybook-builder-rsbuild@3.4.2)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@rslib/core': link:packages/core
-      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.4.2(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.4.2(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
-      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(typescript@6.0.3)
       '@vitest/mocker': 3.2.7
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -14477,7 +14777,7 @@ snapshots:
       pathe: 2.0.3
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.2.1)
+      rsbuild-plugin-html-minifier-terser: 1.1.5(@rsbuild/core@2.2.2)
       sirv: 2.0.4
       storybook: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
       ts-dedent: 2.3.0
@@ -14494,10 +14794,10 @@ snapshots:
       - msw
       - vite
 
-  storybook-react-rsbuild@3.4.2(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(@types/react-dom@19.2.5)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3):
+  storybook-react-rsbuild@3.4.2(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(@types/react-dom@19.2.5)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 5.4.0
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@storybook/react': 10.5.10(@types/react-dom@19.2.5)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(supports-color@9.4.0)(typescript@6.0.3)
       find-up: 5.0.0
@@ -14508,7 +14808,7 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
       storybook: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14523,12 +14823,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.4.2(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3)(vue@3.5.42):
+  storybook-vue3-rsbuild@3.4.2(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(supports-color@9.4.0)(typescript@6.0.3)(vue@3.5.42):
     dependencies:
-      '@rsbuild/core': 2.2.1(@module-federation/runtime-tools@2.9.0)
+      '@rsbuild/core': 2.2.2(@module-federation/runtime-tools@2.9.0)
       '@storybook/vue3': 10.5.10(storybook@10.5.10)(vue@3.5.42)
       storybook: 10.5.10(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8)(react@19.2.8)
-      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.1)(@rspack/core@2.2.1)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.4.2(@rsbuild/core@2.2.2)(@rspack/core@2.2.2)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.10)(typescript@6.0.3)
       vue: 3.5.42(typescript@6.0.3)
       vue-docgen-api: 4.79.2(vue@3.5.42)
       vue-docgen-loader: 2.0.1(supports-color@9.4.0)(vue-docgen-api@4.79.2)
@@ -14648,13 +14948,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylus-loader@8.1.3(@rspack/core@2.2.1)(stylus@0.64.0):
+  stylus-loader@8.1.3(@rspack/core@2.2.2)(stylus@0.64.0):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
       stylus: 0.64.0(supports-color@9.4.0)
     optionalDependencies:
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 
   stylus@0.64.0(supports-color@9.4.0):
     dependencies:
@@ -14815,7 +15115,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.6.0(@rspack/core@2.2.1)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.6.0(@rspack/core@2.2.2)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
@@ -14823,7 +15123,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.9.0)(@swc/helpers@0.5.23)
 
   ts-dedent@2.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalog:
   '@module-federation/storybook-addon': '^6.0.19'
   '@playwright/test': '1.62.1'
   '@reduxjs/toolkit': '^2.12.0'
-  '@rsbuild/core': '~2.2.1'
+  '@rsbuild/core': '~2.2.2'
   '@rsbuild/plugin-babel': '^2.1.0'
   '@rsbuild/plugin-less': '^2.0.1'
   '@rsbuild/plugin-node-polyfill': '^1.4.6'


### PR DESCRIPTION
## Summary

Upgrade `@rsbuild/core` from `~2.2.1` to `~2.2.2` in the workspace catalog and generated Storybook templates. This refreshes the bundled `@rspack/core` to 2.2.2 and keeps generated projects aligned with the repository.

## Related links

- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.2.2

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).