### PR TITLE
docs: prepare website for Rslib 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,6 @@
 
 English | [简体中文](./README.zh-CN.md)
 
-> [!NOTE]
-> The `main` branch is under active development for **Rslib 1.0**.
->
-> The stable **0.x** releases are maintained in the [v0.x](https://github.com/web-infra-dev/rslib/tree/v0.x) branch.
-
 Rslib is a library development tool based on [Rsbuild](https://rsbuild.rs).
 
 It gives developers a simple way to create JavaScript libraries and UI component libraries, and provides tool integrations and best practices for building, debugging, documentation, and testing throughout library development.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Rslib has the following features:
 
 ## 📚 Documentation
 
-- [Rslib v1 docs](https://v1.rslib.rs)
-- [Rslib v0 docs](https://rslib.rs)
+- [Rslib v1 docs](https://rslib.rs)
+- [Rslib v0 docs](https://v0.rslib.rs)
 
 ## 🦀 Rstack
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,8 +35,8 @@ Rslib 具备以下特性：
 
 ## 📚 文档
 
-- [Rslib v1 文档](https://v1.rslib.rs/zh/)
-- [Rslib v0 文档](https://rslib.rs/zh/)
+- [Rslib v1 文档](https://rslib.rs/zh/)
+- [Rslib v0 文档](https://v0.rslib.rs/zh/)
 
 ## 🦀 Rstack
 

--- a/website/docs/en/_nav.json
+++ b/website/docs/en/_nav.json
@@ -18,5 +18,18 @@
     "text": "Blog",
     "link": "/blog/",
     "activeMatch": "/blog/"
+  },
+  {
+    "text": "Version",
+    "items": [
+      {
+        "text": "Changelog",
+        "link": "https://github.com/web-infra-dev/rslib/releases"
+      },
+      {
+        "text": "Rslib 0.x Docs",
+        "link": "https://v0.rslib.rs/"
+      }
+    ]
   }
 ]

--- a/website/docs/zh/_nav.json
+++ b/website/docs/zh/_nav.json
@@ -18,5 +18,18 @@
     "text": "博客",
     "link": "/blog/",
     "activeMatch": "/blog/"
+  },
+  {
+    "text": "版本",
+    "items": [
+      {
+        "text": "更新日志",
+        "link": "https://github.com/web-infra-dev/rslib/releases"
+      },
+      {
+        "text": "Rslib 0.x 文档",
+        "link": "https://v0.rslib.rs/zh/"
+      }
+    ]
   }
 ]

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -4,16 +4,19 @@ import {
   Link,
   type DocLayoutProps,
 } from '@rspress/core/theme-original';
+import { Announcement } from '@rstackjs/doc-ui/announcement';
 import { BlogBackButton } from '@rstackjs/doc-ui/blog-back-button';
 import { NavIcon } from '@rstackjs/doc-ui/nav-icon';
 import { HomeLayout } from './pages';
 import '@rstackjs/doc-ui/theme.css';
 import './index.scss';
-import { useLang, usePage } from '@rspress/core/runtime';
+import { NoSSR, useLang, usePage } from '@rspress/core/runtime';
 import {
   Search as PluginAlgoliaSearch,
   ZH_LOCALES,
 } from '@rspress/plugin-algolia/runtime';
+
+const ANNOUNCEMENT_URL = '/blog/v1-0';
 
 const DocLayout = (props: DocLayoutProps) => {
   const { page } = usePage();
@@ -36,7 +39,32 @@ const DocLayout = (props: DocLayoutProps) => {
   );
 };
 
-const Layout = () => <BaseLayout beforeNavTitle={<NavIcon />} />;
+const Layout = () => {
+  const { page } = usePage();
+  const lang = useLang();
+
+  return (
+    <BaseLayout
+      beforeNavTitle={<NavIcon />}
+      beforeNav={
+        <NoSSR>
+          <Announcement
+            href={
+              lang === 'en' ? ANNOUNCEMENT_URL : `/${lang}${ANNOUNCEMENT_URL}`
+            }
+            message={
+              lang === 'en'
+                ? 'Rslib 1.0 has been released!'
+                : 'Rslib 1.0 正式发布！'
+            }
+            localStorageKey="rslib-v1-announcement-closed"
+            display={page.pageType === 'home'}
+          />
+        </NoSSR>
+      }
+    />
+  );
+};
 
 const Search = () => {
   const lang = useLang();


### PR DESCRIPTION
## Summary

This PR prepares the website for the Rslib 1.0 release by adding a bilingual homepage announcement linked to the upcoming 1.0 blog, plus a Version menu with GitHub releases and the Rslib 0.x documentation. It updates the versioned README links so Rslib 1.x uses `rslib.rs` and Rslib 0.x uses `v0.rslib.rs`, removes the stale `v1.rslib.rs` links, and removes the obsolete Rslib 1.0 development notice.

## Related links

- https://github.com/web-infra-dev/rslib/pull/1889

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).