### PR TITLE
docs: add links for Rslib 1.x documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Rslib has the following features:
 
 ## 📚 Documentation
 
-- [Rslib docs](https://rslib.rs)
+- [Rslib docs](https://v0.rslib.rs)
 
 ## 🎯 Ecosystem
 
@@ -52,7 +52,7 @@ The following diagram illustrates the relationship between Rslib and other tools
 
 ## 📚 Getting started
 
-To get started with Rslib, see the [Quick start](https://rslib.rs/guide/start/quick-start).
+To get started with Rslib, see the [Quick start](https://v0.rslib.rs/guide/start/quick-start).
 
 ## 🦀 Rstack
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@ Rslib 提供了以下功能：
 
 ## 📚 文档
 
-- [Rslib 文档](https://rslib.rs/zh)
+- [Rslib 文档](https://v0.rslib.rs/zh)
 
 ## 🎯 生态
 
@@ -47,7 +47,7 @@ Rslib 基于 Rsbuild 实现，并完全复用 Rsbuild 的能力和生态系统�
 
 ## 📚 快速上手
 
-你可以参考 [快速上手](https://rslib.rs/zh/guide/start/quick-start) 来开始体验 Rslib。
+你可以参考 [快速上手](https://v0.rslib.rs/zh/guide/start/quick-start) 来开始体验 Rslib。
 
 ## 🦀 Rstack
 

--- a/website/docs/en/_nav.json
+++ b/website/docs/en/_nav.json
@@ -18,5 +18,18 @@
     "text": "Blog",
     "link": "/blog/",
     "activeMatch": "/blog/"
+  },
+  {
+    "text": "Version",
+    "items": [
+      {
+        "text": "Changelog",
+        "link": "https://github.com/web-infra-dev/rslib/releases"
+      },
+      {
+        "text": "Rslib 1.x Docs",
+        "link": "https://rslib.rs/"
+      }
+    ]
   }
 ]

--- a/website/docs/zh/_nav.json
+++ b/website/docs/zh/_nav.json
@@ -18,5 +18,18 @@
     "text": "博客",
     "link": "/blog/",
     "activeMatch": "/blog/"
+  },
+  {
+    "text": "版本",
+    "items": [
+      {
+        "text": "更新日志",
+        "link": "https://github.com/web-infra-dev/rslib/releases"
+      },
+      {
+        "text": "Rslib 1.x 文档",
+        "link": "https://rslib.rs/zh/"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

This PR adds a bilingual Version menu to the Rslib 0.x documentation with links to GitHub releases and the Rslib 1.x documentation at `rslib.rs` ahead of the canonical-domain switch. It also updates the English and Chinese README documentation and Quick start links to use `v0.rslib.rs`, keeping the v0.x branch aligned with its versioned documentation. The menu follows the multi-version navigation used by Rsbuild.

## Related links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).