### PR TITLE
feat(dts)!: move temporary declarations to .rstack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,5 @@ test-results
 **/@mf-types/**
 .env.local
 .env.*.local
-.rslib/**/*
+.rstack/declarations/**/*
 !dist-path/

--- a/packages/plugin-dts/README.md
+++ b/packages/plugin-dts/README.md
@@ -63,7 +63,7 @@ Configure a custom tsconfig.json file path for API Extractor to bundle declarati
 
 When declaration bundling is enabled, TypeScript configuration is used in two stages:
 
-- `source.tsconfigPath` is used to generate temporary declaration files in `.rslib/declarations`.
+- `source.tsconfigPath` is used to generate temporary declaration files in `.rstack/declarations`.
 - `bundle.tsconfigPath` is used by API Extractor to analyze and bundle the temporary declaration files generated above.
 
 By default, both stages use `source.tsconfigPath`. If you want API Extractor to use a separate TypeScript configuration, for example to adjust module resolution options such as `paths`, use the following configuration:

--- a/packages/plugin-dts/src/index.ts
+++ b/packages/plugin-dts/src/index.ts
@@ -185,7 +185,7 @@ export const pluginDts: (options?: PluginDtsOptions) => RsbuildPlugin = (
           await cleanDtsFiles(cwd, dtsEmitPath);
         }
 
-        // clean .rslib temp folder
+        // clean temporary declaration files
         if (bundle) {
           await clearTempDeclarationDir(cwd);
         }

--- a/packages/plugin-dts/src/utils.ts
+++ b/packages/plugin-dts/src/utils.ts
@@ -203,8 +203,7 @@ export function mergeAliasWithTsConfigPaths(
   return Object.keys(mergedPaths).length > 0 ? mergedPaths : {};
 }
 
-export const TEMP_FOLDER = '.rslib';
-export const TEMP_DTS_DIR: string = `${TEMP_FOLDER}/declarations`;
+export const TEMP_DTS_DIR = '.rstack/declarations';
 
 export function ensureTempDeclarationDir(cwd: string, name: string): string {
   const dirPath = path.join(cwd, TEMP_DTS_DIR, name);
@@ -215,7 +214,7 @@ export function ensureTempDeclarationDir(cwd: string, name: string): string {
 
   fs.mkdirSync(dirPath, { recursive: true });
 
-  const gitIgnorePath = path.join(cwd, TEMP_FOLDER, '.gitignore');
+  const gitIgnorePath = path.join(cwd, TEMP_DTS_DIR, '.gitignore');
   fs.writeFileSync(gitIgnorePath, '**/*\n');
 
   return dirPath;

--- a/packages/plugin-dts/tests/utils.test.ts
+++ b/packages/plugin-dts/tests/utils.test.ts
@@ -3,11 +3,60 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { CompilerOptions } from 'typescript6-api';
 import {
+  clearTempDeclarationDir,
   cleanTsBuildInfoFile,
+  ensureTempDeclarationDir,
   loadTsconfigResultForExecutable,
   mergeAliasWithTsConfigPaths,
   prettyTime,
 } from '../src/utils';
+
+describe('temporary declaration directory', () => {
+  test('should manage declarations under .rstack without affecting sibling contents', async () => {
+    const tempDir = await fs.mkdtemp(
+      path.join(__dirname, 'temp-declarations-'),
+    );
+
+    try {
+      const hookPath = path.join(tempDir, '.rstack/hooks/pre-commit');
+      const cachePath = path.join(tempDir, '.rstack/cache/fmt/cache.json');
+      await fs.mkdir(path.dirname(hookPath), { recursive: true });
+      await fs.mkdir(path.dirname(cachePath), { recursive: true });
+      await fs.writeFile(hookPath, 'pnpm lint\n');
+      await fs.writeFile(cachePath, '{}\n');
+
+      const esmDir = ensureTempDeclarationDir(tempDir, 'esm');
+      const cjsDir = ensureTempDeclarationDir(tempDir, 'cjs');
+
+      expect(esmDir).toBe(path.join(tempDir, '.rstack/declarations/esm'));
+      await fs.writeFile(path.join(esmDir, 'index.d.ts'), 'export {};\n');
+      await fs.writeFile(path.join(cjsDir, 'index.d.cts'), 'export {};\n');
+
+      const gitIgnorePath = path.join(
+        tempDir,
+        '.rstack/declarations/.gitignore',
+      );
+      expect(await fs.readFile(gitIgnorePath, 'utf8')).toBe('**/*\n');
+      await expect(
+        fs.access(path.join(tempDir, '.rstack/.gitignore')),
+      ).rejects.toThrow();
+      await expect(fs.access(path.join(tempDir, '.rslib'))).rejects.toThrow();
+
+      await clearTempDeclarationDir(tempDir);
+
+      expect(
+        await fs.readdir(path.join(tempDir, '.rstack/declarations')),
+      ).toEqual([]);
+      expect(await fs.readFile(hookPath, 'utf8')).toBe('pnpm lint\n');
+      expect(await fs.readFile(cachePath, 'utf8')).toBe('{}\n');
+
+      ensureTempDeclarationDir(tempDir, 'esm');
+      expect(await fs.readFile(gitIgnorePath, 'utf8')).toBe('**/*\n');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('prettyTime', () => {
   test('should pretty time correctly', () => {

--- a/tests/integration/dts-tsgo/bundle/index.test.ts
+++ b/tests/integration/dts-tsgo/bundle/index.test.ts
@@ -133,7 +133,7 @@ describe('dts with tsgo when bundle: true', () => {
     expect(entries).toMatchSnapshot();
   });
 
-  test('should clean dts dist files and .rslib folder', async () => {
+  test('should clean dts dist files and temporary declaration files', async () => {
     const fixturePath = join(__dirname, 'clean');
 
     const checkFiles = await createTempFiles(fixturePath, true);

--- a/tests/integration/dts/bundle/index.test.ts
+++ b/tests/integration/dts/bundle/index.test.ts
@@ -178,7 +178,7 @@ describe('dts when bundle: true', () => {
     expect(entries).toMatchSnapshot();
   });
 
-  test('should clean dts dist files and .rslib folder', async () => {
+  test('should clean dts dist files and temporary declaration files', async () => {
     const fixturePath = join(__dirname, 'clean');
 
     const checkFiles = await createTempFiles(fixturePath, true);

--- a/tests/integration/dts/isolated/index.test.ts
+++ b/tests/integration/dts/isolated/index.test.ts
@@ -101,8 +101,8 @@ describe('isolated dts', () => {
       join(fixturePath, 'dist-types/cjs/stale.d.cts'),
       join(fixturePath, 'dist-bundle/esm/stale.d.ts'),
       join(fixturePath, 'dist-bundle/cjs/stale.d.cts'),
-      join(fixturePath, '.rslib/declarations/esm/stale.d.ts'),
-      join(fixturePath, '.rslib/declarations/cjs/stale.d.ts'),
+      join(fixturePath, '.rstack/declarations/esm/stale.d.ts'),
+      join(fixturePath, '.rstack/declarations/cjs/stale.d.ts'),
     ];
 
     await Promise.all(

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -471,24 +471,34 @@ export async function createTempFiles(
   checkFile.push(tempFileCjs, tempFileEsm, tempFileMapCjs, tempFileMapEsm);
 
   if (bundle) {
-    const tempDirRslib = join(fixturePath, '.rslib', 'declarations', 'cjs');
-    const tempDirRslibEsm = join(fixturePath, '.rslib', 'declarations', 'esm');
-    const tempFileRslibCjs = join(tempDirRslib, 'tempFile.d.ts');
-    const tempFileRslibEsm = join(tempDirRslibEsm, 'tempFile.d.ts');
+    const tempDeclarationDirCjs = join(
+      fixturePath,
+      '.rstack',
+      'declarations',
+      'cjs',
+    );
+    const tempDeclarationDirEsm = join(
+      fixturePath,
+      '.rstack',
+      'declarations',
+      'esm',
+    );
+    const tempDeclarationFileCjs = join(tempDeclarationDirCjs, 'tempFile.d.ts');
+    const tempDeclarationFileEsm = join(tempDeclarationDirEsm, 'tempFile.d.ts');
 
-    await fs.promises.mkdir(tempDirRslib, { recursive: true });
-    await fs.promises.mkdir(tempDirRslibEsm, { recursive: true });
+    await fs.promises.mkdir(tempDeclarationDirCjs, { recursive: true });
+    await fs.promises.mkdir(tempDeclarationDirEsm, { recursive: true });
 
     await fs.promises.writeFile(
-      tempFileRslibCjs,
+      tempDeclarationFileCjs,
       'console.log("temp file for cjs");',
     );
     await fs.promises.writeFile(
-      tempFileRslibEsm,
+      tempDeclarationFileEsm,
       'console.log("temp file for esm");',
     );
 
-    checkFile.push(tempFileRslibCjs, tempFileRslibEsm);
+    checkFile.push(tempDeclarationFileCjs, tempDeclarationFileEsm);
   }
 
   return checkFile;

--- a/website/docs/en/config/lib/dts.mdx
+++ b/website/docs/en/config/lib/dts.mdx
@@ -113,7 +113,7 @@ Configure a custom tsconfig.json file path for API Extractor to bundle declarati
 
 When declaration bundling is enabled, TypeScript configuration is used in two stages:
 
-- [source.tsconfigPath](/config/rsbuild/source#sourcetsconfigpath) is used to generate temporary declaration files in `.rslib/declarations`.
+- [source.tsconfigPath](/config/rsbuild/source#sourcetsconfigpath) is used to generate temporary declaration files in `.rstack/declarations`.
 - `dts.bundle.tsconfigPath` is used by API Extractor to analyze and bundle the temporary declaration files generated above.
 
 By default, both stages use `source.tsconfigPath`. If you want API Extractor to use a separate TypeScript configuration, for example to adjust module resolution options such as `paths`, use the following configuration:

--- a/website/docs/en/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/en/guide/upgrade/v0-to-v1.mdx
@@ -351,6 +351,10 @@ export default {
 };
 ```
 
+## Temporary declaration directory update
+
+Rslib generates temporary declaration files during declaration bundling. Rslib v1 changes the directory where these files are stored from `.rslib/declarations` to `.rstack/declarations`. After upgrading, you can safely remove the old `.rslib` directory.
+
 ## Node.js template update
 
 Rslib v1 no longer provides a dual ESM/CJS Node.js template and only provides a pure ESM template. When creating a project, update the `--template` argument as follows:

--- a/website/docs/zh/config/lib/dts.mdx
+++ b/website/docs/zh/config/lib/dts.mdx
@@ -113,7 +113,7 @@ Rslib 基于 API Extractor 对类型声明文件进行打包，可能会存在�
 
 开启类型声明文件打包后，Rslib 会在两个阶段使用 TypeScript 配置：
 
-- [source.tsconfigPath](/config/rsbuild/source#sourcetsconfigpath) 用于在 `.rslib/declarations` 目录中生成临时类型声明文件。
+- [source.tsconfigPath](/config/rsbuild/source#sourcetsconfigpath) 用于在 `.rstack/declarations` 目录中生成临时类型声明文件。
 - `dts.bundle.tsconfigPath` 由 API Extractor 用于分析并打包上述生成的临时类型声明文件。
 
 默认情况下，两个阶段都使用 `source.tsconfigPath`。如果希望 API Extractor 使用独立的 TypeScript 配置，例如单独调整 `paths` 等模块解析选项，可以按如下方式配置：

--- a/website/docs/zh/guide/upgrade/v0-to-v1.mdx
+++ b/website/docs/zh/guide/upgrade/v0-to-v1.mdx
@@ -351,6 +351,10 @@ export default {
 };
 ```
 
+## 临时类型声明目录调整
+
+在类型打包过程中，Rslib 会生成临时类型声明文件。Rslib v1 对这些文件所在的目录进行了调整，由 `.rslib/declarations` 改为 `.rstack/declarations`。升级后，可以安全删除旧的 `.rslib` 目录。
+
 ## Node.js 模板更新
 
 Rslib v1 不再提供 ESM/CJS 双格式的 Node.js 模板，仅提供纯 ESM 模板。创建项目时，`--template` 参数需要按下表更新：


### PR DESCRIPTION
## Summary

- Move temporary declaration files generated during declaration bundling from `.rslib/declarations` to `.rstack/declarations`, while preserving existing `.rstack` hooks and cache data.
- Document this breaking change and note that the old `.rslib` directory can be safely removed after upgrading.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).