### PR TITLE
docs: refine Rslib feature descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ It gives developers a simple way to create JavaScript libraries and UI component
 
 Rslib has the following features:
 
-- **Easy to configure**: Rslib provides out-of-the-box tooling that enables developers to build libraries with zero configuration. It also provides a set of semantic build configurations that can be extended as project needs grow.
+- **Easy to configure**: Out-of-the-box tooling enables developers to build libraries with zero configuration. Rslib also provides a set of semantic build configurations that can be extended as project needs grow.
 
-- **Performance-focused**: Rslib is powered by [Rspack](https://rspack.rs) and integrates high-performance Rust-based tools from the community, including [SWC](https://swc.rs/) and [Lightning CSS](https://lightningcss.dev/), delivering first-class build speed and development experience.
+- **Performance-focused**: Powered by [Rspack](https://rspack.rs), it integrates high-performance Rust-based tools from the community, including [SWC](https://swc.rs/) and [Lightning CSS](https://lightningcss.dev/), delivering first-class build speed and development experience.
 
-- **Plugin ecosystem**: Rslib supports [Rsbuild's official plugins](https://rsbuild.rs/plugins/list/) and is compatible with most webpack plugins and all Rspack plugins, allowing developers to use existing community or in-house plugins in Rslib and carry over the knowledge and engineering experience they have gained in the webpack and Rspack ecosystems.
+- **Plugin ecosystem**: Supports [Rsbuild plugins](https://rsbuild.rs/plugins/list/), Rspack plugins, and webpack plugins, allowing developers to reuse existing plugin ecosystems and continue using familiar development workflows and engineering practices.
 
-- **Flexible outputs**: Rslib is designed around the diverse ways libraries are published and consumed. It supports flexibly configuring build outputs for different runtimes, distribution methods, and downstream build tools to meet the delivery needs of different types of libraries.
+- **Flexible outputs**: Designed around the diverse ways libraries are published and consumed, it supports flexible build output configuration for different runtimes, distribution methods, and downstream build tools to meet the delivery needs of different types of libraries.
 
-- **Framework agnostic**: Rslib is not coupled to frontend UI frameworks. It supports React, Vue, Svelte, Solid, and other frameworks through plugins, allowing developers to build component libraries for different frameworks with a consistent configuration and development workflow.
+- **Framework agnostic**: Decoupled from frontend UI frameworks, it supports React, Vue, Svelte, Solid, and other frameworks through plugins, allowing developers to build component libraries for different frameworks with a consistent configuration and development workflow.
 
 ## 📚 Documentation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,15 +23,15 @@ Rslib 是一个基于 [Rsbuild](https://rsbuild.rs/zh/) 的库开发工具。
 
 Rslib 具备以下特性：
 
-- **易于配置**：Rslib 为库开发提供开箱即用的构建能力，使开发者能够在零配置的情况下开发库项目。同时，Rslib 提供一套语义化的构建配置，可随着项目需求灵活扩展。
+- **易于配置**：为库开发提供开箱即用的构建能力，使开发者能够在零配置的情况下开发库项目。同时，Rslib 提供一套语义化的构建配置，可随着项目需求灵活扩展。
 
-- **性能优先**：Rslib 由 [Rspack](https://rspack.rs/zh/) 驱动，集成了社区中基于 Rust 的高性能工具，包括 [SWC](https://swc.rs/) 和 [Lightning CSS](https://lightningcss.dev/)，以提供一流的构建速度和开发体验。
+- **性能优先**：由 [Rspack](https://rspack.rs/zh/) 驱动，集成了社区中基于 Rust 的高性能工具，包括 [SWC](https://swc.rs/) 和 [Lightning CSS](https://lightningcss.dev/)，以提供一流的构建速度和开发体验。
 
-- **插件生态**：Rslib 可以使用 [Rsbuild 的官方插件](https://rsbuild.rs/zh/plugins/list/)，也兼容大部分 webpack 插件和所有 Rspack 插件，这意味着开发者可以在 Rslib 中使用社区或公司内现有的插件，并沿用在 webpack 和 Rspack 生态中积累的知识与工程经验。
+- **插件生态**：支持使用 [Rsbuild 插件](https://rsbuild.rs/zh/plugins/list/)、Rspack 插件和 webpack 插件，开发者可复用现有插件生态，沿用熟悉的开发经验与工程实践。
 
-- **产物灵活**：Rslib 设计时充分考虑了库发布与消费场景的多样性，支持根据不同的运行环境、分发方式和下游构建工具灵活配置产物输出，满足不同类型库的交付需求。
+- **产物灵活**：设计时充分考虑了库发布与消费场景的多样性，支持根据不同的运行环境、分发方式和下游构建工具灵活配置产物输出，满足不同类型库的交付需求。
 
-- **框架无关**：Rslib 不与前端 UI 框架耦合，并通过插件支持 React、Vue、Svelte、Solid 等框架，让开发者能够以一致的配置和开发方式构建不同框架的组件库。
+- **框架无关**：不与前端 UI 框架耦合，并通过插件支持 React、Vue、Svelte、Solid 等框架，让开发者能够以一致的配置和开发方式构建不同框架的组件库。
 
 ## 📚 文档
 

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -22,15 +22,15 @@ In the future, Rslib will explore additional possibilities by leveraging the new
 
 Rslib has the following features:
 
-- **Easy to configure**: Rslib provides out-of-the-box tooling that enables developers to build libraries with zero configuration. It also provides a set of semantic build configurations that can be extended as project needs grow.
+- **Easy to configure**: Out-of-the-box tooling enables developers to build libraries with zero configuration. Rslib also provides a set of semantic build configurations that can be extended as project needs grow.
 
-- **Performance-focused**: Rslib is powered by [Rspack](https://rspack.rs) and integrates high-performance Rust-based tools from the community, including [SWC](https://swc.rs/) and [Lightning CSS](https://lightningcss.dev/), delivering first-class build speed and development experience.
+- **Performance-focused**: Powered by [Rspack](https://rspack.rs), it integrates high-performance Rust-based tools from the community, including [SWC](https://swc.rs/) and [Lightning CSS](https://lightningcss.dev/), delivering first-class build speed and development experience.
 
-- **Plugin ecosystem**: Rslib supports [Rsbuild's official plugins](https://rsbuild.rs/plugins/list/) and is compatible with most webpack plugins and all Rspack plugins, allowing developers to use existing community or in-house plugins in Rslib and carry over the knowledge and engineering experience they have gained in the webpack and Rspack ecosystems.
+- **Plugin ecosystem**: Supports [Rsbuild plugins](https://rsbuild.rs/plugins/list/), Rspack plugins, and webpack plugins, allowing developers to reuse existing plugin ecosystems and continue using familiar development workflows and engineering practices.
 
-- **Flexible outputs**: Rslib is designed around the diverse ways libraries are published and consumed. It supports flexibly configuring build outputs for different runtimes, distribution methods, and downstream build tools to meet the delivery needs of different types of libraries.
+- **Flexible outputs**: Designed around the diverse ways libraries are published and consumed, it supports flexible build output configuration for different runtimes, distribution methods, and downstream build tools to meet the delivery needs of different types of libraries.
 
-- **Framework agnostic**: Rslib is not coupled to frontend UI frameworks. It supports React, Vue, Svelte, Solid, and other frameworks through plugins, allowing developers to build component libraries for different frameworks with a consistent configuration and development workflow.
+- **Framework agnostic**: Decoupled from frontend UI frameworks, it supports React, Vue, Svelte, Solid, and other frameworks through plugins, allowing developers to build component libraries for different frameworks with a consistent configuration and development workflow.
 
 ## Rstack
 

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -22,15 +22,15 @@ Rslib 基于 Rspack 与 Rsbuild 实现，针对库开发场景的多样化需求
 
 Rslib 具备以下特性：
 
-- **易于配置**：Rslib 为库开发提供开箱即用的构建能力，使开发者能够在零配置的情况下开发库项目。同时，Rslib 提供一套语义化的构建配置，可随着项目需求灵活扩展。
+- **易于配置**：为库开发提供开箱即用的构建能力，使开发者能够在零配置的情况下开发库项目。同时，Rslib 提供一套语义化的构建配置，可随着项目需求灵活扩展。
 
-- **性能优先**：Rslib 由 [Rspack](https://rspack.rs/zh/) 驱动，集成了社区中基于 Rust 的高性能工具，包括 [SWC](https://swc.rs/) 和 [Lightning CSS](https://lightningcss.dev/)，以提供一流的构建速度和开发体验。
+- **性能优先**：由 [Rspack](https://rspack.rs/zh/) 驱动，集成了社区中基于 Rust 的高性能工具，包括 [SWC](https://swc.rs/) 和 [Lightning CSS](https://lightningcss.dev/)，以提供一流的构建速度和开发体验。
 
-- **插件生态**：Rslib 可以使用 [Rsbuild 的官方插件](https://rsbuild.rs/zh/plugins/list/)，也兼容大部分 webpack 插件和所有 Rspack 插件，这意味着开发者可以在 Rslib 中使用社区或公司内现有的插件，并沿用在 webpack 和 Rspack 生态中积累的知识与工程经验。
+- **插件生态**：支持使用 [Rsbuild 插件](https://rsbuild.rs/zh/plugins/list/)、Rspack 插件和 webpack 插件，开发者可复用现有插件生态，沿用熟悉的开发经验与工程实践。
 
-- **产物灵活**：Rslib 设计时充分考虑了库发布与消费场景的多样性，支持根据不同的运行环境、分发方式和下游构建工具灵活配置产物输出，满足不同类型库的交付需求。
+- **产物灵活**：设计时充分考虑了库发布与消费场景的多样性，支持根据不同的运行环境、分发方式和下游构建工具灵活配置产物输出，满足不同类型库的交付需求。
 
-- **框架无关**：Rslib 不与前端 UI 框架耦合，并通过插件支持 React、Vue、Svelte、Solid 等框架，让开发者能够以一致的配置和开发方式构建不同框架的组件库。
+- **框架无关**：不与前端 UI 框架耦合，并通过插件支持 React、Vue、Svelte、Solid 等框架，让开发者能够以一致的配置和开发方式构建不同框架的组件库。
 
 ## Rstack
 


### PR DESCRIPTION
## Summary

The Rslib feature descriptions were repetitive and inconsistent across the README and localized documentation. This PR streamlines the feature copy, generalizes the plugin ecosystem wording, and keeps the English and Chinese README and introduction pages in sync.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).