### PR TITLE
feat(core): add output.exports option

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1859,6 +1859,7 @@ export async function composeCreateRsbuildConfig(
   rslibConfig: RslibConfig,
 ): Promise<RsbuildConfigWithLibInfo[]> {
   const constantRsbuildConfig = await createConstantRsbuildConfig();
+  // `output.exports` is a top-level Rslib option and must not be merged into each lib.
   const {
     lib: rawLibConfigsArray,
     mode: _mode,
@@ -1867,6 +1868,7 @@ export async function composeCreateRsbuildConfig(
     dev: _dev,
     server: _server,
     logLevel,
+    output: { exports: _exports, ...sharedOutput } = {},
     ...sharedRsbuildConfig
   } = rslibConfig;
   // debug mode should always verbose logs
@@ -1906,7 +1908,7 @@ export async function composeCreateRsbuildConfig(
     }
 
     const userConfig = mergeRsbuildConfig<LibConfig>(
-      sharedRsbuildConfig,
+      { ...sharedRsbuildConfig, output: sharedOutput },
       libConfig,
     );
 

--- a/packages/core/src/createRslib.ts
+++ b/packages/core/src/createRslib.ts
@@ -7,6 +7,7 @@ import {
 } from '@rsbuild/core';
 import util from 'node:util';
 import { composeRsbuildEnvironments, pruneEnvironments } from './config';
+import { ExportsPlugin } from './exports/plugin';
 import type { Format, RslibConfig } from './types';
 import type {
   BuildOptions,
@@ -212,13 +213,27 @@ export async function createRslib(
       } satisfies RsbuildPlugin);
     }
 
-    const { environments } = await composeRsbuildEnvironments(config);
+    const { environments, environmentWithInfos } =
+      await composeRsbuildEnvironments(config);
 
     const rsbuildInstance = await createRsbuildInstance(
       options,
       'production',
       pruneEnvironments(environments, buildOptions.lib),
     );
+
+    if (config.output?.exports) {
+      if (buildOptions.watch) {
+        logger.warn(
+          'The "output.exports" option is ignored in watch mode because writing package.json can trigger another rebuild.',
+        );
+      } else {
+        const root = config.root ? ensureAbsolutePath(cwd, config.root) : cwd;
+        rsbuildInstance.addPlugins([
+          ExportsPlugin({ root, libInfos: environmentWithInfos }),
+        ]);
+      }
+    }
 
     const buildResult = await rsbuildInstance.build({
       watch: buildOptions.watch,

--- a/packages/core/src/exports/generate.ts
+++ b/packages/core/src/exports/generate.ts
@@ -1,0 +1,124 @@
+import path from 'node:path';
+import type { RequireKey, RsbuildConfigWithLibInfo } from '../types';
+import { logger } from '../utils/logger';
+
+export type CollectedEntry = {
+  entryName: string;
+  /** Path relative to the package root, or absolute for different Windows drives, using forward slashes. */
+  jsFile: string;
+};
+
+export type ExportsField = {
+  [key: string]: string | ExportsField;
+};
+
+type LibInfo = RequireKey<RsbuildConfigWithLibInfo, 'id'>;
+
+export type GenerateExportsOptions = {
+  libInfos: LibInfo[];
+  collected: Map<string, CollectedEntry[]>;
+};
+
+type PreparedLib = {
+  format: 'esm' | 'cjs';
+  entries: CollectedEntry[];
+};
+
+type EntrySlots = {
+  esm?: string;
+  cjs?: string;
+};
+
+function isOutsidePackageRoot(filePath: string): boolean {
+  return path.isAbsolute(filePath) || filePath.startsWith('../');
+}
+
+function prepareLib(
+  libInfo: LibInfo,
+  entries: CollectedEntry[],
+): PreparedLib | undefined {
+  const format = libInfo.format;
+  if (format !== 'esm' && format !== 'cjs') {
+    logger.warn(
+      `Skip generating the "exports" field for the "${libInfo.id}" environment because the "${format}" format is not supported.`,
+    );
+    return;
+  }
+  return { format, entries };
+}
+
+function buildEntryValue(slots: EntrySlots): string | ExportsField | undefined {
+  if (slots.esm && slots.cjs) {
+    return {
+      import: slots.esm,
+      require: slots.cjs,
+    };
+  }
+  return slots.esm ?? slots.cjs;
+}
+
+export function generateExports(
+  options: GenerateExportsOptions,
+): ExportsField | undefined {
+  const { libInfos, collected } = options;
+
+  const hasJavaScriptEntries = [...collected.values()].some(
+    (entries) => entries.length > 0,
+  );
+  if (!hasJavaScriptEntries) {
+    logger.warn(
+      'Skip generating the "exports" field because no JavaScript entry files were generated.',
+    );
+    return;
+  }
+
+  const preparedLibs: PreparedLib[] = [];
+  for (const libInfo of libInfos) {
+    const entries = collected.get(libInfo.id) ?? [];
+    if (entries.length === 0) continue;
+    const lib = prepareLib(libInfo, entries);
+    if (lib) preparedLibs.push(lib);
+  }
+
+  const entrySlotsByName = new Map<string, EntrySlots>();
+  for (const lib of preparedLibs) {
+    for (const entry of lib.entries) {
+      if (isOutsidePackageRoot(entry.jsFile)) {
+        logger.warn(
+          `Skip generating the "exports" field because the "${entry.entryName}" entry points to an output file outside the package root: "${entry.jsFile}".`,
+        );
+        return;
+      }
+
+      const slots = entrySlotsByName.get(entry.entryName) ?? {};
+      const target = `./${entry.jsFile}`;
+      const existingTarget = slots[lib.format];
+      if (existingTarget && existingTarget !== target) {
+        logger.warn(
+          `Skip generating the "exports" field because the "${entry.entryName}" entry has multiple "${lib.format}" output files: "${existingTarget}" and "${target}".`,
+        );
+        return;
+      }
+      slots[lib.format] = target;
+      entrySlotsByName.set(entry.entryName, slots);
+    }
+  }
+  if (entrySlotsByName.size === 0) return;
+
+  const exportsField: ExportsField = {
+    './package.json': './package.json',
+  };
+  // Keep the main entry before other entry subpaths, then sort the rest for stable output.
+  const sortedEntries = [...entrySlotsByName].sort(([a], [b]) => {
+    if (a === 'index') return -1;
+    if (b === 'index') return 1;
+    return a.localeCompare(b);
+  });
+  for (const [entryName, slots] of sortedEntries) {
+    const value = buildEntryValue(slots);
+    if (value) {
+      exportsField[entryName === 'index' ? '.' : `./${entryName}`] = value;
+    }
+  }
+  return exportsField;
+}

--- a/packages/core/src/exports/plugin.ts
+++ b/packages/core/src/exports/plugin.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RsbuildPlugin } from '@rsbuild/core';
+import { RSLIB_CSS_ENTRY_FLAG } from '../css/cssConfig';
+import { isJavaScriptOutputFile } from '../exe/utils';
+import type { RequireKey, RsbuildConfigWithLibInfo } from '../types';
+import { logger } from '../utils/logger';
+import { normalizeSlash, readPackageJson } from '../utils/helper';
+import { generateExports, type CollectedEntry } from './generate';
+
+export type ExportsPluginOptions = {
+  root: string;
+  libInfos: RequireKey<RsbuildConfigWithLibInfo, 'id'>[];
+};
+
+export const ExportsPlugin = ({
+  root,
+  libInfos,
+}: ExportsPluginOptions): RsbuildPlugin => {
+  return {
+    name: 'rslib:exports',
+    setup(api) {
+      api.onAfterBuild(({ environments, stats }) => {
+        if (!stats) return;
+
+        const statsList = 'stats' in stats ? stats.stats : [stats];
+        // Environment names correspond to lib IDs, allowing entries to be matched with their output formats.
+        const collected = new Map<string, CollectedEntry[]>();
+        const failedEnvironments = new Set<string>();
+
+        for (const environment of Object.values(environments)) {
+          const environmentStats = statsList[environment.index];
+          if (!environmentStats || environmentStats.hasErrors()) {
+            failedEnvironments.add(environment.name);
+            continue;
+          }
+
+          const entries: CollectedEntry[] = [];
+          const outputPath =
+            environmentStats.compilation.outputOptions.path ??
+            environment.distPath;
+
+          for (const [entryName, entrypoint] of environmentStats.compilation
+            .entrypoints) {
+            // Global CSS uses placeholder entries that should not be exposed by the package.
+            if (entryName.startsWith(RSLIB_CSS_ENTRY_FLAG)) continue;
+            const entryFile = [...entrypoint.getEntrypointChunk().files].find(
+              isJavaScriptOutputFile,
+            );
+            if (!entryFile) continue;
+            entries.push({
+              entryName,
+              jsFile: normalizeSlash(
+                path.relative(root, path.join(outputPath, entryFile)),
+              ),
+            });
+          }
+          collected.set(environment.name, entries);
+        }
+
+        if (failedEnvironments.size > 0) {
+          const failedEnvironmentNames = [...failedEnvironments]
+            .map((name) => `"${name}"`)
+            .join(', ');
+          logger.warn(
+            `Skip generating the "exports" field because the following environments failed to compile: ${failedEnvironmentNames}.`,
+          );
+          return;
+        }
+
+        const pkgJson = readPackageJson(root);
+        if (!pkgJson) return;
+
+        const exportsField = generateExports({ libInfos, collected });
+        if (!exportsField) return;
+
+        fs.writeFileSync(
+          path.join(root, 'package.json'),
+          `${JSON.stringify({ ...pkgJson, exports: exportsField }, null, 2)}\n`,
+        );
+        logger.info('generated "exports" field in package.json.');
+      });
+    },
+  };
+};

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -507,7 +507,7 @@ export interface LibConfig extends EnvironmentConfig {
   /**
    * @inheritdoc
    */
-  output?: RslibOutputConfig;
+  output?: Omit<RslibOutputConfig, 'exports'>;
   /**
    * Options for experimental features.
    * @defaultValue `{}`
@@ -558,6 +558,14 @@ interface RslibOutputConfig extends OutputConfig {
    * @default `true` for ESM/CJS, `false` for UMD/MF/IIFE
    */
   autoExternal?: OutputConfig['autoExternal'];
+  /**
+   * Whether to generate the `exports` field in `package.json` from the build entries.
+   * When multiple entries are configured, each entry will be exposed as a subpath in the `exports` field.
+   *
+   * @defaultValue `false`
+   * @see {@link https://rslib.rs/config/rsbuild/output#outputexports}
+   */
+  exports?: boolean;
 }
 
 export interface RslibConfig extends RsbuildConfig, SharedLibConfig {

--- a/packages/core/tests/exports.test.ts
+++ b/packages/core/tests/exports.test.ts
@@ -1,0 +1,210 @@
+import path from 'node:path';
+import { describe, expect, it, rs } from '@rstest/core';
+import type {
+  CollectedEntry,
+  GenerateExportsOptions,
+} from '../src/exports/generate';
+import { generateExports } from '../src/exports/generate';
+import type { RequireKey, RsbuildConfigWithLibInfo } from '../src/types';
+
+rs.mock('rslog');
+
+type LibInfo = RequireKey<RsbuildConfigWithLibInfo, 'id'>;
+
+const createLibInfo = (id: string, format: LibInfo['format']): LibInfo => ({
+  id,
+  format,
+  config: {} as unknown as LibInfo['config'],
+});
+
+const createCollected = (
+  entries: Record<string, [entryName: string, jsFile: string][]>,
+): Map<string, CollectedEntry[]> =>
+  new Map(
+    Object.entries(entries).map(([id, list]) => [
+      id,
+      list.map(([entryName, jsFile]) => ({ entryName, jsFile })),
+    ]),
+  );
+
+describe('generateExports', () => {
+  it('should generate import and require conditions for esm and cjs entries', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [createLibInfo('esm', 'esm'), createLibInfo('cjs', 'cjs')],
+      collected: createCollected({
+        esm: [['index', 'dist/esm/index.mjs']],
+        cjs: [['index', 'dist/cjs/index.js']],
+      }),
+    };
+
+    expect(generateExports(options)).toEqual({
+      './package.json': './package.json',
+      '.': {
+        import: './dist/esm/index.mjs',
+        require: './dist/cjs/index.js',
+      },
+    });
+  });
+
+  it('should generate a string value when only one format exists', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [createLibInfo('esm', 'esm')],
+      collected: createCollected({
+        esm: [['index', 'dist/esm/index.mjs']],
+      }),
+    };
+
+    expect(generateExports(options)).toEqual({
+      './package.json': './package.json',
+      '.': './dist/esm/index.mjs',
+    });
+  });
+
+  it('should expose non-index entries as subpaths', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [createLibInfo('esm', 'esm')],
+      collected: createCollected({
+        esm: [['foo', 'dist/esm/foo.mjs']],
+      }),
+    };
+
+    expect(generateExports(options)).toEqual({
+      './package.json': './package.json',
+      './foo': './dist/esm/foo.mjs',
+    });
+  });
+
+  it('should keep the index entry first and sort other entries', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [createLibInfo('esm', 'esm')],
+      collected: createCollected({
+        esm: [
+          ['foo', 'dist/esm/foo.mjs'],
+          ['utils/numbers', 'dist/esm/utils/numbers.mjs'],
+          ['index', 'dist/esm/index.mjs'],
+          ['bar', 'dist/esm/bar.mjs'],
+        ],
+      }),
+    };
+
+    const exportsField = generateExports(options);
+
+    expect(Object.keys(exportsField!)).toEqual([
+      './package.json',
+      '.',
+      './bar',
+      './foo',
+      './utils/numbers',
+    ]);
+    expect(exportsField).toEqual({
+      './package.json': './package.json',
+      '.': './dist/esm/index.mjs',
+      './bar': './dist/esm/bar.mjs',
+      './foo': './dist/esm/foo.mjs',
+      './utils/numbers': './dist/esm/utils/numbers.mjs',
+    });
+  });
+
+  it('should skip unsupported formats and keep supported ones', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [
+        createLibInfo('esm', 'esm'),
+        createLibInfo('umd', 'umd'),
+        createLibInfo('mf', 'mf'),
+      ],
+      collected: createCollected({
+        esm: [['index', 'dist/esm/index.mjs']],
+        umd: [['index', 'dist/umd/index.js']],
+        mf: [['index', 'dist/mf/index.js']],
+      }),
+    };
+
+    expect(generateExports(options)).toEqual({
+      './package.json': './package.json',
+      '.': './dist/esm/index.mjs',
+    });
+  });
+
+  it('should return undefined when all formats are unsupported', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [createLibInfo('umd', 'umd')],
+      collected: createCollected({
+        umd: [['index', 'dist/umd/index.js']],
+      }),
+    };
+
+    expect(generateExports(options)).toBeUndefined();
+  });
+
+  it('should return undefined when no JavaScript entries are generated', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [createLibInfo('esm', 'esm')],
+      collected: createCollected({
+        esm: [],
+      }),
+    };
+
+    expect(generateExports(options)).toBeUndefined();
+  });
+
+  it('should skip libs without collected entries', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [createLibInfo('esm', 'esm'), createLibInfo('cjs', 'cjs')],
+      collected: createCollected({
+        esm: [['index', 'dist/esm/index.mjs']],
+      }),
+    };
+
+    expect(generateExports(options)).toEqual({
+      './package.json': './package.json',
+      '.': './dist/esm/index.mjs',
+    });
+  });
+
+  it('should return undefined when an entry is outside the package root', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [createLibInfo('esm', 'esm')],
+      collected: createCollected({
+        esm: [['index', '../outside/index.mjs']],
+      }),
+    };
+
+    expect(generateExports(options)).toBeUndefined();
+
+    const absoluteOptions: GenerateExportsOptions = {
+      libInfos: [createLibInfo('esm', 'esm')],
+      collected: createCollected({
+        esm: [['index', path.resolve(__dirname, 'outside/index.mjs')]],
+      }),
+    };
+
+    expect(generateExports(absoluteOptions)).toBeUndefined();
+  });
+
+  it('should return undefined when an entry has multiple outputs of the same format', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [createLibInfo('esm', 'esm'), createLibInfo('esm2', 'esm')],
+      collected: createCollected({
+        esm: [['index', 'dist/esm/index.mjs']],
+        esm2: [['index', 'dist/esm2/index.mjs']],
+      }),
+    };
+
+    expect(generateExports(options)).toBeUndefined();
+  });
+
+  it('should allow duplicate identical outputs of the same format', () => {
+    const options: GenerateExportsOptions = {
+      libInfos: [createLibInfo('esm', 'esm'), createLibInfo('esm2', 'esm')],
+      collected: createCollected({
+        esm: [['index', 'dist/esm/index.mjs']],
+        esm2: [['index', 'dist/esm/index.mjs']],
+      }),
+    };
+
+    expect(generateExports(options)).toEqual({
+      './package.json': './package.json',
+      '.': './dist/esm/index.mjs',
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1224,6 +1224,16 @@ importers:
 
   tests/integration/exe/multi-target: {}
 
+  tests/integration/exports/build-error: {}
+
+  tests/integration/exports/dual-format: {}
+
+  tests/integration/exports/esm-only: {}
+
+  tests/integration/exports/multiple-entries: {}
+
+  tests/integration/exports/umd: {}
+
   tests/integration/extension-alias: {}
 
   tests/integration/external-helpers/config-override:

--- a/tests/integration/exports/build-error/package.json
+++ b/tests/integration/exports/build-error/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "exports-build-error-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/exports/build-error/rslib.config.ts
+++ b/tests/integration/exports/build-error/rslib.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig()],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+  output: {
+    exports: true,
+  },
+});

--- a/tests/integration/exports/build-error/src/index.ts
+++ b/tests/integration/exports/build-error/src/index.ts
@@ -1,0 +1,3 @@
+import { missing } from './missing';
+
+export const index = missing;

--- a/tests/integration/exports/dual-format/package.json
+++ b/tests/integration/exports/dual-format/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "exports-dual-format-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/exports/dual-format/rslib.config.ts
+++ b/tests/integration/exports/dual-format/rslib.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleCjsConfig, generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig(), generateBundleCjsConfig()],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+  output: {
+    exports: true,
+  },
+});

--- a/tests/integration/exports/dual-format/src/index.ts
+++ b/tests/integration/exports/dual-format/src/index.ts
@@ -1,0 +1,1 @@
+export const index = 'index';

--- a/tests/integration/exports/esm-only/package.json
+++ b/tests/integration/exports/esm-only/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "exports-esm-only-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/exports/esm-only/rslib.config.ts
+++ b/tests/integration/exports/esm-only/rslib.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [generateBundleEsmConfig()],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+  output: {
+    exports: true,
+  },
+});

--- a/tests/integration/exports/esm-only/src/index.ts
+++ b/tests/integration/exports/esm-only/src/index.ts
@@ -1,0 +1,1 @@
+export const index = 'index';

--- a/tests/integration/exports/index.test.ts
+++ b/tests/integration/exports/index.test.ts
@@ -1,0 +1,114 @@
+import { createRslib } from '@rslib/core';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterAll, describe, expect, onTestFinished, test } from '@rstest/core';
+import { buildAndGetResults, expectBuildToFail } from 'test-helper';
+
+const fixtures = [
+  'dual-format',
+  'esm-only',
+  'multiple-entries',
+  'umd',
+  'build-error',
+];
+
+// The "exports" field is written back to the fixture package.json after
+// building, keep a backup and restore it once the tests are done.
+const packageJsonContents = new Map(
+  fixtures.map((fixture) => [
+    fixture,
+    readFileSync(join(__dirname, fixture, 'package.json'), 'utf8'),
+  ]),
+);
+
+afterAll(() => {
+  for (const [fixture, content] of packageJsonContents) {
+    writeFileSync(join(__dirname, fixture, 'package.json'), content);
+  }
+});
+
+const readFixtureExports = (fixture: string) =>
+  JSON.parse(readFileSync(join(__dirname, fixture, 'package.json'), 'utf8'))
+    .exports;
+
+describe('output.exports', () => {
+  test('should generate import and require conditions when building esm and cjs formats', async () => {
+    const fixturePath = join(__dirname, 'dual-format');
+    await buildAndGetResults({ fixturePath });
+
+    expect(readFixtureExports('dual-format')).toEqual({
+      './package.json': './package.json',
+      '.': {
+        import: './dist/esm/index.mjs',
+        require: './dist/cjs/index.js',
+      },
+    });
+  });
+
+  test('should generate a string value when building a single format', async () => {
+    const fixturePath = join(__dirname, 'esm-only');
+    await buildAndGetResults({ fixturePath });
+
+    expect(readFixtureExports('esm-only')).toEqual({
+      './package.json': './package.json',
+      '.': './dist/esm/index.mjs',
+    });
+  });
+
+  test('should not write exports in watch mode', async () => {
+    const fixture = 'esm-only';
+    const fixturePath = join(__dirname, fixture);
+    const packageJsonPath = join(fixturePath, 'package.json');
+    const originalPackageJson = packageJsonContents.get(fixture)!;
+    writeFileSync(packageJsonPath, originalPackageJson);
+
+    const rslib = await createRslib({
+      cwd: fixturePath,
+      config: {
+        lib: [{ format: 'esm' }],
+        output: {
+          exports: true,
+        },
+        logLevel: 'silent',
+      },
+    });
+    const buildDone = new Promise<void>((resolve) => {
+      rslib.onAfterCreateRsbuild(({ rsbuild }) => {
+        rsbuild.onAfterBuild({
+          order: 'post',
+          handler: () => resolve(),
+        });
+      });
+    });
+    const buildResult = await rslib.build({ watch: true });
+    onTestFinished(() => buildResult.close());
+
+    await buildDone;
+    expect(readFileSync(packageJsonPath, 'utf8')).toBe(originalPackageJson);
+  });
+
+  test('should expose each bundleless entry as a subpath', async () => {
+    const fixturePath = join(__dirname, 'multiple-entries');
+    await buildAndGetResults({ fixturePath });
+
+    expect(readFixtureExports('multiple-entries')).toEqual({
+      './package.json': './package.json',
+      '.': './dist/esm/index.mjs',
+      './utils/numbers': './dist/esm/utils/numbers.mjs',
+    });
+  });
+
+  test('should not generate exports when building the umd format', async () => {
+    const fixturePath = join(__dirname, 'umd');
+    await buildAndGetResults({ fixturePath });
+
+    expect(readFixtureExports('umd')).toBeUndefined();
+  });
+
+  test('should not generate exports when the build fails', async () => {
+    const fixturePath = join(__dirname, 'build-error');
+    await expectBuildToFail(buildAndGetResults({ fixturePath }));
+
+    expect(readFixtureExports('build-error')).toBeUndefined();
+  });
+});

--- a/tests/integration/exports/multiple-entries/package.json
+++ b/tests/integration/exports/multiple-entries/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "exports-multiple-entries-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/exports/multiple-entries/rslib.config.ts
+++ b/tests/integration/exports/multiple-entries/rslib.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleEsmConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [
+    generateBundleEsmConfig({
+      bundle: false,
+    }),
+  ],
+  source: {
+    entry: {
+      index: ['./src/**'],
+    },
+  },
+  output: {
+    exports: true,
+  },
+});

--- a/tests/integration/exports/multiple-entries/src/index.ts
+++ b/tests/integration/exports/multiple-entries/src/index.ts
@@ -1,0 +1,1 @@
+export const index = 'index';

--- a/tests/integration/exports/multiple-entries/src/utils/numbers.ts
+++ b/tests/integration/exports/multiple-entries/src/utils/numbers.ts
@@ -1,0 +1,1 @@
+export const numbers = 'numbers';

--- a/tests/integration/exports/umd/package.json
+++ b/tests/integration/exports/umd/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "exports-umd-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/exports/umd/rslib.config.ts
+++ b/tests/integration/exports/umd/rslib.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rslib/core';
+import { generateBundleUmdConfig } from 'test-helper';
+
+export default defineConfig({
+  lib: [generateBundleUmdConfig()],
+  source: {
+    entry: {
+      index: './src/index.ts',
+    },
+  },
+  output: {
+    exports: true,
+  },
+});

--- a/tests/integration/exports/umd/src/index.ts
+++ b/tests/integration/exports/umd/src/index.ts
@@ -1,0 +1,1 @@
+export const index = 'index';

--- a/website/docs/en/config/rsbuild/output.mdx
+++ b/website/docs/en/config/rsbuild/output.mdx
@@ -94,6 +94,36 @@ The `wasm` option only takes effect when [lib.wasm.mode](/config/lib/wasm#wasmmo
 
 Whether to emit CSS to the output bundles.
 
+## output.exports
+
+Whether to generate the `exports` field in `package.json` from the build entries after the build finishes.
+
+In Rslib, the default value for this option is `false`.
+
+When set to `true`, Rslib writes the `exports` field to `package.json` after a successful build:
+
+- The `./package.json` subpath is always exposed.
+- The entry named `index` is exposed as the main subpath (`.`), and other entries are exposed as subpaths with the same name, such as `./utils/numbers`.
+- When both `esm` and `cjs` libs produce the same entry, the subpath value is an object with `import` and `require` conditions, otherwise it is the output file path.
+
+For example, building `esm` and `cjs` libs with an `index` entry generates:
+
+```json
+{
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js"
+    }
+  }
+}
+```
+
+:::note
+`output.exports` only applies to the `esm` and `cjs` formats, and entries from other formats such as `umd`, `mf`, and `iife` are skipped. It is also ignored in watch mode, and the existing `exports` field in `package.json` will be overwritten.
+:::
+
 ## output.externals <RsbuildDocBadge path="/config/output/externals" text="output.externals" />
 
 - **CLI:** `--externals <pkg>` (repeatable, e.g. `--externals react --externals react-dom`)

--- a/website/docs/zh/config/rsbuild/output.mdx
+++ b/website/docs/zh/config/rsbuild/output.mdx
@@ -90,6 +90,36 @@ const defaultDistPath = {
 
 是否将 CSS 输出到产物中。
 
+## output.exports
+
+是否在构建结束后，根据构建入口生成 `package.json` 中的 `exports` 字段。
+
+在 Rslib 中，该选项的默认值为 `false`。
+
+设置为 `true` 时，Rslib 会在构建成功后将 `exports` 字段写入 `package.json`：
+
+- 始终会暴露 `./package.json` 子路径。
+- 名为 `index` 的入口会作为主子路径（`.`）暴露，其他入口会以相同的名称作为子路径暴露，例如 `./utils/numbers`。
+- 当 `esm` 和 `cjs` 产物包含同一个入口时，子路径的值为带有 `import` 和 `require` 条件的对象，否则为产物文件路径。
+
+例如，构建包含 `index` 入口的 `esm` 和 `cjs` 产物时会生成：
+
+```json
+{
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js"
+    }
+  }
+}
+```
+
+:::note
+`output.exports` 仅对 `esm` 和 `cjs` 格式生效，`umd`、`mf`、`iife` 等其他格式的产物会被跳过。该选项在 watch 模式下会被忽略，并且会覆盖 `package.json` 中已有的 `exports` 字段。
+:::
+
 ## output.externals <RsbuildDocBadge path="/config/output/externals" text="output.externals" />
 
 - **命令行：** `--externals <pkg>`（可重复，例如 `--externals react --externals react-dom`）


### PR DESCRIPTION
## Summary

This PR adds an `output.exports` option to generate the `exports` field in `package.json` from build entries.

- Supports ESM and CJS outputs, including `import` and `require` conditions.
- Supports single and multiple entries.
- Skips generation in watch mode.

This is the first iteration and only covers `exports`. If the remaining fields proposed in the issue are still needed, I’d be happy to add `main`, `module`, and `types` in a follow-up PR.

## Related links

- https://github.com/web-infra-dev/rslib/issues/1291

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).