### PR TITLE
fix(create-rslib): allow esbuild builds in Storybook templates

### DIFF
--- a/packages/create-rslib/src/index.ts
+++ b/packages/create-rslib/src/index.ts
@@ -171,7 +171,12 @@ create({
       label: 'Storybook - component development',
       when: ({ templateName }) =>
         templateName.startsWith('react') || templateName.startsWith('vue'),
-      action: ({ templateName, distFolder, addAgentsMdSearchDirs }) => {
+      action: ({
+        templateName,
+        distFolder,
+        skipFiles,
+        addAgentsMdSearchDirs,
+      }) => {
         const toolFolder = path.join(__dirname, '..', 'template-storybook');
         const subFolder = path.join(toolFolder, templateName);
 
@@ -179,6 +184,7 @@ create({
           from: subFolder,
           to: distFolder,
           isMergePackageJson: true,
+          skipFiles,
         });
         addAgentsMdSearchDirs(toolFolder);
       },

--- a/packages/create-rslib/template-storybook/react-js/pnpm-workspace.yaml
+++ b/packages/create-rslib/template-storybook/react-js/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/packages/create-rslib/template-storybook/react-ts/pnpm-workspace.yaml
+++ b/packages/create-rslib/template-storybook/react-ts/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/packages/create-rslib/template-storybook/vue-js/pnpm-workspace.yaml
+++ b/packages/create-rslib/template-storybook/vue-js/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/packages/create-rslib/template-storybook/vue-ts/pnpm-workspace.yaml
+++ b/packages/create-rslib/template-storybook/vue-ts/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -41,10 +41,12 @@ export const createAndValidate = (
     name = `test-temp-${templateCase.label}`,
     tools: additionalTools = [],
     clean = true,
+    packageManager = 'pnpm',
   }: {
     name?: string;
     tools?: string[];
     clean?: boolean;
+    packageManager?: 'npm' | 'pnpm';
   } = {},
 ) => {
   const dir = path.join(cwd, name);
@@ -66,7 +68,13 @@ export const createAndValidate = (
     command += ` ${toolsCmd}`;
   }
 
-  execSync(command, { cwd });
+  execSync(command, {
+    cwd,
+    env: {
+      ...process.env,
+      npm_config_user_agent: `${packageManager}/0.0.0`,
+    },
+  });
 
   const pkgJson = fse.readJSONSync(path.join(dir, 'package.json'));
   expectPackageJson(
@@ -126,15 +134,29 @@ export const createAndValidate = (
     for (const dep of storybookDeps) {
       expect(pkgJson.devDependencies[dep]).toBeTruthy();
     }
+
+    const pnpmWorkspacePath = path.join(dir, 'pnpm-workspace.yaml');
+    if (packageManager === 'pnpm') {
+      expect(fse.readFileSync(pnpmWorkspacePath, 'utf-8')).toContain(
+        'esbuild: true',
+      );
+    } else {
+      expect(existsSync(pnpmWorkspacePath)).toBe(false);
+    }
   }
 
   if (templateCase.template === 'svelte') {
     expect(pkgJson.devDependencies['@rsbuild/plugin-svelte']).toBeTruthy();
     expect(pkgJson.devDependencies.svelte).toBeTruthy();
     expect(pkgJson.peerDependencies.svelte).toBe('^5.0.0');
-    expect(
-      fse.readFileSync(path.join(dir, 'pnpm-workspace.yaml'), 'utf-8'),
-    ).toContain('svelte-preprocess: false');
+    const pnpmWorkspacePath = path.join(dir, 'pnpm-workspace.yaml');
+    if (packageManager === 'pnpm') {
+      expect(fse.readFileSync(pnpmWorkspacePath, 'utf-8')).toContain(
+        'svelte-preprocess: false',
+      );
+    } else {
+      expect(existsSync(pnpmWorkspacePath)).toBe(false);
+    }
 
     if (templateCase.lang === 'ts') {
       expect(pkgJson.devDependencies['svelte-check']).toBeTruthy();

--- a/packages/create-rslib/test/index.test.ts
+++ b/packages/create-rslib/test/index.test.ts
@@ -165,6 +165,13 @@ describe('react', () => {
       createAndValidate(__dirname, c);
     });
   }
+
+  test('should omit pnpm config from npm Storybook projects', () => {
+    createAndValidate(__dirname, createCase('react', 'ts', ['storybook']), {
+      name: 'test-temp-react-ts-storybook-npm',
+      packageManager: 'npm',
+    });
+  });
 });
 
 describe('vue', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ catalogs:
       specifier: ^2.0.21
       version: 2.0.21
     '@rstackjs/create-toolkit':
-      specifier: 2.2.4
-      version: 2.2.4
+      specifier: 2.2.5
+      version: 2.2.5
     '@rstackjs/doc-ui':
       specifier: 1.14.11
       version: 1.14.11
@@ -678,7 +678,7 @@ importers:
     dependencies:
       '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.2.4
+        version: 2.2.5
     devDependencies:
       '@rslib/tsconfig':
         specifier: workspace:*
@@ -3433,8 +3433,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rstackjs/create-toolkit@2.2.4':
-    resolution: {integrity: sha512-YVnA9aTZKPTql8Hzyf9o5chWAICNJ46CYoPwADrSObyBxF1jlvB5gO5M+yXYoZT/VNWh1Abm0TvTtmAh4EeT3A==}
+  '@rstackjs/create-toolkit@2.2.5':
+    resolution: {integrity: sha512-RVPaqOi2FDlHQT/z/zRyhJ650Zo/w+M3Aa5bYq92Rri2VOh46OIWFzaJGqAHF2/qeP+Ns7+JsRnVSk4H/4otUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@rstackjs/doc-ui@1.14.11':
@@ -9915,7 +9915,7 @@ snapshots:
   '@rstackjs/cli-win32-x64-msvc@0.6.5':
     optional: true
 
-  '@rstackjs/create-toolkit@2.2.4': {}
+  '@rstackjs/create-toolkit@2.2.5': {}
 
   '@rstackjs/doc-ui@1.14.11(@rspress/core@2.0.21)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,7 @@ catalog:
   '@rspress/plugin-sitemap': '^2.0.21'
   '@rspress/plugin-twoslash': '^2.0.21'
   '@rstackjs/doc-ui': '1.14.11'
-  '@rstackjs/create-toolkit': '2.2.4'
+  '@rstackjs/create-toolkit': '2.2.5'
   '@rstest/adapter-rslib': '^0.11.10'
   '@rstest/core': '^0.11.10'
   '@shikijs/transformers': '^4.4.3'


### PR DESCRIPTION
## Summary

- Fix pnpm installs for generated Storybook projects by allowing the esbuild build script.
- Forward package-manager-specific skip files so non-pnpm projects do not receive `pnpm-workspace.yaml`.
- Upgrade `@rstackjs/create-toolkit` to 2.2.5 and cover both pnpm and npm generation.

## Related links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.2.5

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).