### PR TITLE
feat(core): support disabling wasm handling with lib.wasm false

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -499,7 +499,7 @@ export interface LibConfig extends EnvironmentConfig {
   outBase?: string;
   /**
    * Configure how Rslib handles `.wasm` modules. Set to `false` to leave
-   * `.wasm` imports exactly as written in the source.
+   * ESM `.wasm` imports exactly as written in the source.
    *
    * This option can only be configured when `format` is `'esm'`.
    *

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -368,18 +368,20 @@ export type Redirect = {
 
 export type WasmMode = 'compile' | 'preserve';
 
-export type Wasm = {
-  /**
-   * Controls how `.wasm` modules are emitted.
-   *
-   * - `'compile'`: Generates JavaScript loading code and emits `.wasm` files as static assets.
-   * - `'preserve'`: Preserves `.wasm` imports and files for the consumer to handle. Requires `bundle` to be `false`.
-   *
-   * @defaultValue `'compile'` when `bundle` is `true`; `'preserve'` when `bundle` is `false`.
-   * @see {@link https://rslib.rs/config/lib/wasm#wasmmode}
-   */
-  mode?: WasmMode;
-};
+export type Wasm =
+  | {
+      /**
+       * Controls how `.wasm` modules are emitted.
+       *
+       * - `'compile'`: Generates JavaScript loading code and emits `.wasm` files as static assets.
+       * - `'preserve'`: Preserves `.wasm` imports and files for the consumer to handle. Requires `bundle` to be `false`.
+       *
+       * @defaultValue `'compile'` when `bundle` is `true`; `'preserve'` when `bundle` is `false`.
+       * @see {@link https://rslib.rs/config/lib/wasm#wasmmode}
+       */
+      mode?: WasmMode;
+    }
+  | false;
 
 export type LibExperiments = {
   /**
@@ -496,7 +498,8 @@ export interface LibConfig extends EnvironmentConfig {
    */
   outBase?: string;
   /**
-   * Configure how Rslib handles `.wasm` modules.
+   * Configure how Rslib handles `.wasm` modules. Set to `false` to leave
+   * `.wasm` imports exactly as written in the source.
    *
    * This option can only be configured when `format` is `'esm'`.
    *

--- a/packages/core/src/wasm/compose.ts
+++ b/packages/core/src/wasm/compose.ts
@@ -1,6 +1,10 @@
 import type { EnvironmentConfig, Rspack } from '@rsbuild/core';
 import type { Format, Wasm, WasmMode } from '../types';
-import { createWasmPreserveExternal, WasmPreservePlugin } from './preserve';
+import {
+  createWasmPreserveExternal,
+  wasmUntouchedExternal,
+  WasmPreservePlugin,
+} from './preserve';
 
 export const resolveWasmMode = ({
   bundle,
@@ -10,11 +14,15 @@ export const resolveWasmMode = ({
   bundle: boolean;
   format: Format;
   wasmConfig?: Wasm;
-}): WasmMode => {
+}): WasmMode | false => {
   if (wasmConfig !== undefined && format !== 'esm') {
     throw new Error(
       '"wasm" only supports the "esm" format. Set "format" to "esm" or omit it.',
     );
+  }
+
+  if (wasmConfig === false) {
+    return false;
   }
 
   const mode = wasmConfig?.mode ?? (bundle ? 'compile' : 'preserve');
@@ -38,7 +46,7 @@ export const composeWasmConfig = ({
   format: Format;
   jsDistPath: string;
   jsFilename: Rspack.Filename;
-  mode: WasmMode;
+  mode: WasmMode | false;
   outBase: string | null;
 }): {
   externalConfig: EnvironmentConfig;
@@ -46,6 +54,17 @@ export const composeWasmConfig = ({
 } => {
   if (format !== 'esm' || mode === 'compile') {
     return { externalConfig: {}, config: {} };
+  }
+
+  if (mode === false) {
+    return {
+      externalConfig: {
+        output: {
+          externals: [wasmUntouchedExternal],
+        },
+      },
+      config: {},
+    };
   }
 
   const preserveOptions = {

--- a/packages/core/src/wasm/preserve.ts
+++ b/packages/core/src/wasm/preserve.ts
@@ -17,6 +17,33 @@ type WasmPreserveOptions = {
   outBase: string;
 };
 
+/**
+ * Whether an external request is a `.wasm` module imported through ESM syntax.
+ *
+ * `.wasm` files referenced in other ways, such as `new URL('./add.wasm',
+ * import.meta.url)`, are left to the asset pipeline.
+ */
+const isWasmEsmRequest = (
+  data: Rspack.ExternalItemFunctionData,
+): data is Rspack.ExternalItemFunctionData & { request: string } =>
+  Boolean(data.request?.endsWith('.wasm')) && data.dependencyType === 'esm';
+
+/**
+ * An external that keeps `.wasm` imports exactly as written in the source,
+ * without rewriting the request or emitting the `.wasm` file.
+ */
+export const wasmUntouchedExternal = ((
+  data: Rspack.ExternalItemFunctionData,
+  callback: (err?: Error, result?: Rspack.ExternalItemValue) => void,
+): void => {
+  if (!isWasmEsmRequest(data)) {
+    callback();
+    return;
+  }
+
+  callback(undefined, data.request);
+}) as Rspack.ExternalItem;
+
 export const createWasmPreserveExternal = (
   options: WasmPreserveOptions,
 ): Rspack.ExternalItem => {
@@ -30,12 +57,12 @@ export const createWasmPreserveExternal = (
       type?: Rspack.ExternalsType,
     ) => void,
   ): Promise<void> => {
-    const { request, getResolve, context, contextInfo, dependencyType } = data;
-
-    if (!request?.endsWith('.wasm') || dependencyType !== 'esm') {
+    if (!isWasmEsmRequest(data)) {
       callback();
       return;
     }
+
+    const { request, getResolve, context, contextInfo } = data;
 
     if (!getResolve || !context || !contextInfo) {
       callback();

--- a/tests/integration/wasm/index.test.ts
+++ b/tests/integration/wasm/index.test.ts
@@ -86,6 +86,20 @@ describe('wasm static', () => {
     expect(existsSync(join(preserveBundlelessDir, 'add.wasm'))).toBe(true);
   });
 
+  test('keeps wasm imports untouched when wasm is disabled', async () => {
+    const rawBundleDir = join(fixturePath, 'dist/static/raw-bundle');
+    expect(readFileSync(join(rawBundleDir, 'index.js'), 'utf8')).toContain(
+      'from "./add.wasm"',
+    );
+    expect(wasmFiles(rawBundleDir)).toEqual([]);
+
+    const rawBundlelessDir = join(fixturePath, 'dist/static/raw-bundleless');
+    expect(readFileSync(join(rawBundlelessDir, 'utils.js'), 'utf8')).toContain(
+      'from "./add.wasm"',
+    );
+    expect(wasmFiles(rawBundlelessDir)).toEqual([]);
+  });
+
   test('handles a nested bundleless JS filename', async () => {
     const distDir = join(
       fixturePath,

--- a/tests/integration/wasm/static/rslib.config.ts
+++ b/tests/integration/wasm/static/rslib.config.ts
@@ -25,6 +25,20 @@ export default defineConfig({
       },
     }),
     generateBundleEsmConfig({
+      bundle: true,
+      wasm: false,
+      output: {
+        distPath: './dist/static/raw-bundle',
+      },
+    }),
+    generateBundleEsmConfig({
+      bundle: false,
+      wasm: false,
+      output: {
+        distPath: './dist/static/raw-bundleless',
+      },
+    }),
+    generateBundleEsmConfig({
       bundle: false,
       wasm: { mode: 'preserve' },
       output: {

--- a/website/docs/en/config/lib/wasm.mdx
+++ b/website/docs/en/config/lib/wasm.mdx
@@ -1,5 +1,5 @@
 ---
-description: 'Configure lib.wasm to select the output mode for WASM modules.'
+description: 'Configure lib.wasm to select the output mode for WASM modules, or disable the handling of WASM modules.'
 ---
 
 # lib.wasm
@@ -7,9 +7,11 @@ description: 'Configure lib.wasm to select the output mode for WASM modules.'
 - **Type:**
 
 ```ts
-type Wasm = {
-  mode?: 'compile' | 'preserve';
-};
+type Wasm =
+  | {
+      mode?: 'compile' | 'preserve';
+    }
+  | false;
 ```
 
 - **Default:**

--- a/website/docs/en/guide/advanced/wasm.mdx
+++ b/website/docs/en/guide/advanced/wasm.mdx
@@ -288,7 +288,7 @@ If any of these module names resolve to JavaScript output, avoid changing its re
 
 ## Disable wasm handling
 
-When [lib.wasm](/config/lib/wasm) is set to `false`, Rslib does not process `.wasm` modules imported with ESM syntax. The imports are kept as written in the output, and you need to make sure the `.wasm` files are correctly located in the output.
+When [lib.wasm](/config/lib/wasm) is set to `false`, Rslib preserves the original import specifiers for `.wasm` modules imported using ESM syntax, without resolving the modules or emitting the corresponding `.wasm` files. You are responsible for managing these files and ensuring that the imports resolve correctly from the emitted JavaScript files.
 
 `.wasm` files referenced with `new URL('./add.wasm', import.meta.url)` go through the static asset pipeline and are not affected by [lib.wasm](/config/lib/wasm).
 

--- a/website/docs/en/guide/advanced/wasm.mdx
+++ b/website/docs/en/guide/advanced/wasm.mdx
@@ -71,8 +71,6 @@ You can use [lib.wasm.mode](/config/lib/wasm#wasmmode) to select the output mode
 - [bundle](/config/lib/bundle) is `true`: Only `compile` mode is available.
 - [bundle](/config/lib/bundle) is `false`: `preserve` mode is used by default when the `.wasm` modules are resolved and loaded by a downstream build tool that supports WebAssembly ESM Integration (such as Rsbuild or Rspack) or a target runtime with native support (such as [Node.js](https://nodejs.org/api/esm.html#wasm-modules) versions matching `>=24.5.0`). If the consumer does not support this feature, or you do not want to rely on it to handle the `.wasm` modules, use `compile` mode.
 
-You can also set [lib.wasm](/config/lib/wasm) to `false`, and Rslib will not process `.wasm` modules at all. The imports are kept as written in the output, and you need to make sure the `.wasm` files are correctly located in the output.
-
 The following source files demonstrate how to configure the `compile` and `preserve` modes and their build outputs.
 
 <Tabs>
@@ -287,6 +285,12 @@ If any of these module names resolve to JavaScript output, avoid changing its re
 - [lib.autoExtension](/config/lib/auto-extension)
 
 :::
+
+## Disable wasm handling
+
+When [lib.wasm](/config/lib/wasm) is set to `false`, Rslib does not process `.wasm` modules imported with ESM syntax. The imports are kept as written in the output, and you need to make sure the `.wasm` files are correctly located in the output.
+
+`.wasm` files referenced with `new URL('./add.wasm', import.meta.url)` go through the static asset pipeline and are not affected by [lib.wasm](/config/lib/wasm).
 
 ## Use with wasm-bindgen
 

--- a/website/docs/en/guide/advanced/wasm.mdx
+++ b/website/docs/en/guide/advanced/wasm.mdx
@@ -71,6 +71,8 @@ You can use [lib.wasm.mode](/config/lib/wasm#wasmmode) to select the output mode
 - [bundle](/config/lib/bundle) is `true`: Only `compile` mode is available.
 - [bundle](/config/lib/bundle) is `false`: `preserve` mode is used by default when the `.wasm` modules are resolved and loaded by a downstream build tool that supports WebAssembly ESM Integration (such as Rsbuild or Rspack) or a target runtime with native support (such as [Node.js](https://nodejs.org/api/esm.html#wasm-modules) versions matching `>=24.5.0`). If the consumer does not support this feature, or you do not want to rely on it to handle the `.wasm` modules, use `compile` mode.
 
+You can also set [lib.wasm](/config/lib/wasm) to `false`, and Rslib will not process `.wasm` modules at all. The imports are kept as written in the output, and you need to make sure the `.wasm` files are correctly located in the output.
+
 The following source files demonstrate how to configure the `compile` and `preserve` modes and their build outputs.
 
 <Tabs>

--- a/website/docs/zh/config/lib/wasm.mdx
+++ b/website/docs/zh/config/lib/wasm.mdx
@@ -1,5 +1,5 @@
 ---
-description: '配置 lib.wasm，选择 WASM 模块的输出模式。'
+description: '配置 lib.wasm，选择 WASM 模块的输出模式，或禁用对 WASM 模块的处理。'
 ---
 
 # lib.wasm
@@ -7,9 +7,11 @@ description: '配置 lib.wasm，选择 WASM 模块的输出模式。'
 - **类型：**
 
 ```ts
-type Wasm = {
-  mode?: 'compile' | 'preserve';
-};
+type Wasm =
+  | {
+      mode?: 'compile' | 'preserve';
+    }
+  | false;
 ```
 
 - **默认值：**

--- a/website/docs/zh/guide/advanced/wasm.mdx
+++ b/website/docs/zh/guide/advanced/wasm.mdx
@@ -71,6 +71,8 @@ TypeScript 目前无法解析 `import source` 和 `import.source()`。如果你�
 - [bundle](/config/lib/bundle) 为 `true`：仅支持 `compile` 模式。
 - [bundle](/config/lib/bundle) 为 `false`：默认使用 `preserve` 模式，适用于 `.wasm` 模块由支持 WebAssembly ESM Integration 的下游构建工具（如 Rsbuild 或 Rspack）或目标运行时（如 [Node.js](https://nodejs.org/api/esm.html#wasm-modules) `>=24.5.0`）解析和加载的场景。如果消费方不支持该特性，或不希望依赖其处理 `.wasm` 模块，则使用 `compile` 模式。
 
+你也可以将 [lib.wasm](/config/lib/wasm) 设置为 `false`，此时 Rslib 不会对 `.wasm` 模块做任何处理，导入语句会原样保留在产物中，你需要自行保证 `.wasm` 文件正确地位于产物中。
+
 以下通过一组示例源码，介绍 compile 和 preserve 模式的配置方式及构建结果。
 
 <Tabs>

--- a/website/docs/zh/guide/advanced/wasm.mdx
+++ b/website/docs/zh/guide/advanced/wasm.mdx
@@ -288,7 +288,7 @@ Rslib 会更新 JavaScript 产物中对 `.wasm` 文件的 import，使其指向�
 
 ## 禁用 wasm 处理
 
-将 [lib.wasm](/config/lib/wasm) 设置为 `false` 时，Rslib 不会处理通过 ESM 语法导入的 `.wasm` 模块，导入语句会原样保留在产物中，你需要自行保证 `.wasm` 文件正确地位于产物中。
+将 [lib.wasm](/config/lib/wasm) 设置为 `false` 时，Rslib 会保留通过 ESM 语法导入的 `.wasm` 模块的原始导入路径，不解析这些模块，也不输出对应的 `.wasm` 文件。你需要自行管理这些文件，并确保导入路径能够从产物中的 JavaScript 文件正确解析。
 
 通过 `new URL('./add.wasm', import.meta.url)` 引用的 `.wasm` 文件由静态资源流程处理，不受 [lib.wasm](/config/lib/wasm) 影响。
 

--- a/website/docs/zh/guide/advanced/wasm.mdx
+++ b/website/docs/zh/guide/advanced/wasm.mdx
@@ -71,8 +71,6 @@ TypeScript 目前无法解析 `import source` 和 `import.source()`。如果你�
 - [bundle](/config/lib/bundle) 为 `true`：仅支持 `compile` 模式。
 - [bundle](/config/lib/bundle) 为 `false`：默认使用 `preserve` 模式，适用于 `.wasm` 模块由支持 WebAssembly ESM Integration 的下游构建工具（如 Rsbuild 或 Rspack）或目标运行时（如 [Node.js](https://nodejs.org/api/esm.html#wasm-modules) `>=24.5.0`）解析和加载的场景。如果消费方不支持该特性，或不希望依赖其处理 `.wasm` 模块，则使用 `compile` 模式。
 
-你也可以将 [lib.wasm](/config/lib/wasm) 设置为 `false`，此时 Rslib 不会对 `.wasm` 模块做任何处理，导入语句会原样保留在产物中，你需要自行保证 `.wasm` 文件正确地位于产物中。
-
 以下通过一组示例源码，介绍 compile 和 preserve 模式的配置方式及构建结果。
 
 <Tabs>
@@ -287,6 +285,12 @@ Rslib 会更新 JavaScript 产物中对 `.wasm` 文件的 import，使其指向�
 - [lib.autoExtension](/config/lib/auto-extension)
 
 :::
+
+## 禁用 wasm 处理
+
+将 [lib.wasm](/config/lib/wasm) 设置为 `false` 时，Rslib 不会处理通过 ESM 语法导入的 `.wasm` 模块，导入语句会原样保留在产物中，你需要自行保证 `.wasm` 文件正确地位于产物中。
+
+通过 `new URL('./add.wasm', import.meta.url)` 引用的 `.wasm` 文件由静态资源流程处理，不受 [lib.wasm](/config/lib/wasm) 影响。
 
 ## 与 wasm-bindgen 配合使用
 


### PR DESCRIPTION
## Summary

Adds `lib.wasm: false`, which leaves `.wasm` imports exactly as written in the source and emits no `.wasm` files, so the modules can be handled outside Rslib. Like the existing `lib.wasm` object form, it only applies when `format` is `'esm'`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
