### PR TITLE
feat(create-rslib): add ReactLynx templates

### DIFF
--- a/packages/create-rslib/src/index.ts
+++ b/packages/create-rslib/src/index.ts
@@ -22,6 +22,8 @@ export const TEMPLATES: string[] = [
   'node-ts',
   'react-js',
   'react-ts',
+  'reactlynx-js',
+  'reactlynx-ts',
   'vue-js',
   'vue-ts',
   'svelte-js',
@@ -41,8 +43,9 @@ async function getTemplateName({ template }: Argv) {
     await select({
       message: 'Select template',
       options: [
-        { value: 'node', label: 'Node.js package' },
+        { value: 'node', label: 'Node.js' },
         { value: 'react', label: 'React' },
+        { value: 'reactlynx', label: 'ReactLynx' },
         { value: 'vue', label: 'Vue' },
         { value: 'svelte', label: 'Svelte' },
         { value: 'solid', label: 'Solid' },
@@ -72,6 +75,10 @@ function mapESLintTemplate(templateName: string): ESLintTemplateName {
     case 'svelte-js':
     case 'svelte-ts':
       return templateName;
+    case 'reactlynx-js':
+      return 'react-js';
+    case 'reactlynx-ts':
+      return 'react-ts';
     default: {
       const language = templateName.split('-').pop();
       return `vanilla-${language}` as ESLintTemplateName;
@@ -84,6 +91,10 @@ function mapRslintTemplate(templateName: string): RslintTemplateName {
     case 'react-js':
     case 'react-ts':
       return templateName;
+    case 'reactlynx-js':
+      return 'react-js';
+    case 'reactlynx-ts':
+      return 'react-ts';
     default: {
       const language = templateName.split('-').pop();
       return `vanilla-${language}` as RslintTemplateName;
@@ -170,7 +181,7 @@ create({
       value: 'storybook',
       label: 'Storybook - component development',
       when: ({ templateName }) =>
-        templateName.startsWith('react') || templateName.startsWith('vue'),
+        templateName.startsWith('react-') || templateName.startsWith('vue-'),
       action: ({
         templateName,
         distFolder,

--- a/packages/create-rslib/template-reactlynx-js/AGENTS.md
+++ b/packages/create-rslib/template-reactlynx-js/AGENTS.md
@@ -1,0 +1,3 @@
+## Docs
+
+- Lynx: https://lynxjs.org/llms.txt

--- a/packages/create-rslib/template-reactlynx-js/package.json
+++ b/packages/create-rslib/template-reactlynx-js/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "rslib-reactlynx-js",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": "./dist/index.jsx",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rslib",
+    "dev": "rslib --watch",
+    "test": "rstest",
+    "test:watch": "rstest --watch"
+  },
+  "devDependencies": {
+    "@lynx-js/react": "^0.126.0",
+    "@lynx-js/react-rsbuild-plugin": "^0.20.1",
+    "@rsbuild/plugin-react": "^2.1.0",
+    "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.11.12",
+    "@rstest/core": "^0.11.12",
+    "happy-dom": "^20.14.0"
+  },
+  "peerDependencies": {
+    "@lynx-js/react": ">=0.100.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/create-rslib/template-reactlynx-js/rslib.config.js
+++ b/packages/create-rslib/template-reactlynx-js/rslib.config.js
@@ -1,0 +1,19 @@
+import { pluginReact } from '@rsbuild/plugin-react';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  bundle: false,
+  output: {
+    target: 'web',
+    filename: {
+      js: '[name].jsx',
+    },
+  },
+  plugins: [
+    pluginReact({
+      swcReactOptions: {
+        runtime: 'preserve',
+      },
+    }),
+  ],
+});

--- a/packages/create-rslib/template-reactlynx-js/rstest.config.js
+++ b/packages/create-rslib/template-reactlynx-js/rstest.config.js
@@ -1,0 +1,9 @@
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { withDefaultConfig } from '@lynx-js/react/testing-library/rstest-config';
+import { withRslibConfig } from '@rstest/adapter-rslib';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  extends: [withDefaultConfig(), withRslibConfig()],
+  plugins: [pluginReactLynx()],
+});

--- a/packages/create-rslib/template-reactlynx-js/src/ScrollList.jsx
+++ b/packages/create-rslib/template-reactlynx-js/src/ScrollList.jsx
@@ -1,0 +1,17 @@
+export function ScrollList() {
+  return (
+    <scroll-view
+      scroll-orientation="horizontal"
+      style={{ width: '240px', height: '80px' }}
+    >
+      {['red', 'green', 'blue'].map((color) => (
+        <view
+          key={color}
+          style={{ width: '120px', height: '80px', backgroundColor: color }}
+        >
+          <text style={{ color: 'white' }}>{color}</text>
+        </view>
+      ))}
+    </scroll-view>
+  );
+}

--- a/packages/create-rslib/template-reactlynx-js/src/index.js
+++ b/packages/create-rslib/template-reactlynx-js/src/index.js
@@ -1,0 +1,1 @@
+export { ScrollList } from './ScrollList';

--- a/packages/create-rslib/template-reactlynx-js/tests/index.test.jsx
+++ b/packages/create-rslib/template-reactlynx-js/tests/index.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@lynx-js/react/testing-library';
+import { expect, test } from '@rstest/core';
+import { ScrollList } from '../src/ScrollList';
+
+test('renders the color items', () => {
+  render(<ScrollList />);
+
+  for (const color of ['red', 'green', 'blue']) {
+    const item = screen.getByText(color).parentElement;
+    expect(item?.style.backgroundColor).toBe(color);
+  }
+});

--- a/packages/create-rslib/template-reactlynx-ts/AGENTS.md
+++ b/packages/create-rslib/template-reactlynx-ts/AGENTS.md
@@ -1,0 +1,3 @@
+## Docs
+
+- Lynx: https://lynxjs.org/llms.txt

--- a/packages/create-rslib/template-reactlynx-ts/package.json
+++ b/packages/create-rslib/template-reactlynx-ts/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "rslib-reactlynx-ts",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.jsx"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rslib",
+    "dev": "rslib --watch",
+    "test": "rstest",
+    "test:watch": "rstest --watch"
+  },
+  "devDependencies": {
+    "@lynx-js/react": "^0.126.0",
+    "@lynx-js/react-rsbuild-plugin": "^0.20.1",
+    "@lynx-js/types": "^4.2.1",
+    "@rsbuild/plugin-react": "^2.1.0",
+    "@rslib/core": "workspace:*",
+    "@rstest/adapter-rslib": "^0.11.12",
+    "@rstest/core": "^0.11.12",
+    "@types/node": "^24.13.3",
+    "@types/react": "^19.2.18",
+    "happy-dom": "^20.14.0",
+    "typescript": "^6.0.3"
+  },
+  "peerDependencies": {
+    "@lynx-js/react": ">=0.100.0",
+    "@lynx-js/types": ">=4",
+    "@types/react": ">=19"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/create-rslib/template-reactlynx-ts/rslib.config.ts
+++ b/packages/create-rslib/template-reactlynx-ts/rslib.config.ts
@@ -1,0 +1,20 @@
+import { pluginReact } from '@rsbuild/plugin-react';
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  bundle: false,
+  dts: true,
+  output: {
+    target: 'web',
+    filename: {
+      js: '[name].jsx',
+    },
+  },
+  plugins: [
+    pluginReact({
+      swcReactOptions: {
+        runtime: 'preserve',
+      },
+    }),
+  ],
+});

--- a/packages/create-rslib/template-reactlynx-ts/rstest.config.ts
+++ b/packages/create-rslib/template-reactlynx-ts/rstest.config.ts
@@ -1,0 +1,9 @@
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { withDefaultConfig } from '@lynx-js/react/testing-library/rstest-config';
+import { withRslibConfig } from '@rstest/adapter-rslib';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  extends: [withDefaultConfig(), withRslibConfig()],
+  plugins: [pluginReactLynx()],
+});

--- a/packages/create-rslib/template-reactlynx-ts/src/ScrollList.tsx
+++ b/packages/create-rslib/template-reactlynx-ts/src/ScrollList.tsx
@@ -1,0 +1,19 @@
+import type { JSX } from '@lynx-js/react';
+
+export function ScrollList(): JSX.Element {
+  return (
+    <scroll-view
+      scroll-orientation="horizontal"
+      style={{ width: '240px', height: '80px' }}
+    >
+      {['red', 'green', 'blue'].map((color) => (
+        <view
+          key={color}
+          style={{ width: '120px', height: '80px', backgroundColor: color }}
+        >
+          <text style={{ color: 'white' }}>{color}</text>
+        </view>
+      ))}
+    </scroll-view>
+  );
+}

--- a/packages/create-rslib/template-reactlynx-ts/src/index.ts
+++ b/packages/create-rslib/template-reactlynx-ts/src/index.ts
@@ -1,0 +1,1 @@
+export { ScrollList } from './ScrollList';

--- a/packages/create-rslib/template-reactlynx-ts/tests/index.test.tsx
+++ b/packages/create-rslib/template-reactlynx-ts/tests/index.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@lynx-js/react/testing-library';
+import { expect, test } from '@rstest/core';
+import { ScrollList } from '../src/ScrollList';
+
+test('renders the color items', () => {
+  render(<ScrollList />);
+
+  for (const color of ['red', 'green', 'blue']) {
+    const item = screen.getByText(color).parentElement;
+    expect(item?.style.backgroundColor).toBe(color);
+  }
+});

--- a/packages/create-rslib/template-reactlynx-ts/tests/tsconfig.json
+++ b/packages/create-rslib/template-reactlynx-ts/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "types": ["@lynx-js/types", "@rslib/core/types", "node"]
+  },
+  "include": ["./"]
+}

--- a/packages/create-rslib/template-reactlynx-ts/tsconfig.json
+++ b/packages/create-rslib/template-reactlynx-ts/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2022"],
+    "jsx": "preserve",
+    "jsxImportSource": "@lynx-js/react",
+    "target": "ES2022",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["@lynx-js/types", "@rslib/core/types"],
+    "useDefineForClassFields": true,
+    "rootDir": "src",
+
+    /* modules */
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+
+    /* type checking */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src"]
+}

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -197,6 +197,15 @@ export const createAndValidate = (
       pkgJson.devDependencies['@lynx-js/react-rsbuild-plugin'],
     ).toBeTruthy();
     expect(pkgJson.peerDependencies['@lynx-js/react']).toBeTruthy();
+    expect(
+      templateCase.lang === 'ts'
+        ? pkgJson.exports['.'].default
+        : pkgJson.exports,
+    ).toBe('./dist/index.jsx');
+    if (templateCase.lang === 'ts') {
+      expect(pkgJson.exports['.'].types).toBe('./dist/index.d.ts');
+      expect(pkgJson.types).toBe('./dist/index.d.ts');
+    }
   }
 
   if (templateCase.template === 'react') {

--- a/packages/create-rslib/test/helper.ts
+++ b/packages/create-rslib/test/helper.ts
@@ -191,6 +191,14 @@ export const createAndValidate = (
     }
   }
 
+  if (templateCase.template === 'reactlynx') {
+    expect(pkgJson.devDependencies['@lynx-js/react']).toBeTruthy();
+    expect(
+      pkgJson.devDependencies['@lynx-js/react-rsbuild-plugin'],
+    ).toBeTruthy();
+    expect(pkgJson.peerDependencies['@lynx-js/react']).toBeTruthy();
+  }
+
   if (templateCase.template === 'react') {
     const configFile = path.join(
       dir,

--- a/packages/create-rslib/test/index.test.ts
+++ b/packages/create-rslib/test/index.test.ts
@@ -38,6 +38,11 @@ const CASES_REACT: TemplateCase[] = [
   createCase('react', 'ts', ['react-compiler', 'rspress', 'storybook']),
 ];
 
+const CASES_REACTLYNX: TemplateCase[] = [
+  createCase('reactlynx', 'js'),
+  createCase('reactlynx', 'ts'),
+];
+
 const CASES_VUE: TemplateCase[] = [
   createCase('vue', 'js'),
   createCase('vue', 'ts'),
@@ -63,6 +68,8 @@ describe('parseTemplateName', () => {
     expect(parseTemplateName('node-ts')).toBe('node-ts');
     expect(parseTemplateName('react-ts')).toBe('react-ts');
     expect(parseTemplateName('react-js')).toBe('react-js');
+    expect(parseTemplateName('reactlynx-ts')).toBe('reactlynx-ts');
+    expect(parseTemplateName('reactlynx-js')).toBe('reactlynx-js');
     expect(parseTemplateName('vue-ts')).toBe('vue-ts');
     expect(parseTemplateName('vue-js')).toBe('vue-js');
     expect(parseTemplateName('svelte-js')).toBe('svelte-js');
@@ -74,6 +81,7 @@ describe('parseTemplateName', () => {
   test('should handle template without language suffix and default to ts', () => {
     expect(parseTemplateName('node')).toBe('node-ts');
     expect(parseTemplateName('react')).toBe('react-ts');
+    expect(parseTemplateName('reactlynx')).toBe('reactlynx-ts');
     expect(parseTemplateName('vue')).toBe('vue-ts');
     expect(parseTemplateName('svelte')).toBe('svelte-ts');
     expect(parseTemplateName('solid')).toBe('solid-ts');
@@ -177,6 +185,14 @@ describe('react', () => {
 describe('vue', () => {
   for (const c of CASES_VUE) {
     test(`should create ${c.label} project as expected`, async () => {
+      createAndValidate(__dirname, c);
+    });
+  }
+});
+
+describe('reactlynx', () => {
+  for (const c of CASES_REACTLYNX) {
+    test(`should create ${c.label} project as expected`, () => {
       createAndValidate(__dirname, c);
     });
   }

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -107,6 +107,7 @@ preprocessors
 publint
 pxtorem
 quxx
+reactlynx
 rebranded
 reduxjs
 riscv

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -51,13 +51,14 @@ After creating the project, do the following:
 
 When creating a project, you can choose from the following templates provided by `create-rslib`:
 
-| Template        | Description              |
-| --------------- | ------------------------ |
-| Node.js package | Node.js package          |
-| React           | React component library  |
-| Vue             | Vue component library    |
-| Svelte          | Svelte component library |
-| Solid           | Solid component library  |
+| Template  | Description                 |
+| --------- | --------------------------- |
+| Node.js   | Node.js package             |
+| React     | React component library     |
+| ReactLynx | ReactLynx component library |
+| Vue       | Vue component library       |
+| Svelte    | Svelte component library    |
+| Solid     | Solid component library     |
 
 ### Optional tools
 
@@ -144,7 +145,7 @@ Options:
   --packageName <name>  specify the package name
 
 Available templates:
-  node-js, node-ts, react-js, react-ts, vue-js, vue-ts, svelte-js, svelte-ts, solid-js, solid-ts
+  node-js, node-ts, react-js, react-ts, reactlynx-js, reactlynx-ts, vue-js, vue-ts, svelte-js, svelte-ts, solid-js, solid-ts
 
 Optional tools:
   react-compiler, eslint, rslint, biome, prettier, rspress, storybook

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -51,13 +51,14 @@ import { PackageManagerTabs } from '@theme';
 
 在创建项目时，你可以选择 `create-rslib` 提供的下列模板：
 
-| 模板            | 描述          |
-| --------------- | ------------- |
-| Node.js package | Node.js 包    |
-| React           | React 组件库  |
-| Vue             | Vue 组件库    |
-| Svelte          | Svelte 组件库 |
-| Solid           | Solid 组件库  |
+| 模板      | 描述             |
+| --------- | ---------------- |
+| Node.js   | Node.js 包       |
+| React     | React 组件库     |
+| ReactLynx | ReactLynx 组件库 |
+| Vue       | Vue 组件库       |
+| Svelte    | Svelte 组件库    |
+| Solid     | Solid 组件库     |
 
 ### 可选工具
 
@@ -144,7 +145,7 @@ Options:
   --packageName <name>  specify the package name
 
 Available templates:
-  node-js, node-ts, react-js, react-ts, vue-js, vue-ts, svelte-js, svelte-ts, solid-js, solid-ts
+  node-js, node-ts, react-js, react-ts, reactlynx-js, reactlynx-ts, vue-js, vue-ts, svelte-js, svelte-ts, solid-js, solid-ts
 
 Optional tools:
   react-compiler, eslint, rslint, biome, prettier, rspress, storybook


### PR DESCRIPTION
## Summary

Add JavaScript and TypeScript ReactLynx templates to create-rslib, with builds that preserve JSX and optional Rstest component testing. Reuse the React lint presets, include Lynx documentation in the generated `AGENTS.md`, and document the new template in the quick-start guide.

## Related links

- [ReactLynx examples](https://github.com/rstackjs/rstack-examples/pull/501)
- [ReactLynx solution guide](https://github.com/web-infra-dev/rslib/pull/1911)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
