### PR TITLE
feat(core): accept loadConfig result as config input

### DIFF
--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -140,13 +140,14 @@ const loadConfig = async (
   root: string,
   command?: CommandName,
 ) => {
-  const { content: config, filePath: configFilePath } = await baseLoadConfig({
+  const result = await baseLoadConfig({
     cwd: root,
     path: options.config,
     envMode: options.envMode,
     loader: options.configLoader,
     command,
   });
+  const { content: config, filePath: configFilePath } = result;
 
   if (configFilePath === null) {
     config.lib = [{} satisfies LibConfig];
@@ -155,7 +156,7 @@ const loadConfig = async (
 
   applyCliOptions(config, options, root);
 
-  return config;
+  return result;
 };
 
 const restart: RestartFn = async ({ action }) => {

--- a/packages/core/src/createRslib.ts
+++ b/packages/core/src/createRslib.ts
@@ -21,12 +21,7 @@ import type {
   StartDevServerResult,
   StartMFDevServerOptions,
 } from './types/rslib';
-import {
-  ensureAbsolutePath,
-  getNodeEnv,
-  isFunction,
-  setNodeEnv,
-} from './utils/helper';
+import { ensureAbsolutePath, getNodeEnv, setNodeEnv } from './utils/helper';
 import { isDebug, isDebugKey, logger } from './utils/logger';
 
 const pruneMFEnvironments = (
@@ -121,16 +116,18 @@ export async function createRslib(
       })
     : null;
 
-  const configOrFactory = options.config;
-  const configInput = isFunction(configOrFactory)
-    ? await configOrFactory()
-    : configOrFactory;
-  const loadConfigResult = isLoadConfigResult(configInput)
-    ? configInput
-    : undefined;
-  const config: RslibConfig = loadConfigResult
-    ? loadConfigResult.content
-    : (configInput as RslibConfig | undefined) || {};
+  let config =
+    typeof options.config === 'function'
+      ? await options.config()
+      : options.config;
+  let loadConfigResult: LoadConfigResult | undefined;
+
+  if (isLoadConfigResult(config)) {
+    loadConfigResult = config;
+    config = config.content;
+  }
+
+  config ||= {};
 
   if (envs) {
     // define the public environment variables

--- a/packages/core/src/createRslib.ts
+++ b/packages/core/src/createRslib.ts
@@ -2,11 +2,13 @@ import {
   createRsbuild,
   type EnvironmentConfig,
   loadEnv,
+  type RsbuildConfig,
   type RsbuildInstance,
   type RsbuildPlugin,
 } from '@rsbuild/core';
 import util from 'node:util';
 import { composeRsbuildEnvironments, pruneEnvironments } from './config';
+import type { LoadConfigResult } from './loadConfig';
 import type { Format, RslibConfig } from './types';
 import type {
   BuildOptions,
@@ -96,6 +98,16 @@ const applyDebugInspectConfigPlugin = (
   });
 };
 
+function isLoadConfigResult(result: unknown): result is LoadConfigResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'content' in result &&
+    'filePath' in result &&
+    'dependencies' in result
+  );
+}
+
 /**
  * Create an Rslib instance.
  */
@@ -110,9 +122,15 @@ export async function createRslib(
     : null;
 
   const configOrFactory = options.config;
-  const config = isFunction(configOrFactory)
+  const configInput = isFunction(configOrFactory)
     ? await configOrFactory()
-    : configOrFactory || ({} as RslibConfig);
+    : configOrFactory;
+  const loadConfigResult = isLoadConfigResult(configInput)
+    ? configInput
+    : undefined;
+  const config: RslibConfig = loadConfigResult
+    ? loadConfigResult.content
+    : (configInput as RslibConfig | undefined) || {};
 
   if (envs) {
     // define the public environment variables
@@ -155,19 +173,21 @@ export async function createRslib(
     mode: 'development' | 'production',
     environments: Record<string, EnvironmentConfig>,
   ): Promise<RsbuildInstance> => {
+    const rsbuildConfig: RsbuildConfig = {
+      mode,
+      root: config.root,
+      plugins: config.plugins,
+      dev: config.dev,
+      server: config.server,
+      logLevel: isDebug() ? 'info' : config.logLevel,
+      environments,
+    };
     const rsbuildInstance = await createRsbuild({
       cwd: options.cwd,
       callerName: 'rslib',
-      config: {
-        ...(config._privateMeta ? { _privateMeta: config._privateMeta } : {}),
-        mode,
-        root: config.root,
-        plugins: config.plugins,
-        dev: config.dev,
-        server: config.server,
-        logLevel: isDebug() ? 'info' : config.logLevel,
-        environments,
-      },
+      config: loadConfigResult
+        ? { ...loadConfigResult, content: rsbuildConfig }
+        : rsbuildConfig,
       restart: options.restart,
     });
 

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -1,7 +1,6 @@
 import {
   loadConfig as loadRsbuildConfig,
   type LoadConfigOptions,
-  type RsbuildConfig,
   type LoadConfigResult as RsbuildLoadConfigResult,
 } from '@rsbuild/core';
 import type { RslibConfig } from './types';
@@ -80,9 +79,6 @@ export async function loadConfig<Config = RslibConfig>(
     ...options,
     configFileNames: options.configFileNames ?? RSLIB_CONFIG_FILE_NAMES,
   });
-
-  // Metadata is passed through the load result instead of the config object.
-  delete (result.content as RsbuildConfig)._privateMeta;
 
   return result;
 }

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -1,6 +1,8 @@
 import {
   loadConfig as loadRsbuildConfig,
   type LoadConfigOptions,
+  type RsbuildConfig,
+  type LoadConfigResult as RsbuildLoadConfigResult,
 } from '@rsbuild/core';
 import type { RslibConfig } from './types';
 
@@ -20,17 +22,8 @@ export type RslibConfigDefinition =
 
 export type ConfigLoader = LoadConfigOptions['loader'];
 
-export type LoadConfigResult<Config = RslibConfig> = {
-  /**
-   * The loaded configuration object.
-   */
-  content: Config;
-  /**
-   * The path to the loaded configuration file.
-   * Return `null` if the configuration file is not found.
-   */
-  filePath: string | null;
-};
+export type LoadConfigResult<Config = RslibConfig> =
+  RsbuildLoadConfigResult<Config>;
 
 /**
  * This function helps you to autocomplete configuration types.
@@ -83,17 +76,17 @@ const RSLIB_CONFIG_FILE_NAMES = [
 export async function loadConfig<Config = RslibConfig>(
   options: LoadConfigOptions = {},
 ): Promise<LoadConfigResult<Config>> {
-  const { content, filePath } = await loadRsbuildConfig<Config>({
+  const result = await loadRsbuildConfig<Config>({
     ...options,
     configFileNames: options.configFileNames ?? RSLIB_CONFIG_FILE_NAMES,
   });
 
-  return { content, filePath };
+  return result;
 }
 
 export {
+  loadEnv,
   type LoadConfigOptions,
   type LoadEnvOptions,
   type LoadEnvResult,
-  loadEnv,
 } from '@rsbuild/core';

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -75,12 +75,10 @@ const RSLIB_CONFIG_FILE_NAMES = [
 export async function loadConfig<Config = RslibConfig>(
   options: LoadConfigOptions = {},
 ): Promise<LoadConfigResult<Config>> {
-  const result = await loadRsbuildConfig<Config>({
+  return loadRsbuildConfig<Config>({
     ...options,
     configFileNames: options.configFileNames ?? RSLIB_CONFIG_FILE_NAMES,
   });
-
-  return result;
 }
 
 export {

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -81,6 +81,9 @@ export async function loadConfig<Config = RslibConfig>(
     configFileNames: options.configFileNames ?? RSLIB_CONFIG_FILE_NAMES,
   });
 
+  // Metadata is passed through the load result instead of the config object.
+  delete (result.content as RsbuildConfig)._privateMeta;
+
   return result;
 }
 

--- a/packages/core/src/types/rslib.ts
+++ b/packages/core/src/types/rslib.ts
@@ -6,6 +6,7 @@ import type {
   RsbuildInstance,
   StartDevServerResult,
 } from '@rsbuild/core';
+import type { LoadConfigResult } from '../loadConfig';
 import type { RslibConfig } from './config';
 
 export type CommonOptions = {
@@ -100,6 +101,8 @@ export type OnAfterCreateRsbuildFn = (params: {
   rsbuild: RsbuildInstance;
 }) => void | Promise<void>;
 
+type RslibConfigInput = RslibConfig | LoadConfigResult;
+
 export type CreateRslibOptions = {
   /**
    * The root path of current project.
@@ -107,10 +110,10 @@ export type CreateRslibOptions = {
    */
   cwd?: string;
   /**
-   * Rslib configurations.
+   * Rslib configuration or the result returned by `loadConfig`.
    * Passing a function to load the config asynchronously with custom logic.
    */
-  config?: RslibConfig | (() => Promise<RslibConfig>);
+  config?: RslibConfigInput | (() => Promise<RslibConfigInput>);
   /**
    * Whether to call `loadEnv` to load environment variables and define them
    * as global variables via `source.define`.

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -21,6 +21,23 @@ import { logger } from '../src/utils/logger';
 rs.mock('rslog');
 
 describe('Should load config file correctly', () => {
+  test('accepts the complete loadConfig result', async () => {
+    const result = await loadConfig({
+      path: join(__dirname, 'fixtures/config/cli-options/rslib.config.ts'),
+    });
+    const cwd = join(__dirname, '..');
+    const rslib = await createRslib({ cwd, config: result });
+
+    rslib.onAfterCreateRsbuild(({ rsbuild }) => {
+      expect(rsbuild.context.configFile).toBe(result.filePath);
+      expect(rsbuild.context.configFileDependencies).toEqual(
+        result.dependencies,
+      );
+    });
+
+    await rslib.inspectConfig();
+  });
+
   test('Load config.js in cjs project', async () => {
     const fixtureDir = join(__dirname, 'fixtures/config/cjs');
     const configFilePath = join(fixtureDir, 'rslib.config.js');
@@ -31,10 +48,6 @@ describe('Should load config file correctly', () => {
         entry: {
           index: './foo/index.js',
         },
-      },
-      _privateMeta: {
-        configFileDependencies: [],
-        configFilePath,
       },
     });
   });
@@ -50,10 +63,6 @@ describe('Should load config file correctly', () => {
           index: './foo/index.js',
         },
       },
-      _privateMeta: {
-        configFileDependencies: [],
-        configFilePath,
-      },
     });
   });
 
@@ -67,10 +76,6 @@ describe('Should load config file correctly', () => {
         entry: {
           index: './foo/index.ts',
         },
-      },
-      _privateMeta: {
-        configFileDependencies: [],
-        configFilePath,
       },
     });
   });
@@ -86,10 +91,6 @@ describe('Should load config file correctly', () => {
           index: './foo/index.js',
         },
       },
-      _privateMeta: {
-        configFileDependencies: [],
-        configFilePath,
-      },
     });
   });
 
@@ -103,10 +104,6 @@ describe('Should load config file correctly', () => {
         entry: {
           index: './foo/index.js',
         },
-      },
-      _privateMeta: {
-        configFileDependencies: [],
-        configFilePath,
       },
     });
   });
@@ -122,10 +119,6 @@ describe('Should load config file correctly', () => {
           index: './foo/index.js',
         },
       },
-      _privateMeta: {
-        configFileDependencies: [],
-        configFilePath,
-      },
     });
   });
 
@@ -140,10 +133,6 @@ describe('Should load config file correctly', () => {
           index: './foo/index.ts',
         },
       },
-      _privateMeta: {
-        configFileDependencies: [],
-        configFilePath,
-      },
     });
   });
 
@@ -157,9 +146,6 @@ describe('Should load config file correctly', () => {
         entry: {
           index: './foo/index.js',
         },
-      },
-      _privateMeta: {
-        configFilePath,
       },
     });
   });
@@ -414,10 +400,6 @@ describe('CLI options', () => {
       const config = rslib.getRslibConfig();
       expect(config).toMatchInlineSnapshot(`
       {
-        "_privateMeta": {
-          "configFileDependencies": [],
-          "configFilePath": "<WORKSPACE>/tests/fixtures/config/cli-options/rslib.config.ts",
-        },
         "lib": [
           {
             "autoExtension": false,

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -49,6 +49,10 @@ describe('Should load config file correctly', () => {
           index: './foo/index.js',
         },
       },
+      _privateMeta: {
+        configFileDependencies: [],
+        configFilePath,
+      },
     });
   });
 
@@ -62,6 +66,10 @@ describe('Should load config file correctly', () => {
         entry: {
           index: './foo/index.js',
         },
+      },
+      _privateMeta: {
+        configFileDependencies: [],
+        configFilePath,
       },
     });
   });
@@ -77,6 +85,10 @@ describe('Should load config file correctly', () => {
           index: './foo/index.ts',
         },
       },
+      _privateMeta: {
+        configFileDependencies: [],
+        configFilePath,
+      },
     });
   });
 
@@ -90,6 +102,10 @@ describe('Should load config file correctly', () => {
         entry: {
           index: './foo/index.js',
         },
+      },
+      _privateMeta: {
+        configFileDependencies: [],
+        configFilePath,
       },
     });
   });
@@ -105,6 +121,10 @@ describe('Should load config file correctly', () => {
           index: './foo/index.js',
         },
       },
+      _privateMeta: {
+        configFileDependencies: [],
+        configFilePath,
+      },
     });
   });
 
@@ -118,6 +138,10 @@ describe('Should load config file correctly', () => {
         entry: {
           index: './foo/index.js',
         },
+      },
+      _privateMeta: {
+        configFileDependencies: [],
+        configFilePath,
       },
     });
   });
@@ -133,6 +157,10 @@ describe('Should load config file correctly', () => {
           index: './foo/index.ts',
         },
       },
+      _privateMeta: {
+        configFileDependencies: [],
+        configFilePath,
+      },
     });
   });
 
@@ -146,6 +174,9 @@ describe('Should load config file correctly', () => {
         entry: {
           index: './foo/index.js',
         },
+      },
+      _privateMeta: {
+        configFilePath,
       },
     });
   });
@@ -400,6 +431,10 @@ describe('CLI options', () => {
       const config = rslib.getRslibConfig();
       expect(config).toMatchInlineSnapshot(`
       {
+        "_privateMeta": {
+          "configFileDependencies": [],
+          "configFilePath": "<WORKSPACE>/tests/fixtures/config/cli-options/rslib.config.ts",
+        },
         "lib": [
           {
             "autoExtension": false,

--- a/tests/integration/cli/build/build.test.ts
+++ b/tests/integration/cli/build/build.test.ts
@@ -243,6 +243,10 @@ describe('build command', async () => {
             autoExtension: 'false'
           }
         ],
+        _privateMeta: {
+          configFilePath: '<ROOT>/tests/integration/cli/build/options/rslib.config.ts',
+          configFileDependencies: []
+        },
         source: {
           define: {}
         },

--- a/tests/integration/cli/build/build.test.ts
+++ b/tests/integration/cli/build/build.test.ts
@@ -243,10 +243,6 @@ describe('build command', async () => {
             autoExtension: 'false'
           }
         ],
-        _privateMeta: {
-          configFilePath: '<ROOT>/tests/integration/cli/build/options/rslib.config.ts',
-          configFileDependencies: []
-        },
         source: {
           define: {}
         },

--- a/tests/scripts/shared.ts
+++ b/tests/scripts/shared.ts
@@ -280,15 +280,16 @@ export async function rslibBuild({
   modifyConfig?: (config: RslibConfig) => void;
   lib?: string[];
 }) {
-  const { content: rslibConfig } = await loadConfig({
+  const result = await loadConfig({
     cwd,
     path,
   });
+  const rslibConfig = result.content;
   modifyConfig?.(rslibConfig);
   process.chdir(cwd);
   const rslib = await createRslib({
     cwd,
-    config: rslibConfig,
+    config: result,
   });
   const buildResult = await rslib.build({
     lib,

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -35,14 +35,19 @@ The first parameter of `createRslib` is an `options` object with the following p
 ```ts
 type CreateRslibOptions = {
   cwd?: string;
-  config?: RslibConfig | (() => Promise<RslibConfig>);
+  config?:
+    | RslibConfig
+    | LoadConfigResult
+    | (() => Promise<RslibConfig | LoadConfigResult>);
   loadEnv?: boolean | LoadEnvOptions;
 };
 ```
 
 - `cwd`: The root path of the current build, defaults to `process.cwd()`.
-- `config`: Rslib configuration object. Refer to [Configuration overview](/config/) for all available configuration options.
+- `config`: Rslib configuration object or the complete result returned by [loadConfig](#loadconfig). Refer to [Configuration overview](/config/) for all available configuration options.
 - `loadEnv`: Whether to call the [loadEnv](/api/javascript-api/core#loadenv) method to load environment variables and define them as global variables via [source.define](/config/rsbuild/source#sourcedefine).
+
+Pass the complete `loadConfig` result to preserve configuration file paths and imported dependencies for file watching and persistent cache invalidation. Passing only `result.content` does not preserve this metadata.
 
 ### Load configuration async
 
@@ -53,9 +58,9 @@ import { createRslib, loadConfig } from '@rslib/core';
 
 const rslib = await createRslib({
   config: async () => {
-    const { content } = await loadConfig();
-    someFunctionToUpdateConfig(content);
-    return content;
+    const result = await loadConfig();
+    someFunctionToUpdateConfig(result.content);
+    return result;
   },
 });
 ```
@@ -126,25 +131,26 @@ function loadConfig(params?: {
 }): Promise<{
   content: RslibConfig;
   filePath: string | null;
+  dependencies: string[];
 }>;
 ```
 
 - **Example:**
 
 ```ts
-import { loadConfig } from '@rslib/core';
+import { createRslib, loadConfig } from '@rslib/core';
 
 // load `rslib.config.*` file by default
-const { content } = await loadConfig();
+const result = await loadConfig();
 
-console.log(content); // -> Rslib config object
+console.log(result.content); // -> Rslib config object
 
 const rslib = await createRslib({
-  config: content,
+  config: result,
 });
 ```
 
-If the Rslib config file does not exist in the cwd directory, the return value of the loadConfig method is `{ content: {}, filePath: null }`.
+If the Rslib config file does not exist in the cwd directory, the return value of the loadConfig method is `{ content: {}, filePath: null, dependencies: [] }`.
 
 When `path` is not specified, `loadConfig` searches for config files in the following order:
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -35,14 +35,19 @@ const rslib = await createRslib({
 ```ts
 type CreateRslibOptions = {
   cwd?: string;
-  config?: RslibConfig | (() => Promise<RslibConfig>);
+  config?:
+    | RslibConfig
+    | LoadConfigResult
+    | (() => Promise<RslibConfig | LoadConfigResult>);
   loadEnv?: boolean | LoadEnvOptions;
 };
 ```
 
 - `cwd`：当前执行构建的根路径，默认值为 `process.cwd()`
-- `config`：Rslib 配置对象。参考 [配置总览](/config/) 查看所有可用的配置项。
+- `config`：Rslib 配置对象或 [loadConfig](#loadconfig) 的完整返回结果。参考 [配置总览](/config/) 查看所有可用的配置项。
 - `loadEnv`：是否调用 [loadEnv](/api/javascript-api/core#loadenv) 方法来加载环境变量，并通过 [source.define](/config/rsbuild/source#sourcedefine) 定义为全局变量。
+
+传入完整的 `loadConfig` 返回结果，可以保留配置文件路径和导入依赖，用于文件监听和持久化缓存失效。仅传入 `result.content` 不会保留这些元数据。
 
 ### 异步加载配置
 
@@ -53,9 +58,9 @@ import { createRslib, loadConfig } from '@rslib/core';
 
 const rslib = await createRslib({
   config: async () => {
-    const { content } = await loadConfig();
-    someFunctionToUpdateConfig(content);
-    return content;
+    const result = await loadConfig();
+    someFunctionToUpdateConfig(result.content);
+    return result;
   },
 });
 ```
@@ -126,25 +131,26 @@ function loadConfig(params?: {
 }): Promise<{
   content: RslibConfig;
   filePath: string | null;
+  dependencies: string[];
 }>;
 ```
 
 - **示例：**
 
 ```ts
-import { loadConfig } from '@rslib/core';
+import { createRslib, loadConfig } from '@rslib/core';
 
 // 默认加载 `rslib.config.*` 配置文件
-const { content } = await loadConfig();
+const result = await loadConfig();
 
-console.log(content); // -> Rslib 配置对象
+console.log(result.content); // -> Rslib 配置对象
 
 const rslib = await createRslib({
-  config: content,
+  config: result,
 });
 ```
 
-如果 cwd 目录下不存在 Rslib 配置文件，loadConfig 方法的返回值为 `{ content: {}, filePath: null }`。
+如果 cwd 目录下不存在 Rslib 配置文件，loadConfig 方法的返回值为 `{ content: {}, filePath: null, dependencies: [] }`。
 
 未指定 `path` 时，`loadConfig` 会按照以下顺序查找配置文件：
 


### PR DESCRIPTION
## Motivation

Rslib relies on private configuration metadata to preserve file watching and cache dependencies. Rsbuild now supports passing the complete load result directly ([rsbuild#8147](https://github.com/web-infra-dev/rsbuild/pull/8147)).

## Changes

Allow `createRslib` to accept a complete `loadConfig` result, directly or through an async factory, and forward its file path and dependencies alongside the transformed Rsbuild configuration.

Preserve Rsbuild's loaded configuration, including `_privateMeta`, while removing Rslib's explicit forwarding of that private field.

Update the CLI, test helper, and API documentation to pass complete results; callers passing only `result.content` must migrate to preserve configuration watching and cache dependencies.