### PR TITLE
chore(vscode): format TypeScript files on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,11 +16,13 @@
   "mdx.validate.validateFileLinks": "ignore",
   "editor.defaultFormatter": "rstack.rstack",
   "[typescript]": {
+    "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.sortImports": "always"
     }
   },
   "[typescriptreact]": {
+    "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.sortImports": "always"
     }


### PR DESCRIPTION
## Motivation

The workspace enables `source.sortImports` on save for TypeScript and TSX. This TypeScript code action also rewrites re-exports and can remove their trailing commas. For example, saving `packages/core/src/loadConfig.ts` removes the comma after `type LoadEnvResult`, while `rs fmt` restores it.

Although Rstack is configured as the default formatter, `editor.formatOnSave` is not enabled in the workspace. Unless developers enable it in their user settings, saving runs import sorting without a subsequent formatting pass, leaving the file inconsistent with the repository format. This behavior was reproduced with VS Code's bundled TypeScript 6.0.3.

## Changes

Enable `editor.formatOnSave` for TypeScript and TSX so manual saves run Rstack formatting after import sorting. Keep the existing import sorting behavior and leave other languages' save settings unchanged.